### PR TITLE
Refuse a wrong row type rather than repairing it

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet/AdoClrCorrelationDataContextBuilder.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoClrCorrelationDataContextBuilder.cs
@@ -53,7 +53,11 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             ArgumentNullException.ThrowIfNull(id);
 
-            _parameters.Add(_implementor.CorrelVariableField(id.getName(), ordinal, type));
+            // the getter reads the field as linq4j and declares into the block it was created with, not one
+            // passed to it, so there is nothing for a block of this builder's to receive
+            var field = _implementor.GetCorrelVariableGetter(id.getName()).field(null, ordinal, type);
+
+            _parameters.Add(_implementor.Translator.Translate(field));
             return offset++;
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
@@ -91,7 +91,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
             // the schema SPI defines a convention's expression as linq4j, so this is the one thing here that
             // arrives as a linq4j tree, and it is translated where it is produced rather than composed into
             // anything first. Everything else this node builds is an expression tree from the start.
-            var dataSource = implementor.Translate(Schemas.unwrap(convention.Expression, typeof(AdoDataSource)));
+            var dataSource = implementor.Translator.Translate(Schemas.unwrap(convention.Expression, typeof(AdoDataSource)));
 
             // a correlated sub-query leaves a parameter per correlation variable in the SQL, and the values
             // live on the context the builder closed over the outer row. Without the enricher the command is

--- a/src/Apache.Calcite.Linq/ClrEnumerableRelImplementor.cs
+++ b/src/Apache.Calcite.Linq/ClrEnumerableRelImplementor.cs
@@ -83,41 +83,7 @@ namespace Apache.Calcite.Linq
         /// Gets the translator that turns a linq4j expression into a CLR one. One serves the whole plan, so a
         /// variable means the same thing wherever a node mentions it.
         /// </summary>
-        internal LixToClrTranslator Translator { get; }
-
-        /// <summary>
-        /// Translates a linq4j expression into a CLR one.
-        /// </summary>
-        /// <param name="node">The expression to translate.</param>
-        /// <returns>The same expression, as a <see cref="System.Linq.Expressions"/> tree.</returns>
-        /// <remarks>
-        /// A node of this convention builds expressions directly and has no need of this. It is here for the
-        /// node that cannot: one whose expression comes from a generator of Calcite's, which produces linq4j
-        /// and nothing else. Translate such an expression where it is produced rather than composing it into
-        /// a larger tree first.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException"></exception>
-        public Expression Translate(J.Node node)
-        {
-            ArgumentNullException.ThrowIfNull(node);
-
-            return Translator.Translate(node);
-        }
-
-        /// <summary>
-        /// Translates a linq4j block, and the declarations it carries, into one CLR expression.
-        /// </summary>
-        /// <param name="body">The block to translate, whose last statement is its value.</param>
-        /// <param name="returnType">The type the block yields.</param>
-        /// <returns>The block, as a <see cref="System.Linq.Expressions"/> tree.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public Expression TranslateBody(J.BlockStatement body, Type returnType)
-        {
-            ArgumentNullException.ThrowIfNull(body);
-            ArgumentNullException.ThrowIfNull(returnType);
-
-            return Translator.TranslateBody(body, returnType);
-        }
+        public LixToClrTranslator Translator { get; }
 
         /// <summary>
         /// Gets the internal parameters, which reach the query through the <see cref="DataContext"/> it is
@@ -277,29 +243,6 @@ namespace Apache.Calcite.Linq
         }
 
         /// <summary>
