### PR TITLE
Port Calcite's EnumerableConvention tests, and fix the six defects they found

### DIFF
--- a/src/Apache.Calcite.Linq.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Linq.Tests/ClrEnumerableDifferentialTests.cs
@@ -1437,9 +1437,20 @@ namespace Apache.Calcite.Linq.Tests
         [TestMethod]
         public void ShouldRunATableFunction() => Gives("SELECT * FROM TABLE(NUMBERS(3))", "1", "2", "3");
 
+        // A join over a one-column table function puts a sort on it, and that is EnumerableSort's defect:
+        // it optimises the scan's ARRAY to SCALAR and hands the Object[] rows on unchanged. Refused rather
+        // than answered, because Calcite is wrong here in the same way and this convention does what Calcite
+        // does — ClrEnumerableRowFormatTests carries the whole measurement. Restore the expected rows "1",
+        // "2" when EnumerableSort is fixed.
         [TestMethod]
-        public void ShouldRunATableFunctionInAJoin() =>
-            Gives("SELECT \"S\".\"ID\" FROM \"SALES\" AS \"S\", TABLE(NUMBERS(2)) AS \"N\" WHERE \"S\".\"ID\" = \"N\".\"N\" ORDER BY 1", "1", "2");
+        public void ShouldRefuseATableFunctionInAJoin()
+        {
+            var act = () => Gives("SELECT \"S\".\"ID\" FROM \"SALES\" AS \"S\", TABLE(NUMBERS(2)) AS \"N\" WHERE \"S\".\"ID\" = \"N\".\"N\" ORDER BY 1", "1", "2");
+
+            act.Should().Throw<java.lang.IllegalStateException>()
+                .WithInnerException<java.lang.IllegalStateException>()
+                .WithMessage("*ClrEnumerableSort handed up a sequence of System.Object[] where its row type is java.lang.Integer*");
+        }
 
         // The window table functions, which are the path RexImpTable implements rather than the schema.
         // TumbleImplementor and tumblingWindowSelector each name a parameter `_input`, and what lines the two

--- a/src/Apache.Calcite.Linq.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Linq.Tests/ClrEnumerableDifferentialTests.cs
@@ -44,6 +44,10 @@ namespace Apache.Calcite.Linq.Tests
         static ClrEnumerableDifferentialTests()
         {
             ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.util.Smalls).Assembly);
+
+            // RelBuilder.create opens a Calcite connection to get a prepare context, and the driver loads its
+            // factory by name. Class.forName finds it only if calcite-core is on the boot class path.
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.CalciteJdbc41Factory).Assembly);
         }
 
         /// <summary>
@@ -136,6 +140,53 @@ namespace Apache.Calcite.Linq.Tests
         }
 
         /// <summary>
+        /// A table of one NOT NULL INTEGER column, which is the row shape every other fixture here avoids.
+        /// </summary>
+        /// <remarks>
+        /// One column and NOT NULL is what makes <c>JavaRowFormat.optimize</c> answer <c>SCALAR</c>, and
+        /// <c>SCALAR.javaRowClass</c> then answers <c>int</c> rather than <c>java.lang.Integer</c>. A
+        /// sequence still carries the box — Java has no <c>Enumerable&lt;int&gt;</c> to carry anything else
+        /// — so a node that closes its operator over the physical row type instead of the boxed one builds a
+        /// tree that will not compile. Seven did, and no test had this shape: every set operation here is
+        /// over <c>REGION</c> or <c>LABEL</c>, and both are VARCHAR.
+        ///
+        /// <para>A collation, so that the merge union and the sorted aggregate can be reached over it as
+        /// well. <c>SALES</c> advertises none and <c>SORTED</c> has two columns.</para>
+        /// </remarks>
+        sealed class ScalarsTable : AbstractTable, ScannableTable
+        {
+
+            static readonly int[] Rows = [1, 2, 2, 4];
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("N", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .build();
+            }
+
+            /// <inheritdoc />
+            public override Statistic getStatistic()
+            {
+                return Statistics.of(Rows.Length,
+                    new java.util.ArrayList(),
+                    com.google.common.collect.ImmutableList.of(RelCollations.of(0)));
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root)
+            {
+                var list = new java.util.ArrayList();
+                foreach (var n in Rows)
+                    list.add(new object[] { java.lang.Integer.valueOf(n) });
+
+                return Linq4j.asEnumerable(list);
+            }
+
+        }
+
+        /// <summary>
         /// A table with a timestamp, which is what a window table function needs and <c>SALES</c> has not.
         /// </summary>
         /// <remarks>
@@ -213,7 +264,11 @@ namespace Apache.Calcite.Linq.Tests
         /// <param name="topDown">Whether the planner optimises top down, which is what asks a node to pass a
         /// trait down to its inputs or derive one from them.</param>
         /// <returns></returns>
-        static List<string> Run(string sql, bool clr, bool topDown = false, bool planOnly = false, bool sortedAggregate = false, bool batchNestedLoopJoin = false, bool limitSort = false, bool markJoin = false, bool excludeHashJoin = false, bool excludeMergeJoin = false, bool interpreter = false)
+        /// <summary>
+        /// The schema every query here is planned against.
+        /// </summary>
+        /// <returns></returns>
+        internal static SchemaPlus Schema()
         {
             var rootSchema = Frameworks.createRootSchema(true);
             rootSchema.add("SALES", new SalesTable());
@@ -221,6 +276,7 @@ namespace Apache.Calcite.Linq.Tests
             rootSchema.add("NUMBERS", TableFunctionImpl.create((java.lang.Class)typeof(NumbersTableFunction), "eval"));
             rootSchema.add("EVENTS", new EventsTable());
             rootSchema.add("SORTED", new SortedTable());
+            rootSchema.add("SCALARS", new ScalarsTable());
             rootSchema.add("FIB", org.apache.calcite.schema.impl.TableFunctionImpl.create(org.apache.calcite.util.Smalls.FIBONACCI_LIMIT_100_TABLE_METHOD));
 
             // A CUSTOM-format fixture, which every other table here is not. HrSchema's rows are instances of
@@ -230,6 +286,22 @@ namespace Apache.Calcite.Linq.Tests
             // cannot name a CLR class, so a CLR-backed table would leave EnumerableConvention with no plan to
             // compare against.
             rootSchema.add("HR", new org.apache.calcite.adapter.java.ReflectiveSchema(new org.apache.calcite.test.schemata.hr.HrSchema()));
+
+            // the hierarchy CALCITE-4054 is about, which is a recursive query whose step is a correlate over
+            // the transient table. ReflectiveSchemaWithoutRowCount is Calcite's own wrapper and is what keeps
+            // the planner from costing the scan out of the plan.
+            rootSchema.add("HIER", new org.apache.calcite.test.ReflectiveSchemaWithoutRowCount(new org.apache.calcite.test.schemata.hr.HierarchySchema()));
+
+            // a column of every type Calcite has an implementor for, which is where IS EMPTY finds a list to
+            // ask about. Calcite's own EnumerableCalcTest uses it for the same reason.
+            rootSchema.add("CATCHALL", new org.apache.calcite.adapter.java.ReflectiveSchema(new org.apache.calcite.test.schemata.catchall.CatchallSchema()));
+
+            return rootSchema;
+        }
+
+        static List<string> Run(string sql, bool clr, bool topDown = false, bool planOnly = false, bool sortedAggregate = false, bool batchNestedLoopJoin = false, bool limitSort = false, bool markJoin = false, bool excludeHashJoin = false, bool excludeMergeJoin = false, bool interpreter = false, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            var rootSchema = Schema();
 
             var rules = new java.util.ArrayList();
             var calcRules = new java.util.ArrayList();
@@ -288,7 +360,7 @@ namespace Apache.Calcite.Linq.Tests
                 .defaultSchema(rootSchema)
                 .programs(
                     markJoin ? MarkJoinSubQueryProgram() : Programs.subQuery(org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE),
-                    new DefaultRulesProgram(rules, topDown, (clr && topDown) || excludeMergeJoin, excludeHashJoin),
+                    new DefaultRulesProgram(rules, topDown, (clr && topDown) || excludeMergeJoin, excludeHashJoin, add, remove),
                     Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE))
                 .build();
 
@@ -332,6 +404,74 @@ namespace Apache.Calcite.Linq.Tests
                 return string.Join("|", array.Select(Render));
 
             return row?.ToString() ?? "<null>";
+        }
+
+        /// <summary>
+        /// Runs a plan built against a <see cref="RelBuilder"/> in one convention and returns its rows
+        /// rendered as text.
+        /// </summary>
+        /// <param name="build">Builds the logical plan.</param>
+        /// <param name="clr">Whether to plan into this convention or into Calcite's.</param>
+        /// <param name="planOnly"></param>
+        /// <param name="add">Rules to register alongside Calcite's.</param>
+        /// <param name="remove">Rules to take away once everything is registered.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Some of what <c>EnumerableConvention</c>'s own tests reach cannot be written as SQL:
+        /// <c>Combine</c> has no syntax at all, the POSIX regex operators are not in the core parser, and a
+        /// recursive query over a transient table is built with <c>transientScan</c> and <c>repeatUnion</c>.
+        /// Calcite tests all of those through <c>CalciteAssert.withRel</c>; this is that, against both
+        /// conventions.
+        ///
+        /// <para>The programs are the ones <see cref="Run"/> uses, less the sub-query pass, which has nothing
+        /// to rewrite in a plan that was never a query.</para>
+        /// </remarks>
+        internal static List<string> RunRel(Func<RelBuilder, RelNode> build, bool clr, bool planOnly = false, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            var rootSchema = Schema();
+
+            var rules = new java.util.ArrayList();
+            if (clr)
+                foreach (var rule in ClrEnumerableRules.Rules())
+                    rules.add(rule);
+
+            var calcRules = new java.util.ArrayList();
+            if (clr)
+                foreach (var rule in ClrEnumerableRules.CalcRules())
+                    calcRules.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRules.add(rule);
+
+            var config = Frameworks.newConfigBuilder().defaultSchema(rootSchema).build();
+            var logical = build(RelBuilder.create(config));
+
+            var planner = (org.apache.calcite.plan.volcano.VolcanoPlanner)logical.getCluster().getPlanner();
+            planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+            planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);
+
+            var convention = clr ? (Convention)ClrEnumerableConvention.Instance : EnumerableConvention.INSTANCE;
+            var empty = new java.util.ArrayList();
+
+            var chosen = new DefaultRulesProgram(rules, false, false, false, add, remove)
+                .run(planner, logical, logical.getTraitSet().replace(convention).simplify(), empty, empty);
+
+            var physical = Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE)
+                .run(planner, chosen, chosen.getTraitSet(), empty, empty);
+
+            if (planOnly)
+                return [org.apache.calcite.plan.RelOptUtil.toString(physical)];
+
+            var parameters = new java.util.HashMap();
+            var bindable = physical is ClrEnumerableRel node
+                ? ClrEnumerableInterpretable.ToBindable(parameters, null, node, ClrEnumerablePrefer.Array)
+                : EnumerableInterpretable.toBindable(parameters, null, (EnumerableRel)physical, EnumerableRel.Prefer.ARRAY);
+
+            var rows = new List<string>();
+            var enumerator = bindable.bind(new TestDataContext(rootSchema, parameters)).enumerator();
+            while (enumerator.moveNext())
+                rows.Add(Render(enumerator.current()));
+
+            return rows;
         }
 
         /// <summary>
@@ -396,6 +536,70 @@ namespace Apache.Calcite.Linq.Tests
             var calcite = Run(sql, false);
 
             mine.Should().Equal(calcite, "'{0}' should give what EnumerableConvention gives", sql);
+        }
+
+        /// <summary>
+        /// Requires that a query gives the same rows in both conventions, and that this convention really
+        /// planned the node it was aimed at.
+        /// </summary>
+        /// <param name="node">The node this convention must have chosen.</param>
+        /// <param name="sql"></param>
+        /// <param name="remove">Rules to take away from this convention's run alone, so that the planner has
+        /// nothing it prefers to <paramref name="node"/>.</param>
+        /// <remarks>
+        /// Both conventions' rules are in one planner and <c>VolcanoCost</c> compares the row count and
+        /// nothing else, so a node of Calcite's and the same node of this convention never differ in cost and
+        /// the planner keeps whichever it saw first — Calcite's, which <c>registerDefaultRules</c> registers.
+        /// A test that only compares rows can therefore be comparing Calcite against Calcite, and three of
+        /// the ones here were: <c>ClrEnumerableLimit</c> had never run at all. The plan assertion is what
+        /// makes the comparison mean something, and the rules taken away are what make the plan possible.
+        ///
+        /// <para>Only this convention's run loses them. Calcite's side is planned as it always is, and is the
+        /// oracle.</para>
+        /// </remarks>
+        static void SameThrough(string node, string sql, RelOptRule[]? remove = null, bool sortedAggregate = false, bool batchNestedLoopJoin = false, bool limitSort = false, RelOptRule[]? add = null)
+        {
+            Run(sql, true, planOnly: true, sortedAggregate: sortedAggregate, batchNestedLoopJoin: batchNestedLoopJoin, limitSort: limitSort, add: add, remove: remove)[0]
+                .Should().Contain(node, "'{0}' should be planned through {1}", sql, node);
+
+            var mine = Run(sql, true, sortedAggregate: sortedAggregate, batchNestedLoopJoin: batchNestedLoopJoin, limitSort: limitSort, add: add, remove: remove);
+            var calcite = Run(sql, false, sortedAggregate: sortedAggregate, batchNestedLoopJoin: batchNestedLoopJoin, limitSort: limitSort, add: add);
+
+            mine.Should().Equal(calcite, "'{0}' should give what EnumerableConvention gives", sql);
+        }
+
+        /// <summary>
+        /// Requires that a plan built against a <see cref="RelBuilder"/> gives the same rows in both
+        /// conventions.
+        /// </summary>
+        /// <param name="build"></param>
+        /// <param name="add"></param>
+        /// <param name="remove"></param>
+        internal static void SameRel(Func<RelBuilder, RelNode> build, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            var mine = RunRel(build, true, add: add, remove: remove);
+            var calcite = RunRel(build, false, add: add, remove: remove);
+
+            mine.Should().Equal(calcite, "the plan should give what EnumerableConvention gives");
+        }
+
+        /// <summary>
+        /// Requires that a plan built against a <see cref="RelBuilder"/> gives the same rows in both
+        /// conventions, and that this convention really planned the node it was aimed at.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="build"></param>
+        /// <param name="add"></param>
+        /// <param name="remove"></param>
+        internal static void SameRelThrough(string node, Func<RelBuilder, RelNode> build, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            RunRel(build, true, planOnly: true, add: add, remove: remove)[0]
+                .Should().Contain(node, "the plan should be planned through {0}", node);
+
+            var mine = RunRel(build, true, add: add, remove: remove);
+            var calcite = RunRel(build, false, add: add, remove: remove);
+
+            mine.Should().Equal(calcite, "the plan should give what EnumerableConvention gives");
         }
 
         /// <summary>
