### PR TITLE
Update GitHub Actions to their latest majors

### DIFF
--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         submodules: recursive
     - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
     - name: Install GitVersion
@@ -65,12 +65,12 @@ jobs:
           Apache.Calcite.dist.msbuildproj
     - name: Upload MSBuild Log
       if: ${{ always() }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: msbuild.binlog
         path: msbuild.binlog
     - name: Upload NuGet Packages
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: nuget
         path: dist/nuget
@@ -78,7 +78,7 @@ jobs:
       run: tar czvf tests.tar.gz tests
       working-directory: dist
     - name: Upload Tests
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: tests
         path: dist/tests.tar.gz
@@ -108,11 +108,11 @@ jobs:
     runs-on: ${{ fromJSON('{"win-x86":["windows-2022"],"win-x64":["windows-2022"],"linux-x64":["ubuntu-24.04"],"linux-arm64":["ubuntu-24.04-arm"],"osx-x64":["macos-15-intel"],"osx-arm64":["macos-15"]}')[matrix.sys] }}
     steps:
     - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
     - name: Add NuGet Source (GitHub)
@@ -122,7 +122,7 @@ jobs:
         GITHUB_REPOS: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Download Tests
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: tests
     - name: Restore Tests
@@ -175,7 +175,7 @@ jobs:
       run: tar czvf TestResults.tar.gz TestResults
     - name: Upload Test Results
       if: always() && startsWith(env.RET, 'TestResults--')
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.RET }}
         path: TestResults.tar.gz
@@ -187,11 +187,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Setup .NET 10.0
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
     - name: Install GitVersion
@@ -202,7 +202,7 @@ jobs:
       id: GitVersion
       uses: gittools/actions/gitversion/execute@v4
     - name: Download NuGet Packages
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: nuget
         path: dist/nuget


### PR DESCRIPTION
| action | was | now |
|---|---|---|
| `actions/checkout` | v5 | v7 |
| `actions/setup-dotnet` | v5 | v6 |
| `actions/upload-artifact` | v5 | v7 |
| `actions/download-artifact` | v5 | v8 |
| `ncipollo/release-action` | v1 | v1 — already the latest major (v1.21.0) |
| `gittools/actions/gitversion/*` | v4 | v4 — skipped, and v4.7.0 is the latest major anyway |

None of the breaking changes reach this workflow:

- The artifact actions now run on Node 24 and want runner 2.327.1 or better. Every runner here is hosted.
- checkout v7 blocks checking out a fork's head for `pull_request_target` and `workflow_run`. This workflow triggers on `pull_request`.
- download-artifact v8 changes `digest-mismatch` from a warning to an error by default, and stopped unzipping downloads whose `Content-Type` says they are not zips. The one download here is an artifact this workflow uploaded, and it is untarred by a later step rather than unzipped by the action.

Verified against the release notes for each major crossed, not just the tag list.