-        /// Reads one field of the outer row a correlated sub-query was entered with.
-        /// </summary>
-        /// <param name="name">The correlation variable's name.</param>
-        /// <param name="ordinal">The field's position in the outer row.</param>
-        /// <param name="storageType">The type to read the field as, or <see langword="null"/> for the
-        /// field's own.</param>
-        /// <returns>The field's value.</returns>
-        /// <exception cref="java.lang.IllegalStateException">No such variable is in scope.</exception>
-        /// <remarks>
-        /// <see cref="GetCorrelVariableGetter"/> answers with Calcite's <c>InputGetter</c>, which reads a
-        /// field as linq4j and takes a linq4j block to declare into. This is that, translated, so a node
-        /// outside this assembly can read a correlated field without holding a linq4j tree of its own.
-        /// </remarks>
-        public Expression CorrelVariableField(string name, int ordinal, java.lang.reflect.Type? storageType = null)
-        {
-            ArgumentNullException.ThrowIfNull(name);
-
-            // the getter declares into the block it was created with, not one passed to it, so there is
-            // nothing here for a caller's block to receive
-            return Translate(GetCorrelVariableGetter(name).field(null, ordinal, storageType));
-        }
-
-        /// <summary>
         /// Creates the result a node's <c>Implement</c> returns.
         /// </summary>
         /// <param name="physType">How the rows are represented.</param>
@@ -307,55 +250,41 @@ namespace Apache.Calcite.Linq
         /// <returns></returns>
         public ClrEnumerableResult Result(PhysType physType, Expression expression)
         {
+            RequireRowType(physType, expression);
+
             // PhysTypeImpl keeps its format package-private, and getFormat is the same value in public
-            return new ClrEnumerableResult(Boxed(physType, expression), physType, physType.getFormat());
+            return new ClrEnumerableResult(expression, physType, physType.getFormat());
         }
 
         /// <summary>
-        /// Returns the CLR type of one row of a sequence of the given physical type.
-        /// </summary>
-        /// <param name="physType"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// The row type, boxed. A row of a plan holds Java's values and keeps holding them: a field inside an
-        /// <c>Object[]</c> row is a <c>java.lang.Integer</c> from the table to the converter that hands it
-        /// out, and a one column row is that same value with no array around it. A node may unbox inside
-        /// itself, where the values never leave the expression it is building, but what it hands to the node
-        /// above has to be what the row type says.
-        ///
-        /// <para>Calcite has nothing to decide here: there is no <c>Enumerable&lt;int&gt;</c> in Java, so its
-        /// sequences carry the box whatever the physical type says, and its element type is erased besides. A
-        /// CLR sequence says its element type out loud, so every node has to say the same thing.</para>
-        /// </remarks>
-        public static Type RowType(PhysType physType)
-        {
-            ArgumentNullException.ThrowIfNull(physType);
-
-            return ClrTypes.Resolve(J.Primitive.box(physType.getJavaRowType()));
-        }
-
-        /// <summary>
-        /// Returns the sequence with its rows of the type the physical type says they are.
+        /// Refuses a sequence whose rows are not of the type the physical type says they are.
         /// </summary>
         /// <param name="physType"></param>
         /// <param name="expression"></param>