@@ -1300,6 +1504,288 @@ namespace Apache.Calcite.Linq.Tests
         public void ShouldPlanMatchRecognizeUnderAConverter() =>
             PlanOf("SELECT * FROM \"HR\".\"emps\" MATCH_RECOGNIZE (ORDER BY \"empid\" MEASURES STRT.\"empid\" AS \"s\" PATTERN (STRT UP) DEFINE UP AS UP.\"salary\" > PREV(UP.\"salary\")) AS T", true)
                 .Should().StartWith("EnumerableToClrEnumerableConverter");
+
+        // ------------------------------------------------------------------ a row that is one primitive
+        //
+        // SCALARS is one NOT NULL INTEGER column, so its physical row type is int and its sequence carries
+        // java.lang.Integer. Every node below closes an operator over that row type, and seven of them used
+        // the physical one; each of these failed before the node was corrected, and every one names the node
+        // it is aimed at, because for four of them the planner would otherwise have chosen Calcite's.
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowScan() => Same("SELECT \"N\" FROM \"SCALARS\" ORDER BY 1");
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowProjection() => Same("SELECT \"N\" + 1 FROM \"SCALARS\" ORDER BY 1");
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowDistinct() => Same("SELECT DISTINCT \"N\" FROM \"SCALARS\" ORDER BY 1");
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowAggregate() => Same("SELECT \"N\" FROM \"SCALARS\" GROUP BY \"N\" ORDER BY 1");
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowUnionAll() =>
+            SameThrough("ClrEnumerableUnion", "SELECT \"N\" FROM \"SCALARS\" UNION ALL SELECT \"N\" FROM \"SCALARS\" WHERE \"N\" < 3 ORDER BY 1",
+                remove: [ClrEnumerableRules.ClrEnumerableMergeUnionRule]);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowUnionDistinct() =>
+            SameThrough("ClrEnumerableUnion", "SELECT \"N\" FROM \"SCALARS\" UNION SELECT \"N\" FROM \"SCALARS\" WHERE \"N\" < 3 ORDER BY 1",
+                remove: [EnumerableRules.ENUMERABLE_MERGE_UNION_RULE, ClrEnumerableRules.ClrEnumerableMergeUnionRule]);
+
+        // INTERSECT without ALL is rewritten to an aggregate over a union and never reaches the node; only
+        // INTERSECT ALL does, which is why no set-operation test had ever built one over a primitive row
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowIntersectAll() =>
+            SameThrough("ClrEnumerableIntersect", "SELECT \"N\" FROM \"SCALARS\" INTERSECT ALL SELECT \"N\" FROM \"SCALARS\" WHERE \"N\" < 3 ORDER BY 1");
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowExceptAll() =>
+            SameThrough("ClrEnumerableMinus", "SELECT \"N\" FROM \"SCALARS\" EXCEPT ALL SELECT \"N\" FROM \"SCALARS\" WHERE \"N\" < 3 ORDER BY 1");
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowLimit() =>
+            SameThrough("ClrEnumerableLimit", "SELECT \"N\" FROM \"SCALARS\" ORDER BY \"N\" OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY",
+                remove: [EnumerableRules.ENUMERABLE_LIMIT_RULE]);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowLimitSort() =>
+            SameThrough("ClrEnumerableLimitSort", "SELECT \"N\" FROM \"SCALARS\" ORDER BY \"N\" FETCH NEXT 2 ROWS ONLY",
+                remove: [EnumerableRules.ENUMERABLE_LIMIT_SORT_RULE, EnumerableRules.ENUMERABLE_LIMIT_RULE],
+                limitSort: true);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowMergeUnion() =>
+            SameThrough("ClrEnumerableMergeUnion", "SELECT \"N\" FROM \"SCALARS\" UNION SELECT \"N\" FROM \"SCALARS\" ORDER BY 1",
+                remove: [EnumerableRules.ENUMERABLE_MERGE_UNION_RULE, EnumerableRules.ENUMERABLE_UNION_RULE, EnumerableRules.ENUMERABLE_SORT_RULE]);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowSortedAggregate() =>
+            SameThrough("ClrEnumerableSortedAggregate", "SELECT \"N\" FROM \"SCALARS\" GROUP BY \"N\" ORDER BY 1",
+                remove: [EnumerableRules.ENUMERABLE_AGGREGATE_RULE, EnumerableRules.ENUMERABLE_SORTED_AGGREGATE_RULE, ClrEnumerableRules.ClrEnumerableAggregateRule],
+                sortedAggregate: true);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowCollectedIntoAnArray() =>
+            SameThrough("ClrEnumerableCollect", "SELECT ARRAY(SELECT \"N\" FROM \"SCALARS\") FROM (VALUES (1))",
+                remove: [EnumerableRules.ENUMERABLE_COLLECT_RULE]);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowCollectedIntoAMultiset() =>
+            SameThrough("ClrEnumerableCollect", "SELECT MULTISET(SELECT \"N\" FROM \"SCALARS\") FROM (VALUES (1))",
+                remove: [EnumerableRules.ENUMERABLE_COLLECT_RULE]);
+
+        [TestMethod]
+        public void ShouldAgreeOnAScalarRowUncollected() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[1, 2, 3])",
+                remove: [EnumerableRules.ENUMERABLE_UNCOLLECT_RULE]);
+
+        // ------------------------------------------------------------------ EnumerableUncollectTest
+        //
+        // Every shape UNNEST can take, which is Calcite's own list. The node had one test before this, over an
+        // array of strings, and the branch CALCITE-4063 added — one field, itself a struct of one item —
+        // had never been entered. Each of these names the node, because the planner prefers Calcite's.
+
+        static readonly RelOptRule[] TheirUncollect = [EnumerableRules.ENUMERABLE_UNCOLLECT_RULE];
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArray() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[3, 4]) AS T2(y)", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingANullArray() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(CAST(NULL AS INTEGER ARRAY))", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArrayOfArrays() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[ARRAY[3], ARRAY[4]]) AS T2(y)", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArrayOfLongerArrays() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[ARRAY[3, 4], ARRAY[4, 5]]) AS T2(y)", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArrayOfArraysOfArrays() =>
+            SameThrough("ClrEnumerableUncollect",
+                "SELECT * FROM UNNEST(ARRAY[ARRAY[ARRAY[3, 4], ARRAY[4, 5]], ARRAY[ARRAY[7, 8], ARRAY[9, 10]]]) AS T2(y)",
+                remove: TheirUncollect);
+
+        // CALCITE-4063: one field, a struct of one item, and no ordinality, so the result is the item itself
+        // rather than a list holding it. That is the one branch of the node a lambda of its own stands for.
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArrayOfOneFieldRows() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[ROW(3), ROW(4)]) AS T2(y)", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArrayOfTwoFieldRows() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[ROW(3, 5), ROW(4, 6)]) AS T2(y, z)", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingWithOrdinality() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[ROW(3), ROW(4)]) WITH ORDINALITY AS T2(y, o)", remove: TheirUncollect);
+
+        // UNNEST(ARRAY[ROW(1, ROW(5, 10)), ROW(2, ROW(6, 12))]) has no test, because it does not reach a
+        // convention at all: RelStructuredTypeFlattener throws NoSuchElementException out of
+        // SqlToRelConverter.flattenTypes, which PlannerImpl.rel calls before any planning. Measured on the
+        // Calcite side of this harness as well, and the two sides run the same converter, so it is Calcite's
+        // and it is about how this harness converts rather than about either convention. A row of one field
+        // holding a row is the next test and does run.
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAnArrayOfOneFieldRowsHoldingRows() =>
+            SameThrough("ClrEnumerableUncollect", "SELECT * FROM UNNEST(ARRAY[ROW(ROW(3)), ROW(ROW(4))]) AS T2(y)", remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingAlongsideAnotherInput() =>
+            SameThrough("ClrEnumerableUncollect",
+                "SELECT * FROM (VALUES (1), (2)) T1(x), UNNEST(ARRAY[3, 4]) AS T2(y) ORDER BY 1, 2",
+                remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingArraysAlongsideAnotherInput() =>
+            SameThrough("ClrEnumerableUncollect",
+                "SELECT * FROM (VALUES (1), (2)) T1(x), UNNEST(ARRAY[ARRAY[3, 4], ARRAY[4, 5]]) AS T2(y) ORDER BY 1",
+                remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingRowsAlongsideAnotherInput() =>
+            SameThrough("ClrEnumerableUncollect",
+                "SELECT * FROM (VALUES (1), (2)) T1(x), UNNEST(ARRAY[ROW(3, 5), ROW(4, 6)]) AS T2(y, z) ORDER BY 1, 2",
+                remove: TheirUncollect);
+
+        [TestMethod]
+        public void ShouldAgreeOnUnnestingWithOrdinalityAlongsideAnotherInput() =>
+            SameThrough("ClrEnumerableUncollect",
+                "SELECT * FROM (VALUES (1), (2)) T1(x), UNNEST(ARRAY[ROW(3), ROW(4)]) WITH ORDINALITY AS T2(y, o) ORDER BY 1, 2",
+                remove: TheirUncollect);
+
+        // ------------------------------------------------------------------ EnumerableBatchNestedLoopJoinTest
+
+        [TestMethod]
+        public void ShouldAgreeOnABatchNestedLoopJoinOnAStringKey() =>
+            SameBatchNestedLoopJoin("SELECT d.\"name\", e.\"salary\" FROM \"HR\".\"depts\" d JOIN \"HR\".\"emps\" e ON d.\"name\" = e.\"name\" ORDER BY 1, 2");
+
+        [TestMethod]
+        public void ShouldAgreeOnABatchNestedLoopJoinFromANotInSubQuery() =>
+            SameBatchNestedLoopJoin("SELECT COUNT(e.\"name\") FROM \"HR\".\"emps\" e WHERE e.\"deptno\" NOT IN (SELECT d.\"deptno\" FROM \"HR\".\"depts\" d WHERE d.\"name\" = 'Sales')");
+
+        [TestMethod]
+        public void ShouldAgreeOnABatchNestedLoopJoinOnTwoEqualities() =>
+            SameBatchNestedLoopJoin("SELECT COUNT(e.\"name\") FROM \"HR\".\"emps\" e JOIN \"HR\".\"depts\" d ON d.\"deptno\" = e.\"empid\" AND d.\"deptno\" = e.\"deptno\"");
+
+        [TestMethod]
+        public void ShouldAgreeOnABatchNestedLoopJoinOnAMismatchedKey() =>
+            SameBatchNestedLoopJoin("SELECT COUNT(e.\"name\") FROM \"HR\".\"emps\" e JOIN \"HR\".\"depts\" d ON d.\"deptno\" = e.\"empid\"");
+
+        [TestMethod]
+        public void ShouldAgreeOnABatchNestedLoopLeftJoinCount() =>
+            SameBatchNestedLoopJoin("SELECT COUNT(d.\"deptno\") FROM \"HR\".\"depts\" d LEFT JOIN \"HR\".\"emps\" e ON d.\"deptno\" = e.\"deptno\"");
+
+        // two batch joins in one plan, which is where Calcite's own node has to fall back to a compact row
+        // builder or exceed what a Java method may hold. An expression tree has no such limit and builds the
+        // one form, so this is the query that says the difference does not change the answer.
+        [TestMethod]
+        public void ShouldAgreeOnADoubleBatchNestedLoopJoin() =>
+            SameBatchNestedLoopJoin("SELECT e.\"name\", d.\"name\", l.\"name\" FROM \"HR\".\"emps\" e JOIN \"HR\".\"depts\" d ON d.\"deptno\" <> e.\"empid\" JOIN \"HR\".\"locations\" l ON e.\"empid\" <> l.\"empid\" AND d.\"deptno\" = l.\"empid\" ORDER BY 1, 2, 3");
+
+        // ------------------------------------------------------------------ EnumerableCorrelateTest, in SQL
+
+        [TestMethod]
+        public void ShouldAgreeOnACorrelateFromExists() =>
+            Same("SELECT e.\"empid\", e.\"name\" FROM \"HR\".\"emps\" e WHERE EXISTS (SELECT 1 FROM \"HR\".\"depts\" d WHERE d.\"deptno\" = e.\"deptno\") ORDER BY 1");
+
+        // CALCITE-2930's shape: the correlated condition compares against a nullable column, so the field the
+        // sub-query reads is a box rather than a primitive
+        [TestMethod]
+        public void ShouldAgreeOnACorrelateOverABoxedPrimitive() =>
+            Same("SELECT e.\"empid\" FROM \"HR\".\"emps\" e WHERE NOT EXISTS (SELECT 1 FROM \"HR\".\"depts\" d WHERE d.\"deptno\" = e.\"commission\") ORDER BY 1");
+
+        /// <summary>
+        /// CALCITE-5638: a scalar sub-query correlated on two columns at once, under a filter that is itself
+        /// correlated.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnAComplexNestedCorrelatedSubQuery() =>
+            Same("SELECT \"empid\", \"deptno\", (SELECT COUNT(*) FROM \"HR\".\"emps\" AS x WHERE x.\"salary\" > \"emps\".\"salary\" AND x.\"deptno\" < \"emps\".\"deptno\") FROM \"HR\".\"emps\" WHERE \"empid\" < \"salary\" ORDER BY 1, 2, 3");
+
+        // ------------------------------------------------------------------ EnumerableMergeUnionTest
+        //
+        // The order keys Calcite's own tests use and this convention had none of: a nullable column ordered
+        // with the nulls at either end, and a second key running the other way.
+
+        [TestMethod]
+        public void ShouldAgreeOnAMergeUnionAllOrderedByANullableKeyNullsFirst() =>
+            Same("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" UNION ALL SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" WHERE \"ID\" < 4 ORDER BY \"AMOUNT\" ASC NULLS FIRST, \"ID\" DESC");
+
+        [TestMethod]
+        public void ShouldAgreeOnAMergeUnionOrderedByANullableKeyNullsFirst() =>
+            Same("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" UNION SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" WHERE \"ID\" < 4 ORDER BY \"AMOUNT\" ASC NULLS FIRST, \"ID\" DESC");
+
+        [TestMethod]
+        public void ShouldAgreeOnAMergeUnionAllOrderedByANullableKeyNullsLast() =>
+            Same("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" UNION ALL SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" WHERE \"ID\" < 4 ORDER BY \"AMOUNT\" ASC NULLS LAST, \"ID\" DESC");
+
+        [TestMethod]
+        public void ShouldAgreeOnAMergeUnionOrderedByANullableKeyNullsLast() =>
+            Same("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" UNION SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" WHERE \"ID\" < 4 ORDER BY \"AMOUNT\" ASC NULLS LAST, \"ID\" DESC");
+
+        [TestMethod]
+        public void ShouldAgreeOnAMergeUnionOfOneColumnOrderedByIt() =>
+            Same("SELECT \"LABEL\" FROM \"SALES\" UNION SELECT \"LABEL\" FROM \"SALES\" WHERE \"ID\" < 4 ORDER BY 1");
+
+        // ------------------------------------------------------------------ EnumerableHashJoinTest
+
+        [TestMethod]
+        public void ShouldAgreeOnAFullJoinOnACompositeNullableKey() =>
+            SameHashJoin("SELECT a.\"ID\", b.\"ID\" FROM \"SALES\" a FULL JOIN \"SALES\" b ON a.\"REGION\" = b.\"REGION\" AND a.\"AMOUNT\" = b.\"AMOUNT\" ORDER BY 1, 2");
+
+        [TestMethod]
+        public void ShouldAgreeOnASemiJoinOnACompositeNullableKey() =>
+            SameHashJoin("SELECT a.\"ID\" FROM \"SALES\" a WHERE (a.\"REGION\", a.\"AMOUNT\") IN (SELECT b.\"REGION\", b.\"AMOUNT\" FROM \"SALES\" b WHERE b.\"ID\" < 4) ORDER BY 1");
+
+        // an equality and something else besides, which the hash join tests on the pair it has already matched
+        [TestMethod]
+        public void ShouldAgreeOnAHashJoinWithAnExtraPredicate() =>
+            SameHashJoin("SELECT a.\"ID\", b.\"ID\" FROM \"SALES\" a JOIN \"SALES\" b ON a.\"REGION\" = b.\"REGION\" AND a.\"ID\" < b.\"ID\" ORDER BY 1, 2");
+
+        [TestMethod]
+        public void ShouldAgreeOnALeftHashJoinWithAnExtraPredicate() =>
+            SameHashJoin("SELECT a.\"ID\", b.\"ID\" FROM \"SALES\" a LEFT JOIN \"SALES\" b ON a.\"REGION\" = b.\"REGION\" AND a.\"ID\" < b.\"ID\" ORDER BY 1, 2");
+
+        [TestMethod]
+        public void ShouldAgreeOnARightHashJoinWithAnExtraPredicate() =>
+            SameHashJoin("SELECT a.\"ID\", b.\"ID\" FROM \"SALES\" a RIGHT JOIN \"SALES\" b ON a.\"REGION\" = b.\"REGION\" AND a.\"ID\" < b.\"ID\" ORDER BY 1, 2");
+
+        [TestMethod]
+        public void ShouldAgreeOnASemiHashJoinWithAnExtraPredicate() =>
+            SameHashJoin("SELECT a.\"ID\" FROM \"SALES\" a WHERE EXISTS (SELECT 1 FROM \"SALES\" b WHERE a.\"REGION\" = b.\"REGION\" AND a.\"ID\" < b.\"ID\") ORDER BY 1");
+
+        // ------------------------------------------------------------------ EnumerableLimitSortTest
+        //
+        // The order keys Calcite's own limit-sort tests use: a nullable column with the nulls at either end,
+        // and a second key. This convention's five limit-sort tests were all one key with the default null
+        // ordering.
+
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortWithNullsFirst() =>
+            SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS FIRST, \"ID\" FETCH NEXT 3 ROWS ONLY");
+
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortWithNullsLast() =>
+            SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS LAST, \"ID\" FETCH NEXT 3 ROWS ONLY");
+
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortWithNullsFirstAndAnOffset() =>
+            SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS FIRST, \"ID\" OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY");
+
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortWithNullsLastAndAnOffset() =>
+            SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS LAST, \"ID\" OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY");
+
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortOverSeveralKeysRunningBothWays() =>
+            SameLimitSort("SELECT \"ID\", \"REGION\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"REGION\" DESC, \"AMOUNT\" NULLS LAST, \"ID\" OFFSET 1 ROWS FETCH NEXT 4 ROWS ONLY");
 
     }
 

