### PR TITLE
Register Calcite's JDBC driver, because expanding a view needs one

### DIFF
--- a/Apache.Calcite.sln
+++ b/Apache.Calcite.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitmodules = .gitmodules
 		Apache.Calcite.dist.msbuildproj = Apache.Calcite.dist.msbuildproj
 		.github\workflows\Apache.Calcite.yml = .github\workflows\Apache.Calcite.yml
+		CLAUDE.md = CLAUDE.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		GitVersion.yml = GitVersion.yml

--- a/src/Apache.Calcite.Data.Tests/CalciteViewTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteViewTests.cs
@@ -1,0 +1,200 @@
+using System;
+
+using Xunit;
+
+namespace Apache.Calcite.Data.Tests
+{
+
+    /// <summary>
+    /// Tests that a view is expanded and queried correctly through the ADO.NET surface.
+    /// </summary>
+    /// <remarks>
+    /// View expansion is supplied by <c>CalcitePreparingStmt.expandView</c>, which the prepare path
+    /// reaches through Calcite's own preparing statement rather than through anything this project
+    /// writes. Nothing else in this suite queries a view, so a change to how the preparing statement is
+    /// constructed could drop view support without a single test failing. These are that test.
+    ///
+    /// <para>Both routes to a view are covered, because they enter at different points: a view declared
+    /// in the model is a <c>ViewTable</c> built by <c>ModelHandler</c> at connection time, while
+    /// <c>CREATE VIEW</c> is a DDL statement executed by <c>ServerDdlExecutor</c> against a live schema.
+    /// Only the second needs the server parser.</para>
+    /// </remarks>
+    public class CalciteViewTests
+    {
+
+        static CalciteViewTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.server.ServerDdlExecutor).Assembly);
+        }
+
+        /// <summary>
+        /// A model whose schema holds nothing but views: one over a VALUES, one over that view, and one
+        /// whose SQL is given as a list of lines.
+        /// </summary>
+        static readonly string ViewModelConnectionString = new CalciteConnectionStringBuilder
+        {
+            Model =
+                "inline:{" +
+                "\"version\":\"1.0\"," +
+                "\"defaultSchema\":\"adhoc\"," +
+                "\"schemas\":[{" +
+                    "\"name\":\"adhoc\"," +
+                    "\"tables\":[" +
+                        // each name is cast inside the VALUES, not after it: a VALUES unifies its literals
+                        // to the widest CHAR, so a bare 'Bob' is padded to the width of 'Alice' and casting
+                        // the padded CHAR to VARCHAR afterwards keeps the spaces
+                        "{\"name\":\"EMPS\",\"type\":\"view\"," +
+                         "\"sql\":\"SELECT * FROM (VALUES (10, CAST('Alice' AS VARCHAR(16)), 3), (20, CAST('Bob' AS VARCHAR(16)), 1), (30, CAST('Carol' AS VARCHAR(16)), 3)) AS T(ID, NAME, DEPTNO)\"}," +
+                        "{\"name\":\"EMPS_IN_3\",\"type\":\"view\"," +
+                         "\"sql\":\"SELECT ID, NAME FROM EMPS WHERE DEPTNO = 3\"}," +
+                        "{\"name\":\"TWO_LINES\",\"type\":\"view\"," +
+                         "\"sql\":[\"SELECT 1 AS X\",\"UNION ALL SELECT 2\"]}" +
+                    "]}]}",
+            Schema = "adhoc",
+        };
+
+        [Fact]
+        public void Model_view_should_be_queryable()
+        {
+            using var c = new CalciteConnection(ViewModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT ID, NAME FROM EMPS ORDER BY ID";
+
+            using var r = cmd.ExecuteReader();
+
+            Assert.True(r.Read());
+            Assert.Equal(10, r.GetInt32(0));
+            Assert.Equal("Alice", r.GetString(1));
+            Assert.True(r.Read());
+            Assert.Equal(20, r.GetInt32(0));
+            Assert.Equal("Bob", r.GetString(1));
+            Assert.True(r.Read());
+            Assert.Equal(30, r.GetInt32(0));
+            Assert.Equal("Carol", r.GetString(1));
+            Assert.False(r.Read());
+        }
+
+        /// <summary>
+        /// A predicate applied over the view has to survive expansion, which is where the view's own plan
+        /// and the caller's are merged rather than stacked.
+        /// </summary>
+        [Fact]
+        public void Model_view_should_expand_under_an_outer_predicate()
+        {
+            using var c = new CalciteConnection(ViewModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT NAME FROM EMPS WHERE DEPTNO = 3 ORDER BY NAME";
+
+            using var r = cmd.ExecuteReader();
+
+            Assert.True(r.Read());
+            Assert.Equal("Alice", r.GetString(0));
+            Assert.True(r.Read());
+            Assert.Equal("Carol", r.GetString(0));
+            Assert.False(r.Read());
+        }
+
+        /// <summary>
+        /// A view defined over another view expands twice.
+        /// </summary>
+        [Fact]
+        public void View_over_a_view_should_expand()
+        {
+            using var c = new CalciteConnection(ViewModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT NAME FROM EMPS_IN_3 ORDER BY NAME";
+
+            using var r = cmd.ExecuteReader();
+
+            Assert.True(r.Read());
+            Assert.Equal("Alice", r.GetString(0));
+            Assert.True(r.Read());
+            Assert.Equal("Carol", r.GetString(0));
+            Assert.False(r.Read());
+        }
+
+        /// <summary>
+        /// A view's row type is the source of the result's column metadata, so it is worth asserting
+        /// separately from the rows: the metadata is built from the validated row type rather than from
+        /// anything the view's plan produces.
+        /// </summary>
+        [Fact]
+        public void Model_view_should_report_column_metadata()
+        {
+            using var c = new CalciteConnection(ViewModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT ID, NAME FROM EMPS";
+
+            using var r = cmd.ExecuteReader();
+
+            Assert.Equal(2, r.FieldCount);
+            Assert.Equal("ID", r.GetName(0));
+            Assert.Equal("NAME", r.GetName(1));
+            Assert.Equal(typeof(int), r.GetFieldType(0));
+            Assert.Equal(typeof(string), r.GetFieldType(1));
+        }
+
+        /// <summary>
+        /// <c>JsonView.sql</c> accepts a list of strings, which are joined with newlines.
+        /// </summary>
+        [Fact]
+        public void Multi_line_view_sql_should_be_concatenated()
+        {
+            using var c = new CalciteConnection(ViewModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT X FROM TWO_LINES ORDER BY X";
+
+            using var r = cmd.ExecuteReader();
+
+            Assert.True(r.Read());
+            Assert.Equal(1, r.GetInt32(0));
+            Assert.True(r.Read());
+            Assert.Equal(2, r.GetInt32(0));
+            Assert.False(r.Read());
+        }
+
+        /// <summary>
+        /// The other route to a view: a DDL statement against a live schema, which needs the server
+        /// parser exactly as <see cref="CalciteDdlTests"/> does.
+        /// </summary>
+        static readonly string ServerDdlConnectionString = new CalciteConnectionStringBuilder
+        {
+            Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
+            ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            Schema = "adhoc",
+        };
+
+        [Fact]
+        public void Created_view_should_be_queryable()
+        {
+            using var c = new CalciteConnection(ServerDdlConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+
+            cmd.CommandText = "CREATE TABLE IF NOT EXISTS \"viewsrc\" (\"id\" INTEGER NOT NULL, \"grp\" INTEGER NOT NULL)";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = "INSERT INTO \"viewsrc\" VALUES (1, 7), (2, 8), (3, 7)";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = "CREATE VIEW \"viewgrp7\" AS SELECT \"id\" FROM \"viewsrc\" WHERE \"grp\" = 7";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = "SELECT \"id\" FROM \"viewgrp7\" ORDER BY \"id\"";
+            using var r = cmd.ExecuteReader();
+
+            Assert.True(r.Read());
+            Assert.Equal(1, r.GetInt32(0));
+            Assert.True(r.Read());
+            Assert.Equal(3, r.GetInt32(0));
+            Assert.False(r.Read());
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -27,6 +27,26 @@ namespace Apache.Calcite.Data.Internal
     {
 
         /// <summary>
+        /// Registers Calcite's JDBC driver, which a view needs and nothing else does.
+        /// </summary>
+        /// <remarks>
+        /// <c>ViewTableMacro.apply</c> reads <c>MaterializedViewTable.MATERIALIZATION_CONNECTION</c>, and
+        /// that field's initializer is <c>DriverManager.getConnection("jdbc:calcite:")</c> — so expanding
+        /// any view, however it was declared, goes through the JDBC driver. Under IKVM nothing had
+        /// registered one, and every view failed at validation.
+        ///
+        /// <para>Both halves are needed. Constructing the <c>Driver</c> runs its static initializer, which
+        /// is what calls <c>register()</c>; and the assembly has to be on the boot class path first,
+        /// because <c>UnregisteredDriver</c> resolves its factory by name through <c>Class.forName</c> and
+        /// cannot see a class that is only in a referenced assembly.</para>
+        /// </remarks>
+        static CalciteSession()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.Driver).Assembly);
+            new org.apache.calcite.jdbc.Driver();
+        }
+
+        /// <summary>
         /// Maps each <see cref="CalciteConnectionStringBuilder"/> key constant to the
         /// corresponding <see cref="CalciteConnectionProperty"/>, which is the authoritative
         /// source of the camelCase property name Calcite expects.


### PR DESCRIPTION
Adding the view coverage that the prepare-pipeline work needs turned up a live defect: **no view works through `Apache.Calcite.Data` at all.**## The defect`ViewTableMacro.apply` reads `MaterializedViewTable.MATERIALIZATION_CONNECTION`, and that field's initializer is `DriverManager.getConnection("jdbc:calcite:")`. So expanding any view goes through the JDBC driver, however the view was declared. Under IKVM nothing had registered one, and every view failed during validation:```MaterializedViewTable..cctor -> DriverManager.getConnection  <- ViewTableMacro.apply  <- CalciteSchema.getTableBasedOnNullaryFunction  <- EmptyScope.resolve_ ... SqlValidatorImpl.validate```Both halves of the fix are needed, and the second only showed up after the first:- Constructing the `Driver` runs its static initializer, which is what calls `register()`.- The assembly has to be on the boot class path first, because `UnregisteredDriver` resolves its factory by name through `Class.forName` and cannot see a class that lives only in a referenced assembly.The registration goes in `CalciteSession`'s static constructor, so it runs before any session can plan.## Why it was invisibleNothing in the suite queried a view — no `CREATE VIEW`, no `views` in any model. `CalciteViewTests` covers both routes in, because they enter at different points: a model view is a `ViewTable` built by `ModelHandler` at connection time, while `CREATE VIEW` is DDL executed by `ServerDdlExecutor` against a live schema. Only the second needs the server parser.Six tests: a model view queried directly; the same view under an outer predicate, where expansion has to merge rather than stack; a view over a view; the list form of `JsonView.sql`; the column metadata a view''s row type produces; and `CREATE TABLE` / `INSERT` / `CREATE VIEW` / `SELECT` end to end.One detail worth keeping: the names in the fixture are cast to `VARCHAR` *inside* the `VALUES`. A `VALUES` unifies its literals to the widest `CHAR`, so a bare `''Bob''` comes back padded to the width of `''Alice''` — and casting the already-padded `CHAR` afterwards keeps the spaces.## Verification`dotnet build Apache.Calcite.sln`, then every suite:| | ||---|---|| `Apache.Calcite.Data.Tests` | 281 passed || `Apache.Calcite.Linq.Tests` | 435 passed || `Apache.Calcite.Adapter.AdoNet.Tests` | 103 passed || `Apache.Calcite.Tests` | 11 passed |This is the prerequisite for the custom Prepare pipeline work, which moves the code that constructs `CalcitePreparingStmt` — the thing that supplies view expansion.