-        /// <returns></returns>
-        static Expression Boxed(PhysType physType, Expression expression)
+        /// <exception cref="java.lang.IllegalStateException">The two disagree.</exception>
+        /// <remarks>
+        /// Calcite's <c>EnumerableRelImplementor.result</c> records what it is handed and asks nothing, its
+        /// sequences being erased. This asks, because a node here can build a sequence of the wrong type and
+        /// every node below it will still compile.
+        ///
+        /// <para>It refuses rather than repairing. Converting the sequence would leave the node wrong and the
+        /// plan right, at the cost of a delegate per row, and would hide the next node written that way — as
+        /// it did: this method boxed for a while, and three nodes were wrong underneath it with every test
+        /// passing.</para>
+        /// </remarks>
+        static void RequireRowType(PhysType physType, Expression expression)
         {
             if (expression.Type.IsGenericType == false || expression.Type.GetGenericTypeDefinition() != typeof(IEnumerable<>))
-                return expression;
+                return;
 
             var actual = expression.Type.GetGenericArguments()[0];
-            var expected = RowType(physType);
+            var expected = physType.RowType();
             if (actual == expected)
-                return expression;
+                return;
 
-            var row = Expression.Parameter(actual, "row");
+            var node = new System.Diagnostics.StackTrace().GetFrame(2)?.GetMethod()?.DeclaringType?.Name ?? "?";
 
-            return Expression.Call(null,
-                ClrBuiltInMethod.Select.MakeGenericMethod(actual, expected),
-                expression,
-                Expression.Lambda(typeof(Func<,>).MakeGenericType(actual, expected), ClrEnumUtils.Convert(row, expected), row));
+            throw new java.lang.IllegalStateException($"{node} handed up a sequence of {actual} where its row type is {expected}.");
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Linq/ClrEnumerableResult.cs
+++ b/src/Apache.Calcite.Linq/ClrEnumerableResult.cs
@@ -24,7 +24,15 @@ namespace Apache.Calcite.Linq
         /// <param name="expression">Expression yielding the sequence of rows.</param>
         /// <param name="physType">The Java type returned by this relational expression, and how it maps onto the fields of the logical row type.</param>
         /// <param name="format">How a row is represented.</param>
-        public ClrEnumerableResult(Expression expression, PhysType physType, JavaRowFormat format)
+        /// <remarks>
+        /// Internal, so that <see cref="ClrEnumerableRelImplementor.Result"/> is the only way a node has of
+        /// making one. That method is where a sequence is required to carry the rows its physical type says
+        /// it carries, and a node that built its own result would not be asked. One did, and was the last
+        /// node in the plan still handing up a CLR primitive where the row type was a Java box — correct
+        /// only because it had been fixed by hand, and silently wrong again the moment anything about it
+        /// changed.
+        /// </remarks>
+        internal ClrEnumerableResult(Expression expression, PhysType physType, JavaRowFormat format)
         {
             Expression = expression ?? throw new ArgumentNullException(nameof(expression));
             PhysType = physType ?? throw new ArgumentNullException(nameof(physType));

--- a/src/Apache.Calcite.Linq/ClrPhysTypes.cs
+++ b/src/Apache.Calcite.Linq/ClrPhysTypes.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Linq.Expressions;
 
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.linq4j.function;
 
 using Apache.Calcite.Linq.Tree;
+
+using J = org.apache.calcite.linq4j.tree;
 
 namespace Apache.Calcite.Linq
 {
@@ -32,7 +35,7 @@ namespace Apache.Calcite.Linq
         /// What PhysType.convertTo does, which cannot be reused because it composes a linq4j select onto a
         /// linq4j sequence and the sequence here is not one. The selector is still PhysType's.
         /// </remarks>
-        public static System.Linq.Expressions.Expression ConvertTo(ClrEnumerableRelImplementor implementor, PhysType physType, System.Linq.Expressions.Expression source, JavaRowFormat targetFormat)
+        public static System.Linq.Expressions.Expression ConvertTo(this PhysType physType, ClrEnumerableRelImplementor implementor, System.Linq.Expressions.Expression source, JavaRowFormat targetFormat)
         {
             if (physType.getFormat() == targetFormat)
                 return source;
@@ -62,13 +65,36 @@ namespace Apache.Calcite.Linq
         /// A row of <c>JavaRowFormat.ARRAY</c> is an array, whose own equality is by reference, so a set
         /// operation over one is wrong without this.
         /// </remarks>
-        public static Expression Comparer(ClrEnumerableRelImplementor implementor, PhysType physType)
+        public static Expression Comparer(this PhysType physType, ClrEnumerableRelImplementor implementor)
         {
             var comparer = physType.comparer();
 
             return comparer == null
                 ? Expression.Constant(null, typeof(EqualityComparer))
                 : implementor.Translator.Translate(comparer);
+        }
+
+        /// <summary>
+        /// Returns the CLR type of one row of a sequence of the given physical type.
+        /// </summary>
+        /// <param name="physType"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The row type, boxed. A row of a plan holds Java's values and keeps holding them: a field inside an
+        /// <c>Object[]</c> row is a <c>java.lang.Integer</c> from the table to the converter that hands it
+        /// out, and a one column row is that same value with no array around it. A node may unbox inside
+        /// itself, where the values never leave the expression it is building, but what it hands to the node
+        /// above has to be what the row type says.
+        ///
+        /// <para>Calcite has nothing to decide here: there is no <c>Enumerable&lt;int&gt;</c> in Java, so its
+        /// sequences carry the box whatever the physical type says, and its element type is erased besides. A
+        /// CLR sequence says its element type out loud, so every node has to say the same thing.</para>
+        /// </remarks>
+        public static Type RowType(this PhysType physType)
+        {
+            ArgumentNullException.ThrowIfNull(physType);
+
+            return ClrTypes.Resolve(J.Primitive.box(physType.getJavaRowType()));
         }
 
     }

--- a/src/Apache.Calcite.Linq/Convert/EnumerableToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Linq/Convert/EnumerableToClrEnumerableConverter.cs
@@ -60,7 +60,7 @@ namespace Apache.Calcite.Linq.Convert
             var enumerable = new EnumerableRelImplementor(implementor.RexBuilder, implementor.Map);
             var result = enumerable.visitChild(null, 0, (EnumerableRel)getInput(), pref.ToCalcite());
 
-            var rowType = ClrEnumerableRelImplementor.RowType(result.physType);
+            var rowType = result.physType.RowType();
             var source = implementor.Translator.TranslateBody(result.block, typeof(Enumerable));
 
             return implementor.Result(result.physType,

--- a/src/Apache.Calcite.Linq/Convert/EnumerableToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Linq/Convert/EnumerableToClrEnumerableConverter.cs
@@ -63,10 +63,8 @@ namespace Apache.Calcite.Linq.Convert
             var rowType = ClrEnumerableRelImplementor.RowType(result.physType);
             var source = implementor.Translator.TranslateBody(result.block, typeof(Enumerable));
 
-            return new ClrEnumerableResult(
-                Expression.Call(null, ClrBuiltInMethod.FromJava.MakeGenericMethod(rowType), source),
-                result.physType,
-                result.format);
+            return implementor.Result(result.physType,
+                Expression.Call(null, ClrBuiltInMethod.FromJava.MakeGenericMethod(rowType), source));
         }
 
     }

--- a/src/Apache.Calcite.Linq/LixToClrTranslator.cs
+++ b/src/Apache.Calcite.Linq/LixToClrTranslator.cs
@@ -32,7 +32,7 @@ namespace Apache.Calcite.Linq
     ///
     /// <para>A translator carries the scope its tree is translated in, so one is used for one tree.</para>
     /// </remarks>
-    sealed class LixToClrTranslator
+    public sealed class LixToClrTranslator
     {
 
         /// <summary>

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableAggregate.cs
@@ -71,8 +71,8 @@ namespace Apache.Calcite.Linq.Rel
 
             var physType = PhysTypeImpl.of(typeFactory, getRowType(), pref.PreferCustom());
             var inputPhysType = result.PhysType;
-            var sourceType = ClrEnumerableRelImplementor.RowType(inputPhysType);
-            var rowType = ClrEnumerableRelImplementor.RowType(physType);
+            var sourceType = inputPhysType.RowType();
+            var rowType = physType.RowType();
 
             var keyPhysType = inputPhysType.project(groupSet.asList(), getGroupType() != Group.SIMPLE, JavaRowFormat.LIST);
             var groupCount = getGroupCount();
@@ -183,7 +183,7 @@ namespace Apache.Calcite.Linq.Rel
                         Expression.Call(lambdaFactory, AccInitializer),
                         Expression.Call(lambdaFactory, AccAdder),
                         Expression.Call(lambdaFactory, ResultSelector, Function2Of(setsResultSelector, keyParameter.Type, accType, rowType)),
-                        ClrPhysTypes.Comparer(implementor, keyPhysType)));
+                        keyPhysType.Comparer(implementor)));
             }
 
             if (groupCount == 0)