--- a/src/Apache.Calcite.Linq.Tests/ClrEnumerableRelTests.cs
+++ b/src/Apache.Calcite.Linq.Tests/ClrEnumerableRelTests.cs
@@ -1,0 +1,612 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.plan;
+using org.apache.calcite.rel.core;
+using org.apache.calcite.rel.rules;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.fun;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.adapter.enumerable;
+
+namespace Apache.Calcite.Linq.Tests
+{
+
+    /// <summary>
+    /// Runs a plan built against a <see cref="org.apache.calcite.tools.RelBuilder"/> through this convention
+    /// and through Calcite's, and requires the same rows.
+    /// </summary>
+    /// <remarks>
+    /// The same oracle as <see cref="ClrEnumerableDifferentialTests"/>, for the plans that cannot be written
+    /// as SQL. <c>Combine</c> has no syntax; the POSIX regex operators are not in the core parser; a
+    /// recursive query over a transient table is built with <c>transientScan</c> and <c>repeatUnion</c>; and
+    /// a column with a collation of its own can only be given a type by hand. Calcite reaches all four
+    /// through <c>CalciteAssert.withRel</c>, and every test here is one of its own ported.
+    /// </remarks>
+    [TestClass]
+    public class ClrEnumerableRelTests
+    {
+
+        static java.lang.Integer I(int value) => java.lang.Integer.valueOf(value);
+
+        // ------------------------------------------------------------------ EnumerableCombineTest
+        //
+        // A combine puts one query per column and one row per position, so a shorter query contributes null.
+        // There is no SQL for it, which is why the only test this convention had was written by hand.
+
+        [TestMethod]
+        public void ShouldAgreeOnCombiningTwoQueries() =>
+            ClrEnumerableDifferentialTests.SameRel(builder =>
+            {
+                builder.scan("HR", "emps").filter(builder.equals(builder.field("deptno"), builder.literal(I(10)))).project(builder.field("name"));
+                builder.scan("HR", "depts").project(builder.field("name"));
+
+                return builder.combine(2).build();
+            });
+
+        [TestMethod]
+        public void ShouldAgreeOnCombiningQueriesOfDifferentLengths() =>
+            ClrEnumerableDifferentialTests.SameRel(builder =>
+            {
+                builder.scan("HR", "emps").project(builder.field("name"));
+                builder.scan("HR", "depts").project(builder.field("name"));
+
+                return builder.combine(2).build();
+            });
+
+        [TestMethod]
+        public void ShouldAgreeOnCombiningQueriesOfSeveralColumns() =>
+            ClrEnumerableDifferentialTests.SameRel(builder =>
+            {
+                builder.scan("HR", "emps").filter(builder.equals(builder.field("deptno"), builder.literal(I(10)))).project(builder.field("empid"), builder.field("name"));
+                builder.scan("HR", "depts").project(builder.field("deptno"), builder.field("name"));
+
+                return builder.combine(2).build();
+            });
+
+        [TestMethod]
+        public void ShouldAgreeOnCombiningQueriesOfDifferentColumnCounts() =>
+            ClrEnumerableDifferentialTests.SameRel(builder =>
+            {
+                builder.scan("HR", "depts").project(builder.field("name"));
+                builder.scan("HR", "emps").filter(builder.equals(builder.field("deptno"), builder.literal(I(10))))
+                    .project(builder.field("empid"), builder.field("name"), builder.field("deptno"));
+
+                return builder.combine(2).build();
+            });
+
+        // ------------------------------------------------------------------ EnumerableCalcTest
+
+        /// <summary>
+        /// CALCITE-3536: a COALESCE of a nullable field and a literal, whose null strategy the implementor
+        /// gets to decide.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnCoalesce() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps")
+                .project(builder.call(SqlStdOperatorTable.COALESCE, builder.field("commission"), builder.literal(I(0))))
+                .sort(0)
+                .build());
+
+        [TestMethod]
+        public void ShouldAgreeOnAPosixRegexThatMatches() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.POSIX_REGEX_CASE_SENSITIVE, "E..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnAPosixRegexThatDoesNot() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.POSIX_REGEX_CASE_SENSITIVE, "e..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnACaseInsensitivePosixRegexThatMatches() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.POSIX_REGEX_CASE_INSENSITIVE, "E..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnACaseInsensitivePosixRegexOfTheOtherCase() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.POSIX_REGEX_CASE_INSENSITIVE, "e..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnANegatedPosixRegex() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_SENSITIVE, "E..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnANegatedPosixRegexOfTheOtherCase() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_SENSITIVE, "e..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnANegatedCaseInsensitivePosixRegex() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_INSENSITIVE, "E..c");
+
+        [TestMethod]
+        public void ShouldAgreeOnANegatedCaseInsensitivePosixRegexOfTheOtherCase() => ShouldAgreeOnPosixRegex(SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_INSENSITIVE, "e..c");
+
+        /// <summary>
+        /// CALCITE-4419: the POSIX regex operators have no syntax in the core parser and are only reachable
+        /// through a builder.
+        /// </summary>
+        /// <param name="op"></param>
+        /// <param name="pattern"></param>
+        static void ShouldAgreeOnPosixRegex(SqlOperator op, string pattern) =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps")
+                .filter(builder.call(op, builder.field("name"), builder.literal(pattern)))
+                .project(builder.field("empid"), builder.field("name"))
+                .sort(0)
+                .build());
+
+        /// <summary>
+        /// CALCITE-6680: IS EMPTY over a nullable collection, which answers on the null rather than reading it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnIsEmptyOverACollection() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("CATCHALL", "everyTypes")
+                .project(builder.call(SqlStdOperatorTable.IS_EMPTY, builder.field("list")))
+                .sort(0)
+                .build());
+
+        /// <summary>
+        /// CALCITE-7357: IS DISTINCT FROM as a projection rather than as a join key.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnIsDistinctFromAsAProjection() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps")
+                .project(
+                    builder.field("commission"),
+                    builder.call(SqlStdOperatorTable.IS_DISTINCT_FROM, builder.field("commission"), builder.literal(null)))
+                .sort(0, 1)
+                .build());
+
+        // ------------------------------------------------------------------ EnumerableCorrelateTest
+        //
+        // A correlate is only chosen when the joins are taken away and JOIN_TO_CORRELATE is put in, which is
+        // what Calcite's own tests do from Hook.PLANNER. Both sides get the same treatment here, so a
+        // correlate is what each of them plans.
+
+        static readonly RelOptRule[] AddJoinToCorrelate = [CoreRules.JOIN_TO_CORRELATE];
+
+        static readonly RelOptRule[] RemoveTheJoins =
+        [
+            EnumerableRules.ENUMERABLE_JOIN_RULE,
+            EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE,
+            ClrEnumerableRules.ClrEnumerableJoinRule,
+            ClrEnumerableRules.ClrEnumerableMergeJoinRule,
+        ];
+
+        /// <summary>
+        /// CALCITE-2605: a left outer join run as a correlate.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnALeftOuterJoinRunAsACorrelate() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps").@as("e")
+                .scan("HR", "depts").@as("d")
+                .join(JoinRelType.LEFT, builder.equals(builder.field(2, "e", "deptno"), builder.field(2, "d", "deptno")))
+                .project(builder.field("e", "empid"), builder.field("e", "name"), builder.field("d", "name"))
+                .sort(0)
+                .build(),
+                add: AddJoinToCorrelate, remove: RemoveTheJoins);
+
+        /// <summary>
+        /// CALCITE-2621: a semi join run as a correlate.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnASemiJoinRunAsACorrelate() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps").@as("e")
+                .scan("HR", "depts").@as("d")
+                .semiJoin(builder.equals(builder.field(2, "e", "deptno"), builder.field(2, "d", "deptno")))
+                .project(builder.field("empid"), builder.field("name"))
+                .sort(0)
+                .build(),
+                add: AddJoinToCorrelate, remove: RemoveTheJoins);
+
+        /// <summary>
+        /// CALCITE-2920: an anti join run as a correlate.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnAnAntiJoinRunAsACorrelate() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "depts").@as("d")
+                .scan("HR", "emps").@as("e")
+                .antiJoin(builder.equals(builder.field(2, "d", "deptno"), builder.field(2, "e", "deptno")))
+                .project(builder.field("deptno"), builder.field("name"))
+                .sort(0)
+                .build(),
+                add: AddJoinToCorrelate, remove: RemoveTheJoins);
+
+        /// <summary>
+        /// An anti join on more than an equality, run as a correlate.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnANonEquiAntiJoinRunAsACorrelate() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps").@as("e")
+                .scan("HR", "emps").@as("e2")
+                .antiJoin(
+                    builder.and(
+                        builder.equals(builder.field(2, "e", "deptno"), builder.field(2, "e2", "deptno")),
+                        builder.call(SqlStdOperatorTable.GREATER_THAN, builder.field(2, "e2", "salary"), builder.field(2, "e", "salary"))))
+                .project(builder.field("name"), builder.field("salary"))
+                .sort(0)
+                .build(),
+                add: AddJoinToCorrelate, remove: RemoveTheJoins);
+
+        /// <summary>
+        /// CALCITE-2920: an anti join whose key is null on one side, which is NOT EXISTS and not NOT IN.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnAnAntiJoinOverANullKeyRunAsACorrelate() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps").@as("empOther")
+                .filter(builder.notEquals(builder.field("empOther", "deptno"), builder.literal(I(10))))
+                .scan("HR", "emps").@as("empSales")
+                .filter(builder.equals(builder.field("empSales", "deptno"), builder.literal(I(10))))
+                .antiJoin(builder.equals(builder.field(2, "empOther", "commission"), builder.field(2, "empSales", "commission")))
+                .project(builder.field("empid"), builder.field("name"))
+                .sort(0)
+                .build(),
+                add: AddJoinToCorrelate, remove: RemoveTheJoins);
+
+        // ------------------------------------------------------------------ EnumerableRepeatUnionTest
+
+        /// <summary>
+        /// A recursive query of two columns, only one of which advances.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnARecursiveQueryOverTwoColumns() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(["i", "j"], I(0), I(0))
+                .transientScan("AUX")
+                .filter(builder.call(SqlStdOperatorTable.LESS_THAN, builder.field(0), builder.literal(I(10))))
+                .project(
+                    builder.call(SqlStdOperatorTable.MOD,
+                        builder.call(SqlStdOperatorTable.PLUS, builder.field(0), builder.literal(I(1))),
+                        builder.literal(I(10))),
+                    builder.field(1))
+                .repeatUnion("AUX", false)
+                .build());
+
+        /// <summary>
+        /// A recursive query whose step multiplies, so each iteration reads the row the last one wrote.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnARecursiveFactorial() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(["n", "fact"], I(0), I(1))
+                .transientScan("D")
+                .filter(builder.call(SqlStdOperatorTable.LESS_THAN, builder.field("n"), builder.literal(I(7))))
+                .project(
+                    java.util.Arrays.asList([
+                        builder.call(SqlStdOperatorTable.PLUS, builder.field("n"), builder.literal(I(1))),
+                        builder.call(SqlStdOperatorTable.MULTIPLY,
+                            builder.call(SqlStdOperatorTable.PLUS, builder.field("n"), builder.literal(I(1))),
+                            builder.field("fact"))]),
+                    java.util.Arrays.asList(["n", "fact"]))
+                .repeatUnion("D", true)
+                .build());
+
+        /// <summary>
+        /// One recursive query inside another, so two spools are live at once.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnNestedRecursion() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(["n"], I(1))
+                .transientScan("T_IN")
+                .filter(builder.call(SqlStdOperatorTable.LESS_THAN, builder.field("n"), builder.literal(I(9))))
+                .project(builder.call(SqlStdOperatorTable.PLUS, builder.field("n"), builder.literal(I(1))))
+                .repeatUnion("T_IN", true)
+                .transientScan("T_OUT")
+                .filter(builder.call(SqlStdOperatorTable.LESS_THAN, builder.field("n"), builder.literal(I(100))))
+                .project(builder.call(SqlStdOperatorTable.MULTIPLY, builder.field("n"), builder.literal(I(10))))
+                .repeatUnion("T_OUT", true)
+                .build());
+
+        /// <summary>
+        /// CALCITE-4139: a recursive query whose seed holds a null, which the transient table has to store.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnARecursiveQueryOverANull() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(["i"], I(1), I(2), null, I(3))
+                .transientScan("DELTA")
+                .filter(builder.call(SqlStdOperatorTable.LESS_THAN, builder.field(0), builder.literal(I(3))))
+                .project(builder.call(SqlStdOperatorTable.PLUS, builder.field(0), builder.literal(I(1))))
+                .repeatUnion("DELTA", true)
+                .build());
+
+        /// <summary>
+        /// CALCITE-4054: a repeat union whose step is a correlate with the transient scan on its right.
+        /// </summary>
+        /// <remarks>
+        /// The spool is written while the correlate is reading it, which is the one shape that exercises
+        /// <c>ClrEnumerableDefaults.LazyCollectionSpool</c> as a write. That method converted nothing for a
+        /// while and no test had ever written to a spool.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAgreeOnARecursiveQueryWhoseStepIsACorrelate() =>
+            ClrEnumerableDifferentialTests.SameRel(builder =>
+            {
+                builder
+                    .scan("HIER", "emps")
+                    .filter(builder.equals(builder.field("empid"), builder.literal(I(2))))
+                    .project(builder.field("emps", "empid"), builder.field("emps", "name"))
+                    .transientScan("#DELTA#");
+
+                // popped, so that it can be pushed back as the join's *right* input, which is the whole point
+                // of CALCITE-4054: the spool is read from inside the correlate's inner loop
+                var transientScan = builder.build();
+
+                return builder
+                    .scan("HIER", "hierarchies")
+                    .push(transientScan)
+                    .join(JoinRelType.INNER, builder.equals(builder.field(2, "#DELTA#", "empid"), builder.field(2, "hierarchies", "managerid")))
+                    .scan("HIER", "emps")
+                    .join(JoinRelType.INNER, builder.equals(builder.field(2, "hierarchies", "subordinateid"), builder.field(2, "emps", "empid")))
+                    .project(builder.field("emps", "empid"), builder.field("emps", "name"))
+                    .repeatUnion("#DELTA#", true)
+                    .sort(0)
+                    .build();
+            },
+                add: AddJoinToCorrelate,
+                remove: [.. RemoveTheJoins, JoinCommuteRule.Config.DEFAULT.toRule()]);
+
+        // ------------------------------------------------------------------ EnumerableJoinTest
+
+        /// <summary>
+        /// CALCITE-2920: an anti join whose key is null on one side, run as a hash anti join rather than as a
+        /// correlate.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnAnAntiJoinOverANullKey() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps").@as("empOther")
+                .filter(builder.notEquals(builder.field("empOther", "deptno"), builder.literal(I(10))))
+                .scan("HR", "emps").@as("empSales")
+                .filter(builder.equals(builder.field("empSales", "deptno"), builder.literal(I(10))))
+                .antiJoin(builder.equals(builder.field(2, "empOther", "commission"), builder.field(2, "empSales", "commission")))
+                .project(builder.field("empid"), builder.field("name"))
+                .sort(0)
+                .build());
+
+        /// <summary>
+        /// An anti join with a second condition that reads only the left input, which cannot be pushed down
+        /// onto it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnAnAntiJoinWhoseConditionReadsOnlyTheLeft() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HR", "emps")
+                .scan("HR", "depts")
+                .antiJoin(
+                    builder.equals(builder.field(2, 0, "deptno"), builder.field(2, 1, "deptno")),
+                    builder.equals(builder.field(2, 0, "name"), builder.literal("ddd")))
+                .project(builder.field(0))
+                .sort(0)
+                .build());
+
+        /// <summary>
+        /// A recursive query whose step is two merge joins, so each round sorts what the last one spooled.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnARecursiveQueryWhoseStepIsAMergeJoin() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .scan("HIER", "emps")
+                .filter(builder.equals(builder.field("empid"), builder.literal(I(2))))
+                .project(builder.field("emps", "empid"), builder.field("emps", "name"))
+                .transientScan("#DELTA#")
+                .sort(builder.field("empid"))
+                .scan("HIER", "hierarchies")
+                .sort(builder.field("managerid"))
+                .join(JoinRelType.INNER, builder.equals(builder.field(2, "#DELTA#", "empid"), builder.field(2, "hierarchies", "managerid")))
+                .sort(builder.field("subordinateid"))
+                .scan("HIER", "emps")
+                .sort(builder.field("empid"))
+                .join(JoinRelType.INNER, builder.equals(builder.field(2, "hierarchies", "subordinateid"), builder.field(2, "emps", "empid")))
+                .project(builder.field("emps", "empid"), builder.field("emps", "name"))
+                .repeatUnion("#DELTA#", true)
+                .sort(0)
+                .build(),
+                add: [org.apache.calcite.interpreter.Bindables.BINDABLE_TABLE_SCAN_RULE],
+                remove: [EnumerableRules.ENUMERABLE_JOIN_RULE, ClrEnumerableRules.ClrEnumerableJoinRule]);
+
+        // ------------------------------------------------------------------ EnumerableRepeatUnionHierarchyTest
+        //
+        // One recursive query walked every way it can be: up the hierarchy and down it, from one start row
+        // and from two, with and without a depth limit, distinct and not. Calcite runs it as one parameterised
+        // test and asserts the order, which is the algorithm's; so does this.
+
+        [TestMethod]
+        [DataRow(true, "1", true, -1)]
+        [DataRow(true, "2", true, -2)]
+        [DataRow(true, "3", true, -1)]
+        [DataRow(true, "4", true, -5)]
+        [DataRow(true, "5", true, -1)]
+        [DataRow(true, "3", true, 0)]
+        [DataRow(true, "3", true, 1)]
+        [DataRow(true, "3", true, 2)]
+        [DataRow(true, "3", true, 10)]
+        [DataRow(true, "1", false, -1)]
+        [DataRow(true, "2", false, -10)]
+        [DataRow(true, "3", false, -100)]
+        [DataRow(true, "4", false, -1)]
+        [DataRow(true, "1", false, 0)]
+        [DataRow(true, "1", false, 1)]
+        [DataRow(true, "1", false, 2)]
+        [DataRow(true, "1", false, 20)]
+        [DataRow(true, "3,5", true, -1)]
+        [DataRow(false, "3,5", true, -1)]
+        [DataRow(true, "3,5", true, 0)]
+        [DataRow(false, "3,5", true, 0)]
+        [DataRow(true, "3,5", true, 1)]
+        [DataRow(false, "3,5", true, 1)]
+        [DataRow(true, "1,3", false, -1)]
+        [DataRow(false, "1,3", false, -1)]
+        public void ShouldAgreeOnWalkingAHierarchy(bool all, string startIds, bool ascendant, int maxDepth)
+        {
+            var fromField = ascendant ? "subordinateid" : "managerid";
+            var toField = ascendant ? "managerid" : "subordinateid";
+
+            ClrEnumerableDifferentialTests.SameRel(builder =>
+            {
+                builder.scan("HIER", "emps");
+
+                var filters = new java.util.ArrayList();
+                foreach (var startId in startIds.Split(','))
+                    filters.add(builder.equals(builder.field("empid"), builder.literal(I(int.Parse(startId)))));
+
+                builder
+                    .filter(builder.or(filters))
+                    .project(builder.field("emps", "empid"), builder.field("emps", "name"))
+                    .transientScan("#DELTA#")
+                    .scan("HIER", "hierarchies")
+                    .join(JoinRelType.INNER, builder.equals(builder.field(2, "#DELTA#", "empid"), builder.field(2, "hierarchies", fromField)))
+                    .scan("HIER", "emps")
+                    .join(JoinRelType.INNER, builder.equals(builder.field(2, "hierarchies", toField), builder.field(2, "emps", "empid")))
+                    .project(builder.field("emps", "empid"), builder.field("emps", "name"))
+                    .repeatUnion("#DELTA#", all, maxDepth);
+
+                return builder.build();
+            });
+        }
+
+        // ------------------------------------------------------------------ EnumerableStringComparisonTest
+        //
+        // CALCITE-3951: a VARCHAR with a collation of its own compares by that collation and not by the
+        // string's own order. There is no syntax for giving a column one, so every test here builds the row
+        // type by hand, as Calcite's do.
+
+        static readonly org.apache.calcite.sql.SqlCollation Primary = Collation(java.text.Collator.PRIMARY);
+        static readonly org.apache.calcite.sql.SqlCollation Secondary = Collation(java.text.Collator.SECONDARY);
+        static readonly org.apache.calcite.sql.SqlCollation Tertiary = Collation(java.text.Collator.TERTIARY);
+        static readonly org.apache.calcite.sql.SqlCollation Identical = Collation(java.text.Collator.IDENTICAL);
+
+        static org.apache.calcite.sql.SqlCollation Collation(int strength) =>
+            new org.apache.calcite.jdbc.JavaCollation(
+                org.apache.calcite.sql.SqlCollation.Coercibility.IMPLICIT,
+                java.util.Locale.US,
+                org.apache.calcite.util.Util.getDefaultCharset(),
+                strength);
+
+        static org.apache.calcite.rel.type.RelDataType Collated(org.apache.calcite.tools.RelBuilder builder, org.apache.calcite.sql.SqlCollation collation) =>
+            builder.getTypeFactory().createTypeWithCharsetAndCollation(
+                builder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR),
+                builder.getTypeFactory().getDefaultCharset(),
+                collation);
+
+        static org.apache.calcite.rel.type.RelDataType CollatedRow(org.apache.calcite.tools.RelBuilder builder) =>
+            builder.getTypeFactory().builder().add("name", Collated(builder, Tertiary)).build();
+
+        static org.apache.calcite.rel.type.RelDataType PlainRow(org.apache.calcite.tools.RelBuilder builder) =>
+            builder.getTypeFactory().builder().add("name", builder.getTypeFactory().createSqlType(SqlTypeName.VARCHAR)).build();
+
+        [TestMethod]
+        public void ShouldAgreeOnSortingStringsByTheDefaultCollation() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(PlainRow(builder), "Legal", "presales", "hr", "Administration", "MARKETING")
+                .sort(builder.field(1, 0, "name"))
+                .build());
+
+        [TestMethod]
+        public void ShouldAgreeOnSortingStringsByTheirOwnCollation() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(CollatedRow(builder), "Legal", "presales", "hr", "Administration", "MARKETING")
+                .sort(builder.field(1, 0, "name"))
+                .build());
+
+        /// <summary>
+        /// CALCITE-5967: an equality on a collated column needs a comparator of its own inside the operator.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnFilteringStringsByTheirOwnCollation() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(CollatedRow(builder), "Legal", "presales", "hr", "Administration", "MARKETING")
+                .filter(builder.equals(builder.field(1, 0, "name"), builder.literal("MARKETING")))
+                .build());
+
+        [TestMethod]
+        public void ShouldAgreeOnAMergeJoinOverACollatedString() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(CollatedRow(builder), "Legal", "presales", "HR", "Administration", "Marketing").@as("v1")
+                .values(CollatedRow(builder), "Marketing", "bureaucracy", "Sales", "HR").@as("v2")
+                .join(JoinRelType.INNER, builder.equals(builder.field(2, 0, "name"), builder.field(2, 1, "name")))
+                .project(builder.field("v1", "name"), builder.field("v2", "name"))
+                .build(),
+                remove: [EnumerableRules.ENUMERABLE_JOIN_RULE, ClrEnumerableRules.ClrEnumerableJoinRule]);
+
+        /// <summary>
+        /// CALCITE-5003: a merge union of two inputs whose collations differ.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnAMergeUnionOverTwoCollations() =>
+            ClrEnumerableDifferentialTests.SameRel(b =>
+            {
+                var builder = b.transform(new DelegateUnaryOperator(c => ((org.apache.calcite.tools.RelBuilder.Config)c).withSimplifyValues(false)));
+
+                return builder
+                    .values(PlainRow(builder), "facilities", "HR", "administration", "Marketing")
+                    .values(CollatedRow(builder), "Marketing", "administration", "presales", "HR")
+                    .union(false)
+                    .sort(0)
+                    .build();
+            },
+            remove: [EnumerableRules.ENUMERABLE_UNION_RULE, ClrEnumerableRules.ClrEnumerableUnionRule]);
+
+        [TestMethod]
+        public void ShouldAgreeOnEveryCollatedComparison()
+        {
+            foreach (var (left, right, op, collation) in Comparisons())
+                ClrEnumerableDifferentialTests.SameRel(builder => builder
+                    .values(["aux"], java.lang.Boolean.FALSE)
+                    .project(
+                        java.util.Collections.singletonList(
+                            builder.call(op,
+                                builder.getRexBuilder().makeLiteral(left, Collated(builder, collation)),
+                                builder.getRexBuilder().makeLiteral(right, Collated(builder, collation)))))
+                    .build());
+        }
+
+        /// <summary>
+        /// The comparisons <c>EnumerableStringComparisonTest.testStringComparison</c> makes, which are one
+        /// test there and one row each here.
+        /// </summary>
+        /// <returns></returns>
+        static IEnumerable<(string Left, string Right, SqlOperator Op, org.apache.calcite.sql.SqlCollation Collation)> Comparisons()
+        {
+            var lt = SqlStdOperatorTable.LESS_THAN;
+            var gt = SqlStdOperatorTable.GREATER_THAN;
+            var eq = SqlStdOperatorTable.EQUALS;
+            var ne = SqlStdOperatorTable.NOT_EQUALS;
+
+            foreach (var op in new[] { lt, gt })
+                foreach (var (l, r) in new[] { ("a", "A"), ("A", "a"), ("a", "b"), ("A", "B"), ("a", "B"), ("A", "b"), ("b", "a"), ("B", "A"), ("B", "a"), ("b", "A") })
+                    yield return (l, r, op, Tertiary);
+
+            foreach (var op in new[] { eq, ne })
+                foreach (var (l, r) in new[] { ("aaa", "AAA"), ("AAA", "AAA"), ("AAA", "BBB") })
+                    yield return (l, r, op, Tertiary);
+
+            foreach (var collation in new[] { Primary, Secondary, Tertiary, Identical })
+                foreach (var (l, r) in new[] { ("ABC", "ABC"), ("abc", "ÀBC"), ("abc", "ABC"), ("", "") })
+                    yield return (l, r, eq, collation);
+        }
+
+        /// <summary>
+        /// A <see cref="java.util.function.UnaryOperator"/> reading a delegate, so that a builder's
+        /// configuration can be changed from C#.
+        /// </summary>
+        /// <param name="transform"></param>
+        sealed class DelegateUnaryOperator(Func<object, object> transform) : java.util.function.UnaryOperator
+        {
+
+            /// <inheritdoc />
+            public object apply(object value) => transform(value);
+
+            /// <inheritdoc />
+            public java.util.function.Function andThen(java.util.function.Function after) => throw new NotSupportedException();
+
+            /// <inheritdoc />
+            public java.util.function.Function compose(java.util.function.Function before) => throw new NotSupportedException();
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Linq.Tests/ClrEnumerableRowFormatTests.cs
+++ b/src/Apache.Calcite.Linq.Tests/ClrEnumerableRowFormatTests.cs
@@ -8,15 +8,27 @@ namespace Apache.Calcite.Linq.Tests
 {
 
     /// <summary>
-    /// Holds the one place this convention departs from Calcite deliberately: a pass-through node keeps its
-    /// input's row format rather than re-optimising it.
+    /// Holds the one shape neither convention can run, and the defect underneath it, which is Calcite's.
     /// </summary>
     /// <remarks>
-    /// <para>Sort, limit, limit-sort, spool and repeat union yield their input's rows unchanged, and Calcite
-    /// builds their physical type with the overload that optimises — which turns ARRAY into SCALAR for a
-    /// one-field row type. A table function cannot reshape its rows, so it passes <c>optimize = false</c> and
-    /// keeps an honest ARRAY; a pass-through node above it then optimises that away without touching the
-    /// rows, and a consumer reads field 0 as the row itself.</para>
+    /// <para>Sort, limit, limit-sort, spool and repeat union yield their input's rows unchanged, and build
+    /// their physical type with the overload that optimises — which turns ARRAY into SCALAR for a one-field
+    /// row type. A table function cannot reshape its rows, so it passes <c>optimize = false</c> and keeps an
+    /// honest ARRAY; the sort above it then names SCALAR and hands the ARRAY rows on regardless. Nothing
+    /// reconciles the two, in either convention: <c>EnumerableSort</c> names a format it does not produce.
+    /// </para>
+    ///
+    /// <para><b>Every node here carries Calcite's own text, and neither convention answers the query.</b>
+    /// Calcite reaches a cast and throws; this convention refuses a node further up, because
+    /// <c>ClrEnumerableRelImplementor.RequireRowType</c> checks the element type a CLR sequence has to name
+    /// and Java's erased <c>Enumerable</c> does not. Same defect, caught earlier and named.</para>
+    ///
+    /// <para><b>The fix belongs upstream</b>, in <c>EnumerableSort</c> — either it stops optimising a format
+    /// it is only passing through, or it converts the rows into the one it names. Repairing it here was
+    /// tried three ways — in the five pass-through nodes, in the table function scan, and once generally in
+    /// the implementor — and every one of them was this project inventing a behaviour Calcite has not got.
+    /// The measurement said so: across the whole suite the repair fired three times, all in
+    /// <c>ClrEnumerableSort</c>, all <c>ARRAY Object[] -&gt; SCALAR</c>.</para>
     ///
     /// <para><b>The oracle is <c>Smalls.fibonacciTableWithLimit100</c></b>, a one-column table function
     /// written in Java, so Janino can name it. Every table function of this project's own is a CLR class,
@@ -32,8 +44,6 @@ namespace Apache.Calcite.Linq.Tests
 
         const string Sql =
             "SELECT \"A\".\"N\" FROM TABLE(\"FIB\"()) AS \"A\", TABLE(\"FIB\"()) AS \"B\" WHERE \"A\".\"N\" = \"B\".\"N\" ORDER BY 1";
-
-        static readonly string[] Expected = ["1", "1", "1", "1", "2", "3", "5", "8", "13", "21", "34", "55", "89"];
 
         /// <summary>
         /// Both conventions choose the same plan, so what follows is a difference in the nodes and not in the
@@ -53,33 +63,33 @@ namespace Apache.Calcite.Linq.Tests
         }
 
         /// <summary>
-        /// This convention answers the query.
-        /// </summary>
-        [TestMethod]
-        public void ShouldRunAMergeJoinOverSortedTableFunctions()
-        {
-            ClrEnumerableDifferentialTests.RunFib(Sql, true, true).Should().Equal(Expected);
-        }
-
-        /// <summary>
-        /// <c>EnumerableConvention</c> does not, and that is the demonstration.
+        /// <c>EnumerableConvention</c> cannot run the query: it reads the sort's <c>Object[]</c> row as the
+        /// <c>long</c> the sort said it was.
         /// </summary>
         /// <remarks>
-        /// The sort declares its physical type SCALAR — so its Java row type is <c>long</c> — while yielding
-        /// the table function's <c>Object[]</c> rows unchanged, and the merge join's key accessor then reads
-        /// the row as the value.
-        ///
-        /// <para><b>When this test starts failing, Calcite has fixed it and the divergence should go.</b>
-        /// Flipping those five nodes back to the optimising overload is a one-line change per node, and
-        /// <c>ShouldRunATableFunctionInAJoin</c> is what fails if it is done too early — measured.</para>
+        /// <b>When this test starts failing, Calcite has fixed <c>EnumerableSort</c></b>, and whatever it did
+        /// is what this convention's sort should then say.
         /// </remarks>
         [TestMethod]
-        public void ShouldShowThatCalciteCannotRunTheSameQuery()
+        public void ShouldShowThatCalciteCannotRunTheQuery()
         {
             var act = () => ClrEnumerableDifferentialTests.RunFib(Sql, false, true);
 
             act.Should().Throw<InvalidCastException>()
                 .WithMessage("*System.Object[]*java.lang.Long*");
+        }
+
+        /// <summary>
+        /// This convention cannot either, and refuses before it builds the plan rather than while running it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseTheQueryNamingTheNodeAndBothTypes()
+        {
+            var act = () => ClrEnumerableDifferentialTests.RunFib(Sql, true, true);
+
+            act.Should().Throw<java.lang.IllegalStateException>()
+                .WithInnerException<java.lang.IllegalStateException>()
+                .WithMessage("*ClrEnumerableSort handed up a sequence of System.Object[] where its row type is java.lang.Long*");
         }
 
     }

