### PR TITLE
Take out a boxing pass no plan could reach

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRelImplementor.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRelImplementor.cs
@@ -152,45 +152,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     JavaRowFormat.SCALAR);
 
             // IEnumerable<object>, not the non-generic IEnumerable. Every IEnumerable<T> converts to the
-            // latter, so a sequence this method failed to box would still compile and nothing would say so.
+            // latter, so a sequence of the wrong element type would still compile and nothing would say so.
             // The element type is named here for the same reason a node's is named in RequireRowType.
+            //
+            // The conversion is by variance and cannot fail: a row is never a value type. ClrPhysTypeImpl
+            // boxes what the type factory answers, so RowType is a synthetic record, an Object[], a List or
+            // a box class; RequireRowType holds every node to it; and the one other shape reaching here is
+            // Slice0<object>. There was a boxing pass in front of this for a while, and it was unreachable
+            // on every path -- the boxing it looked for has already happened in the physical type.
             return Expression.Lambda<Func<DataContext, IEnumerable<object>>>(
-                Expression.Convert(BoxScalars(result.Expression), typeof(IEnumerable<object>)),
+                Expression.Convert(result.Expression, typeof(IEnumerable<object>)),
                 Root);
-        }
-
-        /// <summary>
-        /// Boxes a sequence of primitives the way Java would.
-        /// </summary>
-        /// <param name="sequence"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// A one column result is the value, and where that value is a primitive the sequence is of a
-        /// primitive. Handing it out untyped boxes it, and the CLR would box it as its own, which is not the
-        /// java.lang.Integer every reader of a Calcite result expects. The type factory decides what a value
-        /// is, and it says Integer, so this is the same boxing every other conversion here does.
-        ///
-        /// <para>Not <c>EnumerableInterpretable.box</c>, which wraps each row in a one element
-        /// <c>Object[]</c> for the interpreter and has no counterpart here. This has no counterpart there
-        /// either: generated Java produces an <c>Enumerable</c> of objects and the question cannot arise.
-        /// It belongs with <see cref="ImplementRoot"/> because that is where a plan becomes the sequence a
-        /// caller reads.</para>
-        /// </remarks>
-        static Expression BoxScalars(Expression sequence)
-        {
-            if (sequence.Type.IsGenericType == false)
-                return sequence;
-
-            var elementType = sequence.Type.GetGenericArguments()[0];
-            if (elementType.IsValueType == false)
-                return sequence;
-
-            var row = Expression.Parameter(elementType, "row");
-
-            return Expression.Call(null,
-                ClrBuiltInMethod.Select.MakeGenericMethod(elementType, typeof(object)),
-                sequence,
-                Expression.Lambda(ClrEnumUtils.Convert(row, typeof(object)), row));
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysType.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysType.cs
@@ -38,14 +38,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// Returns the CLR type that represents a row.
         /// </summary>
         /// <remarks>
-        /// <c>PhysType.getRowType</c>. Unboxed, as Calcite's is: the physical type of a one column row of
-        /// <c>INTEGER NOT NULL</c> is <see cref="int"/>, and a node reading a field of it inside its own lambda
-        /// wants that.
+        /// <c>PhysType.getRowType</c>, <b>boxed</b>, which is where this diverges from Calcite. The physical
+        /// type of a one column row of <c>INTEGER NOT NULL</c> is <c>java.lang.Integer</c>, not
+        /// <see cref="int"/>: a CLR sequence states its element type and nothing autoboxes at the boundary,
+        /// so the choice is made once here rather than at each call site.
         ///
-        /// <para>What a <em>sequence</em> of these rows carries is this boxed, which is not the same type and
-        /// is the one a node hands to the node above it. Calcite boxes at the call site — <c>joinSelector</c>
-        /// and <c>generateComparator</c> both write <c>Primitive.box(physType.getRowType())</c> — and so
-        /// does this convention, through <c>ClrEnumUtils.Boxed</c>.</para>
+        /// <para>Calcite can leave it to its callers, because there is no <c>Enumerable&lt;int&gt;</c> in
+        /// Java — the element is a reference whatever the physical type says, and javac inserts the
+        /// conversion. So <c>joinSelector</c> and <c>generateComparator</c> each write
+        /// <c>Primitive.box(physType.getRowType())</c> where they need it. Here
+        /// <see cref="ClrPhysTypeImpl"/> boxes in its constructor and this is that;
+        /// <c>ClrEnumerableRelImplementor.Result</c> refuses a sequence that disagrees.</para>
         /// </remarks>
         Type RowType { get; }
 


### PR DESCRIPTION
`ClrEnumerableRelImplementor.ImplementRoot` ran `BoxScalars` over the root's sequence, to box a row that was a value type the way Java would. A row is never a value type.

`ClrPhysTypeImpl` boxes on the way in — `javaRowClass = ClrPrimitive.Box(ClrTypes.Resolve(javaRowType))`, and `RowType` returns that — and `ClrPrimitive.Box` maps a Java primitive to its box class and returns everything else unchanged. So a row is a synthetic record, an `Object[]`, a `java.util.List` or a box class. `RequireRowType` holds every node's result to exactly `IEnumerable<RowType>`, and the only other shape reaching the root is `Slice0<object>`. The `IsValueType` test could not be true on any path.

What is left is a variance conversion, which is free and cannot fail.

## The comment that sent me looking for it

`ClrPhysType.RowType` documented the opposite of what `ClrPhysTypeImpl` does — unboxed, "the physical type of a one column row of `INTEGER NOT NULL` is `int`", with a sequence carrying it boxed through `ClrEnumUtils.Boxed`. There is no `ClrEnumUtils.Boxed`, and the constructor boxes. It described Calcite's `PhysType.getRowType`, which this deliberately diverges from and which `CLAUDE.md` already records correctly. Rewritten to say what the code does and why the divergence exists.

Left alone it costs more than a stale comment: it is the reason a reader goes looking for a boxing step that is not there, and the reason the dead pass looked load-bearing.

## Testing

`dotnet build Apache.Calcite.sln` clean. `Apache.Calcite.Tests` 506/506 on net8.0 and net10.0.

Worth saying plainly: the suite passing shows nothing regressed over the queries it runs, not that no query could have reached the pass. The argument for the removal is the structural one above.

## Not done here

Enforcing the invariant — asserting in `ClrPhysTypeImpl`'s constructor that the boxed row class is not a value type — would turn that argument into a check. It is left out because a struct reaching there today would newly throw where `BoxScalars` might have converted it, and that is a behaviour change rather than a removal.