@@ -209,13 +209,13 @@ namespace Apache.Calcite.Linq.Rel
             // the physical type is reached by conversion
             if (getAggCallList().isEmpty() && groupSet.equals(ImmutableBitSet.range(getInput().getRowType().getFieldCount())))
             {
-                var source = ClrPhysTypes.ConvertTo(implementor, inputPhysType, result.Expression, physType.getFormat());
+                var source = inputPhysType.ConvertTo(implementor, result.Expression, physType.getFormat());
 
                 return implementor.Result(physType,
                     Expression.Call(null,
                         ClrBuiltInMethod.Distinct.MakeGenericMethod(source.Type.GetGenericArguments()[0]),
                         source,
-                        ClrPhysTypes.Comparer(implementor, physType)));
+                        physType.Comparer(implementor)));
             }
 
             var keySelector = implementor.Translator.TranslateSelector(
@@ -236,7 +236,7 @@ namespace Apache.Calcite.Linq.Rel
                     Expression.Call(lambdaFactory, AccInitializer),
                     Expression.Call(lambdaFactory, AccAdder),
                     Expression.Call(lambdaFactory, ResultSelector, Function2Of(groupResultSelector, keyParameter.Type, accType, rowType)),
-                    ClrPhysTypes.Comparer(implementor, keyPhysType)));
+                    keyPhysType.Comparer(implementor)));
         }
     }
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableCalc.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableCalc.cs
@@ -112,8 +112,8 @@ namespace Apache.Calcite.Linq.Rel
             var physType = PhysTypeImpl.of(typeFactory, getRowType(), pref.Prefer(result.Format));
 
             var inputJavaType = result.PhysType.getJavaRowType();