--- a/src/Apache.Calcite.Linq.Tests/ClrEnumerableWindowTests.cs
+++ b/src/Apache.Calcite.Linq.Tests/ClrEnumerableWindowTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Apache.Calcite.Linq.Rel;
+
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.rex;
+using org.apache.calcite.sql.type;
+
+namespace Apache.Calcite.Linq.Tests
+{
+
+    /// <summary>
+    /// The parts of <see cref="ClrEnumerableWindow"/> a plan does not reach.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of Calcite's <c>EnumerableWindowTest</c>. Everything else about the node is compared
+    /// against <c>EnumerableConvention</c> by the differential tests; <c>copy</c> is not, because the planner
+    /// only calls it while it is exploring and a plan that came out right says nothing about whether the
+    /// constants survived.
+    /// </remarks>
+    [TestClass]
+    public class ClrEnumerableWindowTests
+    {
+
+        /// <summary>
+        /// A node with no inputs, to hang a window on.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <param name="traitSet"></param>
+        sealed class Leaf(RelOptCluster cluster, RelTraitSet traitSet) : AbstractRelNode(cluster, traitSet)
+        {
+
+        }
+
+        [TestMethod]
+        public void ShouldKeepTheConstantsItIsGivenWhenCopied()
+        {
+            var typeFactory = new org.apache.calcite.sql.type.SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+            var planner = new org.apache.calcite.plan.hep.HepPlanner(org.apache.calcite.plan.hep.HepProgram.builder().build());
+            var cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+            var traitSet = RelTraitSet.createEmpty();
+            var input = new Leaf(cluster, traitSet);
+
+            var booleanType = typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+            var rowType = typeFactory.createSqlType(SqlTypeName.ROW);
+
+            var constants = com.google.common.collect.ImmutableList.of(RexLiteral.fromJdbcString(booleanType, SqlTypeName.BOOLEAN, "TRUE"));
+            var original = new ClrEnumerableWindow(cluster, traitSet, input, constants, rowType, com.google.common.collect.ImmutableList.of());
+
+            var replacements = com.google.common.collect.ImmutableList.of(RexLiteral.fromJdbcString(booleanType, SqlTypeName.BOOLEAN, "FALSE"));
+            var updated = original.copy(replacements);
+
+            updated.Should().NotBeSameAs(original);
+            original.getConstants().size().Should().Be(1);
+            original.getConstants().get(0).Should().BeSameAs(constants.get(0));
+            updated.getConstants().size().Should().Be(1);
+            updated.getConstants().get(0).Should().BeSameAs(replacements.get(0));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Linq.Tests/DefaultRulesProgram.cs
+++ b/src/Apache.Calcite.Linq.Tests/DefaultRulesProgram.cs
@@ -14,6 +14,9 @@ namespace Apache.Calcite.Linq.Tests
     /// node's <c>passThroughTraits</c>, <c>deriveTraits</c> and <c>getDeriveMode</c>.</param>
     /// <param name="excludeMergeJoin">Whether to drop <c>EnumerableMergeJoinRule</c> after the default rules
     /// are registered. See the remarks.</param>
+    /// <param name="add">Rules to register alongside Calcite's, for a test that needs one Calcite ships but
+    /// does not register — <c>JOIN_TO_CORRELATE</c>, say.</param>
+    /// <param name="remove">Rules to take away once everything is registered, of either convention.</param>
     /// <remarks>
     /// Listing rules by hand is what the harness used to do, and it was not Calcite's planner but a fraction
     /// of one. <c>CalcitePrepareImpl</c> calls <c>RelOptUtil.registerDefaultRules</c>, which adds the
@@ -38,7 +41,7 @@ namespace Apache.Calcite.Linq.Tests
     /// do this — every trait method here builds from <c>getTraitSet()</c> — and a merge join written here
     /// must not follow Calcite's text on that line.</para>
     /// </remarks>
-    public sealed class DefaultRulesProgram(java.util.List extra, bool topDown = false, bool excludeMergeJoin = false, bool excludeHashJoin = false) : Program
+    public sealed class DefaultRulesProgram(java.util.List extra, bool topDown = false, bool excludeMergeJoin = false, bool excludeHashJoin = false, RelOptRule[]? add = null, RelOptRule[]? remove = null) : Program
     {
 
         /// <inheritdoc />
@@ -61,8 +64,18 @@ namespace Apache.Calcite.Linq.Tests
             if (excludeHashJoin)
                 planner.removeRule(EnumerableRules.ENUMERABLE_JOIN_RULE);
 
+            foreach (var rule in add ?? [])
+                planner.addRule(rule);
+
             for (int i = 0; i < extra.size(); i++)
                 planner.addRule((RelOptRule)extra.get(i));
+
+            // last, so that a caller can take away one of this convention's rules as well as one of
+            // Calcite's. Calcite's own tests do this from Hook.PLANNER, which likewise runs after
+            // registration: a node is only reached by taking away whatever the planner would otherwise
+            // prefer, and with two conventions in one planner that is sometimes a rule of ours
+            foreach (var rule in remove ?? [])
+                planner.removeRule(rule);
 
             for (int i = 0; i < materializations.size(); i++)
                 planner.addMaterialization((RelOptMaterialization)materializations.get(i));

--- a/src/Apache.Calcite.Linq.Tests/Tree/PhysTypeTranslationTests.cs
+++ b/src/Apache.Calcite.Linq.Tests/Tree/PhysTypeTranslationTests.cs
@@ -193,6 +193,33 @@ namespace Apache.Calcite.Linq.Tests.Tree
             translated.Type.Should().Be(typeof(org.apache.calcite.linq4j.function.Function1));
         }
 
+        /// <summary>
+        /// CALCITE-3364: a one-column row converted from an array to a scalar, which is what a table function
+        /// of one value needs before it can be grouped.
+        /// </summary>
+        /// <remarks>
+        /// The selector <c>PhysType</c> emits here ends in <c>public int apply(Object[] o)</c> — the physical
+        /// field type, not the box. A sequence carries the box, so the conversion has to end in one; this is
+        /// the shape of it, and the only one no plan reaches.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldConvertAOneColumnRowFromAnArrayToAScalar()
+        {
+            var oneColumn = typeFactory.builder().add("intField", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+            var array = PhysTypeImpl.of(typeFactory, oneColumn, JavaRowFormat.ARRAY, false);
+
+            var implementor = new ClrEnumerableRelImplementor(new org.apache.calcite.rex.RexBuilder(typeFactory), new java.util.HashMap());
+            var rows = new object[][] { [Integer.valueOf(1)], [Integer.valueOf(2)] };
+
+            var converted = array.ConvertTo(implementor, Expression.Constant(rows, typeof(IEnumerable<object[]>)), JavaRowFormat.SCALAR);
+
+            converted.Type.Should().Be(typeof(IEnumerable<Integer>), "a sequence of a one-column scalar row carries the box");
+
+            var value = Expression.Lambda<Func<IEnumerable<Integer>>>(converted).Compile()();
+
+            value.Should().Equal([Integer.valueOf(1), Integer.valueOf(2)]);
+        }
+
     }
 
 }

--- a/src/Apache.Calcite.Linq/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Linq/ClrEnumerableDefaults.cs
@@ -2088,14 +2088,20 @@ namespace Apache.Calcite.Linq
 
                 for (int i = 0; iterationLimit < 0 || i < iterationLimit; i++)
                 {
+                    // a round that returned no row this sequence had not already returned is the end of it,
+                    // and not a round that read no rows. Calcite's own enumerator says the same thing by
+                    // setting `current` only where `checkValue` passed and stopping where it is still DUMMY.
+                    // Counting what was read instead is an infinite loop for every UNION rather than UNION
+                    // ALL: the iterative part re-reads the whole spool each round and so never runs dry.
                     var any = false;
 
                     foreach (var row in iteration)
                     {
-                        any = true;
-
                         if (processed == null || processed.Add(row))
+                        {
+                            any = true;
                             yield return row;
+                        }
                     }
 
                     if (any == false)

--- a/src/Apache.Calcite.Linq/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Linq/ClrEnumerableDefaults.cs
@@ -521,6 +521,11 @@ namespace Apache.Calcite.Linq
         /// <para>Matching nothing is not the same as being dropped: a null-keyed build row is kept under a
         /// null key, which nothing probes, and a right or a full join ends by returning the rows that matched
         /// nothing — those among them.</para>
+        ///
+        /// <para>Calcite has two of these and so does this: <c>hashEquiJoin_</c> where the condition is an
+        /// equality alone, and <c>hashJoinWithPredicate_</c> where it is not. They differ in more than the
+        /// extra test — what "matched nothing" means is a key in one and a row in the other — so they are
+        /// two methods rather than one with a null check inside the loop.</para>
         /// </remarks>
         public static IEnumerable<TResult> HashJoin<TSource, TInner, TKey, TResult>(
             IEnumerable<TSource> outer,
@@ -533,11 +538,32 @@ namespace Apache.Calcite.Linq
             bool generateNullsOnRight,
             Func<TSource, TInner, bool>? predicate)
         {
+            return predicate == null
+                ? HashEquiJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, generateNullsOnLeft, generateNullsOnRight)
+                : HashJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, generateNullsOnLeft, generateNullsOnRight, predicate);
+        }
+
+        /// <summary>
+        /// Joins two sequences on a key alone.
+        /// </summary>
+        /// <remarks>
+        /// The counterpart of <c>EnumerableDefaults.hashEquiJoin_</c>. What is left over at the end is a
+        /// <em>key</em> no outer row carried, and every build row under it comes out together.
+        /// </remarks>
+        static IEnumerable<TResult> HashEquiJoin<TSource, TInner, TKey, TResult>(
+            IEnumerable<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            Func<TSource, TInner, TResult> resultSelector,
+            EqualityComparer? comparer,
+            bool generateNullsOnLeft,
+            bool generateNullsOnRight)
+        {
             // the lookup is a java.util.HashMap, as linq4j's toLookup builds one: a right or a full join ends
             // with the rows of the right input that matched nothing, and the order those come out in is this
             // map's. See JavaHashingTests for why that order is the same in every process.
             var lookup = new java.util.HashMap();
-            var matched = generateNullsOnLeft ? new java.util.HashSet() : null;
 
             foreach (var row in inner)
             {
@@ -551,6 +577,90 @@ namespace Apache.Calcite.Linq
                 bucket.Add(row);
             }
 
+            // every key the build side has, less the ones an outer row carries. Calcite keeps it this way
+            // round, and it matters where the lookup holds a key nothing probes: that key's rows are what a
+            // right or a full join owes against a null left.
+            var unmatched = generateNullsOnLeft ? new java.util.HashSet(lookup.keySet()) : null;
+
+            foreach (var row in outer)
+            {
+                var key = outerKeySelector(row);
+                var any = false;
+
+                if (key != null)
+                {
+                    var wrapped = JavaWrapped.Of(comparer, JavaValues.From(key));
+                    unmatched?.remove(wrapped);
+
+                    if (lookup.get(wrapped) is List<TInner> bucket)
+                    {
+                        foreach (var other in bucket)
+                        {
+                            any = true;
+                            yield return resultSelector(row, other);
+                        }
+                    }
+                }
+
+                if (any == false && generateNullsOnRight)
+                    yield return resultSelector(row, default!);
+            }
+
+            if (unmatched == null)
+                yield break;
+
+            for (var i = lookup.entrySet().iterator(); i.hasNext();)
+            {
+                var entry = (java.util.Map.Entry)i.next();
+                if (unmatched.contains(entry.getKey()) == false)
+                    continue;
+
+                foreach (var other in (List<TInner>)entry.getValue())
+                    yield return resultSelector(default!, other);
+            }
+        }
+
+        /// <summary>
+        /// Joins two sequences on a key and something else besides.
+        /// </summary>
+        /// <remarks>
+        /// The counterpart of <c>EnumerableDefaults.hashJoinWithPredicate_</c>. What is left over at the end
+        /// is a <em>row</em> the predicate rejected or the key never reached, and the leftovers come out in
+        /// the build input's own order rather than the lookup's.
+        ///
+        /// <para>Per row and not per key, which is the whole difference. A build row whose key matched but
+        /// whose predicate did not has matched nothing, and a right join owes it a row against a null left.
+        /// Tracking the key instead lost it, because some other row under that key had passed.</para>
+        /// </remarks>
+        static IEnumerable<TResult> HashJoinWithPredicate<TSource, TInner, TKey, TResult>(
+            IEnumerable<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            Func<TSource, TInner, TResult> resultSelector,
+            EqualityComparer? comparer,
+            bool generateNullsOnLeft,
+            bool generateNullsOnRight,
+            Func<TSource, TInner, bool> predicate)
+        {
+            // read once, because a right or a full join walks it twice
+            IEnumerable<TInner> innerToLookUp = generateNullsOnLeft ? new List<TInner>(inner) : inner;
+
+            var lookup = new java.util.HashMap();
+
+            foreach (var row in innerToLookUp)
+            {
+                var key = innerKeySelector(row);
+
+                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                if (lookup.get(wrapped) is not List<TInner> bucket)
+                    lookup.put(wrapped, bucket = []);
+
+                bucket.Add(row);
+            }
+
+            var unmatched = generateNullsOnLeft ? new List<TInner>(innerToLookUp) : null;
+
             foreach (var row in outer)
             {
                 var key = outerKeySelector(row);
@@ -558,13 +668,16 @@ namespace Apache.Calcite.Linq
 
                 if (key != null && lookup.get(JavaWrapped.Of(comparer, JavaValues.From(key))) is List<TInner> bucket)
                 {
+                    var accepted = new List<TInner>();
                     foreach (var other in bucket)
-                    {
-                        if (predicate != null && predicate(row, other) == false)
-                            continue;
+                        if (predicate(row, other))
+                            accepted.Add(other);
 
+                    unmatched?.RemoveAll(accepted.Contains);
+
+                    foreach (var other in accepted)
+                    {
                         any = true;
-                        matched?.add(JavaWrapped.Of(comparer, JavaValues.From(key)));
                         yield return resultSelector(row, other);
                     }
                 }
@@ -573,18 +686,11 @@ namespace Apache.Calcite.Linq
                     yield return resultSelector(row, default!);
             }
 
-            if (matched == null)
+            if (unmatched == null)
                 yield break;
 
-            for (var i = lookup.entrySet().iterator(); i.hasNext();)
-            {
-                var entry = (java.util.Map.Entry)i.next();
-                if (matched.contains(entry.getKey()))
-                    continue;
-
-                foreach (var other in (List<TInner>)entry.getValue())
-                    yield return resultSelector(default!, other);
-            }
+            foreach (var other in unmatched)
+                yield return resultSelector(default!, other);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Linq/ClrEnumerableRelImplementor.cs
+++ b/src/Apache.Calcite.Linq/ClrEnumerableRelImplementor.cs
@@ -271,20 +271,42 @@ namespace Apache.Calcite.Linq
         /// plan right, at the cost of a delegate per row, and would hide the next node written that way — as
         /// it did: this method boxed for a while, and three nodes were wrong underneath it with every test
         /// passing.</para>
+        ///
+        /// <para>A result that is not an <see cref="IEnumerable{T}"/> at all is refused as well. Letting one
+        /// through was how seven more nodes would have escaped had any of them handed up an array or an
+        /// <c>IOrderedEnumerable</c>: a check with a way out is a check only for the shapes that already
+        /// pass.</para>
         /// </remarks>
         static void RequireRowType(PhysType physType, Expression expression)
         {
+            var expected = physType.RowType();
+
             if (expression.Type.IsGenericType == false || expression.Type.GetGenericTypeDefinition() != typeof(IEnumerable<>))
-                return;
+                throw new java.lang.IllegalStateException($"{Node()} handed up a {expression.Type} where a sequence of {expected} was wanted.");
 
             var actual = expression.Type.GetGenericArguments()[0];
-            var expected = physType.RowType();
             if (actual == expected)
                 return;
 
-            var node = new System.Diagnostics.StackTrace().GetFrame(2)?.GetMethod()?.DeclaringType?.Name ?? "?";
+            throw new java.lang.IllegalStateException($"{Node()} handed up a sequence of {actual} where its row type is {expected}.");
+        }
 
-            throw new java.lang.IllegalStateException($"{node} handed up a sequence of {actual} where its row type is {expected}.");
+        /// <summary>
+        /// Names the node whose <c>Implement</c> called <see cref="Result"/>, for a refusal's message.
+        /// </summary>
+        /// <returns></returns>
+        static string Node()
+        {
+            var trace = new System.Diagnostics.StackTrace();
+
+            for (int i = 1; i < trace.FrameCount; i++)
+            {
+                var type = trace.GetFrame(i)?.GetMethod()?.DeclaringType;
+                if (type != null && type != typeof(ClrEnumerableRelImplementor))
+                    return type.Name;
+            }
+
+            return "?";
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Linq/ClrEnumerableRelImplementor.cs
+++ b/src/Apache.Calcite.Linq/ClrEnumerableRelImplementor.cs
@@ -35,7 +35,7 @@ namespace Apache.Calcite.Linq
 
         readonly RexBuilder rexBuilder;
         readonly java.util.Map map;
-        readonly Dictionary<string, RexToLixTranslator.InputGetter> corrVars = [];
+        readonly Dictionary<string, CorrelInputGetter> corrVars = [];
 
         /// <summary>
         /// Initializes a new instance.
@@ -243,6 +243,28 @@ namespace Apache.Calcite.Linq
         }
 
         /// <summary>
+        /// Registers on Calcite's implementor every correlation variable in scope here.
+        /// </summary>
+        /// <param name="enumerable"></param>
+        /// <remarks>
+        /// A converter runs an <c>EnumerableConvention</c> sub-plan on an implementor of Calcite's, and that
+        /// implementor keeps its own correlation variables. So a sub-plan of Calcite's sitting under a
+        /// correlate of this convention finds none, and <c>RexToLixTranslator.visitFieldAccess</c> reads a
+        /// null getter — a recursive query whose step is a correlate over a transient table is one, because
+        /// the transient scan is interpreted and only Calcite has a node for that.
+        ///
+        /// <para>The registration is replayed rather than the getter handed over, because Calcite builds its
+        /// own getter and keeps the map private. It is the same registration: <c>registerCorrelVariable</c>
+        /// appends a field read to the block it is given, and the block is the one this convention's
+        /// correlate will translate.</para>
+        /// </remarks>
+        internal void ReplayCorrelVariables(EnumerableRelImplementor enumerable)
+        {
+            foreach (var pair in corrVars)
+                enumerable.registerCorrelVariable(pair.Key, pair.Value.Parameter, pair.Value.Block, pair.Value.PhysType);
+        }
+
+        /// <summary>
         /// Creates the result a node's <c>Implement</c> returns.
         /// </summary>
         /// <param name="physType">How the rows are represented.</param>
@@ -323,6 +345,21 @@ namespace Apache.Calcite.Linq
         /// <param name="physType"></param>
         sealed class CorrelInputGetter(string name, J.ParameterExpression pe, J.BlockBuilder corrBlock, PhysType physType) : RexToLixTranslator.InputGetter
         {
+
+            /// <summary>
+            /// Gets the parameter holding the outer row.
+            /// </summary>
+            public J.ParameterExpression Parameter => pe;
+
+            /// <summary>
+            /// Gets the block a field read is declared into.
+            /// </summary>
+            public J.BlockBuilder Block => corrBlock;
+
+            /// <summary>
+            /// Gets the outer row's physical type.
+            /// </summary>
+            public PhysType PhysType => physType;
 
             /// <inheritdoc />
             public J.Expression field(J.BlockBuilder list, int index, java.lang.reflect.Type storageType)

--- a/src/Apache.Calcite.Linq/ClrPhysTypes.cs
+++ b/src/Apache.Calcite.Linq/ClrPhysTypes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 using org.apache.calcite.adapter.enumerable;
@@ -34,22 +35,38 @@ namespace Apache.Calcite.Linq
         /// <remarks>
         /// What PhysType.convertTo does, which cannot be reused because it composes a linq4j select onto a
         /// linq4j sequence and the sequence here is not one. The selector is still PhysType's.
+        ///
+        /// <para>The rows come out boxed, as every sequence here carries them. PhysType's selector answers
+        /// with the physical field type — CALCITE-3364's one-column conversion ends in
+        /// <c>public int apply(Object[] o)</c> — and a caller of this hands what it gets back up to the node
+        /// above.</para>
         /// </remarks>
         public static System.Linq.Expressions.Expression ConvertTo(this PhysType physType, ClrEnumerableRelImplementor implementor, System.Linq.Expressions.Expression source, JavaRowFormat targetFormat)
         {
             if (physType.getFormat() == targetFormat)
                 return source;
 
-            var sourceType = ClrTypes.Resolve(physType.getJavaRowType());
+            var sourceType = physType.RowType();
             var row = org.apache.calcite.linq4j.tree.Expressions.parameter(physType.getJavaRowType(), "o");
             var fields = new java.util.ArrayList();
             for (int i = 0; i < physType.getRowType().getFieldCount(); i++)
                 fields.add(java.lang.Integer.valueOf(i));
 
             var selector = implementor.Translator.TranslateSelector(physType.generateSelector(row, fields, targetFormat), sourceType);
+            var rowType = PhysTypeImpl.of(implementor.TypeFactory, physType.getRowType(), targetFormat, false).RowType();
+
+            if (selector.ReturnType != rowType)
+            {
+                var parameter = Expression.Parameter(sourceType, "row");
+
+                selector = Expression.Lambda(
+                    typeof(Func<,>).MakeGenericType(sourceType, rowType),
+                    ClrEnumUtils.Convert(Expression.Invoke(selector, parameter), rowType),
+                    parameter);
+            }
 
             return System.Linq.Expressions.Expression.Call(null,
-                ClrBuiltInMethod.Select.MakeGenericMethod(sourceType, selector.ReturnType),
+                ClrBuiltInMethod.Select.MakeGenericMethod(sourceType, rowType),
                 source,
                 selector);
         }

--- a/src/Apache.Calcite.Linq/Convert/EnumerableToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Linq/Convert/EnumerableToClrEnumerableConverter.cs
@@ -1,7 +1,6 @@
 using System.Linq.Expressions;
 
 using Apache.Calcite.Linq.Runtime;
-using Apache.Calcite.Linq.Tree;
 
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.linq4j;
@@ -58,6 +57,11 @@ namespace Apache.Calcite.Linq.Convert
         {
             // the same map, so a value Calcite stashes reaches the DataContext this plan is bound with
             var enumerable = new EnumerableRelImplementor(implementor.RexBuilder, implementor.Map);
+
+            // and the same correlation variables, because a sub-plan of Calcite's under a correlate of this
+            // convention reads the outer row through them
+            implementor.ReplayCorrelVariables(enumerable);
+
             var result = enumerable.visitChild(null, 0, (EnumerableRel)getInput(), pref.ToCalcite());
 
             var rowType = result.physType.RowType();

--- a/src/Apache.Calcite.Linq/LixToClrTranslator.cs
+++ b/src/Apache.Calcite.Linq/LixToClrTranslator.cs
@@ -618,6 +618,8 @@ namespace Apache.Calcite.Linq
                 var array = Expression.Variable(source.Type, "array");
                 var index = Expression.Variable(typeof(int), "index");
 
+                // the continue label sits before the step and not at the top of the loop, for the reason it
+                // does in For: a Java continue still advances the loop, and here the advance is the index
                 return Expression.Block(typeof(void), [array, index, element],
                     Expression.Assign(array, source),
                     Expression.Assign(index, Expression.Constant(0)),
@@ -627,10 +629,10 @@ namespace Apache.Calcite.Linq
                             Expression.Block(typeof(void),
                                 Expression.Assign(element, ClrEnumUtils.Convert(Expression.ArrayAccess(array, index), element.Type)),
                                 body,
+                                Expression.Label(loop.Continue),
                                 Expression.PostIncrementAssign(index)),
                             Expression.Break(loop.Break)),
-                        loop.Break,
-                        loop.Continue));
+                        loop.Break));
             }
 
             var iterator = Expression.Variable(typeof(java.util.Iterator), "iterator");
