### PR TITLE
Rewrite the design document and the three packaged READMEs against the code

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -2,16 +2,16 @@
 
 [![NuGet](https://img.shields.io/nuget/v/Apache.Calcite.Adapter.AdoNet)](https://www.nuget.org/packages/Apache.Calcite.Adapter.AdoNet)
 
-**Apache.Calcite.Adapter.AdoNet** lets [Apache Calcite](https://calcite.apache.org/) treat any ADO.NET data source as a first-class relational schema. Calcite can then plan and execute federated SQL queries across those sources — pushing filters, projections, joins, aggregations, and sorts down to the underlying database wherever possible.
+**Apache.Calcite.Adapter.AdoNet** lets [Apache Calcite](https://calcite.apache.org/) treat any ADO.NET data source as a first-class relational schema. Calcite can then plan and execute federated SQL queries across those sources — pushing filters, projections, joins, aggregations, sorts, and set operations down to the underlying database wherever possible.
 
-Use this package together with [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) to federate SQL Server, SQLite, PostgreSQL, MySQL, and any other ADO.NET-capable database under a single Calcite connection.
+Use this package together with [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) to federate SQL Server, SQLite, and any other ADO.NET-capable database under a single Calcite connection.
 
 ## How it works
 
-1. You create an `AdoDataSource` (or use one of the built-in subclasses) that describes how to open connections and how to discover the remote schema.
-2. You register it with Calcite — either via a JSON model or programmatically via `SchemaPlus`.
-3. Calcite's planner generates an optimal query plan, pushing as much SQL as possible back to the source using the correct SQL dialect.
-4. Results are merged in-process and delivered through the standard `DbDataReader` API.
+1. You describe the remote database with an `AdoDataSource` — a `DbProviderFactory` plus a connection string, or a .NET 7+ `DbDataSource`.
+2. You register it with Calcite as a schema, either programmatically or through a JSON model.
+3. Calcite's planner produces a query plan, pushing as much SQL as possible back to the source in the right dialect.
+4. Whatever cannot be pushed down runs in-process, and the results arrive through the standard `DbDataReader`.
 
 ## Install
 
@@ -22,153 +22,160 @@ dotnet add package Apache.Calcite.Data
 
 Targets **.NET 8**, and is verified on **.NET 8** and **.NET 10**.
 
-## Quick start — JSON model
-
-Wire up a SQL Server database as a Calcite schema using the JSON model:
-
-```json
-{
-  "version": "1.0",
-  "defaultSchema": "SQLSERVER",
-  "schemas": [
-    {
-      "name": "SQLSERVER",
-      "type": "custom",
-      "factory": "Apache.Calcite.Adapter.AdoNet.AdoSchemaFactory",
-      "operand": {
-        "providerName":      "Microsoft.Data.SqlClient",
-        "connectionString":  "Server=localhost;Database=AdventureWorks;Integrated Security=true",
-        "metadataType":      "SqlServer"
-      }
-    }
-  ]
-}
-```
-
-Then query it normally:
-
-```csharp
-using Apache.Calcite.Data;
-
-await using var conn = new CalciteConnection("Model=path/to/model.json");
-await conn.OpenAsync();
-
-await using var cmd = conn.CreateCommand();
-cmd.CommandText = """
-    SELECT p."ProductID", p."Name", SUM(d."OrderQty") AS "TotalQty"
-    FROM "SQLSERVER"."SalesOrderDetail" d
-    JOIN "SQLSERVER"."Product"          p ON p."ProductID" = d."ProductID"
-    GROUP BY p."ProductID", p."Name"
-    ORDER BY "TotalQty" DESC
-    """;
-
-await using var reader = await cmd.ExecuteReaderAsync();
-while (await reader.ReadAsync())
-    Console.WriteLine($"{reader.GetInt32(0)}\t{reader.GetString(1)}\t{reader.GetInt32(2)}");
-```
-
 ## Quick start — code-driven registration
 
-Register an ADO.NET data source directly on the Calcite root schema without a JSON model:
+`AdoSchema.Create` builds the schema; `SchemaPlus.add` puts it on the connection under a name:
 
 ```csharp
-using System.Data.Common;
 using Apache.Calcite.Adapter.AdoNet;
-using Apache.Calcite.Adapter.AdoNet.Metadata;
 using Apache.Calcite.Data;
-using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
 
-// 1. Describe the data source.
-var factory    = SqlClientFactory.Instance;
-var connString = "Server=localhost;Database=AdventureWorks;Integrated Security=true";
-var metadata   = new SqlServerDatabaseMetadata(
-    new SqlClientDataSource(connString));   // DbDataSource from Microsoft.Data.SqlClient
-
-var dataSource = new DbProviderAdoDataSource(factory, connString, metadata);
+// 1. Any DbDataSource will do. The matching metadata provider is chosen for you.
+var dataSource = SqliteFactory.Instance.CreateDataSource("Data Source=sales.db");
 
 // 2. Open a Calcite connection and attach the schema.
-await using var conn = new CalciteConnection();
+await using var conn = new CalciteConnection("Lex=JAVA;CaseSensitive=false");
 await conn.OpenAsync();
 
-AdoSchema.Register(conn.RootSchema, "AW", dataSource);
+var root = conn.RootSchema;
+root.add("ADO", AdoSchema.Create(root, "ADO", dataSource, null, null));
 
-// 3. Query across schemas.
+// 3. Query it.
 await using var cmd = conn.CreateCommand();
-cmd.CommandText = """
-    SELECT "Name" FROM "AW"."Product" WHERE "ListPrice" > ? ORDER BY "Name"
-    """;
-cmd.Parameters.Add(new CalciteParameter("price", 500m));
+cmd.CommandText = "SELECT NAME FROM ADO.EMPS WHERE SALARY > ? ORDER BY NAME";
+cmd.Parameters.Add(new CalciteParameter("salary", 100.0));
 
 await using var reader = await cmd.ExecuteReaderAsync();
 while (await reader.ReadAsync())
     Console.WriteLine(reader.GetString(0));
 ```
 
-## Federated query across two databases
+The last two arguments to `AdoSchema.Create` are the database and schema name to restrict discovery to; pass `null` for either to take the source's default. Overloads accept an `AdoDataSource`, an `AdoDatabaseMetadata`, or an `AdoDatabaseMetadataFactory` where you need to choose the metadata provider yourself.
 
-One of the key strengths of Calcite is federating queries across completely different databases:
+## Quick start — JSON model
+
+The adapter can also be named from a [Calcite model](https://calcite.apache.org/docs/model.html). **Two things are required and neither is obvious:**
+
+- The `factory` value must be the IKVM name of the CLR class — `cli.` followed by its .NET full name. Calcite resolves a model's factory through Java's `Class.forName`, which does not know a bare .NET type name.
+- The assembly must be on IKVM's boot class path *before* the connection is opened, because `Class.forName` cannot see a type that is only in a referenced assembly.
 
 ```csharp
-// Attach two data sources under different schema names.
-AdoSchema.Register(conn.RootSchema, "SQL",    sqlServerDataSource);
-AdoSchema.Register(conn.RootSchema, "SQLITE", sqliteDataSource);
+// Once, at startup — before opening any connection that uses the model.
+ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
+DbProviderFactories.RegisterFactory("Microsoft.Data.Sqlite", SqliteFactory.Instance);
+```
 
-// Join them in a single SQL statement — Calcite handles the cross-source planning.
+```json
+{
+  "version": "1.0",
+  "defaultSchema": "ADO",
+  "schemas": [
+    {
+      "name": "ADO",
+      "type": "custom",
+      "factory": "cli.Apache.Calcite.Adapter.AdoNet.AdoSchemaFactory",
+      "operand": {
+        "adoProviderName": "Microsoft.Data.Sqlite",
+        "adoConnectionString": "Data Source=sales.db"
+      }
+    }
+  ]
+}
+```
+
+```csharp
+await using var conn = new CalciteConnection($"Model=inline:{model};Lex=JAVA;CaseSensitive=false");
+await conn.OpenAsync();
+```
+
+### Operand reference
+
+| Operand | Required | Meaning |
+|---------|----------|---------|
+| `adoProviderName` | yes, unless `adoDataSource` is given | Invariant name registered with `DbProviderFactories`. |
+| `adoConnectionString` | yes, with `adoProviderName` | Connection string handed to that factory. |
+| `adoDataSource` | — | Assembly-qualified .NET type name of a `DbDataSource` with a parameterless constructor. Used instead of the two above. |
+| `adoDatabaseMetadata` | — | Assembly-qualified .NET type name of an `AdoDatabaseMetadata` to use instead of the detected one. |
+| `adoDatabaseMetadataFactory` | — | Assembly-qualified .NET type name of an `AdoDatabaseMetadataFactory`. |
+| `adoDatabase` | — | Restrict discovery to one database. |
+| `adoSchema` | — | Restrict discovery to one schema. |
+
+A missing `adoProviderName` or `adoConnectionString` throws `AdoCalciteException`, and so does a type name that cannot be loaded.
+
+## Federated query across two databases
+
+Federating across unrelated databases is the point of the adapter:
+
+```csharp
+var root = conn.RootSchema;
+root.add("SQL",    AdoSchema.Create(root, "SQL",    sqlServerDataSource, null, null));
+root.add("SQLITE", AdoSchema.Create(root, "SQLITE", sqliteDataSource,    null, null));
+
 await using var cmd = conn.CreateCommand();
 cmd.CommandText = """
-    SELECT s."CustomerId", s."Name", COUNT(o."OrderId") AS "Orders"
-    FROM   "SQL"."Customers"  s
-    JOIN   "SQLITE"."Orders"  o ON o."CustomerId" = s."CustomerId"
-    GROUP BY s."CustomerId", s."Name"
+    SELECT s.CustomerId, s.Name, COUNT(o.OrderId) AS Orders
+    FROM   SQL.Customers  s
+    JOIN   SQLITE.Orders  o ON o.CustomerId = s.CustomerId
+    GROUP BY s.CustomerId, s.Name
     """;
 ```
 
-## Built-in metadata implementations
+Each side is pushed to its own database as far as it can go, and the join runs in-process.
 
-The adapter ships provider-specific `AdoDatabaseMetadata` subclasses that configure the correct SQL dialect, quoting style, and schema-discovery queries for each database:
+## Provider support
 
-| Class | Database |
-|-------|----------|
-| `SqlServerDatabaseMetadata` | Microsoft SQL Server |
-| `SqliteDatabaseMetadata` | SQLite |
-| `OdbcDatabaseMetadata` | Generic ODBC sources |
-| `OleDbDatabaseMetadata` | Generic OLE DB sources |
-| `AdoInformationSchemaDatabaseMetadata` | Any database exposing an `INFORMATION_SCHEMA` |
+`AdoDatabaseMetadataFactoryImpl` — the default, used when you do not name one — inspects the connection the data source produces and selects a metadata provider:
 
-For databases not listed above, extend `AdoDatabaseMetadata` to supply the correct `SqlDialect`, table enumeration, and column-type mappings.
+| Connection type | Discovery |
+|---|---|
+| `Microsoft.Data.SqlClient.SqlConnection`, `System.Data.SqlClient.SqlConnection` | SQL Server, via `INFORMATION_SCHEMA` |
+| `Microsoft.Data.Sqlite.SqliteConnection` | SQLite |
+| `System.Data.Odbc.OdbcConnection` | Generic ODBC, via `INFORMATION_SCHEMA` |
+| `System.Data.OleDb.OleDbConnection` | Generic OLE DB, via `INFORMATION_SCHEMA` |
 
-## Key types
+Anything else throws `AdoCalciteException` naming the connection type. To support it, derive from `AdoDatabaseMetadata` — the abstract base that supplies the `SqlDialect`, table and column enumeration, and type mapping — and pass your implementation to an `AdoSchema.Create` overload, or name it in the `adoDatabaseMetadata` operand. The built-in implementations are internal; `AdoDatabaseMetadata` and `AdoDatabaseMetadataFactory` are the extension points.
+
+## Key public types
 
 | Type | Purpose |
 |------|---------|
+| `AdoSchema` | The Calcite `Schema` that enumerates tables from a data source. `AdoSchema.Create(...)` is how you build one. |
+| `AdoSchemaFactory` | The `SchemaFactory` a JSON model names. |
 | `AdoDataSource` | Abstract base — implement to connect Calcite to any ADO.NET source. |
-| `DbProviderAdoDataSource` | `AdoDataSource` backed by a `DbProviderFactory` and a connection string. |
-| `DbDataSourceAdoDataSource` | `AdoDataSource` backed by a .NET 7+ `DbDataSource`. |
-| `AdoSchema` | The Calcite `Schema` implementation that enumerates tables from a data source. |
-| `AdoDatabaseSchema` | Represents a single database-level schema within the adapter. |
-| `AdoSchemaFactory` | `SchemaFactory` used to instantiate `AdoSchema` from a Calcite model JSON. |
-| `AdoDatabaseMetadata` | Abstract base for schema/column/dialect discovery. |
+| `DbProviderAdoDataSource` | `AdoDataSource` over a `DbProviderFactory`, a connection string, and an `AdoDatabaseMetadata`. |
+| `DbDataSourceAdoDataSource` | `AdoDataSource` over a .NET 7+ `DbDataSource` and an `AdoDatabaseMetadata`. |
+| `AdoDatabaseMetadata` | Abstract base for schema, column, and dialect discovery. |
+| `AdoDatabaseMetadataFactory` | Chooses the metadata provider for a data source. `AdoDatabaseMetadataFactoryImpl.Instance` is the default. |
+| `AdoDatabaseSchema` | A single database-level schema within the adapter. |
+| `AdoConvention` | The calling convention a pushed-down subtree is planned into. |
+| `AdoRules` | The adapter's conversion rules. |
+| `DbCommandEnricher` | Hook for adjusting each `DbCommand` before it runs. |
+| `AdoCalciteException` | What the adapter throws. |
 
 ## Pushdown support
 
-The adapter includes Calcite conversion rules for the following relational operators, which are pushed to the source as SQL when the dialect supports them:
+The adapter provides Calcite conversion rules for these operators, which become SQL against the source when the dialect supports them:
 
 - `AdoFilter` — `WHERE` predicates
 - `AdoProject` — column projections
 - `AdoJoin` — inner and outer joins
-- `AdoAggregate` — `GROUP BY` / aggregate functions
-- `AdoSort` — `ORDER BY` / `LIMIT` / `OFFSET`
+- `AdoAggregate` — `GROUP BY` and aggregate functions
+- `AdoSort` — `ORDER BY`, `LIMIT`, `OFFSET`
 - `AdoUnion` / `AdoIntersect` / `AdoMinus` — set operations
 - `AdoValues` — constant value sets
+- `AdoTableScan` — the scan itself
 
-Any operator that cannot be pushed down is executed in-process by Calcite's enumerable runtime.
+Anything that cannot be pushed down runs in-process. Converters exist into both execution conventions — `AdoToClrEnumerableConverter` for the compiled-.NET convention that `Apache.Calcite.Data` plans into, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under either.
+
+Correlated sub-queries are supported: `AdoCorrelationDataContext` carries the outer row's values into the inner query.
 
 ## Related packages
 
 | Package | Purpose |
 |---------|---------|
-| [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) | The core ADO.NET provider — required to open connections and execute SQL. |
-| [`Apache.Calcite.Extensions`](https://www.nuget.org/packages/Apache.Calcite.Extensions) | .NET helper types for Calcite connection properties and IKVM interop. |
+| [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) | The ADO.NET provider — required to open connections and execute SQL. |
+| [`Apache.Calcite.Extensions`](https://www.nuget.org/packages/Apache.Calcite.Extensions) | The calling convention plans are compiled into, the prepare pipeline behind it, and the IKVM interop helpers. |
 
 ## Further reading
 

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -1,187 +1,310 @@
 # Apache.Calcite.Data — Design
 
 `Apache.Calcite.Data` is an ADO.NET provider for Apache Calcite. It exposes Calcite to .NET
-applications through the standard `System.Data.Common` abstractions while running Calcite's
-planner and runtime in-process via IKVM.
+applications through the standard `System.Data.Common` abstractions while running Calcite's parser,
+validator and planner in-process via IKVM.
 
-This document describes how the provider is structured and how a request flows from a .NET
-caller into the Calcite engine and back.
+A statement is not handed to Calcite's own prepare framework. `Apache.Calcite.Extensions` owns the
+pipeline that takes SQL text to a chosen plan and compiles that plan into a
+`System.Linq.Expressions` tree; this project drives that pipeline and adapts what comes back to
+`DbDataReader`. Janino never runs.
+
+This document describes how the provider is structured and how a statement flows from a .NET caller
+into Calcite and back.
 
 ---
 
 ## Scope
 
-- **Driver/provider**, not an adapter. The provider is the consumer's entry point into Calcite,
-  not a way to expose ADO.NET data sources to Calcite.
-- **Native in-process engine.** Calcite's Java code is loaded through IKVM and called directly.
-  The provider does **not** wrap Calcite's JDBC driver, Avatica, or any remote protocol.
-- **JDBC parity at the behavior level.** Connection properties, model handling, SQL execution,
-  and metadata semantics aim to match the Calcite JDBC driver, but the public surface is
-  idiomatic .NET (`Db*` base classes, PascalCase, `IDisposable`).
+- **Driver/provider**, not an adapter. The provider is the consumer's entry point into Calcite, not
+  a way to expose ADO.NET data sources to Calcite. (`Apache.Calcite.Adapter.AdoNet` is the other
+  direction.)
+- **Native in-process engine.** Calcite's Java code is loaded through IKVM and called directly. The
+  provider does not go through Calcite's JDBC driver on the statement path and speaks no Avatica
+  wire protocol.
+- **JDBC parity at the behavior level.** Connection properties, model handling, SQL execution and
+  metadata semantics aim to match the Calcite JDBC driver, but the public surface is idiomatic .NET
+  (`Db*` base classes, PascalCase, `IDisposable`).
+
+### What is still Calcite's, and named honestly
+
+Three things carry Java names through this design and are not going away:
+
+- **Avatica's metadata value types.** `ColumnMetaData`, `AvaticaParameter`, `Meta.CursorFactory` and
+  `Meta.StatementType` come from `org.apache.calcite.avatica`, and the prepare pipeline produces
+  them because that is what Calcite's own prepare produces. They are plain descriptors. Nothing here
+  constructs an Avatica `Meta`, a service, or a connection.
+- **`CalcitePrepare.Context` and `CalcitePrepare.Dummy`.** `PrepareContext` implements the former —
+  it is the interface Calcite's validator, catalog reader and `SqlToRelConverter` read the schema,
+  type factory and configuration from. The latter is a thread-local stack Calcite's own parse-to-rel
+  reads the context off, so `CalciteSession.Plan` pushes onto it for the duration of a prepare.
+  `CalcitePrepare.DEFAULT_FACTORY` and `prepareSql` are never called.
+- **Calcite's JDBC driver, registered once, for views.** `CalciteSession`'s static constructor puts
+  `org.apache.calcite.jdbc.Driver`'s assembly on IKVM's boot class path and constructs one.
+  `ViewTableMacro.apply` reads `MaterializedViewTable.MATERIALIZATION_CONNECTION`, whose initializer
+  is `DriverManager.getConnection("jdbc:calcite:")` — so expanding any view, however declared, goes
+  through the driver. Without the registration every view fails at validation. No statement executed
+  by this provider goes through it.
 
 ---
 
 ## Layered Architecture
 
-The implementation is organized as a small set of layers with clear responsibilities. The
-public ADO.NET surface only sees the engine through an interface; the engine is the only thing
-that touches Calcite's Java types directly.
-
 ### 1. ADO.NET Surface
 
-Public, consumer-facing classes that implement the `System.Data.Common` contracts.
+Public, consumer-facing classes implementing the `System.Data.Common` contracts.
 
 | Class | Base | Role |
 | --- | --- | --- |
-| `CalciteConnection` | `DbConnection` | Owns connection state, opens/closes the engine session, exposes Calcite-native accessors. |
-| `CalciteCommand` | `DbCommand` | Holds SQL text and parameters, executes against the connection's session. |
-| `CalciteDataReader` | `DbDataReader` | Streams rows produced by an `ICalciteResult`. |
-| `CalciteParameter` / `CalciteParameterCollection` | `DbParameter` / `DbParameterCollection` | Provider parameter model. |
-| `CalciteTransaction` | `DbTransaction` | Transaction handle (semantics bounded by Calcite). |
+| `CalciteConnection` | `DbConnection` | Owns connection state and the `CalciteSession`; exposes Calcite-native accessors and hook registration. |
+| `CalciteCommand` | `DbCommand` | Holds SQL text and parameters; builds a `CalciteExecuteRequest` and calls the session. |
+| `CalciteDataReader` | `DbDataReader` | Streams rows out of one or more `CalciteResult`s; `NextResult` walks a batch's results. |
+| `CalciteBatch` / `CalciteBatchCommand` / `CalciteBatchCommandCollection` | `DbBatch` / `DbBatchCommand` / `DbBatchCommandCollection` | Runs several statements sequentially on one session. |
+| `CalciteParameter` / `CalciteParameterCollection` | `DbParameter` / `DbParameterCollection` | Provider parameter model. Placeholders are positional `?`; `ParameterName` is informational. |
+| `CalciteTransaction` | `DbTransaction` | Exists to satisfy frameworks that require a non-null transaction. `Commit` and `Rollback` throw `NotSupportedException`, and `BeginDbTransaction` throws before one is ever handed out. |
+| `CalciteDataSource` | `DbDataSource` | The `DbDataSource` entry point. |
 | `CalciteProviderFactory` | `DbProviderFactory` | Standard ADO.NET factory registration. |
-| `CalciteConnectionStringBuilder` | `DbConnectionStringBuilder` | Strongly typed connection string keys (`Model`, `Schema`, `CaseSensitive`, `Conformance`, …). |
-| `CalciteException` | `DbException` | Provider-specific failures, including engine errors. |
+| `CalciteConnectionStringBuilder` | `DbConnectionStringBuilder` | Typed connection-string keys (`Model`, `Schema`, `CaseSensitive`, `Conformance`, …). Unknown keys are preserved and forwarded. |
+| `CalciteException` | `DbException` | Provider failures, including planning and execution errors. |
 
-`CalciteConnection` also exposes Calcite-native accessors directly so consumers can interact
-with the engine without an `Unwrap`-style escape hatch:
+`CalciteConnection` also exposes Calcite-native objects directly, so there is no `Unwrap`-style
+escape hatch:
 
 - `RootSchema` → `org.apache.calcite.schema.SchemaPlus`
 - `TypeFactory` → `org.apache.calcite.adapter.java.JavaTypeFactory`
 - `Config` → `org.apache.calcite.config.CalciteConnectionConfig`
 
-These properties throw `InvalidOperationException` if the connection is not open.
+All three go through `RequireSession()` and throw `InvalidOperationException` when the connection is
+not open.
 
-### 2. Session Boundary
+`CalciteConnection` and `CalciteCommand` each carry `RegisterHook` overloads — for a Java
+`Consumer`, for an `Action<object>`, and for each primitive, which are wrapped in `Hook.propertyJ`.
+The connection's hooks and the command's are concatenated per request, connection first.
 
-`CalciteSession` is the per-connection runtime state created when `CalciteConnection.Open()`
-succeeds. It is the boundary between the public ADO.NET surface and the internal Calcite
-engine.
+### 2. Session (`Internal/CalciteSession`)
 
-- Holds the resolved `CalciteConnectionStringBuilder` and the `ICalciteClient` for the open
-  connection.
-- Owns the engine client lifetime; disposing the session disposes the client.
-- Accessed internally through `CalciteConnection.RequireSession()`, which enforces that the
-  connection is open.
+`CalciteSession` is the per-connection engine state, created on the first `CalciteConnection.Open()`
+and kept alive across `Close`/`Open` cycles — a schema registered on `RootSchema` or a table created
+by DDL survives a close. `Dispose` is what ends it, and only marks the session disposed so later
+execute calls throw `ObjectDisposedException`.
 
-### 3. Engine Abstraction (`ICalciteClient`)
+Construction, from the `CalciteConnectionStringBuilder`:
 
-`ICalciteClient` is the internal contract between the ADO.NET surface and the Calcite engine.
-It hides the concrete implementation so the surface layer never references Calcite Java types
-directly through internal flows (it only does so when the public connection deliberately
-re-exposes them).
+- Builds the root schema with `CalciteSchema.createRootSchema(addMetadataSchema: true)`, then
+  applies the `Model` key through Calcite's `ModelHandler` — either `inline:`-prefixed (or
+  brace-leading) JSON, or a file path, which must exist. The handler's `defaultSchemaName()` wins
+  over the `Schema` key.
+- Builds a `java.util.Properties` from every remaining key, translating each to the camelCase name
+  Calcite expects via a static map from connection-string key to `CalciteConnectionProperty`, and
+  wraps it in a `CalciteConnectionConfigImpl`.
+- Creates a `JavaTypeFactoryImpl`, and resolves the default schema path to zero or one name.
 
-The interface exposes:
+Anything thrown here that is not already a `CalciteException` is wrapped in one.
 
-- `RootSchema`, `TypeFactory`, `Config` — engine state surfaced upward to `CalciteConnection`.
-- `ExecuteAsync(CalciteExecuteRequest, CancellationToken)` — executes a prepared SQL request
-  and returns an `ICalciteResult` row stream.
+The session exposes three private steps and two public entry points.
 
-### 4. Engine Implementation (`CalciteEngineClient`)
+**`Plan`** constructs a `PrepareContext`, pushes it onto `CalcitePrepare.Dummy`, and calls
+`ClrPrepareImpl.Prepare(ctx, sql, Object[], -1)`, returning a `ClrSignature`. The element type is
+what makes the pipeline ask for array-shaped rows; `-1` means no row limit. Nothing is executed and
+no per-statement state is created.
 
-`CalciteEngineClient` is the only component that drives Calcite directly. It takes the place
-of `CalciteConnectionImpl`, `CalciteStatement`, and `CalciteResultSet` from the JDBC driver,
-but it does so without depending on Avatica or any JDBC plumbing.
+**`Bind`** builds the execution-time `DataContext`: a fresh `AtomicBoolean` cancel flag, the
+positional parameters converted by `ParameterBinder`, the command timeout in milliseconds, and
+`signature.InternalParameters` — assembled into one `StatementDataContext`. This mirrors what
+`CalciteConnectionImpl.enumerable()` does immediately before `signature.enumerable(dataContext)`.
 
-Construction:
+**`ActivateHooks` / `DeactivateHooks`** bind each `CalciteHookEntry` to the current thread with
+`Hook.addThread` for the duration of one request and close the handles in a `finally`.
 
-- Builds the root schema from the connection options via `RootSchemaBuilder`.
-- Creates a `CalciteConnectionConfigImpl` from engine properties produced by the same builder.
-- Creates a `JavaTypeFactoryImpl`.
-- Resolves the default schema path from the `Schema` connection option.
+**`ExecuteReaderAsync`** plans, binds, and — unless the statement is DDL — takes
+`signature.Bind(dataContext).GetEnumerator()`. It returns a `CalciteResult` holding the signature,
+that enumerator, and a records-affected count of `0`. The cancel flag is discarded on this path:
+`cancellationToken` is only checked before planning, and cancelling it afterwards does not interrupt
+enumeration.
 
-Execution:
+**`ExecuteNonQueryAsync`** plans and binds, then branches on `signature.StatementType`:
 
-1. Validates the request and cancellation token.
-2. Constructs a `StatementDataContext` and a `PrepareContext` that mirror what the JDBC driver
-   builds internally (root schema, type factory, config, default schema path, cancel flag, and
-   command timeout).
-3. Calls `CalcitePrepare.DEFAULT_FACTORY` to obtain a prepare instance and invokes
-   `prepareSql(...)` while the prepare context is pushed onto Calcite's thread-local stack.
-4. Materializes the result `Enumerable`, registers cancellation against the cancel flag, and
-   wraps the `Enumerator`, signature, and column mapping in a `CalciteEngineResult`.
-5. Surfaces engine errors as `CalciteException`, leaving cancellation/disposal exceptions
-   unwrapped.
+- DDL (`CREATE`, `ALTER`, `DROP`, `OTHER_DDL`, dispatched on `name()`) has already taken effect
+  during prepare, so there is nothing to enumerate and the count is `0`.
+- `SELECT` reports `-1`, by ADO.NET convention.
+- DML drains the enumerator. Here — and only here, where the enumeration is synchronous and
+  Calcite's check-points can see it — the cancellation token is registered against the cancel flag,
+  scoped to the drain. Because the plan was prepared for `Object[]` rows, the single row's element
+  `[0]` is the `ROWCOUNT BIGINT` column of `RelOptUtil.createDmlRowType`, read through a `ToInt64`
+  that accepts a Java boxed number or a CLR primitive.
 
-### 5. Result Stream (`ICalciteResult` / `CalciteEngineResult`)
+Both entry points wrap any non-`CalciteException` failure in a `CalciteException`.
 
-`ICalciteResult` represents an active row stream. `CalciteEngineResult` adapts Calcite's
-`Enumerator`, the prepared signature, and the column metadata into something the ADO.NET
-reader can consume. It also owns the cancellation registration produced during execution and
-disposes it with the result.
+### 3. Prepare pipeline (`Apache.Calcite.Extensions/Prepare`)
 
-### 6. Type Mapping & Materialization
+This is where a statement becomes a plan. It replaces `CalcitePrepareImpl`'s driver and nothing
+below it: validation, sql-to-rel, view expansion, field trimming and `optimize` are Calcite's own,
+reused as they stand. The driver had to be replaced because its one exit is a `Bindable` — a linq4j
+`Enumerable` — and a plan of `ClrEnumerableConvention` is a compiled delegate.
 
-- `ColumnAdapter` translates the columns described by a `CalcitePrepare.CalciteSignature` into
-  `CalciteColumn` descriptors (name, ordinal, Calcite/CLR types).
-- `CalciteTypeMap` centralizes the mapping between Calcite SQL types and CLR types, including
-  nullability, precision/scale, temporal types, and binary data.
-- `RowMaterializer` converts a single Calcite row (typically `Object[]`) into the values
-  surfaced by `CalciteDataReader`'s typed getters.
+| Type | Counterpart in Calcite | Role |
+| --- | --- | --- |
+| `ClrPrepareImpl` | `CalcitePrepareImpl.prepare_` / `prepare2_` | The driver. Builds the catalog reader, the planner and the preparing statement; parses; executes DDL; describes the result. |
+| `ClrPrepare` | `Prepare` | The algorithm: convert, checked arithmetic, flatten, decorrelate, trim, optimize, implement — with `EXPLAIN`'s two exits where Calcite has them. Knows nothing of a cluster or a schema. |
+| `ClrPreparingStmt` | `CalcitePrepareImpl.CalcitePreparingStmt` | The wiring: cluster, convertlet table, schema, validator, view expansion. Also the `RelOptTable.ViewExpander` given to `SqlToRelConverter`. |
+| `ClrEnumerablePreparingStmt` | — | What one convention adds: the result convention, the program, the root trait set, and the compiler. A second convention writes only these four. |
+| `ClrPrepareResult` | `Prepare.PreparedResult` | What preparing produces, less `getBindable`. |
+| `ClrEnumerablePrepareResult` | `PreparedResultImpl` (anonymous, in `implement`) | Carries an `IClrBindable`. |
+| `ClrExplainResult` / `ClrExplainBindable` | `Prepare.PreparedExplain` / `CalcitePreparedExplain.getBindable` | An `EXPLAIN`: the text is rendered at prepare time and yielded as one row. |
+| `ClrSignature` | `CalcitePrepare.CalciteSignature` | The planned statement, member for member, with `Bindable` swapped for `IClrBindable` and `enumerable` for `Bind`. |
 
-### 7. Parameters
+`ClrPrepareImpl.Prepare` is the entry point this provider uses. It creates a `VolcanoPlanner` with
+`RelOptUtil.registerDefaultRules` **plus** `ClrEnumerableRules.Rules()` — Calcite's own rules stay
+on the planner, so a statement this convention has no node for is still planned and run in
+`EnumerableConvention`, with a converter carrying its rows. That is how a table modification works
+here. `PrepareRel`, the second entry point, plans a `RelNode` that was built rather than parsed; it
+is exercised by tests and not reached from this project.
 
-- `CalciteParameter` / `CalciteParameterCollection` implement the standard ADO.NET parameter
-  model.
-- `CalciteParameterValue` normalizes parameter values for the engine prior to execution.
-- `CalciteExecuteRequest` is the payload consumed by `ICalciteClient.ExecuteAsync`, capturing
-  the SQL text, parameter values, and command-level options such as the timeout.
+A DDL statement is executed inside `Prepare2` rather than planned, exactly as Calcite does. The
+`ClrSignature` it returns has no row type, no columns, a null bindable, `CursorFactory.OBJECT` and
+`StatementType.OTHER_DDL`.
 
-### 8. Configuration
+`Describe` builds one `AvaticaParameter` per dynamic parameter and one `ColumnMetaData` per result
+column, deduces the `CursorFactory` from the columns and the compiled plan's element type, and
+assembles the `ClrSignature`. All of that metadata is ported rather than reused: every piece of it
+is a private static of `CalcitePrepareImpl`.
 
-- `CalciteConnectionStringBuilder` defines the supported keys and provides typed accessors
-  while preserving any unknown keys for the engine.
-- `RootSchemaBuilder` (engine-internal) consumes the builder to produce both the
-  `CalciteSchema` and the engine properties used to build `CalciteConnectionConfigImpl`.
+`ClrSignature.Bind(DataContext)` runs the plan and returns `IEnumerable<object>`, applying the row
+limit when `MaxRowCount` is not negative — the limit lives on the signature, not on the bindable, so
+a caller reaching past it would silently lose it. This provider always passes `-1`.
 
-### 9. Diagnostics & Errors
+`IClrBindable` (in `Apache.Calcite.Extensions/Runtime`) is the compiled plan: `Bind(DataContext)`
+returning rows, plus the `ElementType` the cursor factory is deduced from. It merges Calcite's
+`Bindable` and `Typed`.
 
-- `CalciteException` is the provider-specific exception type. The engine wraps non-cancellation
-  failures in `CalciteException` so callers see a single, consistent error type from the
-  provider.
-- Cancellation surfaces as `OperationCanceledException` propagated from the cancel flag.
-- `ObjectDisposedException` is thrown if the engine client is used after disposal.
+### 4. Execution contexts (`Apache.Calcite.Extensions/Prepare`)
+
+- **`PrepareContext`** implements `CalcitePrepare.Context` over the session's type factory, root
+  schema, config and default schema path. `getDataContext()` returns a throwaway
+  `StatementDataContext` with only the timestamp variables, which is what backs `RexExecutorImpl`
+  for constant folding during optimisation — the same thing `CalciteConnectionImpl.ContextImpl`
+  does. `getRelRunner()` throws `UnsupportedOperationException`.
+- **`StatementDataContext`** implements `DataContext` for execution. It holds the root schema, the
+  type factory, the well-known per-statement variables (`utcTimestamp`, `currentTimestamp`,
+  `localTimestamp`, `sysTimestamp`, `cancelFlag`, `queryTimeout`), the values stashed at plan time
+  through `signature.InternalParameters`, and the bound positional parameters, which Calcite
+  addresses as `?0`, `?1`, …. `getQueryProvider()` returns `Linq4j.DEFAULT_PROVIDER`, the non-JDBC
+  equivalent of the delegation `CalciteConnectionImpl` performs.
+
+### 5. Result stream (`Internal/CalciteResult` and friends)
+
+`CalciteResult` is what an execute call hands back: the `ClrSignature`, a
+`CalciteResultColumns` built from it, an `IEnumerator<object>?`, and a records-affected count. The
+enumerator is the plan's own — a compiled delegate returns it — so nothing stands between a row and
+the reader. `ReadAsync` advances it and wraps the current row in a `CalciteResultRow`; a null
+enumerator (DDL, or a non-query) reads as an empty result. `Dispose` disposes the enumerator, and
+holds nothing else.
+
+`CalciteResultColumns` reads the signature's Avatica `ColumnMetaData` list — name, nullability,
+provider type name — and maps each to a CLR type. The SQL type name takes precedence over the
+runtime representation for date, time and binary columns, because Calcite's `rep` there is the
+internal storage form (`int` days, `long` millis, `ByteString`) rather than what an ADO.NET consumer
+expects. Unsigned SQL types map to the unsigned CLR types. `GetSqlType` reads the signature's
+`RelDataType` instead, and throws where there is none.
+
+`CalciteResultRow` addresses a column within one row without copying it, dispatching on the cursor
+factory's style: `OBJECT` (a one-column result is the value, so only ordinal `0` is valid), `ARRAY`,
+or `LIST`. Any other style throws `NotSupportedException`.
+
+`CalciteResultValue` is the final conversion, from what Calcite produced to what the caller asked
+for: `GetValue` for the reader's untyped path, `GetFieldValue<T>` for the generic one, and a typed
+getter per ADO.NET accessor. Each typed getter is strict — it accepts the representations Calcite
+actually produces for that SQL type and throws `InvalidCastException` otherwise, naming the runtime
+type, the value and the SQL type. `BigDecimalConverter` carries `java.math.BigDecimal` to and from
+`decimal`.
+
+`CalciteDataReader` holds an array of `CalciteResult`s and delegates every accessor to
+`ActiveResult.Current.GetValue(ordinal)`. `NextResult` disposes the result it leaves and advances.
+
+### 6. Parameters
+
+- `CalciteParameter` / `CalciteParameterCollection` implement the ADO.NET parameter model. Where
+  `DbType` was not set explicitly it is inferred from the value's CLR type by `CalciteTypeMap`.
+- `CalciteParameterValue` is the `(DbType, object?)` pair carried into the request.
+- `CalciteExecuteRequest` is the payload the session executes: SQL text, an
+  `ImmutableArray<CalciteParameterValue>` in placeholder order, the command timeout in seconds, and
+  the request's hooks. It also carries `ClampToInt32`, which the `ExecuteNonQuery` surfaces use to
+  narrow a `long` row count.
+- `ParameterBinder` converts each value to the representation Calcite's runtime expects — Java boxed
+  primitives, `BigDecimal`, `ByteString`, `joou` unsigned types, and the internal forms for
+  temporals: days since epoch for `DATE`, milliseconds since epoch for `TIMESTAMP`, milliseconds
+  since midnight for `TIME`. Where the `DbType` is `Object` or unrecognised it infers from the CLR
+  type instead.
+
+### 7. Metadata and configuration
+
+- `CalciteConnectionStringBuilder` defines the supported keys and preserves unknown ones;
+  `CalciteSession` is what turns it into a `Properties` and a `CalciteConnectionConfigImpl`.
+- `CalciteSchemaInfo` builds the `DataTable`s behind `DbConnection.GetSchema` —
+  `MetaDataCollections` and `Restrictions` without a session, and `DataSourceInformation`,
+  `DataTypes`, `ReservedWords`, `Tables` and `Columns` from an open one.
+- `CalciteTypeMap` maps between `DbType` and CLR types for the parameter surface. Result columns do
+  not go through it; `CalciteResultColumns` maps those from the Avatica metadata.
+
+### 8. Diagnostics and errors
+
+- `CalciteException` is the provider's exception type. The session wraps every non-`CalciteException`
+  planning or execution failure in one, so a caller sees a single error type.
+- `ObjectDisposedException` is thrown when a disposed session or result is used.
+- Cancellation is honoured before planning on both paths, and during the drain of a DML statement.
+  It is not wired to a reader's enumeration.
 
 ---
 
 ## End-to-End Execution Flow
 
-A typical query traverses the layers in the following order:
+**A query.**
 
-1. **Construct.** Caller creates a `CalciteConnection` (directly or through
-   `CalciteProviderFactory`) with a connection string.
-2. **Open.** `CalciteConnection.Open()` parses the connection string into a
-   `CalciteConnectionStringBuilder`, asks `CalciteClientFactory` to create an `ICalciteClient`
-   (a `CalciteEngineClient` today), and stores both in a new `CalciteSession`.
-3. **Build command.** Caller creates a `CalciteCommand`, sets `CommandText`, and adds
-   parameters. The command is bound to the connection.
-4. **Execute.** `ExecuteReader` / `ExecuteScalar` / `ExecuteNonQuery` builds a
-   `CalciteExecuteRequest` (SQL, parameters, timeout) and calls
-   `RequireSession().Client.ExecuteAsync(...)`.
-5. **Engine prepare.** `CalciteEngineClient` builds the prepare/data contexts and invokes
-   `CalcitePrepare.prepareSql` to obtain a `CalciteSignature`.
-6. **Engine execute.** The signature's `Enumerable` is materialized into an `Enumerator`,
-   cancellation is wired to the cancel flag, and the enumerator is returned inside a
-   `CalciteEngineResult`.
-7. **Read.** `CalciteDataReader` wraps the result and exposes rows through typed getters,
-   using `ColumnAdapter`/`CalciteTypeMap`/`RowMaterializer` to convert values to CLR types.
-8. **Dispose.** Disposing the reader releases the engine result (and its cancellation
-   registration). Closing/disposing the connection disposes the session, which disposes the
-   engine client.
+1. **Construct.** The caller creates a `CalciteConnection` (directly, through
+   `CalciteProviderFactory`, or from a `CalciteDataSource`) with a connection string.
+2. **Open.** `Open()` creates the `CalciteSession` on first call: root schema, model, config, type
+   factory, default schema path.
+3. **Build command.** The caller sets `CommandText` and adds parameters to a `CalciteCommand`.
+4. **Request.** `ExecuteReader` builds a `CalciteExecuteRequest` from the text, the parameters, the
+   timeout and the resolved hooks, and calls `CalciteSession.ExecuteReaderAsync`.
+5. **Plan.** The session pushes a `PrepareContext` onto `CalcitePrepare.Dummy` and calls
+   `ClrPrepareImpl.Prepare`, which parses, validates, converts to relational algebra, optimises into
+   `ClrEnumerableConvention`, and compiles the chosen plan to a delegate. The result is a
+   `ClrSignature`.
+6. **Bind.** Parameters are converted and assembled with the cancel flag, the timeout and the
+   signature's internal parameters into a `StatementDataContext`.
+7. **Execute.** `signature.Bind(dataContext).GetEnumerator()` is taken and wrapped in a
+   `CalciteResult`. Nothing has been enumerated yet.
+8. **Read.** `CalciteDataReader` pulls rows through `CalciteResult.ReadAsync`, and each accessor
+   goes `CalciteResultRow` → `CalciteResultValue` → CLR value.
+9. **Dispose.** Disposing the reader disposes the result and its enumerator. Disposing the
+   connection disposes the session.
+
+**A non-query** follows steps 1–6, then branches on the statement type as described above and
+returns a `CalciteResult` with a count and no enumerator.
+
+**DDL** never reaches step 7: it took effect during step 5, and the signature it produced has no
+plan to bind.
+
+**`EXPLAIN`** never reaches `Implement`. `ClrPrepare.PrepareSql` renders the plan or the type as
+text and returns a `ClrExplainResult`; `Describe` wraps that text in a `ClrExplainBindable`, which
+yields one row.
 
 ---
 
 ## Direct Engine Access
 
-`CalciteConnection` deliberately exposes selected Calcite-native objects as public properties
-instead of providing a JDBC-style `unwrap` API. This keeps the contract typed and discoverable
-while still allowing advanced consumers to:
+`CalciteConnection` exposes selected Calcite-native objects as public properties rather than
+providing a JDBC-style `unwrap`. This keeps the contract typed and discoverable while letting
+advanced consumers register schemas, tables, functions and views on `RootSchema`, build types with
+`TypeFactory`, and inspect resolved configuration through `Config`.
 
-- Register schemas, tables, functions, and views on `RootSchema`.
-- Build types using `TypeFactory`.
-- Inspect resolved configuration through `Config`.
+A user-defined function written in .NET works here and in no plan Janino compiles: IKVM names a CLR
+class `cli.Namespace.Type`, which `EnumerableConvention` would write into generated Java source and
+Janino cannot resolve. This convention holds the method rather than its name.
 
-The provider does not currently expose the prepare/plan APIs publicly; those remain inside
-`CalciteEngineClient`.
+The prepare and plan APIs are not exposed on the ADO.NET surface. A caller who wants them references
+`Apache.Calcite.Extensions` and uses `ClrPrepareImpl` directly.
 
 ---
 
@@ -189,44 +312,71 @@ The provider does not currently expose the prepare/plan APIs publicly; those rem
 
 ```
 src/
-  Apache.Calcite.Data/                ADO.NET provider (this design)
-    CalciteConnection.cs              Public DbConnection + native engine accessors
-    CalciteCommand.cs                 Public DbCommand
-    CalciteDataReader.cs              Public DbDataReader
-    CalciteParameter.cs               Public DbParameter
-    CalciteParameterCollection.cs     Public DbParameterCollection
-    CalciteTransaction.cs             Public DbTransaction
-    CalciteProviderFactory.cs         Public DbProviderFactory
-    CalciteConnectionStringBuilder.cs Public DbConnectionStringBuilder
-    CalciteException.cs               Public provider exception
-    CalciteSession.cs                 Internal per-connection state
-    ICalciteClient.cs                 Internal engine contract
-    CalciteEngineClient.cs            Internal Calcite-backed engine
-    CalciteClientFactory.cs           Internal engine factory
-    CalciteExecuteRequest.cs          Internal execute payload
-    ICalciteResult.cs                 Internal result handle
-    CalciteEngineResult.cs            Internal Calcite result adapter
-    CalciteColumn.cs                  Internal column descriptor
-    ColumnAdapter.cs                  Internal signature → column mapping
-    CalciteTypeMap.cs                 Internal SQL ↔ CLR type mapping
-    RowMaterializer.cs                Internal row materialization
-    StatementDataContext.cs           Internal Calcite DataContext implementation
-    PrepareContext.cs                 Internal Calcite Context implementation
-    RootSchemaBuilder.cs              Internal schema/config builder
-    CalciteParameterValue.cs          Internal parameter normalization
-  Apache.Calcite.Data.Tests/          xUnit test suite
+  Apache.Calcite.Data/                    ADO.NET provider (this design)
+    CalciteConnection.cs                  DbConnection, native accessors, hook registration
+    CalciteCommand.cs                     DbCommand
+    CalciteDataReader.cs                  DbDataReader over one or more results
+    CalciteBatch.cs                       DbBatch
+    CalciteBatchCommand.cs                DbBatchCommand
+    CalciteBatchCommandCollection.cs      DbBatchCommandCollection
+    CalciteParameter.cs                   DbParameter
+    CalciteParameterCollection.cs         DbParameterCollection
+    CalciteTransaction.cs                 DbTransaction (Commit/Rollback throw)
+    CalciteDataSource.cs                  DbDataSource
+    CalciteProviderFactory.cs             DbProviderFactory
+    CalciteConnectionStringBuilder.cs     DbConnectionStringBuilder
+    CalciteException.cs                   DbException
+    Internal/
+      CalciteSession.cs                   Per-connection engine state; plan, bind, execute
+      CalciteExecuteRequest.cs            Execute payload
+      CalciteParameterValue.cs            (DbType, value) pair
+      ParameterBinder.cs                  CLR value → Calcite runtime representation
+      BigDecimalConverter.cs              decimal ↔ java.math.BigDecimal
+      CalciteResult.cs                    Row stream over a ClrSignature
+      CalciteResultColumns.cs             Avatica ColumnMetaData → ADO.NET column metadata
+      CalciteResultRow.cs                 Column addressing within one row, by cursor style
+      CalciteResultValue.cs               Final value conversion and typed getters
+      CalciteTypeMap.cs                   DbType ↔ CLR type, for parameters
+      CalciteSchemaInfo.cs                GetSchema collections
+      CalciteHookEntry.cs                 (Hook, Consumer) pair
+      CalciteColumn.cs                    Unreferenced
+
+  Apache.Calcite.Extensions/              The convention and the prepare pipeline
+    Prepare/
+      ClrPrepareImpl.cs                   The driver: parse, plan, execute DDL, describe
+      ClrPrepare.cs                       The algorithm, less any wiring
+      ClrPreparingStmt.cs                 Cluster, validator, view expansion
+      ClrPrepareResult.cs                 What preparing produces
+      ClrSignature.cs                     The planned statement
+      ClrExplainResult.cs                 EXPLAIN, rendered at prepare time
+      ClrExplainBindable.cs               …and yielded as one row
+      PrepareContext.cs                   CalcitePrepare.Context
+      StatementDataContext.cs             DataContext for execution
+      Enumerable/
+        ClrEnumerablePreparingStmt.cs     Convention, program, traits, compiler
+        ClrEnumerablePrepareResult.cs     Carries the IClrBindable
+    Runtime/IClrBindable.cs               The compiled plan
+    Adapter/Enumerable/                   ClrEnumerableConvention: nodes, rules, implementor
+    Linq4j/, Interop/                     linq4j → System.Linq.Expressions, Java ↔ CLR values
+
+  Apache.Calcite.Data.Tests/              xUnit tests for this provider
+  Apache.Calcite.Tests/                   xUnit tests for the convention and the pipeline
 ```
 
 ---
 
 ## Design Constraints
 
-- **No JDBC dependency.** The provider must not call into `org.apache.calcite.avatica.*` or
-  Calcite's JDBC entry points. It uses `CalcitePrepare`, `CalciteSchema`, `SchemaPlus`,
-  `JavaTypeFactory`, and `CalciteConnectionConfig` directly.
-- **Layer isolation.** The ADO.NET surface only talks to the engine through `ICalciteClient`
-  (plus the deliberate re-exposure of three engine objects on `CalciteConnection`). The
-  engine implementation never reaches back into the public surface.
-- **Idiomatic .NET.** Public types follow .NET naming and `IDisposable` conventions. JDBC
-  concepts are translated, not copied verbatim.
-- **Targeting.** The provider targets .NET 8 (C# 12).
+- **Nothing on the statement path goes through JDBC or Avatica plumbing.** Calcite's JDBC driver is
+  registered once, for view expansion, and no statement executed here reaches it. Avatica's
+  `ColumnMetaData`, `AvaticaParameter` and `Meta.*` are used as the metadata value types Calcite's
+  prepare produces, and nothing more.
+- **No `Bindable` and no `PreparedResult` on the row path.** A plan is a compiled delegate behind
+  `IClrBindable`; `ClrSignature` and `ClrPrepareResult` exist because Calcite's equivalents are
+  declared in terms of the linq4j types this convention does not produce.
+- **The ADO.NET surface owns no engine logic.** Everything that touches Calcite's planner is in
+  `CalciteSession` and below it. The `Internal` types are reachable from the public surface; the
+  reverse does not happen.
+- **Idiomatic .NET.** Public types follow .NET naming and `IDisposable` conventions. JDBC concepts
+  are translated, not copied.
+- **Targeting.** The provider targets .NET 8, and is verified on .NET 8 and .NET 10.

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -4,11 +4,11 @@
 
 **Apache.Calcite.Data** is a native, in-process ADO.NET provider for [Apache Calcite](https://calcite.apache.org/) — the SQL parser, optimizer, and execution framework that powers many leading database and data-virtualization products.
 
-The Calcite engine runs directly inside your .NET process via [IKVM](https://github.com/ikvmnet/ikvm). There is no JDBC driver, no Avatica server, and no separate process. SQL flows from your `DbConnection` straight into Calcite's planner.
+The Calcite engine runs directly inside your .NET process via [IKVM](https://github.com/ikvmnet/ikvm). There is no Avatica server, no wire protocol, and no separate process — your `DbCommand` goes straight into Calcite's planner and the rows come straight back.
 
 ## Why use this?
 
-- **Standard ADO.NET** — works with any code that understands `DbConnection` / `DbCommand` / `DbDataReader`, including Dapper, EF Core conventions, and generic data-access layers.
+- **Standard ADO.NET** — works with any code that understands `DbConnection` / `DbCommand` / `DbDataReader`, including Dapper and generic data-access layers.
 - **Federated queries** — join CSV files, in-memory collections, REST adapters, JDBC databases, and custom Calcite schemas in a single SQL statement.
 - **Rich SQL** — standards-conformant SQL with window functions, lateral joins, `MATCH_RECOGNIZE`, and much more.
 - **Code-driven schemas** — register .NET objects as Calcite schemas, tables, and user-defined functions at runtime via the `SchemaPlus` API; no JSON model required.
@@ -17,7 +17,7 @@ The Calcite engine runs directly inside your .NET process via [IKVM](https://git
 
 ## Supported platforms
 
-Targets **.NET 8** and is verified on **.NET 8** and **.NET 10**.
+Targets **.NET 8**, and is verified on **.NET 8** and **.NET 10**.
 
 ## Install
 
@@ -60,12 +60,14 @@ while (await reader.ReadAsync())
 
 ## Quick start — model file
 
-Point `Model` at a JSON file on disk:
+Point `Model` at a JSON file on disk. The file must exist, or `Open` throws:
 
 ```csharp
 await using var conn = new CalciteConnection("Model=path/to/model.json;Schema=SALES");
 await conn.OpenAsync();
 ```
+
+If the model declares a `defaultSchema`, it wins over the `Schema` connection-string key.
 
 ## Parameterized queries
 
@@ -100,9 +102,32 @@ cmd.CommandText = "SELECT * FROM \"MEM\".\"USERS\" ORDER BY \"ID\"";
 await using var reader = await cmd.ExecuteReaderAsync();
 ```
 
+Objects registered this way live as long as the connection object does. Closing and reopening the connection keeps them — see [Connection lifetime](#connection-lifetime).
+
+## Batches
+
+`CalciteBatch` runs several statements sequentially on one connection:
+
+```csharp
+await using var batch = conn.CreateBatch();
+
+var insert = batch.CreateBatchCommand();
+insert.CommandText = "INSERT INTO \"T\" VALUES (1, 'a')";
+batch.BatchCommands.Add(insert);
+
+var update = batch.CreateBatchCommand();
+update.CommandText = "UPDATE \"T\" SET \"NAME\" = 'b' WHERE \"ID\" = 1";
+batch.BatchCommands.Add(update);
+
+var total = await batch.ExecuteNonQueryAsync();          // cumulative rows affected
+var first = batch.BatchCommands[0].RecordsAffected;      // per-command count
+```
+
+`ExecuteReader` on a batch produces one result set per command; call `NextResult` to advance between them.
+
 ## Using `DbDataSource` (.NET 7+)
 
-`CalciteDataSource` implements the modern `DbDataSource` pattern for dependency-injection and pooled-connection scenarios:
+`CalciteDataSource` implements the modern `DbDataSource` pattern for dependency-injection scenarios:
 
 ```csharp
 using Apache.Calcite.Data;
@@ -132,28 +157,64 @@ conn.ConnectionString = "Model=path/to/model.json";
 await conn.OpenAsync();
 ```
 
+## Connection lifetime
+
+The Calcite session is created on the **first** `Open()` and reused for the life of the `CalciteConnection` object.
+
+- `Close()` only moves the connection to the `Closed` state. Schemas registered on `RootSchema`, tables created by DDL, and every other in-process artifact survive it and are visible again after the next `Open()`.
+- `Dispose()` is what tears the session down.
+- `ConnectionString` cannot be changed once the connection has been opened. Create a new `CalciteConnection` for different settings.
+
+## Behaviour worth knowing
+
+**Transactions are not supported.** `BeginTransaction` throws `NotSupportedException`, as do `CalciteTransaction.Commit` and `Rollback`. The type exists only so frameworks that require a non-null `DbTransaction` can be satisfied. `EnlistTransaction` throws too.
+
+**`CommandType.Text` only.** Setting any other `CommandType` throws `NotSupportedException`. There is no stored-procedure concept in Calcite.
+
+**Cancellation is coarse.** A `CancellationToken` is observed before a statement is planned. On a DML statement it is also wired to Calcite's cancel flag while the rows are drained. It is **not** wired to a reader's enumeration — cancelling the token after `ExecuteReaderAsync` has returned does not stop `ReadAsync` from producing more rows. `DbCommand.Cancel()` is a no-op.
+
+**`ExecuteNonQuery` return values** follow ADO.NET convention: `-1` for a `SELECT`, `0` for DDL, and the row count Calcite reports for `INSERT` / `UPDATE` / `DELETE` / `MERGE`.
+
+**DDL runs at prepare time.** A `CREATE` or `DROP` has already taken effect by the time the call returns, and produces no rows. DDL also needs a parser that understands it — set `parserFactory=org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl#FACTORY`.
+
+**Materialized views are not substituted**, whatever `materializationsEnabled` says. Calcite builds them through a package-private class this provider cannot reach.
+
+**`spark=true` does nothing here.** This provider never enables a Spark handler; a plan of its convention is an expression tree, not generated Java source.
+
+**A one-column result is the value, not a row of one.** `GetValue(0)` returns it directly.
+
 ## Connection string reference
 
-All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Unknown keys are preserved and forwarded to the engine.
+All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Keys are matched case-insensitively, and unknown keys are preserved and forwarded to the engine.
 
-| Key | Type | Description |
-|-----|------|-------------|
-| `Model` | `string` | Path/URI to a Calcite model JSON file, or `inline:<json>` for an embedded model. |
-| `Schema` | `string` | Default schema name when identifiers are unqualified. |
-| `CaseSensitive` | `bool` | Whether identifier lookup is case-sensitive (default: `true`). |
-| `Conformance` | `string` | SQL conformance level: `DEFAULT`, `STRICT_2003`, `PRAGMATIC_2003`, etc. |
-| `Lex` | `string` | Lexical policy: `ORACLE` (default), `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`. |
-| `Quoting` | `string` | Quote style: `DOUBLE_QUOTE`, `BACK_TICK`, `BACK_TICK_BACKSLASH`, `BRACKET`. |
-| `QuotedCasing` | `string` | How quoted identifiers are stored: `UNCHANGED`, `TO_UPPER`, `TO_LOWER`. |
-| `UnquotedCasing` | `string` | How unquoted identifiers are stored: `UNCHANGED`, `TO_UPPER`, `TO_LOWER`. |
-| `Fun` | `string` | Extra function libraries: `standard` (default), `oracle`, `spatial`, or comma-separated combinations. |
-| `TimeZone` | `string` | Session time zone, e.g. `UTC` or `gmt-3`. Defaults to the JVM time zone. |
-| `Conformance` | `string` | SQL conformance level. |
-| `DefaultNullCollation` | `string` | How NULLs sort when `NULLS FIRST`/`NULLS LAST` is not specified. Default: `HIGH` (Oracle behaviour). |
-| `ForceDecorrelate` | `bool` | Whether the planner aggressively de-correlates subqueries (default: `true`). |
-| `MaterializationsEnabled` | `bool` | Whether the planner may use materializations (default: `false`). |
-| `TypeCoercion` | `bool` | Whether implicit type coercion is applied during validation (default: `true`). |
-| `parserFactory` | `string` | Custom SQL parser factory class, e.g. `org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl#FACTORY`. |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `Model` | `string` | — | Path to a Calcite model JSON file, or `inline:<json>` for an embedded model. |
+| `Schema` | `string` | — | Default schema name when identifiers are unqualified. |
+| `Lex` | `string` | `ORACLE` | Lexical policy: `ORACLE`, `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`. |
+| `CaseSensitive` | `bool` | from `Lex` | Whether identifier lookup is case-sensitive. |
+| `Quoting` | `string` | from `Lex` | Quote style: `DOUBLE_QUOTE`, `BACK_TICK`, `BACK_TICK_BACKSLASH`, `BRACKET`. |
+| `QuotedCasing` | `string` | from `Lex` | How quoted identifiers are stored: `UNCHANGED`, `TO_UPPER`, `TO_LOWER`. |
+| `UnquotedCasing` | `string` | from `Lex` | How unquoted identifiers are stored: `UNCHANGED`, `TO_UPPER`, `TO_LOWER`. |
+| `Conformance` | `string` | `DEFAULT` | SQL conformance level: `DEFAULT`, `STRICT_2003`, `PRAGMATIC_2003`, … |
+| `Fun` | `string` | `standard` | Extra function libraries: `oracle`, `spatial`, or comma-separated combinations. |
+| `DefaultNullCollation` | `string` | `HIGH` | How NULLs sort when `NULLS FIRST`/`NULLS LAST` is not specified. |
+| `TimeZone` | `string` | JVM default | Session time zone, e.g. `UTC` or `gmt-3`. |
+| `TypeCoercion` | `bool` | `true` | Whether implicit type coercion is applied during validation. |
+| `ForceDecorrelate` | `bool` | `true` | Whether the planner aggressively de-correlates subqueries. |
+| `MaterializationsEnabled` | `bool` | `true` | Whether the planner may use materializations. None are supplied here — see above. |
+| `CreateMaterializations` | `bool` | `true` | Whether materializations are created on the fly. |
+| `ApproximateDecimal` | `bool` | `false` | Allow approximate DECIMAL aggregate results. |
+| `ApproximateDistinctCount` | `bool` | `false` | Allow approximate `COUNT(DISTINCT ...)`. |
+| `ApproximateTopN` | `bool` | `false` | Allow approximate Top-N results. |
+| `DruidFetch` | `int` | `16384` | Rows the Druid adapter fetches at a time. |
+| `Spark` | `bool` | `false` | Ignored by this provider. |
+| `SchemaFactory` | `string` | — | Schema factory class name, when not using a model. |
+| `SchemaType` | `string` | — | Schema type: `MAP`, `JDBC`, or `CUSTOM`. |
+| `TypeSystem` | `string` | — | Type system class name. |
+| `parserFactory` | `string` | — | Custom SQL parser factory, e.g. `org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl#FACTORY`. |
+
+Defaults are Calcite's own, from `CalciteConnectionProperty` in the version this package references (1.42).
 
 ## Identifier casing
 
@@ -181,17 +242,26 @@ await using var conn = new CalciteConnection("Model=inline:{...};Lex=MYSQL_ANSI"
 
 ## How queries are executed
 
-Every plan is compiled into a `System.Linq.Expressions` tree and run as .NET code. Calcite's own engine
-generates Java source and compiles it at runtime with Janino; this provider does not, so no Java compiler
-runs when your query is prepared, and a user-defined function written in .NET can be called straight from
-a plan.
+Every plan is compiled into a `System.Linq.Expressions` tree and run as .NET code. Calcite's own engine generates Java source and compiles it at runtime with Janino; this provider does not, so no Java compiler runs when your query is prepared, and a user-defined function written in .NET can be called straight from a plan.
 
-There is nothing to configure, and nothing to switch off — this provider owns the prepare pipeline rather
-than subclassing Calcite's, so a statement never goes through `CalcitePrepare` and never produces a
-`Bindable`.
+There is nothing to configure and nothing to switch off. This provider owns the prepare pipeline rather than subclassing Calcite's: it never calls `CalcitePrepare.prepareSql`, and a statement never produces a Calcite `Bindable`. The rows a reader returns come from the compiled delegate's own enumerator, with nothing in between.
 
-A single plan may still use both engines. Anything the .NET convention has no implementation for is
-planned by Calcite as usual, and rows cross between the two untouched.
+A single plan may still use both engines. Anything the .NET convention has no rule for is planned by Calcite as usual, and rows cross between the two untouched.
+
+## Diagnostics
+
+Calcite's `Hook` points can be attached for the duration of every statement on a connection, or of one command:
+
+```csharp
+using org.apache.calcite.runtime;
+
+conn.RegisterHook(Hook.PLAN_BEFORE_IMPLEMENTATION, plan => Console.WriteLine(plan));
+cmd.RegisterHook(Hook.PROGRAM, /* ... */);
+```
+
+Overloads accept a Java `Consumer`, a .NET `Action<object>`, or a primitive value to set as the hook's property. Connection hooks run before command hooks.
+
+`EXPLAIN PLAN FOR <query>` also works, and returns the rendered plan as a single row.
 
 ## Accessing the Calcite engine directly
 
@@ -203,7 +273,11 @@ planned by Calcite as usual, and rows cross between the two untouched.
 | `TypeFactory` | `org.apache.calcite.adapter.java.JavaTypeFactory` | Construct Calcite `RelDataType` instances. |
 | `Config` | `org.apache.calcite.config.CalciteConnectionConfig` | Inspect resolved connection configuration. |
 
-These properties are only valid while the connection is open.
+These properties are only valid while the connection is open; otherwise they throw `InvalidOperationException`.
+
+## Errors
+
+Planning and execution failures surface as `CalciteException`, a `DbException`, with the underlying Calcite or Java exception as `InnerException`.
 
 ## Related packages
 

--- a/src/Apache.Calcite.Extensions/README.md
+++ b/src/Apache.Calcite.Extensions/README.md
@@ -2,11 +2,11 @@
 
 [![NuGet](https://img.shields.io/nuget/v/Apache.Calcite.Extensions)](https://www.nuget.org/packages/Apache.Calcite.Extensions)
 
-**Apache.Calcite.Extensions** is what .NET adds on top of Apache Calcite running under [IKVM](https://github.com/ikvmnet/ikvm): a calling convention that runs a query plan as compiled .NET code, the prepare pipeline that takes a statement from SQL text to such a plan, and the interop types both need.
+**Apache.Calcite.Extensions** is what .NET adds on top of [Apache Calcite](https://calcite.apache.org/) running under [IKVM](https://github.com/ikvmnet/ikvm): a calling convention that runs a query plan as compiled .NET code, the prepare pipeline that takes a statement from SQL text to such a plan, and the interop types both need.
 
 No Java compiler runs when a statement is prepared, and a .NET user-defined function can be called from SQL.
 
-It is used by [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) and [`Apache.Calcite.Adapter.AdoNet`](https://www.nuget.org/packages/Apache.Calcite.Adapter.AdoNet). Reference it directly to plan and run statements without an ADO.NET connection.
+Most people get this package as a dependency of [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) or [`Apache.Calcite.Adapter.AdoNet`](https://www.nuget.org/packages/Apache.Calcite.Adapter.AdoNet) and never call it directly — every statement on a `CalciteConnection` is already planned and run this way, with nothing to configure. Reference it yourself when you want to drive Calcite's planner without an ADO.NET connection, or want typed access to Calcite's connection properties.
 
 Targets **.NET 8**, and is verified on **.NET 8** and **.NET 10**.
 
@@ -25,15 +25,77 @@ This package replaces that step. A query plan is compiled into a `System.Linq.Ex
 - **No Java compiler runs when you prepare a statement.**
 - **A .NET method can be a SQL function.** Janino cannot resolve the `cli.`-prefixed name IKVM gives a CLR class, so a .NET user-defined function does not work under Calcite's own engine. It works here.
 
-If you are using [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) you already have this — every statement on a `CalciteConnection` is planned and run this way, with no code change and nothing to configure.
+`ClrEnumerableConvention` mirrors Calcite's `EnumerableConvention` node for node and uses the same row types, and converter rules exist in both directions. A plan may hold nodes of both conventions: anything this convention has no rule for is planned by Calcite as usual, and rows cross between the two untouched.
 
-Reference this package directly when you want typed access to Calcite's connection properties, or to plan and run a statement without an ADO.NET connection.
+## Running a plan yourself
 
-## Key types
+Plan into the convention with `ClrEnumerablePrograms`, then compile the root with `ClrEnumerableRelImplementor`. This example is executed by a test in the repository, so it cannot go stale silently:
 
-### `CalciteConnectionProperties`
+```csharp
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+using org.apache.calcite;
+using org.apache.calcite.tools;
 
-Provides strongly-typed .NET properties over a Calcite `java.util.Properties` map. Instead of reading and writing raw string keys, you get compile-time-checked access to every Calcite connection option:
+var config = Frameworks.newConfigBuilder()
+    .defaultSchema(rootSchema)
+    .programs(ClrEnumerablePrograms.Standard())
+    .build();
+
+var planner = Frameworks.getPlanner(config);
+var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+
+// Standard() is three passes, in this order: sub-query expansion, the planner, then the calc rules.
+var expanded = planner.transform(0, logical.getTraitSet(), logical);
+var traits = ClrEnumerablePrograms.DesiredRootTraitSet(planner.getEmptyTraitSet());
+var chosen = planner.transform(1, traits, expanded);
+var physical = (ClrEnumerableRel)planner.transform(2, chosen.getTraitSet(), chosen);
+
+// the root is a node of this convention; build its plan and compile it
+var implementor = new ClrEnumerableRelImplementor(
+    physical.getCluster().getRexBuilder(), new java.util.HashMap());
+var lambda = implementor.ImplementRoot(physical, ClrEnumerablePrefer.Array);
+var plan = (Func<DataContext, System.Collections.IEnumerable>)lambda.Compile();
+
+foreach (var current in plan(dataContext))
+{
+    // a one-column result is the value itself, not a row of one
+    var row = current as object[] ?? [current];
+    Console.WriteLine(string.Join('\t', row));
+}
+```
+
+`ClrEnumerableInterpretable.ToBindable(...)` is the alternative ending: it does the same work and hands back an `IClrBindable`, which you bind to a `DataContext` and enumerate. Use the implementor when you want the `LambdaExpression` itself.
+
+Two things about `ClrEnumerablePrograms.Standard()` are deliberate and worth knowing before you substitute your own program list:
+
+- **The calc rules are a separate pass.** `VolcanoCost.isLt` compares row counts and nothing else, so a project and a calc are never cheaper than one another and the planner keeps whichever it saw first. Rewriting unconditionally afterwards as a hep pass is what makes a project's refusal to implement itself safe. `Programs.standard()` does the same thing for the same reason.
+- **There is no decorrelation.** `Programs.standard()` runs one, and it rewrites a correlated sub-query into a join before the planner sees it — which is the node `ClrEnumerableCorrelate` exists to implement. Leaving it out is what puts a correlate on a plan at all.
+
+A Spark handler is not supported: `ToBindable` throws `UnsupportedOperationException` if one is enabled, because a Spark handler compiles generated Java source and a plan of this convention is an expression tree.
+
+## Key public types
+
+| Type | Purpose |
+|------|---------|
+| `ClrEnumerableConvention` | The calling convention itself. `ClrEnumerableConvention.Instance` is the singleton trait. |
+| `ClrEnumerablePrograms` | The planner passes: `Standard()`, and the individual `SubQuery()` / `Rules()` / `CalcRules()` passes. Also `DesiredRootTraitSet`. |
+| `ClrEnumerableRules` | The convention's rules: `Rules()` and `CalcRules()`. Add these to a planner you built yourself. |
+| `ClrEnumerableRelImplementor` | Builds the expression tree for a plan. `ImplementRoot` returns a `LambdaExpression`. |
+| `ClrEnumerableInterpretable` | `ToBindable` — implement, compile, and return an `IClrBindable`. |
+| `IClrBindable` | A compiled plan. `Bind(DataContext)` returns the rows; `ElementType` says what one row is. |
+| `ClrEnumerablePrefer` | How a caller wants rows represented — `Array` is what a prepared statement asks for. |
+| `ClrEnumerableRelFactories` | `RelBuilder` factories producing nodes of this convention. |
+| `ClrEnumerableRel` | The interface every node of this convention implements. |
+| `CalciteConnectionProperties` | Typed .NET properties over Calcite's `java.util.Properties`. |
+| `CalciteConnectionPropertiesSchemaMap` | The `schema.*` sub-properties, as a dictionary. |
+
+The nodes (`ClrEnumerableCalc`, `ClrEnumerableHashJoin`, `ClrEnumerableWindow`, and the rest) and their rules are public too, so you can subclass or re-register them.
+
+**The SQL-text prepare pipeline is internal to these packages.** `ClrPrepareImpl`, `ClrSignature` and the rest of `Apache.Calcite.Extensions.Prepare` are not part of the public API surface — `Apache.Calcite.Data` reaches them through `InternalsVisibleTo`. To run SQL text, use `Apache.Calcite.Data`; to drive the planner directly, use the public types above.
+
+## `CalciteConnectionProperties`
+
+Strongly-typed .NET properties over a Calcite `java.util.Properties` map. Instead of reading and writing raw string keys, you get compile-time-checked access to Calcite's connection options:
 
 ```csharp
 using Apache.Calcite.Extensions.Config;
@@ -52,13 +114,11 @@ props.ForceDecorrelate     = true;
 props.MaterializationsEnabled = false;
 ```
 
-Available properties mirror every `CalciteConnectionProperty` enum value:
-
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `Model` | `string` | — | URI or inline JSON model. |
 | `Schema` | `string` | — | Default schema name. |
-| `CaseSensitive` | `bool` | `true` | Case-sensitive identifier matching. |
+| `CaseSensitive` | `bool` | from `Lex` (`true` under `ORACLE`) | Case-sensitive identifier matching. |
 | `Lex` | `Lex` | `ORACLE` | Lexical policy (`ORACLE`, `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`). |
 | `Quoting` | `Quoting` | from `Lex` | Identifier quote character. |
 | `QuotedCasing` | `Casing?` | from `Lex` | Storage of quoted identifiers. |
@@ -67,24 +127,31 @@ Available properties mirror every `CalciteConnectionProperty` enum value:
 | `Conformance` | `SqlConformanceEnum` | `DEFAULT` | SQL conformance level. |
 | `DefaultNullCollation` | `NullCollation` | `HIGH` | NULL sort order when `NULLS FIRST`/`LAST` is omitted. |
 | `TimeZone` | `string` | JVM default | Session time zone. |
-| `Locale` | `string` | JVM default | Session locale. |
+| `Locale` | `string` | `Locale.ROOT` | Session locale. |
 | `ForceDecorrelate` | `bool` | `true` | Aggressive subquery de-correlation. |
-| `MaterializationsEnabled` | `bool` | `false` | Use materializations in the planner. |
+| `MaterializationsEnabled` | `bool` | `true` | Use materializations in the planner. |
+| `CreateMaterializations` | `bool` | `true` | Create materializations on the fly. |
 | `TypeCoercion` | `bool` | `true` | Implicit type coercion during validation. |
 | `ApproximateDecimal` | `bool` | `false` | Allow approximate DECIMAL aggregate results. |
 | `ApproximateDistinctCount` | `bool` | `false` | Allow approximate `COUNT(DISTINCT ...)`. |
 | `ApproximateTopN` | `bool` | `false` | Allow approximate Top-N results. |
+| `AutoTemp` | `bool` | `false` | Store query results in a temporary table. |
+| `NullEqualToEmpty` | `bool` | `true` | Treat empty strings as null, for the Druid adapter. |
 | `Spark` | `bool` | `false` | Use Spark as the in-process execution engine. |
-| `TopdownOpt` | `bool` | `false` | Enable top-down optimization in the Volcano planner. |
+| `TopdownOpt` | `bool` | `calcite.planner.topdown.opt` | Enable top-down optimization in the Volcano planner. |
 | `LenientOperatorLookup` | `bool` | `false` | Silently create unknown functions during parsing. |
+| `DruidFetch` | `int` | `16384` | Rows to fetch per Druid query. |
 | `SchemaFactory` | `string` | — | Schema factory class name (when not using a model). |
-| `SchemaType` | `string` | `MAP` | Schema type: `MAP`, `JDBC`, or `CUSTOM`. |
+| `SchemaType` | `string` | — | Schema type: `MAP`, `JDBC`, or `CUSTOM`. |
 | `ParserFactory` | `string` | — | Custom SQL parser factory. |
+| `MetaTableFactory` / `MetaColumnFactory` | `string` | — | Avatica metadata factories. |
 | `TypeSystem` | `string` | — | Type system class name. |
 
-### `CalciteConnectionPropertiesSchemaMap`
+Defaults are Calcite's own, read from `CalciteConnectionProperty` in the version this package references (1.42).
 
-Exposes the `schema.*`-prefixed sub-properties of a `CalciteConnectionProperties` instance as a typed dictionary, making it easy to pass operand values to a custom schema factory:
+## `CalciteConnectionPropertiesSchemaMap`
+
+Exposes the `schema.*`-prefixed sub-properties of a `CalciteConnectionProperties` instance as a typed dictionary, so operand values can be passed to a custom schema factory:
 
 ```csharp
 var props = new CalciteConnectionProperties();
@@ -96,8 +163,8 @@ props.SchemaProperties["flavor"]    = "scannable";
 
 | Package | Purpose |
 |---------|---------|
-| [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) | Core ADO.NET provider for Apache Calcite. |
-| [`Apache.Calcite.Adapter.AdoNet`](https://www.nuget.org/packages/Apache.Calcite.Adapter.AdoNet) | Federated ADO.NET adapter for Calcite. |
+| [`Apache.Calcite.Data`](https://www.nuget.org/packages/Apache.Calcite.Data) | The ADO.NET provider. Executes SQL text through this convention. |
+| [`Apache.Calcite.Adapter.AdoNet`](https://www.nuget.org/packages/Apache.Calcite.Adapter.AdoNet) | Exposes any ADO.NET data source to Calcite as a federated schema. |
 
 ## Further reading
 


### PR DESCRIPTION
Four documentation files that described API which does not exist, or behaviour that is not what happens. Every name in the rewrites was found in the source; the two claims that could not be settled by reading were measured.

## `src/Apache.Calcite.Data/DESIGN.md`

Untouched since 0930359, and describing an architecture that was never built or was replaced by #12. Eight of the types it named are not in the tree: `CalciteEngineClient`, `ICalciteClient`, `CalciteClientFactory`, `CalciteEngineResult`, `ICalciteResult`, `ColumnAdapter`, `RowMaterializer`, `RootSchemaBuilder`. It described the prepare path as `CalcitePrepare.DEFAULT_FACTORY` followed by `prepareSql`, which #12 replaced outright.

It now describes the real pipeline (`CalciteSession.Plan` → `ClrPrepareImpl` → `ClrSignature` → `IClrBindable`), the real prepare types against their Calcite counterparts, and the real result path — `CalciteResult` → `CalciteResultColumns` → `CalciteResultRow` → `CalciteResultValue`, in which nothing materializes a row.

Three claims are corrected rather than dropped:

1. **"No JDBC dependency."** `CalciteSession`'s static constructor registers `org.apache.calcite.jdbc.Driver`, because `ViewTableMacro.apply` reads a field initialized by `DriverManager.getConnection("jdbc:calcite:")`. Every view needs it.
2. **"Must not call into `org.apache.calcite.avatica.*`."** `ColumnMetaData`, `AvaticaParameter` and `Meta.*` are used throughout, as the metadata value types Calcite's prepare produces.
3. **The result "owns the cancellation registration."** It does not. `ExecuteReaderAsync` discards the cancel flag; only the DML drain registers the token.

## `src/Apache.Calcite.Adapter.AdoNet/README.md`

The worst of the three, and the reason this PR grew.

- The code-driven example called **`AdoSchema.Register`, which has never existed.** The API is `AdoSchema.Create(...)` followed by `SchemaPlus.add`.
- The JSON model named operands `providerName` / `connectionString` / `metadataType`. The real ones are `adoProviderName` / `adoConnectionString` / `adoDatabaseMetadata`, plus `adoDatabaseMetadataFactory`, `adoDataSource`, `adoDatabase`, `adoSchema`.
- It tabled five metadata classes as public API — `SqlServerDatabaseMetadata`, `SqliteDatabaseMetadata`, `OdbcDatabaseMetadata`, `OleDbDatabaseMetadata`, `AdoInformationSchemaDatabaseMetadata`. **All five are internal.** The extension points are `AdoDatabaseMetadata` and `AdoDatabaseMetadataFactory`.
- It constructed a `SqlClientDataSource`, which is not a type here or in `Microsoft.Data.SqlClient`.

**The model example could not have worked as written, and this is measured rather than reasoned about.** A model's `factory` is resolved by Java's `Class.forName`, so it needs IKVM's name for a CLR class. Against a SQLite database through `CalciteConnection`:

| `factory` value | result |
|---|---|
| `cli.Apache.Calcite.Adapter.AdoNet.AdoSchemaFactory` | returns the row |
| `Apache.Calcite.Adapter.AdoNet.AdoSchemaFactory` | `Error instantiating JsonCustomSchema(name=ADO)` |

Removing the `ikvm.runtime.Startup.addBootClassPathAssembly` call makes **both** fail. Both halves are now in the README, flagged as non-obvious — no test covers the model path for this adapter, so the probe was written, run, and deleted.

## `src/Apache.Calcite.Extensions/README.md`

Claimed you could reference the package to "plan and run a statement without an ADO.NET connection". You cannot — `ClrPrepareImpl`, `ClrSignature` and the whole `Prepare` namespace are internal, reached from `Apache.Calcite.Data` through `InternalsVisibleTo`. The README now says so plainly and documents the path that *is* public: `ClrEnumerablePrograms` → `ClrEnumerableRelImplementor` / `ClrEnumerableInterpretable` → `IClrBindable`.

The example it uses is the one `ReadmeExampleTests` already pins — which no README has contained since the Linq project was folded in, so that test's "the example in the project README" was pointing at nothing.

## `src/Apache.Calcite.Data/README.md`

Said a statement "never goes through `CalcitePrepare`". Not so: `CalcitePrepare.Context` and `CalcitePrepare.Dummy` are both used. What it never calls is `prepareSql`, and what it never produces is a `Bindable`.

The connection-string table listed `Conformance` twice and omitted nine supported keys. Added for the nuget.org audience: transactions throw, `CommandType.Text` only, `ExecuteNonQuery`'s three return conventions, DDL running at prepare time and needing a DDL parser factory, materialized views never being substituted, `spark` being ignored, and cancellation being observed before planning and during a DML drain but **not** during a reader's enumeration.

## Both property tables carried wrong defaults

Read from `CalciteConnectionProperty` at the `calcite-1.42.0` tag this package references: `materializationsEnabled` and `createMaterializations` are `true`, not `false`; `nullEqualToEmpty` is `true`; `schemaType` and `caseSensitive` have no default of their own and fall back to `lex`.

---

`Internal/CalciteColumn.cs` is listed as unreferenced in DESIGN.md, which it is — `git grep` hits only its own file. Removing it is a code change, so it is not in this PR.

Documentation only; no code changes. The solution builds clean and `ReadmeExampleTests` passes at this commit.