-            var inputType = ClrEnumerableRelImplementor.RowType(result.PhysType);
-            var outputType = ClrEnumerableRelImplementor.RowType(physType);
+            var inputType = result.PhysType.RowType();
+            var outputType = physType.RowType();
 
             var rexBuilder = getCluster().getRexBuilder();
             var mq = getCluster().getMetadataQuery();

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableCollect.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableCollect.cs
@@ -88,7 +88,7 @@ namespace Apache.Calcite.Linq.Rel
                             ? JavaRowFormat.SCALAR
                             : JavaRowFormat.ARRAY;
 
-                        source = ClrPhysTypes.ConvertTo(implementor, result.PhysType, source, targetFormat);
+                        source = result.PhysType.ConvertTo(implementor, source, targetFormat);
                         sourceType = source.Type.GetGenericArguments()[0];
                     }
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableHashJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableHashJoin.cs
@@ -178,7 +178,7 @@ namespace Apache.Calcite.Linq.Rel
                     leftKey,
                     rightKey,
                     selector,
-                    ClrPhysTypes.Comparer(implementor, keyPhysType),
+                    keyPhysType.Comparer(implementor),
                     Expression.Constant(joinType.generatesNullsOnLeft()),
                     Expression.Constant(joinType.generatesNullsOnRight()),
                     predicate));
@@ -196,8 +196,8 @@ namespace Apache.Calcite.Linq.Rel
             var rightResult = implementor.VisitChild(this, 1, (ClrEnumerableRel)right, pref);
 
             var physType = leftResult.PhysType;
-            var leftType = ClrEnumerableRelImplementor.RowType(leftResult.PhysType);
-            var rightType = ClrEnumerableRelImplementor.RowType(rightResult.PhysType);
+            var leftType = leftResult.PhysType.RowType();
+            var rightType = rightResult.PhysType.RowType();
 
             var keyPhysType = leftResult.PhysType.project(joinInfo.leftKeys, JavaRowFormat.LIST);
             var leftKey = NullAwareAccessor(implementor, leftResult.PhysType, joinInfo.leftKeys, leftType);
@@ -210,7 +210,7 @@ namespace Apache.Calcite.Linq.Rel
                     rightResult.Expression,
                     leftKey,
                     rightKey,