@@ -1015,7 +1017,7 @@ namespace Apache.Calcite.Linq
             if (op == ExpressionType.Assign)
                 return Expression.Assign(left, ClrEnumUtils.Convert(right, left.Type));
 
-            if (op.ToString().EndsWith("Assign", StringComparison.Ordinal))
+            if (CompoundAssignments.Contains(op))
                 return Expression.MakeBinary(op, left, ClrEnumUtils.Convert(right, left.Type));
 
             // a shift takes its distance as an int however wide the value being shifted is
@@ -1041,6 +1043,32 @@ namespace Apache.Calcite.Linq
         /// Concatenation, which is what Java's <c>+</c> means when either side is a string.
         /// </summary>
         static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(object), typeof(object)])!;
+
+        /// <summary>
+        /// The operators that assign to their left operand, which therefore must be left alone rather than
+        /// promoted.
+        /// </summary>
+        /// <remarks>
+        /// Written out rather than tested by the operator's name. Three of these end in <c>Checked</c> and not
+        /// in <c>Assign</c>, so a name test lets them fall through to <see cref="Promote"/>, which may wrap the
+        /// left operand in a conversion and leave nothing to assign to.
+        /// </remarks>
+        static readonly HashSet<ExpressionType> CompoundAssignments =
+        [
+            ExpressionType.AddAssign,
+            ExpressionType.AddAssignChecked,
+            ExpressionType.AndAssign,
+            ExpressionType.DivideAssign,
+            ExpressionType.ExclusiveOrAssign,
+            ExpressionType.LeftShiftAssign,
+            ExpressionType.ModuloAssign,
+            ExpressionType.MultiplyAssign,
+            ExpressionType.MultiplyAssignChecked,
+            ExpressionType.OrAssign,
+            ExpressionType.RightShiftAssign,
+            ExpressionType.SubtractAssign,
+            ExpressionType.SubtractAssignChecked,
+        ];
 
         /// <summary>
         /// Brings two operands to the type Java would evaluate them at.

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableAggregateBase.cs
@@ -60,9 +60,8 @@ namespace Apache.Calcite.Linq.Rel
         /// <param name="aggs"></param>
         /// <returns></returns>
         /// <remarks>
-        /// Calcite answers a call that has one with <c>LazyAggregateLambdaFactory</c> and a
-        /// <c>SourceSorter</c> per call. Neither is written here, so such a call is refused where the node is
-        /// built rather than answered wrongly.
+        /// A call that has one is answered with <c>LazyAggregateLambdaFactory</c> and a <c>SourceSorter</c>
+        /// per call, as Calcite answers it. See <see cref="ImplementLambdaFactory"/>, which builds both.
         /// </remarks>
         protected static bool HasOrderedCall(java.util.List aggs)
         {
@@ -71,6 +70,26 @@ namespace Apache.Calcite.Linq.Rel
                     return true;
 
             return false;
+        }
+
+        /// <summary>
+        /// Returns the name the variables of one aggregate's state are built from.
+        /// </summary>
+        /// <param name="agg"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Under <c>CalciteSystemProperty.DEBUG</c> Calcite puts the function's own name in front, so that a
+        /// variable of the plan says which call it belongs to. There is no generated source to read here, but
+        /// the name reaches a debugger the same way.
+        /// </remarks>
+        internal static string AggName(AggImpState agg)
+        {
+            var name = $"a{agg.aggIdx}";
+
+            if (org.apache.calcite.config.CalciteSystemProperty.DEBUG.value() is java.lang.Boolean debug && debug.booleanValue())
+                name = Util.toJavaId(agg.call.getAggregation().getName(), 0).Substring("ID$0$".Length) + name;
+
+            return name;
         }
 
         /// <summary>