-                    ClrPhysTypes.Comparer(implementor, keyPhysType),
+                    keyPhysType.Comparer(implementor),
                     Expression.Constant(joinType.name() == nameof(JoinRelType.ANTI)),
                     Predicate(implementor, leftResult.PhysType, rightResult.PhysType, leftType, rightType)));
         }
@@ -290,9 +290,9 @@ namespace Apache.Calcite.Linq.Rel
             var atMostOneNotNullSafeKey = notNullSafeKeyCount <= 1;
 
             var nullSafeKeyPhysType = leftResult.PhysType.project(leftNullSafeKeys, JavaRowFormat.LIST);
-            var nullSafeKeyComparer = ClrPhysTypes.Comparer(implementor, nullSafeKeyPhysType);
+            var nullSafeKeyComparer = nullSafeKeyPhysType.Comparer(implementor);
             var keyPhysType = leftResult.PhysType.project(joinInfo.leftKeys, JavaRowFormat.LIST);
-            var keyComparer = ClrPhysTypes.Comparer(implementor, keyPhysType);
+            var keyComparer = keyPhysType.Comparer(implementor);
 
             var selector = ClrEnumUtils.MarkJoinSelector(implementor, physType, leftResult.PhysType);
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableInterpreter.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableInterpreter.cs
@@ -95,7 +95,7 @@ namespace Apache.Calcite.Linq.Rel
             if (getRowType().getFieldCount() == 1)
                 source = Expression.Call(null, Slice0, source);
 
-            var rowType = ClrEnumerableRelImplementor.RowType(physType);
+            var rowType = physType.RowType();
 
             return implementor.Result(physType,
                 Expression.Call(null, ClrBuiltInMethod.FromJava.MakeGenericMethod(rowType), source));

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableIntersect.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableIntersect.cs
@@ -56,7 +56,7 @@ namespace Apache.Calcite.Linq.Rel
                     ClrBuiltInMethod.Intersect.MakeGenericMethod(rowType),
                     intersectExp,
                     result.Expression,
-                    ClrPhysTypes.Comparer(implementor, result.PhysType),
+                    result.PhysType.Comparer(implementor),
                     Expression.Constant(all));
             }
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeJoin.cs
@@ -474,7 +474,7 @@ namespace Apache.Calcite.Linq.Rel
                     selector,
                     Expression.Constant(ClrEnumUtils.ToLinq4jJoinType(joinType)),
                     comparator,
-                    ClrPhysTypes.Comparer(implementor, leftKeyPhysType)));
+                    leftKeyPhysType.Comparer(implementor)));
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeUnion.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeUnion.cs
@@ -113,7 +113,7 @@ namespace Apache.Calcite.Linq.Rel
                     sortKeySelector,
                     sortComparator,
                     Expression.Constant(all),
-                    ClrPhysTypes.Comparer(implementor, physType)));
+                    physType.Comparer(implementor)));
 
             return implementor.Result(physType, Expression.Block(body[^1].Type, [sources], body));
         }

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableMinus.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableMinus.cs
@@ -47,13 +47,13 @@ namespace Apache.Calcite.Linq.Rel
                     continue;
                 }
 