@@ -161,10 +180,11 @@ namespace Apache.Calcite.Linq.Rel
 
                 aggStateTypes.addAll(state);
 
+                var aggName = AggName(agg);
                 var decls = new java.util.ArrayList(state.size());
                 for (int j = 0; j < state.size(); j++)
                 {
-                    var pe = J.Expressions.parameter((java.lang.reflect.Type)state.get(j), initBlock.newName($"a{agg.aggIdx}s{j}"));
+                    var pe = J.Expressions.parameter((java.lang.reflect.Type)state.get(j), initBlock.newName($"{aggName}s{j}"));
                     initBlock.add(J.Expressions.declare(0, pe, null));
                     decls.add(pe);
                 }

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableAsofJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableAsofJoin.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using java.util.function;
 
 using org.apache.calcite.adapter.enumerable;
@@ -168,7 +166,7 @@ namespace Apache.Calcite.Linq.Rel
             var rightSource = ClrEnumUtils.BoxRows(rightResult.PhysType, rightResult.Expression);
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             // without nulls, as Calcite keys an ASOF join and has since 1.41: a key of two or more fields is
             // null as a whole where any field of it is null, so a row with a null in its key matches nothing

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableBatchNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableBatchNestedLoopJoin.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using java.util.function;
 
 using org.apache.calcite.adapter.enumerable;
@@ -165,7 +163,7 @@ namespace Apache.Calcite.Linq.Rel
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(JavaRowFormat.CUSTOM));
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var inner = Expression.Lambda(
                 typeof(Func<,>).MakeGenericType(typeof(java.util.List), rightSource.Type),

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableCollect.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableCollect.cs
@@ -73,12 +73,11 @@ namespace Apache.Calcite.Linq.Rel
             {
                 case nameof(SqlTypeName.ARRAY):
                 case nameof(SqlTypeName.MULTISET):
-                    var componentType = getRowType().getFieldList().get(0) is RelDataTypeField field
-                        ? field.getType().getComponentType()
-                        : null;
+                    var componentType = ((RelDataTypeField)getRowType().getFieldList().get(0)).getType().getComponentType()
+                        ?? throw new java.lang.NullPointerException();
                     var childRecordType = ((RelDataTypeField)result.PhysType.getRowType().getFieldList().get(0)).getType();
 
-                    if (componentType != null && SqlTypeUtil.sameNamedType(componentType, childRecordType) == false)
+                    if (SqlTypeUtil.sameNamedType(componentType, childRecordType) == false)
                     {
                         // every element of a multiset is a record, so a scalar is wrapped in something that can
                         // hold one; an array of a single field stays scalar so it still compares correctly

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableCollect.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableCollect.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel;
@@ -67,7 +65,7 @@ namespace Apache.Calcite.Linq.Rel
 
             var collectionType = getCollectionType();
             var source = result.Expression;
-            var sourceType = ClrTypes.Resolve(result.PhysType.getJavaRowType());
+            var sourceType = result.PhysType.RowType();
 
             Expression collection;
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableConditionalCorrelate.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableConditionalCorrelate.cs
@@ -140,7 +140,7 @@ namespace Apache.Calcite.Linq.Rel
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(JavaRowFormat.CUSTOM));
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var inner = Expression.Lambda(
                 typeof(Func<,>).MakeGenericType(leftType, rightSource.Type),

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableCorrelate.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableCorrelate.cs
@@ -121,7 +121,7 @@ namespace Apache.Calcite.Linq.Rel
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(JavaRowFormat.CUSTOM));
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var inner = Expression.Lambda(
                 typeof(Func<,>).MakeGenericType(leftType, rightSource.Type),

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableHashJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableHashJoin.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using java.util.function;
 
 using org.apache.calcite.adapter.enumerable;
@@ -161,7 +159,7 @@ namespace Apache.Calcite.Linq.Rel
             var rightSource = ClrEnumUtils.BoxRows(rightResult.PhysType, rightResult.Expression);
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var leftKey = NullAwareAccessor(implementor, leftResult.PhysType, joinInfo.leftKeys, leftType);
             var rightKey = NullAwareAccessor(implementor, rightResult.PhysType, joinInfo.rightKeys, rightType);
@@ -243,7 +241,7 @@ namespace Apache.Calcite.Linq.Rel
             var rightSource = ClrEnumUtils.BoxRows(rightResult.PhysType, rightResult.Expression);
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var rexBuilder = getCluster().getRexBuilder();
 

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableIntersect.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableIntersect.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel.core;
@@ -50,7 +48,7 @@ namespace Apache.Calcite.Linq.Rel
                     continue;
                 }
 
-                var rowType = ClrTypes.Resolve(result.PhysType.getJavaRowType());
+                var rowType = result.PhysType.RowType();
 
                 intersectExp = Expression.Call(null,
                     ClrBuiltInMethod.Intersect.MakeGenericMethod(rowType),

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimit.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimit.cs
@@ -76,7 +76,7 @@ namespace Apache.Calcite.Linq.Rel
             // physical type is theirs
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format, false);
 
-            var rowType = ClrTypes.Resolve(result.PhysType.getJavaRowType());
+            var rowType = result.PhysType.RowType();
             var v = result.Expression;
 
             if (offset != null)

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimit.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimit.cs
@@ -7,6 +7,7 @@ using java.util.function;
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel;
+using org.apache.calcite.rel.metadata;
 using org.apache.calcite.rex;
 using org.apache.calcite.util;
 
@@ -31,8 +32,10 @@ namespace Apache.Calcite.Linq.Rel
         public static ClrEnumerableLimit Create(RelNode input, RexNode? offset, RexNode? fetch)
         {
             var cluster = input.getCluster();
+            var mq = cluster.getMetadataQuery();
             var traitSet = cluster.traitSetOf(ClrEnumerableConvention.Instance)
-                .replaceIfs(RelCollationTraitDef.INSTANCE, new DelegateSupplier<object>(() => cluster.getMetadataQuery().collations(input)));
+                .replaceIfs(RelCollationTraitDef.INSTANCE, new DelegateSupplier<object>(() => RelMdCollation.limit(mq, input)))
+                .replaceIf(RelDistributionTraitDef.INSTANCE, new DelegateSupplier<object>(() => RelMdDistribution.limit(mq, input)));
 
             return new ClrEnumerableLimit(cluster, traitSet, input, offset, fetch);
         }
@@ -72,9 +75,7 @@ namespace Apache.Calcite.Linq.Rel
         {
             var child = (ClrEnumerableRel)getInput();
             var result = implementor.VisitChild(this, 0, child, pref);
-            // the input's own format, and not re-optimised: a limit yields the rows it was given, so its
-            // physical type is theirs
-            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format, false);
+            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format);
 
             var rowType = result.PhysType.RowType();
             var v = result.Expression;

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimitSort.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimitSort.cs
@@ -64,9 +64,7 @@ namespace Apache.Calcite.Linq.Rel
         {
             var child = (ClrEnumerableRel)getInput();
             var result = implementor.VisitChild(this, 0, child, pref);
-            // the input's own format, and not re-optimised: the rows are the input's, so its physical type
-            // is theirs
-            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format, false);
+            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format);
 
             var inputPhysType = result.PhysType;
             var pair = inputPhysType.generateCollationKey(collation.getFieldCollations());

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimitSort.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableLimitSort.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel;
@@ -72,7 +70,7 @@ namespace Apache.Calcite.Linq.Rel
 
             var inputPhysType = result.PhysType;
             var pair = inputPhysType.generateCollationKey(collation.getFieldCollations());
-            var sourceType = ClrTypes.Resolve(inputPhysType.getJavaRowType());
+            var sourceType = inputPhysType.RowType();
 
             var keySelector = implementor.Translator.TranslateSelector((J.Expression)pair.getKey(), sourceType);
             var comparator = pair.getValue() == null

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeJoin.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using java.util.function;
 
 using org.apache.calcite.adapter.enumerable;
@@ -433,7 +431,7 @@ namespace Apache.Calcite.Linq.Rel
             var rightSource = ClrEnumUtils.BoxRows(rightResult.PhysType, rightResult.Expression);
             var leftType_ = leftSource.Type.GetGenericArguments()[0];
             var rightType_ = rightSource.Type.GetGenericArguments()[0];
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var leftKey = implementor.Translator.TranslateSelector(J.Expressions.lambda(leftKeyPhysType.record(leftExpressions), [left_]), leftType_);
             var rightKey = implementor.Translator.TranslateSelector(J.Expressions.lambda(rightKeyPhysType.record(rightExpressions), [right_]), rightType_);

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeUnion.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableMergeUnion.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel;
@@ -80,7 +78,7 @@ namespace Apache.Calcite.Linq.Rel
         public override ClrEnumerableResult Implement(ClrEnumerableRelImplementor implementor, ClrEnumerablePrefer pref)
         {
             var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(JavaRowFormat.CUSTOM));
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             // the inputs go into a list, because the merge walks all of them at once rather than one after
             // the other; Calcite builds the same list into the block it generates

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableNestedLoopJoin.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using java.util.function;
 
 using org.apache.calcite.adapter.enumerable;
@@ -158,7 +156,7 @@ namespace Apache.Calcite.Linq.Rel
             var rightSource = ClrEnumUtils.BoxRows(rightResult.PhysType, rightResult.Expression);
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var predicate = ClrEnumUtils.GeneratePredicate(implementor, getCluster().getRexBuilder(), left, right, leftResult.PhysType, rightResult.PhysType, getCondition(), true);
             var selector = ClrEnumUtils.MarkJoinSelector(implementor, physType, leftResult.PhysType);
@@ -189,7 +187,7 @@ namespace Apache.Calcite.Linq.Rel
             var rightSource = ClrEnumUtils.BoxRows(rightResult.PhysType, rightResult.Expression);
             var leftType = leftSource.Type.GetGenericArguments()[0];
             var rightType = rightSource.Type.GetGenericArguments()[0];
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             var predicate = ClrEnumUtils.GeneratePredicate(implementor, getCluster().getRexBuilder(), left, right, leftResult.PhysType, rightResult.PhysType, getCondition());
             var selector = ClrEnumUtils.JoinSelector(implementor, joinType, physType, leftResult.PhysType, rightResult.PhysType);

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableProject.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableProject.cs
@@ -28,8 +28,7 @@ namespace Apache.Calcite.Linq.Rel
             var mq = cluster.getMetadataQuery();
             var traitSet = cluster.traitSet()
                 .replace(ClrEnumerableConvention.Instance)
-                .replaceIfs(RelCollationTraitDef.INSTANCE, new DelegateSupplier<object>(() => RelMdCollation.project(mq, input, projects)))
-                .replaceIf(RelDistributionTraitDef.INSTANCE, new DelegateSupplier<object>(() => RelMdDistribution.project(mq, input, projects)));
+                .replaceIfs(RelCollationTraitDef.INSTANCE, new DelegateSupplier<object>(() => RelMdCollation.project(mq, input, projects)));
 
             return new ClrEnumerableProject(cluster, traitSet, input, projects, rowType);
         }

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableRepeatUnion.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableRepeatUnion.cs
@@ -75,9 +75,7 @@ namespace Apache.Calcite.Linq.Rel
             var seedResult = implementor.VisitChild(this, 0, (ClrEnumerableRel)getSeedRel(), pref);
             var iterationResult = implementor.VisitChild(this, 1, (ClrEnumerableRel)getIterativeRel(), pref);
 
-            // the seed's own format, and not re-optimised: a repeat union yields the rows of its two inputs
-            // unchanged, so its physical type is theirs
-            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), seedResult.Format, false);
+            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(seedResult.Format));
             var rowType = seedResult.PhysType.RowType();
 
             body.Add(

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableSort.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableSort.cs
@@ -60,9 +60,7 @@ namespace Apache.Calcite.Linq.Rel
         {
             var child = (ClrEnumerableRel)getInput();
             var result = implementor.VisitChild(this, 0, child, pref);
-            // the input's own format, and not re-optimised: a sort yields the rows it was given, so its
-            // physical type is theirs
-            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format, false);
+            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format);
 
             var inputPhysType = result.PhysType;
             var pair = inputPhysType.generateCollationKey(collation.getFieldCollations());

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableSortedAggregate.cs
@@ -108,8 +108,8 @@ namespace Apache.Calcite.Linq.Rel
 
             var physType = PhysTypeImpl.of(typeFactory, getRowType(), pref.PreferCustom());
             var inputPhysType = result.PhysType;
-            var sourceType = ClrTypes.Resolve(inputPhysType.getJavaRowType());
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var sourceType = inputPhysType.RowType();
+            var rowType = physType.RowType();
 
             var keyPhysType = inputPhysType.project(groupSet.asList(), getGroupType() != Group.SIMPLE, JavaRowFormat.LIST);
             var groupCount = getGroupCount();

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableFunctionScan.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableFunctionScan.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using org.apache.calcite;
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
@@ -109,7 +107,7 @@ namespace Apache.Calcite.Linq.Rel
             var result = implementor.VisitChild(this, 0, child, pref);
             var physType = PhysTypeImpl.of(typeFactory, getRowType(), pref.Prefer(result.Format));
 
-            var sourceType = ClrTypes.Resolve(result.PhysType.getJavaRowType());
+            var sourceType = result.PhysType.RowType();
             var source = Expression.Call(null, ClrBuiltInMethod.ToJava.MakeGenericMethod(sourceType), result.Expression);
 
             var input_ = J.Expressions.parameter((java.lang.Class)typeof(org.apache.calcite.linq4j.Enumerable), "_input");
@@ -134,7 +132,7 @@ namespace Apache.Calcite.Linq.Rel
                 Expression.Assign(inputParameter, source),
                 implementor.Translator.TranslateBody(block.toBlock(), typeof(org.apache.calcite.linq4j.Enumerable)));
 
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             return implementor.Result(physType,
                 Expression.Call(null, ClrBuiltInMethod.FromJava.MakeGenericMethod(rowType), windowed));
@@ -170,7 +168,7 @@ namespace Apache.Calcite.Linq.Rel
 
             block.add(ClrEnumUtils.Translate(translator, getCall(), null));
 
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var rowType = physType.RowType();
 
             return implementor.Result(physType,
                 Expression.Call(null,

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableFunctionScan.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableFunctionScan.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 
 using org.apache.calcite;
 using org.apache.calcite.adapter.enumerable;
+using org.apache.calcite.adapter.java;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel.core;
 using org.apache.calcite.rel.type;
@@ -163,7 +164,7 @@ namespace Apache.Calcite.Linq.Rel
 
             var block = new J.BlockBuilder();
             var translator = RexToLixTranslator
-                .forAggregation(typeFactory, block, null, implementor.Conformance)
+                .forAggregation((JavaTypeFactory)getCluster().getTypeFactory(), block, null, implementor.Conformance)
                 .setCorrelates(implementor.AllCorrelateVariables);
 
             block.add(ClrEnumUtils.Translate(translator, getCall(), null));

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableSpool.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableTableSpool.cs
@@ -76,9 +76,7 @@ namespace Apache.Calcite.Linq.Rel
 
             var result = implementor.VisitChild(this, 0, (ClrEnumerableRel)getInput(), pref);
 
-            // the input's own format, and not re-optimised: a spool writes its input's rows through and
-            // yields them, so its physical type is theirs
-            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), result.Format, false);
+            var physType = PhysTypeImpl.of(implementor.TypeFactory, getRowType(), pref.Prefer(result.Format));
 
             // the table is looked up in the schema the plan is bound with, as Calcite looks it up, rather than
             // read here and held: the collection belongs to the DataContext a run is given, and a plan

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableUncollect.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableUncollect.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 
-using Apache.Calcite.Linq.Tree;
-
 using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.plan;
 using org.apache.calcite.rel;
@@ -114,8 +112,8 @@ namespace Apache.Calcite.Linq.Rel
                     org.apache.calcite.linq4j.tree.Expressions.constant(java.lang.Boolean.valueOf(withOrdinality)),
                     org.apache.calcite.linq4j.tree.Expressions.constant(types));
 
-            var sourceType = ClrTypes.Resolve(result.PhysType.getJavaRowType());
-            var rowType = ClrTypes.Resolve(physType.getJavaRowType());
+            var sourceType = result.PhysType.RowType();
+            var rowType = physType.RowType();
 
             return implementor.Result(physType,
                 Expression.Call(null,

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableUnion.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableUnion.cs
@@ -36,12 +36,10 @@ namespace Apache.Calcite.Linq.Rel
         public virtual ClrEnumerableResult Implement(ClrEnumerableRelImplementor implementor, ClrEnumerablePrefer pref)
         {
             Expression? unionExp = null;
-            ClrEnumerableResult? last = null;
 
             for (int i = 0; i < getInputs().size(); i++)
             {
                 var result = implementor.VisitChild(this, i, (ClrEnumerableRel)getInputs().get(i), pref);
-                last = result;
 
                 if (unionExp == null)
                 {

--- a/src/Apache.Calcite.Linq/Rel/ClrEnumerableWindow.cs
+++ b/src/Apache.Calcite.Linq/Rel/ClrEnumerableWindow.cs
@@ -476,7 +476,7 @@ namespace Apache.Calcite.Linq.Rel
                 var agg = (AggImpState)aggs.get(i);
                 agg.context = new ClrWinAggContext(agg, typeFactory, result.PhysType.getRowType(), constants, exclusion);
 
-                var aggName = $"a{agg.aggIdx}";
+                var aggName = ClrEnumerableAggregateBase.AggName(agg);
                 var state = agg.implementor.getStateType(agg.context);
 
                 var decls = new java.util.ArrayList(state.size());


### PR DESCRIPTION
Stacked on #6.

`RequireRowType` landed in #6 as a guard with nothing to catch, because the tests never built the row it
refuses. This reads every test class Calcite has for `EnumerableConvention` against ours, writes the ones
that were missing, and fixes what they found.

## The row a sequence carries

#6 said a sequence carries the boxed row type and made `Result` the place that says so. Eleven nodes were
corrected there, measured by instrumenting `Result` — which measures the nodes a test reaches. Nine more
were wrong, at nineteen sites, and no test reached any of them: reaching one needs a row that is a single
NOT NULL column, and every set operation, limit and collect in the tests is over a VARCHAR.

`ClrEnumerableSortedAggregate` is the plainest of them. It is a copy of `ClrEnumerableAggregate` that the
earlier pass did not touch, and `SELECT n FROM t GROUP BY n` plans correctly through one and throws through
the other.

`ClrPhysTypes.ConvertTo` had to box its own result too: `PhysType`'s selector answers with the physical
field type — CALCITE-3364's one-column conversion ends in `public int apply(Object[] o)` — and a caller
hands what it gets straight up.

`RequireRowType` no longer returns quietly for a result that is not an `IEnumerable<T>` at all.

## Three defects the ported tests found

**A recursive `UNION` never terminated.** `RepeatUnion` ended a round that read no rows; Calcite ends a
round that returned no row the sequence had not already returned. The iterative part re-reads the whole
spool each round, so it never ran dry. `UNION ALL` was unaffected, which is why all four recursive tests
here passed — all four are `UNION ALL`.

**A converted sub-plan could not see the correlation variables.** The converter runs its input on an
`EnumerableRelImplementor` of Calcite's, which keeps its own map, so a plan of Calcite's under a correlate
of ours read a null getter and threw. That is CALCITE-4054's shape, and it is unavoidable there: a
transient table is read by the interpreter and only Calcite has a node for that.

**A predicated hash join lost the unmatched build rows.** Calcite has two implementations —
`hashEquiJoin_` tracks leftovers per key, `hashJoinWithPredicate_` per row — and this had one, per key. A
right join whose predicate rejected a row that shared a key with one that passed dropped it.

Plus a compound assignment decided by the operator's spelling rather than the operator, a `continue` that
did not advance a `foreach` over an array, and a dead local.

## The harness

Rules to add and to remove, per run. Both conventions sit in one planner and `VolcanoCost` compares the row
count and nothing else, so the planner keeps whichever node it saw first — Calcite's. Three tests here were
comparing Calcite against Calcite, and `ClrEnumerableLimit` had never run. `SameThrough` names the node,
asserts the plan holds it, and takes away whatever the planner would otherwise prefer, from our run alone.

A rel-driven entry point, because `Combine` has no SQL syntax, the POSIX regex operators are not in the
core parser, a transient-table recursion is built with `transientScan`, and a column with its own collation
can only be typed by hand. Calcite reaches all four through `CalciteAssert.withRel`.

And `SCALARS`, one NOT NULL INTEGER column — the row shape no fixture had.

## Coverage

Uncollect 13, Combine 4, Calc 10, StringComparison 6, Correlate 8, RepeatUnion 5, RepeatUnionHierarchy 25,
Join 3, HashJoin 6, BatchNestedLoopJoin 6, MergeUnion 5, LimitSort 5, Window 1, PhysType 1, plus 15 for the
primitive row. 321 Linq tests to 435.

Not ported: `EnumerableCustomAggregateTest`, `EnumerableTableModifyTest`, `RexImplementorTableTest`, the
BigDecimal limit-sort set, the merge-union fetch-pushdown pair, the LISTAGG set and `PhysTypeTest`'s
merge-join comparator are 1.43 and the projects reference 1.42; `PhysTypeTest`'s `fieldClass` pair is about
`PhysTypeImpl`, which is reused rather than ported;
`testCastDifferentCollationShouldNotApplySortProjectTranspose` is about a core rule with no convention in
it; `CodeGeneratorTest`, `StaticFieldDetectorTest` and `TypeFinderTest` are about the Java source Janino
compiles. And `UNNEST(ARRAY[ROW(1, ROW(5, 10)), ...])` throws out of `SqlToRelConverter.flattenTypes`,
which `PlannerImpl` calls before any planning — on the Calcite side of this harness too. Each is written
down where it would have gone.

435 Linq, 275 data, 103 adapter, 11 core, on net8.0 and net10.0.


## Every `implement` against the tag

Each `Rel` here read against its counterpart in `calcite-1.42.0` — the version the projects reference,
taken from `git archive` rather than the working tree. Seven places had drifted, none of them reachable by
a test:

`ClrEnumerableProject.Create` replaced a distribution trait `EnumerableProject.create` does not.
`ClrEnumerableLimit.Create` did not replace the one `EnumerableLimit.create` does, and reached collations
directly rather than through `RelMdCollation`. `ClrEnumerableCollect` skipped its conversion where the
component type was null, which Calcite requires. `ClrEnumerableTableFunctionScan` gave `forAggregation` the
implementor's type factory rather than the cluster's. The `CalciteSystemProperty.DEBUG` prefix on aggregate
state variable names was missing from the aggregate base and the window. And `HasOrderedCall` said such a
call is refused where the node is built — it is not, `ImplementLambdaFactory` answers it, as Calcite's
does.

## `EnumerableSort` names a format it does not produce

The five pass-through nodes — `Sort`, `Limit`, `LimitSort`, `TableSpool`, `RepeatUnion` — were building
their physical type with `optimize: false` where Calcite optimises, and answering their input rather than
`pref`. They now pass Calcite's argument, character for character.

They had been diverging to work around a defect that is Calcite's. `EnumerableSort` optimises a one-field
`ARRAY` to `SCALAR` and hands the `ARRAY` rows on unchanged, so it names a format it does not produce. A
table function cannot reshape what `ScannableTable.scan` gave it, so it keeps an honest `ARRAY` with
`optimize = false`, and the sort above turns that into `SCALAR` without touching a row. Nothing reconciles
the two, in either convention. Calcite reaches a cast and throws `Object[] -> Long`; this convention
refuses earlier, in `RequireRowType`, because a CLR sequence has to name its element type where an erased
`Enumerable` does not. Same defect, caught sooner and with the node named.

Repairing it here was tried three ways — in the five nodes, in the table function scan, and once generally
in the implementor — and each was this project inventing a behaviour Calcite has not got. Measured across
the suite, the general repair fired three times, all in `ClrEnumerableSort`, all `ARRAY Object[] ->
SCALAR`. So it is recorded rather than repaired.

`ClrEnumerableRowFormatTests` holds both refusals side by side, with the plan test that shows the two
conventions choose the same plan — so the difference is in the nodes and not the planning. The fix belongs
in `EnumerableSort`: either it stops optimising a format it is only passing through, or it converts the
rows into the one it names.

**One query stops being answered.** `ShouldRunATableFunctionInAJoin` becomes
`ShouldRefuseATableFunctionInAJoin`, its expected rows kept in a comment to restore when `EnumerableSort`
is fixed. That one has no Calcite oracle at all — `NUMBERS` is a CLR class Janino cannot name, so
`EnumerableConvention` has no plan for it — so this is a capability given up to stay faithful, not a
divergence removed.

435 of 435 Linq tests pass.