-                var rowType = ClrEnumerableRelImplementor.RowType(result.PhysType);
+                var rowType = result.PhysType.RowType();
 
                 minusExp = Expression.Call(null,
                     ClrBuiltInMethod.Except.MakeGenericMethod(rowType),
                     minusExp,
                     result.Expression,
-                    ClrPhysTypes.Comparer(implementor, result.PhysType),
+                    result.PhysType.Comparer(implementor),
                     Expression.Constant(all));
             }
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableRepeatUnion.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableRepeatUnion.cs
@@ -78,7 +78,7 @@ namespace Apache.Calcite.Linq.Rel
             // the seed's own format, and not re-optimised: a repeat union yields the rows of its two inputs
             // unchanged, so its physical type is theirs
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), seedResult.Format, false);
-            var rowType = ClrEnumerableRelImplementor.RowType(seedResult.PhysType);
+            var rowType = seedResult.PhysType.RowType();
 
             body.Add(
                 Expression.Call(null,
@@ -87,7 +87,7 @@ namespace Apache.Calcite.Linq.Rel
                     iterationResult.Expression,
                     Expression.Constant(iterationLimit),
                     Expression.Constant(all),
-                    ClrPhysTypes.Comparer(implementor, physType),
+                    physType.Comparer(implementor),
                     cleanUp));
 
             return implementor.Result(physType, body.Count == 1 ? body[0] : Expression.Block(body));

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableSort.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableSort.cs
@@ -67,7 +67,7 @@ namespace Apache.Calcite.Linq.Rel
             var inputPhysType = result.PhysType;
             var pair = inputPhysType.generateCollationKey(collation.getFieldCollations());
 
-            var sourceType = ClrEnumerableRelImplementor.RowType(inputPhysType);
+            var sourceType = inputPhysType.RowType();
 
             // Pair carries left and right as fields and declares static methods of the same names, which C#
             // cannot tell apart; Map.Entry gives the same two values under names that are not overloaded

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableScan.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableScan.cs
@@ -225,7 +225,7 @@ namespace Apache.Calcite.Linq.Rel
                     || table.unwrap(typeof(FilterableTable)) != null
                     || table.unwrap(typeof(ProjectableFilterableTable)) != null))
                 return Expression.Call(null,
-                    ClrBuiltInMethod.Slice0.MakeGenericMethod(ClrEnumerableRelImplementor.RowType(physType)),
+                    ClrBuiltInMethod.Slice0.MakeGenericMethod(physType.RowType()),
                     FromJava(element, source));
 
             var oldFormat = Format();
@@ -234,7 +234,7 @@ namespace Apache.Calcite.Linq.Rel
                 // Calcite passes the table's own element type along here because a linq4j Enumerable erases
                 // it; a CLR sequence does not, and the two differ wherever a format was optimized away — a
                 // one column table declares Object[] and holds the value itself.
-                return FromJava(ClrEnumerableRelImplementor.RowType(physType), source);
+                return FromJava(physType.RowType(), source);
 
             // the row shape is PhysType's, and record takes linq4j, so the field expressions are linq4j too.
             // That is the whole of it: one call feeding another, translated the moment it is built.
@@ -247,7 +247,7 @@ namespace Apache.Calcite.Linq.Rel
             for (int i = 0; i < fieldCount; i++)
                 expressionList.add(FieldExpression(row, i, physType, oldFormat));
 
-            var rowType = ClrEnumerableRelImplementor.RowType(physType);
+            var rowType = physType.RowType();
             var selector = Expression.Lambda(
                 typeof(Func<,>).MakeGenericType(element, rowType),
                 implementor.Translator.Translate(physType.record(expressionList)),

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableSpool.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableSpool.cs
@@ -93,7 +93,7 @@ namespace Apache.Calcite.Linq.Rel
                     typeof(ModifiableTable)),
                 ModifiableTableGetModifiableCollection);
 
-            var rowType = ClrEnumerableRelImplementor.RowType(result.PhysType);
+            var rowType = result.PhysType.RowType();
 
             return implementor.Result(physType,
                 Expression.Call(null,

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableUnion.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableUnion.cs
@@ -49,11 +49,11 @@ namespace Apache.Calcite.Linq.Rel
                     continue;
                 }
 
-                var rowType = ClrEnumerableRelImplementor.RowType(result.PhysType);
+                var rowType = result.PhysType.RowType();
 
                 unionExp = all
                     ? Expression.Call(null, ClrBuiltInMethod.Concat.MakeGenericMethod(rowType), unionExp, result.Expression)
-                    : Expression.Call(null, ClrBuiltInMethod.Union.MakeGenericMethod(rowType), unionExp, result.Expression, ClrPhysTypes.Comparer(implementor, result.PhysType));
+                    : Expression.Call(null, ClrBuiltInMethod.Union.MakeGenericMethod(rowType), unionExp, result.Expression, result.PhysType.Comparer(implementor));
             }
 
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(JavaRowFormat.CUSTOM));

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableValues.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableValues.cs
@@ -98,7 +98,8 @@ namespace Apache.Calcite.Linq.Rel
         {
             var typeFactory = (JavaTypeFactory)getCluster().getTypeFactory();
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.PreferCustom());
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            // Calcite boxes here too, EnumerableValues building its array with Primitive.box(rowClass)
+            var rowType = physType.RowType();
 
             var fields = getRowType().getFieldList();
             var rows = new List<Expression>();


### PR DESCRIPTION
`ClrEnumerableRelImplementor.Result` is where a node's rows are required to carry the type its physical
type says they carry — the invariant [#5](https://github.com/ikvmnet/calcite-dotnet/pull/5) establishes.
It was enforcing that by *repairing* the sequence, which is not enforcement: it kept the node wrong and
made the plan right, at the cost of a delegate per row.

**Based on `clr-default`.**

## It was covering a live defect

With the repair replaced by a refusal, 65 tests went red — `ClrEnumerableValues` was still building an
unboxed array, and every one of 596 tests had been passing over it.

So the repair is gone. `Result` refuses, and names the node that handed the sequence up.

## The fix is copied, not derived

Calcite's `EnumerableValues.implement`:

```java
Expressions.newArrayInit(Primitive.box(rowClass), expressions)
```

It keeps `rowClass` unboxed and boxes **only** at the array's element type, letting Java autobox each row
in. Ours now does the same, with `ClrEnumUtils.Convert` on each row being that autoboxing written out.

## And a node cannot go round it

`ClrEnumerableResult`'s constructor is `internal`, so `Result` is the only way to make one.
`EnumerableToClrEnumerableConverter` built its own — which is why it was the last node handing up a CLR
primitive, correct today only because it had been fixed by hand.

Two direct calls remain, both inside the implementor: `Result` itself, and `ImplementRoot`'s one-column
slice, which overrides the format to `SCALAR` deliberately.

## The implementor's surface, back to what it maps to

`EnumerableRelImplementor` is `visitChild`, `implementRoot`, `stash`, `registerCorrelVariable`,
`clearCorrelVariable`, `getCorrelVariableGetter`, `result`. Ours had grown four members past it:

| removed | why it existed | what to use |
|---|---|---|
| `Translate` | `LixToClrTranslator` was `internal`, so the adapter could not reach it | `Translator.Translate` — the translator is public now |
| `TranslateBody` | same | `Translator.TranslateBody` |
| `CorrelVariableField` | same wrapper habit | `GetCorrelVariableGetter(...).field(...)`, which Calcite has and we already had |
| `RowType` | — | it is a question about a `PhysType`, so it moved to `ClrPhysTypes` |

`ClrPhysTypes` members are extension methods on `PhysType` now. Calcite writes `physType.record(...)` and
`physType.generateSelector(...)` because they are members; C# cannot add to the interface, but an
extension method says the same thing at the call site: `physType.RowType()`, `physType.Comparer(...)`,
`physType.ConvertTo(...)`.

**11 core, 103 adapter, 275 data, 321 Linq, on net8.0 and net10.0.**

## Known, not fixed

`ClrPhysTypes.ConvertTo` takes its source element type from `ClrTypes.Resolve(physType.getJavaRowType())`
— unboxed, which the invariant forbids. It does not fire because `ConvertTo` is only reached for ARRAY and
CUSTOM rows, where the boxed and unboxed types are the same. A one-column scalar reaching it would throw.
It wants a test that converts the format of a one-column sequence, and then the one-line fix; changing it
now would be reasoning without evidence, which is how the defect above survived in the first place.
