### PR TITLE
Audit all 45 operators against linq4j, and fix the 17 that diverged

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ instead of Janino, and the prepare pipeline that gets a statement to one.
 |---|---|
 | `Apache.Calcite.Adapter.AdoNet` | pushes a plan down to an ADO.NET provider |
 | `Apache.Calcite.Data` | the `DbConnection` / `DbCommand` surface |
-| `Apache.Calcite.Extensions` | `ClrEnumerableConvention` (the async one is not written yet), the prepare pipeline, and the IKVM interop helpers |
+| `Apache.Calcite.Extensions` | `ClrEnumerableConvention` and `ClrAsyncEnumerableConvention`, the prepare pipeline, and the IKVM interop helpers |
 
-`TODO.md` has the outstanding work on the ADO.NET adapter, sized and reasoned. The CLR convention is
-ported and has no list of its own.
+`TODO.md` has the outstanding work on the ADO.NET adapter, sized and reasoned, and the findings of the
+operator audit against linq4j — 45 methods read side by side, 17 of them divergent.
 
 ## Building
 
@@ -56,6 +56,30 @@ ported and has no list of its own.
   by hand.
 
 ## Apache.Calcite.Extensions: the rules that hold
+
+**A port reproduces Calcite's logic, bugs included.** This is a port, and Calcite's behaviour is the
+specification — not SQL, and not what the algorithm ought to be. Do not drop a step because it looks
+unnecessary. Do not optimize what Calcite does not optimize. Where Calcite has a defect, reproduce the
+defect and say so at the site: `EnumerableWindow`'s outer guard is still false after row 0, so an
+`UNBOUNDED`/`UNBOUNDED` frame with `EXCLUDE` never excludes anything, and `ClrEnumerableWindow` shares that.
+Correctness against SQL is a later argument to have upstream; a divergence introduced here is a defect we
+own alone and cannot diff against anything.
+
+**Reach for the type whose semantics match, not the runtime's.** A CLR type is fine where it agrees on what
+the algorithm actually depends on — null handling, iteration order, equality, and whether the operations the
+code is written in terms of exist. `List<T>` for an `ArrayList` is fine. `SortedDictionary` for a `TreeMap`
+is not: it rejects a null key *before* consulting the comparer, which breaks `NULLS FIRST` over a single
+nullable column, and it has no `lastKey` or `headMap`, so the limit sort had to be re-expressed rather than
+transcribed — and both defects came out of that re-expression. `Dictionary` for a `HashMap` is not, wherever
+iteration order reaches the output, which is why the join lookups are `java.util.HashMap`. When the Java
+type is the one that fits, use it — we run on IKVM — and name at the site which property forced it.
+
+**A differential test compares answers, not implementations.** It is a strong oracle for correctness and no
+oracle at all for faithfulness. Three divergences from Calcite have been found by reading rather than by
+testing, and every one returned the right rows: the async `Format` missing its `Row` case, a scan that
+re-derived `deduceElementType`'s precedence by hand, and a limit sort that sorted its whole input where
+linq4j keeps a bounded `TreeMap`. A green suite does not mean a member has been ported. Reading Calcite's
+source for that member is what settles it.
 
 **Where linq4j may appear.** A node holds linq4j only where a generator of Calcite's produced one or takes
 one, and it is translated where it is produced rather than composed into a larger tree first. That is four
@@ -121,6 +145,15 @@ CLR rows into the table's `java.util.Collection` and left `SqlFunctions.toInt` r
 the interpreter read them back — that one did not cast, it simply did not convert, and no test had ever
 written to a spool. **Every boundary where a value crosses between the two runtimes is an
 adapter**, a sequence included — if it casts, it is wrong.
+
+**But `JavaValues.From` is not what keeps that invariant, and mostly cannot be.** It branches on
+`typeof(T).IsValueType`, the static type parameter — so wherever a call site instantiates it from a
+`PhysType.RowType` it compiles away to nothing, that type always being `ClrPrimitive.Box(...)` and therefore
+a Java class. The spool's guard is inert for exactly this reason. What actually holds the line there is
+upstream: `JavaRowFormatExtensions.ObjectArray` builds every array element through `ClrEnumUtils.Convert`,
+which boxes the Java way. `From` earns its keep only in the `Delegate*` SAM adapters, where `T` really is a
+CLR primitive. Do not read a `From` at a boundary as proof the boundary is guarded — go and find where the
+value was boxed.
 
 **`Rules()` and `CalcRules()` are two passes, not one.** `VolcanoCost.isLt` compares the row count and
 nothing else — cpu and io are dead code behind `if (true)` — so a project and a calc are never cheaper
@@ -211,7 +244,7 @@ differential tests cannot use Calcite as the oracle for.
 ## Working with this user
 
 Comprehension questions ("what is X for?", "why would we do Y?") are **defect reports**. Go read the code,
-and Calcite's, and expect to find something wrong. In this session that pattern caught, in order: a
+and Calcite's, and expect to find something wrong. Across sessions that pattern has caught, in order: a
 gratuitous divergence in `Calc`, a cost analysis that was simply false, calling a spool a write, calling a
 deliberate Calcite refusal a blocker to work around, and `Window` translating far more linq4j than the rule
 allows. Every one was a case of reasoning past what had been verified, and usually toward the cheaper

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,29 @@ transcribed — and both defects came out of that re-expression. `Dictionary` fo
 iteration order reaches the output, which is why the join lookups are `java.util.HashMap`. When the Java
 type is the one that fits, use it — we run on IKVM — and name at the site which property forced it.
 
+**"Cannot be reproduced" is usually "did not look for the class."** We run on IKVM, and Calcite's runtime
+and Guava are both on the classpath — `ImmutableList`, `HashMultiset` and `SortedMultiMap` are already used
+here. So a Java collection Calcite's behaviour depends on is generally *available*, not merely imitable:
+`nestedLoopJoinAsList` holds its unmatched right rows in Guava's `Sets.newIdentityHashSet()`, and that was
+written as a CLR `HashSet` over a reference-equality comparer on the grounds that the CLR has no
+`System.identityHashCode`. It does not need one. The order those rows come out in is that map's, and using
+the map is the whole of the fix. Before writing that something cannot be carried across, name the class and
+check whether it is simply reachable.
+
+**A divergence recorded as deliberate is a scope reduction unless Calcite cannot be followed.** The bar is
+whether the CLR makes it impossible — a method returning `IAsyncEnumerable` cannot await before it returns,
+and that is a real one, stated at each site. "Ours holds the same rows in the same order and only reaches
+them sooner" is not: that was `Window`'s laziness, filed under record-do-not-fix for a while, and Calcite
+builds an `ArrayList` and returns `Linq4j.asEnumerable(list)`. Whether ours is better is not the question
+the port gets to answer.
+
+**A claim about how something fails is a claim to run.** Reasoning from a comparator's semantics gave "a
+CLR-boxed row element and a Java-boxed one compare unequal, their hashes agree, so a set operator quietly
+keeps both copies" — a description of a state no query reaches. One query over a table holding CLR-boxed
+values stops on its first row, because what reads a field is `SqlFunctions.toInt` or a cast to the boxed
+type the row type declares. The difference between those two stories is a per-row conversion on every
+scan, nearly added to fix a defect that was in the test table.
+
 **A recursive query can fail to terminate under Calcite too, and then there is no oracle.** A repeat union's
 spool is cleared by a round that wrote nothing, so a step that aggregates the working table oscillates: the
 round that counts one is empty and empties the table, and the round after it counts zero and emits again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,13 @@ operator audit against linq4j — 45 methods read side by side, 17 of them diver
   found in the convention was found by it, three of them in nodes already believed done. Add a query
   there rather than writing an assertion by hand: the expected answer is whatever Calcite says. It lives
   in `Apache.Calcite.Tests`, with the rest of the convention and prepare tests.
+- **`dotnet test --filter` is silently ignored here** — the project runs on Microsoft.Testing.Platform, and
+  `dotnet test` does not forward the flag to the test app. It runs the whole suite and reports success, so a
+  run that looks like one test is 619. Run the built executable instead, which honours it and is faster than
+  the `dotnet test` host by about a third:
+  `src\Apache.Calcite.Tests\bin\Debug\net8.0\Apache.Calcite.Tests.exe --filter FullyQualifiedName~Name`.
+  The whole suite is about 133 seconds that way against about 215 through `dotnet test`; a single test is
+  seconds. `--blame-hang --blame-hang-timeout 90s` names the test that hangs.
 - **Calcite is checked out at `D:\calcite`, and it is 1.43.0-SNAPSHOT.** The projects reference **1.42.0**,
   which is released; `Apache.Calcite.Data.Tests` alone references **1.43.0-SNAPSHOT**, from
   `https://repository.apache.org/content/repositories/snapshots/`, for `calcite-server` and the
@@ -73,6 +80,14 @@ nullable column, and it has no `lastKey` or `headMap`, so the limit sort had to 
 transcribed — and both defects came out of that re-expression. `Dictionary` for a `HashMap` is not, wherever
 iteration order reaches the output, which is why the join lookups are `java.util.HashMap`. When the Java
 type is the one that fits, use it — we run on IKVM — and name at the site which property forced it.
+
+**A recursive query can fail to terminate under Calcite too, and then there is no oracle.** A repeat union's
+spool is cleared by a round that wrote nothing, so a step that aggregates the working table oscillates: the
+round that counts one is empty and empties the table, and the round after it counts zero and emits again.
+Under UNION ALL that runs forever in both conventions. Deduplication is what ends it, the second copy being
+a row the sequence already returned. Before writing a recursive test, check that the shape converges —
+`SameRel` will hang rather than fail, and a hung suite looks like an infinite loop in the operator that was
+just changed. It is worth running the new test alone first.
 
 **A differential test compares answers, not implementations.** It is a strong oracle for correctness and no
 oracle at all for faithfulness. Three divergences from Calcite have been found by reading rather than by

--- a/TODO.md
+++ b/TODO.md
@@ -12,27 +12,6 @@ None of the items below are covered by tests either way: the 98 adapter tests ex
 only. Every bug found in this adapter so far has been in code nothing executed, so write the
 failing test first.
 
-### 0. Correlated sub-queries — done, but thinly tested
-
-Fixed. Kept here only for the note at the end.
-
-The feature was present, reachable, and broken in five separate ways, none of which could be seen
-without `forceDecorrelate=false` — Calcite rewrites a correlated sub-query into a join before it
-reaches the adapter, so eleven passing tests in `AdoCorrelationTests` never touched any of this code.
-
-`AdoToEnumerableConverter` built the correlation data context and never called `Build()` on it.
-`AdoCorrelationDataContext.get` ignored the parameters it was constructed with.
-`AdoCorrelationDataContextBuilderImpl` cast `typeof(X)` to `java.lang.reflect.Type`, which a
-`System.RuntimeType` fails, so the class could never initialize — hidden because C# defers a static
-field until first read and the only read was in `Build()`. The generated SQL carried Calcite's
-positional `?` where ADO.NET matches by name. And correlation values arrived as boxed Java types no
-provider can bind.
-
-`AdoEnumerable.ToProviderValue` unwraps those boxed values, and is now exercised for an integer, a
-real, a string and a date. `Boolean`, `Double`, `BigDecimal` and `ByteString` remain unexercised —
-SQLite has no column of those types in the fixture, so covering them needs either a wider fixture or
-a second provider.
-
 ### 0b. ODBC and OleDb cannot answer what they are
 
 `OdbcDatabaseMetadata` and `OleDbDatabaseMetadata` throw from `Dialect`, `GetDefaultSchema` and
@@ -122,6 +101,9 @@ when several schemas point at one database. Lowest priority; measure before assu
 Sized against measured coverage: `Apache.Calcite.Data` 69.9%, `Apache.Calcite.Adapter.AdoNet` ~60%.
 Listed worst-first by uncovered lines.
 
+- **`AdoEnumerable.ToProviderValue`** — `Boolean`, `Double`, `BigDecimal` and `ByteString` are unexercised.
+  SQLite has no column of those types in the fixture, so covering them needs a wider fixture or a second
+  provider. All that is left of the correlated sub-query work.
 - **`CalciteResultValue`** — 56%, **282 uncovered**, the largest single gap anywhere. It is the whole
   type-conversion surface, and the `DATE`-as-milliseconds bug lived in exactly this kind of code.
 - **`AdoSchemaFactory` from a Calcite model** — 0%. The operand-driven path is the primary documented
@@ -175,34 +157,9 @@ plan can put a Calcite node above an asynchronous one, because Calcite cannot re
 
 ## Audit findings: 45 operators, twelve agents, one method group each
 
-Three divergences have now been found by being asked about, not by testing:
-
-| | ours | Calcite's |
-|---|---|---|
-| `ClrAsyncEnumerableTableScan.Format` | no `Row` case, tested `IsArray` | `EnumerableTableScan.format()` |
-| direct `ScannableTable.scan` in the scan | re-derived `deduceElementType`'s precedence | `getExpression(Queryable.class)` |
-| `OrderByWithFetchAndOffset` | full sort, then skip and take | bounded `TreeMap` (CALCITE-3920, CALCITE-4157) |
-
-All three passed the differential tests, and they had to: **those tests compare answers, and every one of
-these returns the right answer.** They are an oracle for correctness and a null oracle for equivalence. So
-"the suite is green" cannot be the stopping condition for a port.
-
-What found all three was reading Calcite's source for that one member. The audit is therefore: for every
-member of `ClrEnumerableDefaults` against `EnumerableDefaults`, and every node against its `Enumerable*`
-counterpart, read both and record the verdict — ported unchanged, or the exact divergence and why.
-
 **The audit has run.** 45 operators, twelve agents, one method group each. Result: **30 equivalent, 17
 divergent, 1 uncertain.** Everything below was found by reading Calcite beside ours; none of it was visible
 to the differential suite.
-
-### Fixed
-
-- **A null sort key threw.** `SortedDictionary` rejects a null key *before* consulting the comparer, where a
-  `TreeMap` built with a comparator hands one to it, which is the whole job of `Functions.nullsComparator`.
-  Introduced by the limit-sort port itself. Reachable only for a **single**-column collation over a nullable
-  column: a multi-field collation keys on a `FlatLists` row, never null however many fields in it are, which
-  is why four existing NULLS FIRST/LAST tests could not reach it. An agent fuzzed 20,000 cases against
-  `OrderBy().Skip().Take()`: 0 row or order mismatches, 5,714 throws.
 
 ### Wrong rows, latent
 
@@ -213,11 +170,6 @@ to the differential suite.
   never restores it across the seed/iteration boundary, so a non-empty seed followed by an empty round 0
   does not stop it. Differs iff the seed emitted at least one row and round 0 emits nothing new; changes
   rows only for a non-monotone step. Upstream behaviour at HEAD.
-- **`HashEquiJoin` emits unmatched right rows in the wrong order.** linq4j iterates the `HashSet` copy of
-  the key set; we iterate the `HashMap` `entrySet()` filtered by membership. Measured on a JVM: they
-  disagree at 12, 24, 48, 96 distinct build keys, 199/200 trials at n=12. `SalesTable` has six rows, so no
-  test can reach it. One-line fix. Same in the async twin.
-
 ### Eager where Calcite is eager, or the reverse
 
 Calcite builds at call time and returns an enumerable over finished state; our `yield` iterators defer and
@@ -237,9 +189,6 @@ map there. `Window` is the reverse and in our favour: we stream output where Cal
 - **`Take` draws n rows where linq4j draws n+1**, because `takeWhile` reads `current()` before rejecting.
   With `FETCH 0` we never open the input, so `LazyCollectionSpool`'s write-back and `RepeatUnion`'s
   `cleanUp` are skipped where Calcite opens and closes.
-- **`Ordered` finds its last key in O(n)**, `SortedDictionary.Keys` being neither an `IList` nor a LINQ
-  partition. The CALCITE-3920 memory bound is correct; its constant is not.
-
 ### Robustness
 
 - `CorrelateJoin` does not reject RIGHT/FULL (Calcite throws, we silently inner-join) and does not guard a
@@ -280,31 +229,3 @@ yields in `HashMultiset` order, a throw on a null key.
   unproven.
 - A RANGE window bound with an offset over a nullable order key builds `subtract(boxedKey, offs)`, which
   NPEs in Java. Confirm the CLR translation fails the same way.
-
-## A limit sort sorts more than it needs to — fixed
-
-Ported now, and kept here as the worked example of what the audit is for.
-
-`ClrEnumerableDefaults.OrderByWithFetchAndOffset` sorted the whole input and then skipped and took:
-
-    var ordered = OrderBy(source, keySelector, comparator);
-    if (offset > 0) ordered = ordered.Skip(offset);
-    if (fetch != int.MaxValue) ordered = ordered.Take(fetch);
-
-linq4j does not. CALCITE-3920 and CALCITE-4157 changed `EnumerableDefaults.orderBy(source, keySelector,
-comparator, offset, fetch)` to keep a `TreeMap` bounded at `offset + fetch` rows: a row whose key sorts at
-or after the last key held is discarded without being stored, and adding one evicts the last. A comment in
-the source says why a `TreeMap` rather than a heap — it behaves like the plain `orderBy` and is better when
-there are few distinct keys.
-
-So `ORDER BY x FETCH 10` over a million rows holds ten in Calcite and a million here. The rows and their
-order are identical, which is why the differential tests never saw it — this is a divergence in what it
-costs, not in what it answers.
-
-Both conventions have it: the asynchronous `OrderByWithFetchAndOffset` drains into a buffer and hands it to
-the synchronous one, so fixing the synchronous one fixes both.
-
-A plain sort is not this. It has to read its whole input before it can yield anything, in linq4j and here
-alike, and both do it lazily on the first read rather than when the sequence is built. That part is
-faithful.
-

--- a/TODO.md
+++ b/TODO.md
@@ -162,8 +162,15 @@ plan can put a Calcite node above an asynchronous one, because Calcite cannot re
 17 are now transcribed from Calcite's body in both conventions — `HashEquiJoin`'s leftover order,
 `NestedLoopJoin`'s five, `RepeatUnion`'s termination test and clean-up ordering, `SemiJoin`'s two algorithms
 and its memoization, `Take`'s n+1 draw, `CorrelateJoin`'s refusal and null guard, `Cartesian`'s eagerness and
-`int` overflow, the call-time fold in `GroupBy`/`GroupByMultiple`/`AsofJoin`, `JavaSequences`' `reset`, and
-the deletion of `Count`/`IntersectAll`/`ExceptAll`.
+`int` overflow, the call-time fold in `GroupBy`/`GroupByMultiple`/`AsofJoin`/`Window`, `JavaSequences`'
+`reset`, and the deletion of `Count`/`IntersectAll`/`ExceptAll`.
+
+Every one of those was then re-checked against the 1.42 source rather than against the agent report that
+found it, and one had been filed wrongly: `Window`'s laziness was recorded as a divergence to keep, on the
+grounds that it returns the same rows in the same order and only reaches them sooner. `EnumerableWindow`
+generates an `ArrayList`, appends each output row to it and evaluates to `Linq4j.asEnumerable(list)`, once
+per window group — so Calcite computes the whole window where the expression is evaluated, and keeping ours
+lazy was a decision the port is not entitled to make. It collects now.
 
 What no query can reach is pinned directly instead: `ClrEnumerableNestedLoopJoinTests`,
 `ClrRepeatUnionTests`, `ClrEnumerableDefaultsContractTests`.
@@ -179,8 +186,6 @@ What remains below is what was deliberate, and what is still unproven.
 
 - **`Window` reproduces a Calcite bug**: with UNBOUNDED/UNBOUNDED plus EXCLUDE the outer guard is false
   after row 0, so the exclusion never takes effect.
-- **`Window` streams its output** where Calcite collects it first. The reverse of the eagerness the other
-  operators had, and left alone: it holds the same rows in the same order and only reaches them sooner.
 - **RIGHT/FULL unmatched-right order**: Calcite walks an `IdentityHashMap`, whose buckets key on
   `System.identityHashCode`. We now dedup on identity as it does, but there is no CLR counterpart to that
   number, so the unmatched rows come out in insertion order. The set of rows is Calcite's; the order is not,

--- a/TODO.md
+++ b/TODO.md
@@ -173,7 +173,7 @@ Note the asynchronous convention needs none of this. It reads a Calcite sub-plan
 plan can put a Calcite node above an asynchronous one, because Calcite cannot read an
 `IClrAsyncScannableTable` — so it has no converter out and nothing to translate.
 
-## Audit every operator against linq4j, member by member
+## Audit findings: 45 operators, twelve agents, one method group each
 
 Three divergences have now been found by being asked about, not by testing:
 
@@ -191,12 +191,95 @@ What found all three was reading Calcite's source for that one member. The audit
 member of `ClrEnumerableDefaults` against `EnumerableDefaults`, and every node against its `Enumerable*`
 counterpart, read both and record the verdict — ported unchanged, or the exact divergence and why.
 
-It is embarrassingly parallel and each unit is small, which is what makes it a job for one agent per
-member rather than one pass by one reader: an agent holding a single method cannot drift onto something
-else, which is how all three of these got through.
+**The audit has run.** 45 operators, twelve agents, one method group each. Result: **30 equivalent, 17
+divergent, 1 uncertain.** Everything below was found by reading Calcite beside ours; none of it was visible
+to the differential suite.
 
-Where a divergence is deliberate — and several are, `ClrPhysType.RowType` being boxed above all — the
-verdict is the record of that, not a defect.
+### Fixed
+
+- **A null sort key threw.** `SortedDictionary` rejects a null key *before* consulting the comparer, where a
+  `TreeMap` built with a comparator hands one to it, which is the whole job of `Functions.nullsComparator`.
+  Introduced by the limit-sort port itself. Reachable only for a **single**-column collation over a nullable
+  column: a multi-field collation keys on a `FlatLists` row, never null however many fields in it are, which
+  is why four existing NULLS FIRST/LAST tests could not reach it. An agent fuzzed 20,000 cases against
+  `OrderBy().Skip().Take()`: 0 row or order mismatches, 5,714 throws.
+
+### Wrong rows, latent
+
+- **`NestedLoopJoin` SEMI passes a null right row** where both of Calcite's bodies pass the matched inner
+  row. Invisible only because `ClrEnumUtils.JoinSelector` declares the right parameter for SEMI and never
+  reads it. Reachable from `MergeJoin`'s non-equi SEMI path.
+- **`RepeatUnion` stops one round early.** Calcite sets `current` to `DUMMY` at the end of each round but
+  never restores it across the seed/iteration boundary, so a non-empty seed followed by an empty round 0
+  does not stop it. Differs iff the seed emitted at least one row and round 0 emits nothing new; changes
+  rows only for a non-monotone step. Upstream behaviour at HEAD.
+- **`HashEquiJoin` emits unmatched right rows in the wrong order.** linq4j iterates the `HashSet` copy of
+  the key set; we iterate the `HashMap` `entrySet()` filtered by membership. Measured on a JVM: they
+  disagree at 12, 24, 48, 96 distinct build keys, 199/200 trials at n=12. `SalesTable` has six rows, so no
+  test can reach it. One-line fix. Same in the async twin.
+
+### Eager where Calcite is eager, or the reverse
+
+Calcite builds at call time and returns an enumerable over finished state; our `yield` iterators defer and
+re-execute. In `AsofJoin`, `GroupBy`, `GroupByMultiple`, `nestedLoopJoinAsList`, `Cartesian`, `Window`.
+Identical for a single pass; on re-enumeration ours rescans, and **`RepeatUnion` re-enumerates its
+iterative branch every round**, so a `GROUP BY` under a recursive CTE recomputes here and replays a frozen
+map there. `Window` is the reverse and in our favour: we stream output where Calcite collects it.
+
+### Memory and laziness
+
+- **`Cartesian` is fully eager**: `new List(outer.Count * inner.Count)` before the first row, where
+  Calcite's is lazy. Quadratic per merge-join key run, and that `int` multiply overflows around 2^31 pairs.
+- **`NestedLoopJoin` buffers its inner** where Calcite's optimized body re-enumerates per outer row. The
+  asymmetry is Calcite's own, so ours is a divergence rather than a choice.
+- **`SemiJoin` holds every inner row** where linq4j holds distinct keys, and drains the inner even for an
+  empty outer where linq4j memoizes (CALCITE-2909).
+- **`Take` draws n rows where linq4j draws n+1**, because `takeWhile` reads `current()` before rejecting.
+  With `FETCH 0` we never open the input, so `LazyCollectionSpool`'s write-back and `RepeatUnion`'s
+  `cleanUp` are skipped where Calcite opens and closes.
+- **`Ordered` finds its last key in O(n)**, `SortedDictionary.Keys` being neither an `IList` nor a LINQ
+  partition. The CALCITE-3920 memory bound is correct; its constant is not.
+
+### Robustness
+
+- `CorrelateJoin` does not reject RIGHT/FULL (Calcite throws, we silently inner-join) and does not guard a
+  null correlated inner (Calcite substitutes empty, we throw). `LeftMarkJoin` next door does guard.
+- `RepeatUnion`'s `cleanUp` runs after the child enumerators close rather than before, and not at all if the
+  plan is created and never pulled.
+- `JavaSequences.ToJava`'s `reset()` throws where linq4j re-acquires. Only `CartesianProductEnumerator`
+  calls it live.
+
+### Dead code to delete
+
+`Count`, `IntersectAll`, `ExceptAll`, in both conventions, found independently by two agents. Latent
+defects if wired up: CLR `Dictionary` keying that bypasses `JavaWrapped`, source-order output where linq4j
+yields in `HashMultiset` order, a throw on a null key.
+
+### Deliberate: record, do not fix
+
+- **`Window` reproduces a Calcite bug**: with UNBOUNDED/UNBOUNDED plus EXCLUDE the outer guard is false
+  after row 0, so the exclusion never takes effect.
+- **RIGHT/FULL unmatched-right dedup**: Calcite uses an identity set, so two unmatched rows that are the
+  same object emit once; ours emits twice. Ours is the SQL-correct answer.
+- **`HashEquiJoin` retires keys by the comparer** where linq4j uses natural equality on unwrapped keys, and
+  **`SemiJoin` applies the comparer** where linq4j's `contains` ignores it. Ours is more correct in both;
+  both unreachable, the key projection optimising to LIST/SCALAR so `comparer()` is null.
+- **`CompareNullsLastForMergeJoin`** returns 1 for two nulls where Calcite throws and its caller converts to
+  1. Composed behaviour identical; the contract no longer signals two-nulls to a future caller.
+
+### Still to settle
+
+- **`JavaValues.From` is a no-op wherever a row type instantiates it.** It branches on
+  `typeof(T).IsValueType`, and a `PhysType.RowType` is always `ClrPrimitive.Box(...)`, a Java class. The
+  protection at those sites comes from that boxing, not from `From`, which earns its keep only in the
+  `Delegate*` SAM adapters. If it is meant as a boundary guard it should test `value.GetType().IsValueType`
+  as `As` does.
+- **`arrayComparer` compares `object[]` elements by `equals`, and `From` does not recurse into an array.** A
+  set operation with one CLR-native input and one carried across a converter would compare CLR-boxed values
+  against `java.lang.Integer`; hashes agree, so order survives and only deduplication breaks. Reachability
+  unproven.
+- A RANGE window bound with an offset over a nullable order key builds `subtract(boxedKey, offs)`, which
+  NPEs in Java. Confirm the CLR translation fails the same way.
 
 ## A limit sort sorts more than it needs to — fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -191,12 +191,11 @@ What remains below is what was deliberate, and what is still unproven.
   on it unboxes a null. `ShouldAgreeOnFailingARangeFrameWithAnOffsetOverANullableKey` asserts that *both*
   conventions throw, so if Calcite ever fixes it we are told to follow.
 
-### The one thing a port cannot carry across, and what guards it
+### The SPI contract, which needs no enforcing
 
-A row array holding a CLR-boxed value is not equal to one holding the Java-boxed same value, and their
-hashes agree — so a set operator silently keeps both copies and nothing else looks wrong.
-`ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay` proves it.
-
-Nothing enforces this, and nothing should: Calcite requires the same of a `ScannableTable` and converts
-nothing either. It is the contract on `IClrScannableTable` and `IClrAsyncScannableTable`, which now say so
-and name that test.
+A table of this convention's SPI returns what the type factory says, which is Java's — the same contract
+Calcite puts on `ScannableTable`, and for the same reason. Nothing checks it and nothing needs to: what
+reads a field is `SqlFunctions.toInt` or a cast to the boxed type the row type declares, both Calcite's own,
+so a table that gets it wrong stops on its first row.
+`ShouldFailOverATableWhoseValuesAreNotTheTypeFactorys` holds that, so that the failure is not one day read
+as a defect in the scan and answered with a per-row conversion every correct table would pay for.

--- a/TODO.md
+++ b/TODO.md
@@ -182,27 +182,21 @@ still computed before the first is yielded, which is the property the ordering r
 
 What remains below is what was deliberate, and what is still unproven.
 
-### Deliberate: record, do not fix
+### Defects of Calcite's that are reproduced, and tested as such
 
-- **`Window` reproduces a Calcite bug**: with UNBOUNDED/UNBOUNDED plus EXCLUDE the outer guard is false
-  after row 0, so the exclusion never takes effect.
-- **RIGHT/FULL unmatched-right order**: Calcite walks an `IdentityHashMap`, whose buckets key on
-  `System.identityHashCode`. We now dedup on identity as it does, but there is no CLR counterpart to that
-  number, so the unmatched rows come out in insertion order. The set of rows is Calcite's; the order is not,
-  and cannot be.
-- **`CompareNullsLastForMergeJoin`** returns 1 for two nulls where Calcite throws and its caller converts to
-  1. Composed behaviour identical; the contract no longer signals two-nulls to a future caller.
+- **`Window`'s EXCLUDE over an UNBOUNDED/UNBOUNDED frame**: the outer guard is still false after row 0, so
+  the exclusion never takes effect.
+- **A RANGE bound with an offset over a nullable order key throws.** `translateBound` boxes the key type
+  only where the bound has no offset, so with one the key stays `java.lang.Integer` and the `subtract` built
+  on it unboxes a null. `ShouldAgreeOnFailingARangeFrameWithAnOffsetOverANullableKey` asserts that *both*
+  conventions throw, so if Calcite ever fixes it we are told to follow.
 
-### Still to settle
+### The one thing a port cannot carry across, and what guards it
 
-- **`JavaValues.From` is a no-op wherever a row type instantiates it.** It branches on
-  `typeof(T).IsValueType`, and a `PhysType.RowType` is always `ClrPrimitive.Box(...)`, a Java class. The
-  protection at those sites comes from that boxing, not from `From`, which earns its keep only in the
-  `Delegate*` SAM adapters. If it is meant as a boundary guard it should test `value.GetType().IsValueType`
-  as `As` does.
-- **`arrayComparer` compares `object[]` elements by `equals`, and `From` does not recurse into an array.** A
-  set operation with one CLR-native input and one carried across a converter would compare CLR-boxed values
-  against `java.lang.Integer`; hashes agree, so order survives and only deduplication breaks. Reachability
-  unproven.
-- A RANGE window bound with an offset over a nullable order key builds `subtract(boxedKey, offs)`, which
-  NPEs in Java. Confirm the CLR translation fails the same way.
+A row array holding a CLR-boxed value is not equal to one holding the Java-boxed same value, and their
+hashes agree — so a set operator silently keeps both copies and nothing else looks wrong.
+`ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay` proves it.
+
+Nothing enforces this, and nothing should: Calcite requires the same of a `ScannableTable` and converts
+nothing either. It is the contract on `IClrScannableTable` and `IClrAsyncScannableTable`, which now say so
+and name that test.

--- a/TODO.md
+++ b/TODO.md
@@ -157,54 +157,34 @@ plan can put a Calcite node above an asynchronous one, because Calcite cannot re
 
 ## Audit findings: 45 operators, twelve agents, one method group each
 
-**The audit has run.** 45 operators, twelve agents, one method group each. Result: **30 equivalent, 17
-divergent, 1 uncertain.** Everything below was found by reading Calcite beside ours; none of it was visible
-to the differential suite.
+**The audit has run, and its findings are fixed.** 45 operators, twelve agents, one method group each:
+**30 equivalent, 17 divergent, 1 uncertain.** None of the 17 was visible to the differential suite, and all
+17 are now transcribed from Calcite's body in both conventions — `HashEquiJoin`'s leftover order,
+`NestedLoopJoin`'s five, `RepeatUnion`'s termination test and clean-up ordering, `SemiJoin`'s two algorithms
+and its memoization, `Take`'s n+1 draw, `CorrelateJoin`'s refusal and null guard, `Cartesian`'s eagerness and
+`int` overflow, the call-time fold in `GroupBy`/`GroupByMultiple`/`AsofJoin`, `JavaSequences`' `reset`, and
+the deletion of `Count`/`IntersectAll`/`ExceptAll`.
 
-Fixed so far, in both conventions: `HashEquiJoin`'s leftover order, `NestedLoopJoin` (five defects), and
-`RepeatUnion`'s termination test and clean-up ordering. Each carries a test that fails against the old
-behaviour -- `ClrEnumerableNestedLoopJoinTests` and `ClrRepeatUnionTests` for what no query can reach.
+What no query can reach is pinned directly instead: `ClrEnumerableNestedLoopJoinTests`,
+`ClrRepeatUnionTests`, `ClrEnumerableDefaultsContractTests`.
 
-### Eager where Calcite is eager, or the reverse
+Two of the asynchronous twins cannot follow Calcite exactly, and say so at the site: a method returning an
+`IAsyncEnumerable` cannot await before it returns, so the fold in `GroupBy`/`GroupByMultiple`/`AsofJoin` and
+the list in `NestedLoopJoinAsList` happen on the first `MoveNextAsync` rather than at the call. Every row is
+still computed before the first is yielded, which is the property the ordering rests on.
 
-Calcite builds at call time and returns an enumerable over finished state; our `yield` iterators defer and
-re-execute. In `AsofJoin`, `GroupBy`, `GroupByMultiple`, `nestedLoopJoinAsList`, `Cartesian`, `Window`.
-Identical for a single pass; on re-enumeration ours rescans, and **`RepeatUnion` re-enumerates its
-iterative branch every round**, so a `GROUP BY` under a recursive CTE recomputes here and replays a frozen
-map there. `Window` is the reverse and in our favour: we stream output where Calcite collects it.
-
-### Memory and laziness
-
-- **`Cartesian` is fully eager**: `new List(outer.Count * inner.Count)` before the first row, where
-  Calcite's is lazy. Quadratic per merge-join key run, and that `int` multiply overflows around 2^31 pairs.
-- **`SemiJoin` holds every inner row** where linq4j holds distinct keys, and drains the inner even for an
-  empty outer where linq4j memoizes (CALCITE-2909).
-- **`Take` draws n rows where linq4j draws n+1**, because `takeWhile` reads `current()` before rejecting.
-  With `FETCH 0` we never open the input, so `LazyCollectionSpool`'s write-back and `RepeatUnion`'s
-  `cleanUp` are skipped where Calcite opens and closes.
-### Robustness
-
-- `CorrelateJoin` does not reject RIGHT/FULL (Calcite throws, we silently inner-join) and does not guard a
-  null correlated inner (Calcite substitutes empty, we throw). `LeftMarkJoin` next door does guard.
-- `JavaSequences.ToJava`'s `reset()` throws where linq4j re-acquires. Only `CartesianProductEnumerator`
-  calls it live.
-
-### Dead code to delete
-
-`Count`, `IntersectAll`, `ExceptAll`, in both conventions, found independently by two agents. Latent
-defects if wired up: CLR `Dictionary` keying that bypasses `JavaWrapped`, source-order output where linq4j
-yields in `HashMultiset` order, a throw on a null key.
+What remains below is what was deliberate, and what is still unproven.
 
 ### Deliberate: record, do not fix
 
 - **`Window` reproduces a Calcite bug**: with UNBOUNDED/UNBOUNDED plus EXCLUDE the outer guard is false
   after row 0, so the exclusion never takes effect.
+- **`Window` streams its output** where Calcite collects it first. The reverse of the eagerness the other
+  operators had, and left alone: it holds the same rows in the same order and only reaches them sooner.
 - **RIGHT/FULL unmatched-right order**: Calcite walks an `IdentityHashMap`, whose buckets key on
   `System.identityHashCode`. We now dedup on identity as it does, but there is no CLR counterpart to that
   number, so the unmatched rows come out in insertion order. The set of rows is Calcite's; the order is not,
   and cannot be.
-- **`SemiJoin` applies the comparer** where linq4j's `contains` ignores it. Ours is more correct, and
-  unreachable: the key projection optimises to LIST/SCALAR, so `comparer()` is null.
 - **`CompareNullsLastForMergeJoin`** returns 1 for two nulls where Calcite throws and its caller converts to
   1. Composed behaviour identical; the contract no longer signals two-nulls to a future caller.
 

--- a/TODO.md
+++ b/TODO.md
@@ -161,15 +161,10 @@ plan can put a Calcite node above an asynchronous one, because Calcite cannot re
 divergent, 1 uncertain.** Everything below was found by reading Calcite beside ours; none of it was visible
 to the differential suite.
 
-### Wrong rows, latent
+Fixed so far, in both conventions: `HashEquiJoin`'s leftover order, `NestedLoopJoin` (five defects), and
+`RepeatUnion`'s termination test and clean-up ordering. Each carries a test that fails against the old
+behaviour -- `ClrEnumerableNestedLoopJoinTests` and `ClrRepeatUnionTests` for what no query can reach.
 
-- **`NestedLoopJoin` SEMI passes a null right row** where both of Calcite's bodies pass the matched inner
-  row. Invisible only because `ClrEnumUtils.JoinSelector` declares the right parameter for SEMI and never
-  reads it. Reachable from `MergeJoin`'s non-equi SEMI path.
-- **`RepeatUnion` stops one round early.** Calcite sets `current` to `DUMMY` at the end of each round but
-  never restores it across the seed/iteration boundary, so a non-empty seed followed by an empty round 0
-  does not stop it. Differs iff the seed emitted at least one row and round 0 emits nothing new; changes
-  rows only for a non-monotone step. Upstream behaviour at HEAD.
 ### Eager where Calcite is eager, or the reverse
 
 Calcite builds at call time and returns an enumerable over finished state; our `yield` iterators defer and
@@ -182,8 +177,6 @@ map there. `Window` is the reverse and in our favour: we stream output where Cal
 
 - **`Cartesian` is fully eager**: `new List(outer.Count * inner.Count)` before the first row, where
   Calcite's is lazy. Quadratic per merge-join key run, and that `int` multiply overflows around 2^31 pairs.
-- **`NestedLoopJoin` buffers its inner** where Calcite's optimized body re-enumerates per outer row. The
-  asymmetry is Calcite's own, so ours is a divergence rather than a choice.
 - **`SemiJoin` holds every inner row** where linq4j holds distinct keys, and drains the inner even for an
   empty outer where linq4j memoizes (CALCITE-2909).
 - **`Take` draws n rows where linq4j draws n+1**, because `takeWhile` reads `current()` before rejecting.
@@ -193,8 +186,6 @@ map there. `Window` is the reverse and in our favour: we stream output where Cal
 
 - `CorrelateJoin` does not reject RIGHT/FULL (Calcite throws, we silently inner-join) and does not guard a
   null correlated inner (Calcite substitutes empty, we throw). `LeftMarkJoin` next door does guard.
-- `RepeatUnion`'s `cleanUp` runs after the child enumerators close rather than before, and not at all if the
-  plan is created and never pulled.
 - `JavaSequences.ToJava`'s `reset()` throws where linq4j re-acquires. Only `CartesianProductEnumerator`
   calls it live.
 
@@ -208,11 +199,12 @@ yields in `HashMultiset` order, a throw on a null key.
 
 - **`Window` reproduces a Calcite bug**: with UNBOUNDED/UNBOUNDED plus EXCLUDE the outer guard is false
   after row 0, so the exclusion never takes effect.
-- **RIGHT/FULL unmatched-right dedup**: Calcite uses an identity set, so two unmatched rows that are the
-  same object emit once; ours emits twice. Ours is the SQL-correct answer.
-- **`HashEquiJoin` retires keys by the comparer** where linq4j uses natural equality on unwrapped keys, and
-  **`SemiJoin` applies the comparer** where linq4j's `contains` ignores it. Ours is more correct in both;
-  both unreachable, the key projection optimising to LIST/SCALAR so `comparer()` is null.
+- **RIGHT/FULL unmatched-right order**: Calcite walks an `IdentityHashMap`, whose buckets key on
+  `System.identityHashCode`. We now dedup on identity as it does, but there is no CLR counterpart to that
+  number, so the unmatched rows come out in insertion order. The set of rows is Calcite's; the order is not,
+  and cannot be.
+- **`SemiJoin` applies the comparer** where linq4j's `contains` ignores it. Ours is more correct, and
+  unreachable: the key projection optimises to LIST/SCALAR, so `comparer()` is null.
 - **`CompareNullsLastForMergeJoin`** returns 1 for two nulls where Calcite throws and its caller converts to
   1. Composed behaviour identical; the contract no longer signals two-nulls to a future caller.
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -2303,6 +2303,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <para>The accumulator carries each aggregate's state and its last result, so a result that does not
         /// change while the frame is intact is computed once and read again, which is the whole point of the
         /// frame bookkeeping. It is made once for the whole window, as Calcite declares its variables once.</para>
+        ///
+        /// <para><b>Forced by the CLR:</b> the generated block appends each output row to an <c>ArrayList</c>
+        /// and evaluates to <c>Linq4j.asEnumerable(list)</c>, so Calcite computes the whole window where the
+        /// expression is evaluated. A method returning an <see cref="IAsyncEnumerable{T}"/> cannot await
+        /// before it returns, so the rows are produced on the first <c>MoveNextAsync</c> instead. Same
+        /// constraint as <see cref="NestedLoopJoinAsList"/>.</para>
         /// </remarks>
         public static async IAsyncEnumerable<TResult> Window<TSource, TKey, TAccumulator, TResult>(
             IAsyncEnumerable<TSource> source,

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -1832,60 +1832,228 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="joinType"></param>
         /// <returns></returns>
         /// <remarks>
-        /// The counterpart of <c>EnumerableDefaults.nestedLoopJoin</c>. The inner sequence is read once and
-        /// kept, because it is walked again for every outer row.
+        /// <see cref="ClrEnumerableDefaults.NestedLoopJoin"/> over asynchronous sequences, and the same
+        /// dispatch <c>EnumerableDefaults.nestedLoopJoin</c> makes: a join type that generates nulls on the
+        /// left -- RIGHT and FULL -- goes to <see cref="NestedLoopJoinAsList"/>, which reads the inner into
+        /// a list; everything else goes to <see cref="NestedLoopJoinOptimized"/>, which buffers nothing and
+        /// re-enumerates the inner for every outer row. The asymmetry is Calcite's.
+        ///
+        /// <para>The token is an ordinary parameter here rather than an <c>[EnumeratorCancellation]</c> one,
+        /// because this method is not the iterator -- the two bodies are, and each carries the attribute. It
+        /// is declared at all so that the operator ends in a <see cref="CancellationToken"/>, which is what
+        /// <see cref="ClrAsyncBuiltInMethod.Call"/> requires of everything a plan calls.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> NestedLoopJoin<TSource, TInner, TResult>(
+        public static IAsyncEnumerable<TResult> NestedLoopJoin<TSource, TInner, TResult>(
+            IAsyncEnumerable<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource, TInner, bool> predicate,
+            org.apache.calcite.linq4j.JoinType joinType,
+            CancellationToken cancellationToken = default)
+        {
+            if (joinType.generatesNullsOnLeft() == false)
+                return NestedLoopJoinOptimized(outer, inner, resultSelector, predicate, joinType, cancellationToken);
+
+            return NestedLoopJoinAsList(outer, inner, resultSelector, predicate, joinType, cancellationToken);
+        }
+
+        /// <summary>
+        /// Joins two sequences on a condition, building the whole result before yielding any of it.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableDefaults.nestedLoopJoinAsList</c>. The inner is read into a list once, and the
+        /// unmatched right rows are held in a set keyed on identity -- <c>Sets.newIdentityHashSet()</c> --
+        /// so two unmatched rows that are the same object emit once, as they do in Calcite.
+        ///
+        /// <para><b>Forced by the CLR:</b> Calcite runs this whole join at <em>call</em> time and returns
+        /// <c>Linq4j.asEnumerable(result)</c>. A method returning an <see cref="IAsyncEnumerable{T}"/>
+        /// cannot await before it returns, so the work happens on the first <c>MoveNextAsync</c> instead.
+        /// Every row is still computed before the first one is yielded, which is the property the ordering
+        /// depends on.</para>
+        ///
+        /// <para><b>Also forced:</b> the unmatched rows come out in insertion order. Calcite walks an
+        /// <c>IdentityHashMap</c>, whose buckets are keyed on <c>System.identityHashCode</c>; there is no
+        /// CLR counterpart to that number, so the order cannot be reproduced. The set of rows, deduplication
+        /// included, is Calcite's.</para>
+        /// </remarks>
+        static async IAsyncEnumerable<TResult> NestedLoopJoinAsList<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TInner, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
-            var rows = (IReadOnlyList<TInner>)await Buffer(inner, cancellationToken).ConfigureAwait(false);
+        {
             var name = joinType.name();
-            var nullsOnRight = name is nameof(org.apache.calcite.linq4j.JoinType.LEFT) or nameof(org.apache.calcite.linq4j.JoinType.FULL);
-            var nullsOnLeft = name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL);
-            var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
-            var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
-            var matched = nullsOnLeft ? new bool[rows.Count] : null;
+            var generateNullsOnLeft = joinType.generatesNullsOnLeft();
+            var generateNullsOnRight = joinType.generatesNullsOnRight();
+            var result = new List<TResult>();
+            var rightList = await Buffer(inner, cancellationToken).ConfigureAwait(false);
+            HashSet<TInner>? rightUnmatched;
 
-            await foreach (var row in (outer).WithCancellation(cancellationToken))
+            if (generateNullsOnLeft)
             {
-                var any = false;
+                rightUnmatched = new HashSet<TInner>(ClrEnumerableDefaults.IdentityComparer<TInner>.Instance);
 
-                for (int i = 0; i < rows.Count; i++)
-                {
-                    if (predicate(row, rows[i]) == false)
-                        continue;
-
-                    any = true;
-                    if (matched != null)
-                        matched[i] = true;
-
-                    if (semi || anti)
-                        break;
-
-                    yield return resultSelector(row, rows[i]);
-                }
-
-                if (semi && any)
-                    yield return resultSelector(row, default!);
-                else if (anti && any == false)
-                    yield return resultSelector(row, default!);
-                else if (any == false && nullsOnRight)
-                    yield return resultSelector(row, default!);
+                foreach (var right in rightList)
+                    rightUnmatched.Add(right);
+            }
+            else
+            {
+                rightUnmatched = null;
             }
 
-            if (matched == null)
-                yield break;
+            await foreach (var left in outer.WithCancellation(cancellationToken))
+            {
+                var leftMatchCount = 0;
 
-            for (int i = 0; i < rows.Count; i++)
-                if (matched[i] == false)
-                    yield return resultSelector(default!, rows[i]);
+                foreach (var right in rightList)
+                {
+                    if (predicate(left, right))
+                    {
+                        ++leftMatchCount;
+
+                        if (name == nameof(org.apache.calcite.linq4j.JoinType.ANTI))
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            rightUnmatched?.Remove(right);
+
+                            // a semi join emits the matched right row, not a null one, and then stops
+                            result.Add(resultSelector(left, right));
+
+                            if (name == nameof(org.apache.calcite.linq4j.JoinType.SEMI))
+                                break;
+                        }
+                    }
+                }
+
+                if (leftMatchCount == 0 && (generateNullsOnRight || name == nameof(org.apache.calcite.linq4j.JoinType.ANTI)))
+                    result.Add(resultSelector(left, default!));
+            }
+
+            if (rightUnmatched != null)
+                foreach (var right in rightUnmatched)
+                    result.Add(resultSelector(default!, right));
+
+            foreach (var row in result)
+                yield return row;
         }
 
+        /// <summary>
+        /// Joins two sequences on a condition without building the result as a list first.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableDefaults.nestedLoopJoinOptimized</c>, and the same state machine: state 0 moves the
+        /// outer, state 1 moves the inner. The inner is enumerated afresh for every outer row and never read
+        /// into a list.
+        ///
+        /// <para>A join type that is none of the six the switch names -- ASOF, LEFT_ASOF, LEFT_MARK -- falls
+        /// to its default, which returns no pair and no unmatched row either, so the whole join is empty.
+        /// That is what Calcite does, and it is not treated as INNER.</para>
+        ///
+        /// <para>The RIGHT/FULL refusal happens when the caller calls rather than when it enumerates, as
+        /// Calcite's does, which is why this method is not itself the iterator.</para>
+        /// </remarks>
+        static IAsyncEnumerable<TResult> NestedLoopJoinOptimized<TSource, TInner, TResult>(
+            IAsyncEnumerable<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource, TInner, bool> predicate,
+            org.apache.calcite.linq4j.JoinType joinType,
+            CancellationToken cancellationToken = default)
+        {
+            var name = joinType.name();
+
+            if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
+                throw new ArgumentException($"JoinType {name} is unsupported");
+
+            return Walk(cancellationToken);
+
+            async IAsyncEnumerable<TResult> Walk([EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                var outerEnumerator = outer.GetAsyncEnumerator(cancellationToken);
+                IAsyncEnumerator<TInner>? innerEnumerator = null;
+                var outerMatch = false;
+                var outerValue = default(TSource)!;
+                var innerValue = default(TInner)!;
+                var state = 0;
+
+                try
+                {
+                    while (true)
+                    {
+                        switch (state)
+                        {
+                            case 0:
+                                if (await outerEnumerator.MoveNextAsync().ConfigureAwait(false) == false)
+                                    yield break;
+
+                                outerValue = outerEnumerator.Current;
+                                if (innerEnumerator != null)
+                                    await innerEnumerator.DisposeAsync().ConfigureAwait(false);
+                                innerEnumerator = inner.GetAsyncEnumerator(cancellationToken);
+                                outerMatch = false;
+                                state = 1;
+                                continue;
+                            case 1:
+                                if (await innerEnumerator!.MoveNextAsync().ConfigureAwait(false))
+                                {
+                                    innerValue = innerEnumerator.Current;
+
+                                    if (predicate(outerValue, innerValue))
+                                    {
+                                        outerMatch = true;
+
+                                        switch (name)
+                                        {
+                                            case nameof(org.apache.calcite.linq4j.JoinType.ANTI):
+                                                state = 0;
+                                                continue;
+                                            case nameof(org.apache.calcite.linq4j.JoinType.SEMI):
+                                                state = 0;
+                                                // the matched inner row, not a null one -- the fields are
+                                                // what Calcite's current() would have read
+                                                yield return resultSelector(outerValue, innerValue);
+                                                continue;
+                                            case nameof(org.apache.calcite.linq4j.JoinType.INNER):
+                                            case nameof(org.apache.calcite.linq4j.JoinType.LEFT):
+                                                yield return resultSelector(outerValue, innerValue);
+                                                continue;
+                                            default:
+                                                break;
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    state = 0;
+                                    innerValue = default!;
+
+                                    if (outerMatch == false &&
+                                        name is nameof(org.apache.calcite.linq4j.JoinType.LEFT) or nameof(org.apache.calcite.linq4j.JoinType.ANTI))
+                                    {
+                                        yield return resultSelector(outerValue, innerValue);
+                                        continue;
+                                    }
+                                }
+
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                finally
+                {
+                    await outerEnumerator.DisposeAsync().ConfigureAwait(false);
+                    if (innerEnumerator != null)
+                        await innerEnumerator.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
 
         /// <summary>
         /// Joins each row of a sequence to the rows a function of it yields.

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -1434,7 +1434,21 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                             return false;
                         }
 
-                        var c = Compare(leftKey, rightKey);
+                        int c;
+
+                        try
+                        {
+                            c = Compare(leftKey, rightKey);
+                        }
+                        catch (BothValuesAreNullException)
+                        {
+                            // take the left as the bigger, so the right advances and the algorithm carries on.
+                            // Unreachable: the null guard above returns before either key can be null. Calcite
+                            // has the same dead catch, and it is what decides the answer rather than the
+                            // comparison, so it is written here too.
+                            c = 1;
+                        }
+
                         if (c == 0)
                             break;
 
@@ -1588,16 +1602,35 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <summary>
+        /// Raised where a merge join compares two null keys, which it must not call equal.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableDefaults.BothValuesAreNullException</c>, which is private, so it is written again
+        /// rather than reused. It carries no message and is never allowed out of <c>advance</c>.
+        /// </remarks>
+        sealed class BothValuesAreNullException : Exception
+        {
+
+        }
+
+        /// <summary>
         /// Orders two keys with nulls last, refusing to call two nulls equal.
         /// </summary>
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.compareNullsLastForMergeJoin</c>, reached only where no
-        /// comparator was given. Two nulls are not equal, and the caller takes the left as the bigger.
+        /// comparator was given.
+        ///
+        /// <para>Two nulls are a throw rather than an answer, because there is no answer this method could
+        /// give that is right for both of its callers -- calling them equal would join them, and calling
+        /// either one bigger is a decision about which side to advance. Calcite leaves that decision to
+        /// <c>advance</c>, which catches this and takes 1. Returning 1 from here instead composed to the same
+        /// rows and quietly moved the decision, so a second caller would inherit an answer that was only ever
+        /// right for the first.</para>
         /// </remarks>
         static int CompareNullsLastForMergeJoin<TKey>(TKey a, TKey b)
         {
             if (a == null && b == null)
-                return 1;
+                throw new BothValuesAreNullException();
 
             if (a == null)
                 return 1;
@@ -1922,14 +1955,18 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var generateNullsOnRight = joinType.generatesNullsOnRight();
             var result = new List<TResult>();
             var rightList = await Buffer(inner, cancellationToken).ConfigureAwait(false);
-            HashSet<TInner>? rightUnmatched;
+            java.util.Set? rightUnmatched;
 
             if (generateNullsOnLeft)
             {
-                rightUnmatched = new HashSet<TInner>(ClrEnumerableDefaults.IdentityComparer<TInner>.Instance);
+                // Sets.newIdentityHashSet(), which is Guava's, backed by an IdentityHashMap. Not a stand-in
+                // for it: what comes out of here is the order that map's buckets give, keyed on
+                // System.identityHashCode, and nothing written against CLR references reproduces that. We
+                // run on IKVM, so the set Calcite uses is available and is the one used.
+                rightUnmatched = com.google.common.collect.Sets.newIdentityHashSet();
 
                 foreach (var right in rightList)
-                    rightUnmatched.Add(right);
+                    rightUnmatched.add(right);
             }
             else
             {
@@ -1952,7 +1989,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                         }
                         else
                         {
-                            rightUnmatched?.Remove(right);
+                            rightUnmatched?.remove(right);
 
                             // a semi join emits the matched right row, not a null one, and then stops
                             result.Add(resultSelector(left, right));
@@ -1968,8 +2005,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             }
 
             if (rightUnmatched != null)
-                foreach (var right in rightUnmatched)
-                    result.Add(resultSelector(default!, right));
+                for (var i = rightUnmatched.iterator(); i.hasNext();)
+                    result.Add(resultSelector(default!, (TInner)i.next()));
 
             foreach (var row in result)
                 yield return row;

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -2493,46 +2493,86 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.repeatUnion</c>, which is what WITH RECURSIVE becomes. The
         /// iterative part is enumerated afresh each round, reading what the spool beneath it left behind.
+        ///
+        /// <para>Transcribed from Calcite's enumerator rather than re-expressed, because its termination test
+        /// is not the obvious one. It stops when <c>current</c> still holds the <c>DUMMY</c> sentinel after a
+        /// round -- not when the round produced nothing. Those differ, and the difference is reproduced here
+        /// deliberately: see the note at the seed/iteration boundary.</para>
+        ///
+        /// <para>The sentinel itself is a flag. Calcite casts a private <c>DUMMY</c> object to the row type and
+        /// compares by reference; a row can never be that object, so a <see cref="bool"/> decides exactly what
+        /// the reference comparison decides, without a cast that would be a lie about the row type.</para>
         /// </remarks>
         public static async IAsyncEnumerable<TSource> RepeatUnion<TSource>(IAsyncEnumerable<TSource> seed, IAsyncEnumerable<TSource> iteration, int iterationLimit, bool all, EqualityComparer? comparer, Action? cleanUp,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+        {
             ArgumentNullException.ThrowIfNull(seed);
             ArgumentNullException.ThrowIfNull(iteration);
 
+            var processed = all ? null : new HashSet<TSource>(JavaEqualityComparer<TSource>.Of(comparer));
+
+            // Calcite's `current == DUMMY`. Set false wherever `checkValue` passed and Calcite assigned
+            // `current`, and back to true wherever Calcite put the sentinel back.
+            var currentIsDummy = true;
+
+            // the seed enumerator is held for the whole life of the sequence, as Calcite holds it -- it is
+            // closed in `close()` and not when the seed runs out
+            var seedEnumerator = seed.GetAsyncEnumerator(cancellationToken);
+            IAsyncEnumerator<TSource>? iterativeEnumerator = null;
+
             try
             {
-                var processed = all ? null : new HashSet<TSource>(JavaEqualityComparer<TSource>.Of(comparer));
-
-                await foreach (var row in (seed).WithCancellation(cancellationToken))
-                    if (processed == null || processed.Add(row))
-                        yield return row;
-
-                for (int i = 0; iterationLimit < 0 || i < iterationLimit; i++)
+                while (await seedEnumerator.MoveNextAsync().ConfigureAwait(false))
                 {
-                    // a round that returned no row this sequence had not already returned is the end of it,
-                    // and not a round that read no rows. Calcite's own enumerator says the same thing by
-                    // setting `current` only where `checkValue` passed and stopping where it is still DUMMY.
-                    // Counting what was read instead is an infinite loop for every UNION rather than UNION
-                    // ALL: the iterative part re-reads the whole spool each round and so never runs dry.
-                    var any = false;
+                    var value = seedEnumerator.Current;
 
-                    await foreach (var row in (iteration).WithCancellation(cancellationToken))
+                    if (processed == null || processed.Add(value))
                     {
-                        if (processed == null || processed.Add(row))
+                        currentIsDummy = false;
+                        yield return value;
+                    }
+                }
+
+                // The sentinel is NOT put back here, and that is Calcite's, not an oversight of the
+                // transcription. A seed that emitted a row leaves `current` holding that row, so the first
+                // iterative round to produce nothing does not stop the sequence -- it goes round once more,
+                // and only the second empty round stops it. A recursive query whose step reads the working
+                // table row by row cannot tell, because an empty table gives an empty round either way; one
+                // whose step aggregates -- COUNT(*) yields a row over no rows -- can, and does.
+                for (var currentIteration = 0; ; currentIteration++)
+                {
+                    if (iterationLimit >= 0 && currentIteration == iterationLimit)
+                        yield break;
+
+                    iterativeEnumerator = iteration.GetAsyncEnumerator(cancellationToken);
+
+                    while (await iterativeEnumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        var value = iterativeEnumerator.Current;
+
+                        if (processed == null || processed.Add(value))
                         {
-                            any = true;
-                            yield return row;
+                            currentIsDummy = false;
+                            yield return value;
                         }
                     }
 
-                    if (any == false)
+                    if (currentIsDummy)
                         yield break;
+
+                    currentIsDummy = true;
+                    await iterativeEnumerator.DisposeAsync().ConfigureAwait(false);
+                    iterativeEnumerator = null;
                 }
             }
             finally
             {
+                // Calcite's `close()` in its order: the clean-up first, then the two enumerators. An await
+                // foreach would have disposed them first, which is the other way round.
                 cleanUp?.Invoke();
+                await seedEnumerator.DisposeAsync().ConfigureAwait(false);
+                if (iterativeEnumerator != null)
+                    await iterativeEnumerator.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -187,26 +187,27 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <remarks>
-        /// Written out rather than delegated, for the reason the class remarks give. It stops reading the
-        /// input once it has what it needs, which is what makes a fetch over a table a fetch rather than a
-        /// scan.
+        /// <c>EnumerableDefaults.take</c> is <c>takeWhile</c> over <c>n &lt; count</c>, and
+        /// <c>TakeWhileLongEnumerator.moveNext</c> is <c>enumerator.moveNext() &amp;&amp; predicate(current,
+        /// ++n)</c> -- it has to draw a row before it can test it. Two consequences, and both are visible.
+        ///
+        /// <para>A satisfied fetch has drawn one row more than it returned. Over a table that is a row the
+        /// scan actually read.</para>
+        ///
+        /// <para>A count of zero still opens the input and still draws that row. Opening is not free: it is
+        /// what runs a lazy collection spool's write-back and a repeat union's clean-up. Returning an empty
+        /// sequence without touching the input skips both.</para>
         /// </remarks>
         public static async IAsyncEnumerable<TSource> Take<TSource>(IAsyncEnumerable<TSource> source, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            if (count <= 0)
-                yield break;
+            await using var enumerator = source.GetAsyncEnumerator(cancellationToken);
 
-            var taken = 0;
+            var n = -1;
 
-            await foreach (var row in source.WithCancellation(cancellationToken))
-            {
-                yield return row;
-
-                if (++taken >= count)
-                    yield break;
-            }
+            while (await enumerator.MoveNextAsync().ConfigureAwait(false) && ++n < count)
+                yield return enumerator.Current;
         }
 
         /// <summary>
@@ -412,28 +413,6 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <summary>
-        /// Returns each row as many times as it appears in both sequences.
-        /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="other"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        static IEnumerable<TSource> IntersectAll<TSource>(IEnumerable<TSource> source, IEnumerable<TSource> other, IEqualityComparer<TSource> comparer)
-        {
-            var counts = Count(other, comparer);
-
-            foreach (var row in source)
-            {
-                if (counts.TryGetValue(row, out var remaining) == false || remaining == 0)
-                    continue;
-
-                counts[row] = remaining - 1;
-                yield return row;
-            }
-        }
-
-        /// <summary>
         /// Returns the rows of the first sequence that are not in the second.
         /// </summary>
         /// <typeparam name="TSource"></typeparam>
@@ -456,47 +435,6 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 yield return row;
         }
 
-
-        /// <summary>
-        /// Returns each row of the first sequence except as many times as it appears in the second.
-        /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="other"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        static IEnumerable<TSource> ExceptAll<TSource>(IEnumerable<TSource> source, IEnumerable<TSource> other, IEqualityComparer<TSource> comparer)
-        {
-            var counts = Count(other, comparer);
-
-            foreach (var row in source)
-            {
-                if (counts.TryGetValue(row, out var remaining) && remaining > 0)
-                {
-                    counts[row] = remaining - 1;
-                    continue;
-                }
-
-                yield return row;
-            }
-        }
-
-        /// <summary>
-        /// Counts how many times each row appears.
-        /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        static Dictionary<TSource, int> Count<TSource>(IEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
-        {
-            var counts = new Dictionary<TSource, int>(comparer);
-
-            foreach (var row in source)
-                counts[row] = counts.TryGetValue(row, out var count) ? count + 1 : 1;
-
-            return counts;
-        }
 
         /// <summary>
         /// Returns the distinct rows of a sequence.
@@ -919,7 +857,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="anti">Whether the rows without a match are the ones returned.</param>
         /// <param name="predicate"></param>
         /// <returns></returns>
-        public static async IAsyncEnumerable<TSource> SemiJoin<TSource, TInner, TKey>(
+        /// <remarks>
+        /// <c>EnumerableDefaults.semiJoin</c>, which is a dispatch and not an implementation: with no
+        /// predicate it is <c>semiEquiJoin_</c>, which holds the distinct inner <em>keys</em>, and with one it
+        /// is <c>semiJoinWithPredicate_</c>, which holds a lookup of inner <em>rows</em> because the predicate
+        /// has to see them. Those are the two methods below, and they are not the same algorithm.
+        /// </remarks>
+        public static IAsyncEnumerable<TSource> SemiJoin<TSource, TInner, TKey>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
@@ -927,37 +871,110 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             EqualityComparer? comparer,
             bool anti,
             Func<TSource, TInner, bool>? predicate,
+            CancellationToken cancellationToken = default)
+        {
+            return predicate == null
+                ? SemiEquiJoin(outer, inner, outerKeySelector, innerKeySelector, comparer, anti, cancellationToken)
+                : SemiJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, comparer, anti, predicate, cancellationToken);
+        }
+
+        /// <summary>
+        /// Returns the rows of the first sequence whose key is, or is not, one of the second's.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ClrEnumerableDefaults.SemiEquiJoin"/> over asynchronous sequences:
+        /// <c>EnumerableDefaults.semiEquiJoin_</c>, the distinct keys rather than the rows, the two sets that
+        /// keep the comparer off the membership test, and CALCITE-2909's memoization.
+        /// </remarks>
+        static async IAsyncEnumerable<TSource> SemiEquiJoin<TSource, TInner, TKey>(
+            IAsyncEnumerable<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
-            var equality = JavaEqualityComparer<TKey>.Of(comparer);
-            var lookup = new Dictionary<TKey, List<TInner>>(equality);
+        {
+            java.util.HashSet? keys = null;
 
-            await foreach (var row in (inner).WithCancellation(cancellationToken))
+            await foreach (var row in outer.WithCancellation(cancellationToken))
             {
-                var key = innerKeySelector(row);
-                if (key == null)
-                    continue;
+                if (keys == null)
+                {
+                    var distinct = new java.util.HashSet();
+                    keys = new java.util.HashSet();
 
-                if (lookup.TryGetValue(key, out var bucket) == false)
-                    lookup[key] = bucket = [];
+                    await foreach (var innerRow in inner.WithCancellation(cancellationToken))
+                    {
+                        var innerKey = JavaValues.From(innerKeySelector(innerRow));
 
-                bucket.Add(row);
-            }
+                        if (distinct.add(JavaWrapped.Of(comparer, innerKey)))
+                            keys.add(innerKey);
+                    }
+                }
 
-            await foreach (var row in (outer).WithCancellation(cancellationToken))
-            {
                 var key = outerKeySelector(row);
-                var any = false;
+                var found = key != null && keys.contains(JavaValues.From(key));
 
-                if (key != null && lookup.TryGetValue(key, out var bucket))
-                    foreach (var other in (bucket))
-                        if (predicate == null || predicate(row, other))
+                if (found != anti)
+                    yield return row;
+            }
+        }
+
+        /// <summary>
+        /// Returns the rows of the first sequence that have, or have not, a match in the second under a
+        /// condition the key does not express.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ClrEnumerableDefaults.SemiJoinWithPredicate"/> over asynchronous sequences:
+        /// <c>EnumerableDefaults.semiJoinWithPredicate_</c>, which holds the rows and does let the comparer
+        /// reach the lookup.
+        /// </remarks>
+        static async IAsyncEnumerable<TSource> SemiJoinWithPredicate<TSource, TInner, TKey>(
+            IAsyncEnumerable<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti,
+            Func<TSource, TInner, bool> predicate,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            java.util.HashMap? lookup = null;
+
+            await foreach (var row in outer.WithCancellation(cancellationToken))
+            {
+                if (lookup == null)
+                {
+                    lookup = new java.util.HashMap();
+
+                    await foreach (var innerRow in inner.WithCancellation(cancellationToken))
+                    {
+                        var innerKey = JavaWrapped.Of(comparer, JavaValues.From(innerKeySelector(innerRow)));
+
+                        if (lookup.get(innerKey) is not List<TInner> bucket)
+                            lookup.put(innerKey, bucket = []);
+
+                        bucket.Add(innerRow);
+                    }
+                }
+
+                var key = outerKeySelector(row);
+                var found = false;
+
+                if (key != null && lookup.get(JavaWrapped.Of(comparer, JavaValues.From(key))) is List<TInner> matches)
+                {
+                    foreach (var other in matches)
+                    {
+                        if (predicate(row, other))
                         {
-                            any = true;
+                            found = true;
                             break;
                         }
+                    }
+                }
 
-                if (any != anti)
+                if (found != anti)
                     yield return row;
             }
         }
@@ -987,6 +1004,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <para>The index is a <c>java.util.HashMap</c> rather than a <see cref="Dictionary{TKey, TValue}"/>
         /// because the emitted order is that map's iteration order, and nothing else can agree with the map
         /// linq4j walks. Same lesson as the partition order of a window.</para>
+        ///
+        /// <para><b>Forced by the CLR:</b> Calcite builds all three indexes where <c>asofJoin</c> is called
+        /// and only then returns the enumerable that walks them. A method returning an
+        /// <see cref="IAsyncEnumerable{T}"/> cannot await before it returns, so both scans happen on the first
+        /// <c>MoveNextAsync</c>. Every index is still complete before the first row is yielded. Same
+        /// constraint as <see cref="NestedLoopJoinAsList"/>.</para>
         /// </remarks>
         public static async IAsyncEnumerable<TResult> AsofJoin<TSource, TInner, TKey, TResult>(
             IAsyncEnumerable<TSource> outer,
@@ -1544,14 +1567,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <summary>
         /// Returns every pairing of two sequences, in order.
         /// </summary>
+        /// <remarks>
+        /// <c>CartesianProductJoinEnumerator</c>, which extends linq4j's <c>CartesianProductEnumerator</c> and
+        /// holds nothing: it advances the last enumerator first and only falls back to the one before it when
+        /// that runs out, which is this nesting. Building the pairings into a list instead made a merge join
+        /// pay for the whole of a key run before it could yield the first row of it, and multiplied the two
+        /// counts as <see cref="int"/> to size the list -- an overflow at about 2^31 pairs, on the one path
+        /// where a run of equal keys on both sides is exactly what produces them.
+        ///
+        /// <para>Being lazy couples this to the caller: the two lists are the merge join's own buffers, reused
+        /// and cleared per key run, so the pairings must be drained before the join advances. They are -- the
+        /// driving loop yields all of <c>results</c> before it calls <c>Advance</c>. Calcite has the same
+        /// coupling, <c>Linq4j.enumerator(lefts)</c> being a live view of the list it goes on clearing.</para>
+        /// </remarks>
         static IEnumerable<TResult> Cartesian<TSource, TInner, TResult>(IReadOnlyList<TSource> outer, IReadOnlyList<TInner> inner, Func<TSource, TInner, TResult> resultSelector)
         {
-            var rows = new List<TResult>(outer.Count * inner.Count);
             foreach (var left in outer)
                 foreach (var right in inner)
-                    rows.Add(resultSelector(left, right));
-
-            return rows;
+                    yield return resultSelector(left, right);
         }
 
         /// <summary>
@@ -2068,41 +2101,61 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <returns></returns>
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.correlateJoin</c>.
+        ///
+        /// <para>Two things it does before any row moves. RIGHT and FULL are refused -- a correlated join has
+        /// no right side to drive -- and the refusal happens where the enumerable is built rather than where
+        /// it is enumerated, which is why this method is not itself the iterator. And a correlated function
+        /// that answers null is read as an empty sequence rather than dereferenced; Calcite writes
+        /// <c>Linq4j.emptyEnumerable()</c> for it, and <c>LeftMarkJoin</c> next door already guarded it.</para>
+        ///
+        /// <para>The null right row a SEMI join emits is Calcite's too, and for a subtler reason than it
+        /// looks: its enumerator returns without assigning <c>innerValue</c>, so <c>current()</c> reads
+        /// whatever was there. For a join that is SEMI throughout, that is null every time.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> CorrelateJoin<TSource, TInner, TResult>(
+        public static IAsyncEnumerable<TResult> CorrelateJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             Func<TSource, IAsyncEnumerable<TInner>> inner,
             Func<TSource, TInner, TResult> resultSelector,
             org.apache.calcite.linq4j.JoinType joinType,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+            CancellationToken cancellationToken = default)
+        {
             var name = joinType.name();
-            var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
-            var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
-            var nullsOnRight = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
 
-            await foreach (var row in (outer).WithCancellation(cancellationToken))
+            if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
+                throw new ArgumentException($"JoinType {name} is not valid for correlation");
+
+            return Walk(cancellationToken);
+
+            async IAsyncEnumerable<TResult> Walk([EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
-                var any = false;
+                var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
+                var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
+                var nullsOnRight = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
 
-                await foreach (var other in (inner(row).WithCancellation(cancellationToken)))
+                await foreach (var row in outer.WithCancellation(cancellationToken))
                 {
-                    any = true;
+                    var any = false;
 
-                    if (semi || anti)
-                        break;
+                    await foreach (var other in (inner(row) ?? Empty<TInner>(cancellationToken)).WithCancellation(cancellationToken))
+                    {
+                        any = true;
 
-                    yield return resultSelector(row, other);
+                        if (semi || anti)
+                            break;
+
+                        yield return resultSelector(row, other);
+                    }
+
+                    if (semi && any)
+                        yield return resultSelector(row, default!);
+                    else if (anti && any == false)
+                        yield return resultSelector(row, default!);
+                    else if (any == false && nullsOnRight)
+                        yield return resultSelector(row, default!);
                 }
-
-                if (semi && any)
-                    yield return resultSelector(row, default!);
-                else if (anti && any == false)
-                    yield return resultSelector(row, default!);
-                else if (any == false && nullsOnRight)
-                    yield return resultSelector(row, default!);
             }
         }
+
 
 
         /// <summary>
@@ -2122,6 +2175,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// The counterpart of <c>EnumerableDefaults.groupBy</c>. The three functions are Calcite's, because
         /// they come from its <c>AggregateLambdaFactory</c> rather than from anything built here. Groups are
         /// returned in the order their keys were first seen, which is what linq4j's own map ordering gives.
+        /// <para><b>Forced by the CLR:</b> <c>groupBy_</c> drains the input where it is called and returns a
+        /// <c>LookupResultEnumerable</c> over a finished map. A method returning an
+        /// <see cref="IAsyncEnumerable{T}"/> cannot await before it returns, so the fold happens on the first
+        /// <c>MoveNextAsync</c> instead, and a second pass folds again where Calcite replays. Every group is
+        /// still complete before the first one is yielded, which is the property the order rests on. Same
+        /// constraint as <see cref="NestedLoopJoinAsList"/>.</para>
         /// </remarks>
         public static async IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(
             IAsyncEnumerable<TSource> source,
@@ -2170,6 +2229,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <c>GROUPING SETS</c> and has no counterpart on <c>Enumerable</c>. Every row is offered to every
         /// selector, so one pass folds it into one group per grouping set; the keys of two sets never collide
         /// because each carries an indicator per field saying which set it came from.
+        /// <para><b>Forced by the CLR:</b> <c>groupBy_</c> drains the input where it is called and returns a
+        /// <c>LookupResultEnumerable</c> over a finished map. A method returning an
+        /// <see cref="IAsyncEnumerable{T}"/> cannot await before it returns, so the fold happens on the first
+        /// <c>MoveNextAsync</c> instead, and a second pass folds again where Calcite replays. Every group is
+        /// still complete before the first one is yielded, which is the property the order rests on. Same
+        /// constraint as <see cref="NestedLoopJoinAsList"/>.</para>
         /// </remarks>
         public static async IAsyncEnumerable<TResult> GroupByMultiple<TSource, TKey, TResult>(
             IAsyncEnumerable<TSource> source,

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -816,13 +816,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             if (unmatched == null)
                 yield break;
 
-            for (var i = lookup.entrySet().iterator(); i.hasNext();)
+            // the set is walked and each key looked back up, which is what linq4j does and is not the same as
+            // walking the map and filtering by the set. A HashSet copied from a key set does not have the
+            // map's iteration order: HashSet(Collection) sizes its table as
+            // tableSizeFor(max((int) (n / 0.75f) + 1, 16)), while a map grown by insertion holds the smallest
+            // power of two at or above 16 that still leaves n <= 0.75 * cap. The two disagree exactly where
+            // n = 0.75 * 2^k — 12, 24, 48 — and these rows have no ORDER BY over them.
+            for (var i = unmatched.iterator(); i.hasNext();)
             {
-                var entry = (java.util.Map.Entry)i.next();
-                if (unmatched.contains(entry.getKey()) == false)
-                    continue;
+                var key = i.next();
 
-                foreach (var other in (List<TInner>)entry.getValue())
+                foreach (var other in (List<TInner>)lookup.get(key))
                     yield return resultSelector(default!, other);
             }
         }

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -2343,8 +2343,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var frame = new WindowFrame();
             var accumulator = accumulatorInitializer();
 
-            foreach (var rows in Partitions(await Buffer(source, cancellationToken).ConfigureAwait(false), partitionSelector, comparator))
+            var (collection, iterator) = PartitionIterator(await Buffer(source, cancellationToken).ConfigureAwait(false), partitionSelector, comparator);
+            var list = new List<TResult>(PartitionCollectionSize(collection));
+
+            while (iterator.hasNext())
             {
+                var rows = (object[])iterator.next();
+
                 frame.Rows = rows;
                 frame.PartitionRowCount = rows.Length;
 
@@ -2416,14 +2421,20 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     if (uncachedResult != null)
                         accumulator = uncachedResult(frame, accumulator);
 
-                    yield return selector(frame, accumulator);
+                    list.Add(selector(frame, accumulator));
                 }
             }
+
+            ClearPartitionCollection(collection);
+
+            foreach (var row in list)
+                yield return row;
         }
 
 
         /// <summary>
-        /// Returns the rows of each partition, in the window's order.
+        /// Returns the collection the rows were buffered into, and an iterator over the partitions in the
+        /// window's order.
         /// </summary>
         /// <typeparam name="TSource"></typeparam>
         /// <typeparam name="TKey"></typeparam>
@@ -2440,30 +2451,65 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// partition of its own, and <c>arrays</c> sorts with <c>Arrays.sort</c>, which is stable, so rows the
         /// collation does not separate stay in the order they arrived.
         /// </remarks>
-        static IEnumerable<object[]> Partitions<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey>? partitionSelector, java.util.Comparator comparator)
+        static (object Collection, java.util.Iterator Iterator) PartitionIterator<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey>? partitionSelector, java.util.Comparator comparator)
         {
-            java.util.Iterator iterator;
-
             if (partitionSelector == null)
             {
-                // one partition, which is yielded even when it is empty
-                var all = new java.util.ArrayList();
+                // one partition, which is iterated even when it is empty
+                var tempList = new java.util.ArrayList();
                 foreach (var row in source)
-                    all.add(row);
+                    tempList.add(row);
 
-                iterator = org.apache.calcite.runtime.SortedMultiMap.singletonArrayIterator(comparator, all);
+                return (tempList, org.apache.calcite.runtime.SortedMultiMap.singletonArrayIterator(comparator, tempList));
             }
-            else
+
+            var multiMap = new org.apache.calcite.runtime.SortedMultiMap();
+            foreach (var row in source)
+                multiMap.putMulti(partitionSelector(row), row);
+
+            return (multiMap, multiMap.arrays(comparator));
+        }
+
+        /// <summary>
+        /// Returns the size the generated block would size its output list by.
+        /// </summary>
+        /// <remarks>
+        /// <c>new ArrayList&lt;&gt;(collectionExpr.size())</c>. Calcite names <c>Collection.size</c> on
+        /// whichever of the two it has and lets javac resolve it against the receiver, which is the advisory
+        /// <c>Method</c> trap in the other direction: over a <c>SortedMultiMap</c> that resolves to
+        /// <c>HashMap.size</c> and counts partitions, and over the one-partition list it counts rows. Two
+        /// different quantities from one written call, and C# has to dispatch on the type to get both.
+        /// </remarks>
+        static int PartitionCollectionSize(object collection)
+        {
+            return collection switch
             {
-                var multiMap = new org.apache.calcite.runtime.SortedMultiMap();
-                foreach (var row in source)
-                    multiMap.putMulti(partitionSelector(row), row);
+                java.util.Map map => map.size(),
+                java.util.Collection rows => rows.size(),
+                _ => 0,
+            };
+        }
 
-                iterator = multiMap.arrays(comparator);
+        /// <summary>
+        /// Drops the buffered input, as the generated block does before it hands the output list on.
+        /// </summary>
+        /// <remarks>
+        /// <c>collectionExpr.clear()</c>, which Calcite writes as <c>BuiltInMethod.MAP_CLEAR</c> and comments
+        /// "allows gc". It is the reason the whole window can be materialised without the input and the output
+        /// being alive at once, and the same advisory resolution as the size above -- <c>Map.clear</c> named
+        /// on a <c>List</c> is <c>List.clear</c> once javac has seen the receiver.
+        /// </remarks>
+        static void ClearPartitionCollection(object collection)
+        {
+            switch (collection)
+            {
+                case java.util.Map map:
+                    map.clear();
+                    break;
+                case java.util.Collection rows:
+                    rows.clear();
+                    break;
             }
-
-            while (iterator.hasNext())
-                yield return (object[])iterator.next();
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -2201,10 +2201,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var frame = new WindowFrame();
             var accumulator = accumulatorInitializer();
-            var list = new List<TResult>();
 
-            foreach (var rows in Partitions(source, partitionSelector, comparator))
+            var (collection, iterator) = PartitionIterator(source, partitionSelector, comparator);
+            var list = new List<TResult>(PartitionCollectionSize(collection));
+
+            while (iterator.hasNext())
             {
+                var rows = (object[])iterator.next();
+
                 frame.Rows = rows;
                 frame.PartitionRowCount = rows.Length;
 
@@ -2280,11 +2284,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
             }
 
+            ClearPartitionCollection(collection);
+
             return list;
         }
 
         /// <summary>
-        /// Returns the rows of each partition, in the window's order.
+        /// Returns the collection the rows were buffered into, and an iterator over the partitions in the
+        /// window's order.
         /// </summary>
         /// <typeparam name="TSource"></typeparam>
         /// <typeparam name="TKey"></typeparam>
@@ -2301,30 +2308,65 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// partition of its own, and <c>arrays</c> sorts with <c>Arrays.sort</c>, which is stable, so rows the
         /// collation does not separate stay in the order they arrived.
         /// </remarks>
-        static IEnumerable<object[]> Partitions<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey>? partitionSelector, java.util.Comparator comparator)
+        static (object Collection, java.util.Iterator Iterator) PartitionIterator<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey>? partitionSelector, java.util.Comparator comparator)
         {
-            java.util.Iterator iterator;
-
             if (partitionSelector == null)
             {
-                // one partition, which is yielded even when it is empty
-                var all = new java.util.ArrayList();
+                // one partition, which is iterated even when it is empty
+                var tempList = new java.util.ArrayList();
                 foreach (var row in source)
-                    all.add(row);
+                    tempList.add(row);
 
-                iterator = org.apache.calcite.runtime.SortedMultiMap.singletonArrayIterator(comparator, all);
+                return (tempList, org.apache.calcite.runtime.SortedMultiMap.singletonArrayIterator(comparator, tempList));
             }
-            else
+
+            var multiMap = new org.apache.calcite.runtime.SortedMultiMap();
+            foreach (var row in source)
+                multiMap.putMulti(partitionSelector(row), row);
+
+            return (multiMap, multiMap.arrays(comparator));
+        }
+
+        /// <summary>
+        /// Returns the size the generated block would size its output list by.
+        /// </summary>
+        /// <remarks>
+        /// <c>new ArrayList&lt;&gt;(collectionExpr.size())</c>. Calcite names <c>Collection.size</c> on
+        /// whichever of the two it has and lets javac resolve it against the receiver, which is the advisory
+        /// <c>Method</c> trap in the other direction: over a <c>SortedMultiMap</c> that resolves to
+        /// <c>HashMap.size</c> and counts partitions, and over the one-partition list it counts rows. Two
+        /// different quantities from one written call, and C# has to dispatch on the type to get both.
+        /// </remarks>
+        static int PartitionCollectionSize(object collection)
+        {
+            return collection switch
             {
-                var multiMap = new org.apache.calcite.runtime.SortedMultiMap();
-                foreach (var row in source)
-                    multiMap.putMulti(partitionSelector(row), row);
+                java.util.Map map => map.size(),
+                java.util.Collection rows => rows.size(),
+                _ => 0,
+            };
+        }
 
-                iterator = multiMap.arrays(comparator);
+        /// <summary>
+        /// Drops the buffered input, as the generated block does before it hands the output list on.
+        /// </summary>
+        /// <remarks>
+        /// <c>collectionExpr.clear()</c>, which Calcite writes as <c>BuiltInMethod.MAP_CLEAR</c> and comments
+        /// "allows gc". It is the reason the whole window can be materialised without the input and the output
+        /// being alive at once, and the same advisory resolution as the size above -- <c>Map.clear</c> named
+        /// on a <c>List</c> is <c>List.clear</c> once javac has seen the receiver.
+        /// </remarks>
+        static void ClearPartitionCollection(object collection)
+        {
+            switch (collection)
+            {
+                case java.util.Map map:
+                    map.clear();
+                    break;
+                case java.util.Collection rows:
+                    rows.clear();
+                    break;
             }
-
-            while (iterator.hasNext())
-                yield return (object[])iterator.next();
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -135,9 +135,28 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="source"></param>
         /// <param name="count"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// <c>EnumerableDefaults.take</c> is <c>takeWhile</c> over <c>n &lt; count</c>, and
+        /// <c>TakeWhileLongEnumerator.moveNext</c> is <c>enumerator.moveNext() &amp;&amp; predicate(current,
+        /// ++n)</c> -- it has to draw a row before it can test it. Two consequences, and both are visible.
+        ///
+        /// <para>A satisfied fetch has drawn one row more than it returned. Over a table that is a row the
+        /// scan actually read.</para>
+        ///
+        /// <para>A count of zero still opens the input and still draws that row. Opening is not free: it is
+        /// what runs a lazy collection spool's write-back and a repeat union's clean-up. Returning an empty
+        /// sequence without touching the input skips both.</para>
+        /// </remarks>
         public static IEnumerable<TSource> Take<TSource>(IEnumerable<TSource> source, int count)
         {
-            return source.Take(count);
+            ArgumentNullException.ThrowIfNull(source);
+
+            using var enumerator = source.GetEnumerator();
+
+            var n = -1;
+
+            while (enumerator.MoveNext() && ++n < count)
+                yield return enumerator.Current;
         }
 
         /// <summary>
@@ -222,28 +241,6 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <summary>
-        /// Returns each row as many times as it appears in both sequences.
-        /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="other"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        static IEnumerable<TSource> IntersectAll<TSource>(IEnumerable<TSource> source, IEnumerable<TSource> other, IEqualityComparer<TSource> comparer)
-        {
-            var counts = Count(other, comparer);
-
-            foreach (var row in source)
-            {
-                if (counts.TryGetValue(row, out var remaining) == false || remaining == 0)
-                    continue;
-
-                counts[row] = remaining - 1;
-                yield return row;
-            }
-        }
-
-        /// <summary>
         /// Returns the rows of the first sequence that are not in the second.
         /// </summary>
         /// <typeparam name="TSource"></typeparam>
@@ -262,47 +259,6 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 collection.remove(JavaWrapped.Of(comparer, JavaValues.From(row)));
 
             return Unwrap<TSource>(collection);
-        }
-
-        /// <summary>
-        /// Returns each row of the first sequence except as many times as it appears in the second.
-        /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="other"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        static IEnumerable<TSource> ExceptAll<TSource>(IEnumerable<TSource> source, IEnumerable<TSource> other, IEqualityComparer<TSource> comparer)
-        {
-            var counts = Count(other, comparer);
-
-            foreach (var row in source)
-            {
-                if (counts.TryGetValue(row, out var remaining) && remaining > 0)
-                {
-                    counts[row] = remaining - 1;
-                    continue;
-                }
-
-                yield return row;
-            }
-        }
-
-        /// <summary>
-        /// Counts how many times each row appears.
-        /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        static Dictionary<TSource, int> Count<TSource>(IEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
-        {
-            var counts = new Dictionary<TSource, int>(comparer);
-
-            foreach (var row in source)
-                counts[row] = counts.TryGetValue(row, out var count) ? count + 1 : 1;
-
-            return counts;
         }
 
         /// <summary>
@@ -714,6 +670,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="anti">Whether the rows without a match are the ones returned.</param>
         /// <param name="predicate"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// <c>EnumerableDefaults.semiJoin</c>, which is a dispatch and not an implementation: with no
+        /// predicate it is <c>semiEquiJoin_</c>, which holds the distinct inner <em>keys</em>, and with one it
+        /// is <c>semiJoinWithPredicate_</c>, which holds a lookup of inner <em>rows</em> because the predicate
+        /// has to see them. Those are the two methods below, and they are not the same algorithm.
+        /// </remarks>
         public static IEnumerable<TSource> SemiJoin<TSource, TInner, TKey>(
             IEnumerable<TSource> outer,
             IEnumerable<TInner> inner,
@@ -723,35 +685,116 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             bool anti,
             Func<TSource, TInner, bool>? predicate)
         {
-            var equality = JavaEqualityComparer<TKey>.Of(comparer);
-            var lookup = new Dictionary<TKey, List<TInner>>(equality);
+            return predicate == null
+                ? SemiEquiJoin(outer, inner, outerKeySelector, innerKeySelector, comparer, anti)
+                : SemiJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, comparer, anti, predicate);
+        }
 
-            foreach (var row in inner)
-            {
-                var key = innerKeySelector(row);
-                if (key == null)
-                    continue;
-
-                if (lookup.TryGetValue(key, out var bucket) == false)
-                    lookup[key] = bucket = [];
-
-                bucket.Add(row);
-            }
+        /// <summary>
+        /// Returns the rows of the first sequence whose key is, or is not, one of the second's.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableDefaults.semiEquiJoin_</c>. It holds <c>inner.select(innerKeySelector).distinct()</c>
+        /// -- the distinct keys, not the rows -- and asks it <c>contains</c> per outer row.
+        ///
+        /// <para>Two sets, and they are not redundant. <c>distinct(comparer)</c> decides which keys are
+        /// duplicates of one another by the comparer, but the <c>contains</c> that follows is
+        /// <c>EnumerableDefaults.contains</c> over the unwrapped result, which is <c>Objects.equals</c> and
+        /// not the comparer. So a comparer coarser than <c>equals</c> collapses two keys that are not equal,
+        /// and the survivor answers for both. Keying one set by the comparer reproduces that; keying the
+        /// membership test by it as well does not, and was the divergence here.</para>
+        ///
+        /// <para>CALCITE-2909: the keys are not built until the first outer row is in hand, so an empty outer
+        /// never enumerates the inner. Calcite writes <c>Suppliers.memoize</c>; a null local says the same
+        /// thing where one loop is the only consumer.</para>
+        /// </remarks>
+        static IEnumerable<TSource> SemiEquiJoin<TSource, TInner, TKey>(
+            IEnumerable<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti)
+        {
+            java.util.HashSet? keys = null;
 
             foreach (var row in outer)
             {
-                var key = outerKeySelector(row);
-                var any = false;
+                if (keys == null)
+                {
+                    var distinct = new java.util.HashSet();
+                    keys = new java.util.HashSet();
 
-                if (key != null && lookup.TryGetValue(key, out var bucket))
-                    foreach (var other in bucket)
-                        if (predicate == null || predicate(row, other))
+                    foreach (var innerRow in inner)
+                    {
+                        var innerKey = JavaValues.From(innerKeySelector(innerRow));
+
+                        if (distinct.add(JavaWrapped.Of(comparer, innerKey)))
+                            keys.add(innerKey);
+                    }
+                }
+
+                var key = outerKeySelector(row);
+                var found = key != null && keys.contains(JavaValues.From(key));
+
+                if (found != anti)
+                    yield return row;
+            }
+        }
+
+        /// <summary>
+        /// Returns the rows of the first sequence that have, or have not, a match in the second under a
+        /// condition the key does not express.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableDefaults.semiJoinWithPredicate_</c>. This one does hold the inner rows -- the
+        /// predicate is given a pair -- and it is <c>toLookup</c>, so unlike the equi path above the comparer
+        /// does reach the lookup. Memoized on the first outer row for the same reason.
+        /// </remarks>
+        static IEnumerable<TSource> SemiJoinWithPredicate<TSource, TInner, TKey>(
+            IEnumerable<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti,
+            Func<TSource, TInner, bool> predicate)
+        {
+            java.util.HashMap? lookup = null;
+
+            foreach (var row in outer)
+            {
+                if (lookup == null)
+                {
+                    lookup = new java.util.HashMap();
+
+                    foreach (var innerRow in inner)
+                    {
+                        var innerKey = JavaWrapped.Of(comparer, JavaValues.From(innerKeySelector(innerRow)));
+
+                        if (lookup.get(innerKey) is not List<TInner> bucket)
+                            lookup.put(innerKey, bucket = []);
+
+                        bucket.Add(innerRow);
+                    }
+                }
+
+                var key = outerKeySelector(row);
+                var found = false;
+
+                if (key != null && lookup.get(JavaWrapped.Of(comparer, JavaValues.From(key))) is List<TInner> matches)
+                {
+                    foreach (var other in matches)
+                    {
+                        if (predicate(row, other))
                         {
-                            any = true;
+                            found = true;
                             break;
                         }
+                    }
+                }
 
-                if (any != anti)
+                if (found != anti)
                     yield return row;
             }
         }
@@ -780,6 +823,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <para>The index is a <c>java.util.HashMap</c> rather than a <see cref="Dictionary{TKey, TValue}"/>
         /// because the emitted order is that map's iteration order, and nothing else can agree with the map
         /// linq4j walks. Same lesson as the partition order of a window.</para>
+        ///
+        /// <para>Both scans run where this is called, not where its result is enumerated: Calcite builds all
+        /// three indexes and only then returns the enumerable that walks them. A <c>yield</c> in this method
+        /// would defer them to the first row pulled and repeat them for a second pass.</para>
         /// </remarks>
         public static IEnumerable<TResult> AsofJoin<TSource, TInner, TKey, TResult>(
             IEnumerable<TSource> outer,
@@ -840,23 +887,28 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
             }
 
-            for (var i = leftIndex.entrySet().iterator(); i.hasNext();)
+            return Results();
+
+            IEnumerable<TResult> Results()
             {
-                var entry = (java.util.Map.Entry)i.next();
-                var left = (List<TSource>)entry.getValue();
-                var best = (List<TInner>)rightIndex.get(entry.getKey());
-
-                for (int j = 0; j < left.Count; j++)
+                for (var i = leftIndex.entrySet().iterator(); i.hasNext();)
                 {
-                    if (best[j] == null && emitNullsOnRight == false)
-                        continue;
+                    var entry = (java.util.Map.Entry)i.next();
+                    var left = (List<TSource>)entry.getValue();
+                    var best = (List<TInner>)rightIndex.get(entry.getKey());
 
-                    yield return resultSelector(left[j], best[j]);
+                    for (int j = 0; j < left.Count; j++)
+                    {
+                        if (best[j] == null && emitNullsOnRight == false)
+                            continue;
+
+                        yield return resultSelector(left[j], best[j]);
+                    }
                 }
-            }
 
-            foreach (var row in outerWithNullKeys)
-                yield return resultSelector(row, default!);
+                foreach (var row in outerWithNullKeys)
+                    yield return resultSelector(row, default!);
+            }
         }
 
         /// <summary>
@@ -1328,14 +1380,24 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <summary>
         /// Returns every pairing of two sequences, in order.
         /// </summary>
+        /// <remarks>
+        /// <c>CartesianProductJoinEnumerator</c>, which extends linq4j's <c>CartesianProductEnumerator</c> and
+        /// holds nothing: it advances the last enumerator first and only falls back to the one before it when
+        /// that runs out, which is this nesting. Building the pairings into a list instead made a merge join
+        /// pay for the whole of a key run before it could yield the first row of it, and multiplied the two
+        /// counts as <see cref="int"/> to size the list -- an overflow at about 2^31 pairs, on the one path
+        /// where a run of equal keys on both sides is exactly what produces them.
+        ///
+        /// <para>Being lazy couples this to the caller: the two lists are the merge join's own buffers, reused
+        /// and cleared per key run, so the pairings must be drained before the join advances. They are -- the
+        /// driving loop yields all of <c>results</c> before it calls <c>Advance</c>. Calcite has the same
+        /// coupling, <c>Linq4j.enumerator(lefts)</c> being a live view of the list it goes on clearing.</para>
+        /// </remarks>
         static IEnumerable<TResult> Cartesian<TSource, TInner, TResult>(IReadOnlyList<TSource> outer, IReadOnlyList<TInner> inner, Func<TSource, TInner, TResult> resultSelector)
         {
-            var rows = new List<TResult>(outer.Count * inner.Count);
             foreach (var left in outer)
                 foreach (var right in inner)
-                    rows.Add(resultSelector(left, right));
-
-            return rows;
+                    yield return resultSelector(left, right);
         }
 
         /// <summary>
@@ -1877,6 +1939,16 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <returns></returns>
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.correlateJoin</c>.
+        ///
+        /// <para>Two things it does before any row moves. RIGHT and FULL are refused -- a correlated join has
+        /// no right side to drive -- and the refusal happens where the enumerable is built rather than where
+        /// it is enumerated, which is why this method is not itself the iterator. And a correlated function
+        /// that answers null is read as an empty sequence rather than dereferenced; Calcite writes
+        /// <c>Linq4j.emptyEnumerable()</c> for it, and <c>LeftMarkJoin</c> next door already guarded it.</para>
+        ///
+        /// <para>The null right row a SEMI join emits is Calcite's too, and for a subtler reason than it
+        /// looks: its enumerator returns without assigning <c>innerValue</c>, so <c>current()</c> reads
+        /// whatever was there. For a join that is SEMI throughout, that is null every time.</para>
         /// </remarks>
         public static IEnumerable<TResult> CorrelateJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
@@ -1885,30 +1957,39 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             org.apache.calcite.linq4j.JoinType joinType)
         {
             var name = joinType.name();
-            var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
-            var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
-            var nullsOnRight = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
 
-            foreach (var row in outer)
+            if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
+                throw new ArgumentException($"JoinType {name} is not valid for correlation");
+
+            return Walk();
+
+            IEnumerable<TResult> Walk()
             {
-                var any = false;
+                var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
+                var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
+                var nullsOnRight = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
 
-                foreach (var other in inner(row))
+                foreach (var row in outer)
                 {
-                    any = true;
+                    var any = false;
 
-                    if (semi || anti)
-                        break;
+                    foreach (var other in inner(row) ?? [])
+                    {
+                        any = true;
 
-                    yield return resultSelector(row, other);
+                        if (semi || anti)
+                            break;
+
+                        yield return resultSelector(row, other);
+                    }
+
+                    if (semi && any)
+                        yield return resultSelector(row, default!);
+                    else if (anti && any == false)
+                        yield return resultSelector(row, default!);
+                    else if (any == false && nullsOnRight)
+                        yield return resultSelector(row, default!);
                 }
-
-                if (semi && any)
-                    yield return resultSelector(row, default!);
-                else if (anti && any == false)
-                    yield return resultSelector(row, default!);
-                else if (any == false && nullsOnRight)
-                    yield return resultSelector(row, default!);
             }
         }
 
@@ -1929,6 +2010,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// The counterpart of <c>EnumerableDefaults.groupBy</c>. The three functions are Calcite's, because
         /// they come from its <c>AggregateLambdaFactory</c> rather than from anything built here. Groups are
         /// returned in the order their keys were first seen, which is what linq4j's own map ordering gives.
+        /// <para>The fold runs where this is called rather than where its result is enumerated, because
+        /// <c>groupBy_</c> drains the input into the map and then returns a <c>LookupResultEnumerable</c> over
+        /// a map that is already finished. A <c>yield</c> here instead would defer the whole body to the first
+        /// row pulled, and would run it again for a second pass; Calcite replays the map.</para>
         /// </remarks>
         public static IEnumerable<TResult> GroupBy<TSource, TKey, TResult>(
             IEnumerable<TSource> source,
@@ -1950,10 +2035,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 accumulators.put(key, accumulatorAdder.apply(accumulator, row));
             }
 
-            for (var i = accumulators.entrySet().iterator(); i.hasNext();)
+            return Results();
+
+            IEnumerable<TResult> Results()
             {
-                var entry = (java.util.Map.Entry)i.next();
-                yield return JavaValues.As<TResult>(resultSelector.apply(JavaWrapped.Unwrap(entry.getKey()), entry.getValue()));
+                for (var i = accumulators.entrySet().iterator(); i.hasNext();)
+                {
+                    var entry = (java.util.Map.Entry)i.next();
+                    yield return JavaValues.As<TResult>(resultSelector.apply(JavaWrapped.Unwrap(entry.getKey()), entry.getValue()));
+                }
             }
         }
 
@@ -1975,6 +2065,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <c>GROUPING SETS</c> and has no counterpart on <c>Enumerable</c>. Every row is offered to every
         /// selector, so one pass folds it into one group per grouping set; the keys of two sets never collide
         /// because each carries an indicator per field saying which set it came from.
+        /// <para>The fold runs where this is called rather than where its result is enumerated, because
+        /// <c>groupBy_</c> drains the input into the map and then returns a <c>LookupResultEnumerable</c> over
+        /// a map that is already finished. A <c>yield</c> here instead would defer the whole body to the first
+        /// row pulled, and would run it again for a second pass; Calcite replays the map.</para>
         /// </remarks>
         public static IEnumerable<TResult> GroupByMultiple<TSource, TKey, TResult>(
             IEnumerable<TSource> source,
@@ -1999,10 +2093,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
             }
 
-            for (var i = accumulators.entrySet().iterator(); i.hasNext();)
+            return Results();
+
+            IEnumerable<TResult> Results()
             {
-                var entry = (java.util.Map.Entry)i.next();
-                yield return JavaValues.As<TResult>(resultSelector.apply(JavaWrapped.Unwrap(entry.getKey()), entry.getValue()));
+                for (var i = accumulators.entrySet().iterator(); i.hasNext();)
+                {
+                    var entry = (java.util.Map.Entry)i.next();
+                    yield return JavaValues.As<TResult>(resultSelector.apply(JavaWrapped.Unwrap(entry.getKey()), entry.getValue()));
+                }
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -2090,87 +2090,85 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
 
         /// <summary>
-        /// A sort key, held so that it can be null.
-        /// </summary>
-        /// <typeparam name="TKey"></typeparam>
-        /// <param name="Key">The key, which may be null.</param>
-        /// <remarks>
-        /// <see cref="SortedDictionary{TKey, TValue}"/> rejects a null key before it consults the comparer,
-        /// where a <c>TreeMap</c> built with a comparator hands one to it. Since a SQL sort key is null
-        /// wherever its column is, and <c>Functions.nullsComparator</c> exists precisely to order those, the
-        /// key is wrapped in something that is never null and the comparer unwraps it.
-        /// </remarks>
-        readonly record struct Sorted<TKey>(TKey Key);
-
-        /// <summary>
         /// Reads the input, keeping only the rows that can reach the output, and yields them in order.
         /// </summary>
+        /// <remarks>
+        /// linq4j's <c>orderBy(source, keySelector, comparator, offset, fetch)</c>, transcribed. A
+        /// <c>java.util.TreeMap</c> because that is what linq4j uses, and the reason its own comment gives:
+        /// it behaves like the plain <c>orderBy</c> and does better than a heap where there are few distinct
+        /// keys.
+        ///
+        /// <para>Using Calcite's own structure rather than a <c>SortedDictionary</c> settles three things at
+        /// once. It takes the <c>java.util.Comparator</c> this method is handed, unwrapped. It accepts a
+        /// null key and routes it through that comparator — which is the whole job of
+        /// <c>Functions.nullsComparator</c>, and is how NULLS FIRST and NULLS LAST are expressed;
+        /// <c>SortedDictionary</c> rejects a null key before it ever consults the comparer. And
+        /// <c>lastKey</c> and <c>headMap</c> are the operations the algorithm is written in terms of, in
+        /// O(log n), where <c>SortedDictionary</c> offers neither.</para>
+        ///
+        /// <para>One deliberate difference: linq4j stores a one-row group as a <c>Collections.singletonList</c>
+        /// and swaps in an <c>ArrayList</c> when a second row arrives. Ours is always a
+        /// <see cref="List{T}"/>. That is an allocation difference, not a logical one.</para>
+        /// </remarks>
         static IEnumerable<TSource> Ordered<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, int offset, int fetch)
         {
-            var order = comparator == null
-                ? Comparer<TKey>.Default
-                : Comparer<TKey>.Create((x, y) => comparator.compare(x, y));
-
-            // the key is wrapped in a struct, which is never null. A TreeMap built with a comparator routes
-            // a null key through that comparator -- which is the whole job of Functions.nullsComparator, and
-            // is how NULLS FIRST/LAST is expressed -- but SortedDictionary null-checks the key before it
-            // consults the comparer and throws. Wrapping is what makes ours accept what linq4j accepts.
-            //
-            // Only a single-column collation can produce a null key: a multi-field one keys on a FlatLists
-            // row, which is never null however many of its fields are.
-            var map = new SortedDictionary<Sorted<TKey>, List<TSource>>(
-                Comparer<Sorted<TKey>>.Create((x, y) => order.Compare(x.Key, y.Key)));
+            var map = comparator == null ? new java.util.TreeMap() : new java.util.TreeMap(comparator);
             var size = 0L;
-            var needed = fetch == int.MaxValue ? -1L : fetch + (long)offset;
+            var needed = fetch + (long)offset;
 
+            // read the input into a tree map
             foreach (var row in source)
             {
-                var key = keySelector(row);
+                var key = (object?)keySelector(row);
 
                 if (needed >= 0 && size >= needed)
                 {
                     // the current row will never appear in the output, so just skip it
-                    var lastKey = map.Keys.Last();
-                    if (order.Compare(key, lastKey.Key) >= 0)
+                    var lastKey = map.lastKey();
+                    if (Compare(comparator, key, lastKey) >= 0)
                         continue;
 
-                    // remove the last entry, so that at most 'needed' rows are kept
-                    var last = map[lastKey];
+                    // remove last entry from tree map, so that we keep at most 'needed' rows
+                    var last = (List<TSource>)map.get(lastKey);
                     if (last.Count == 1)
-                        map.Remove(lastKey);
+                        map.remove(lastKey);
                     else
                         last.RemoveAt(last.Count - 1);
 
                     size--;
                 }
 
-                if (map.TryGetValue(new Sorted<TKey>(key), out var held))
+                // add the current element to the map
+                if (map.get(key) is List<TSource> held)
                     held.Add(row);
                 else
-                    map[new Sorted<TKey>(key)] = [row];
+                    map.put(key, new List<TSource> { row });
 
                 size++;
             }
 
-            // skip the first 'offset' rows by dropping them from the map
+            // skip the first 'offset' rows by deleting them from the map
             if (offset > 0)
             {
+                // search the key up to (but excluding) which we have to remove entries from the map
                 var skipped = 0;
                 var found = false;
-                var until = default(Sorted<TKey>);
+                object? until = null;
 
-                foreach (var entry in map)
+                for (var i = map.entrySet().iterator(); i.hasNext();)
                 {
-                    skipped += entry.Value.Count;
+                    var entry = (java.util.Map.Entry)i.next();
+                    var rows = (List<TSource>)entry.getValue();
+                    skipped += rows.Count;
 
                     if (skipped > offset)
                     {
-                        // part of this key's rows may still be wanted
+                        // we might need to remove entries from the list
                         var keep = skipped - offset;
-                        if (keep < entry.Value.Count)
-                            entry.Value.RemoveRange(0, entry.Value.Count - keep);
+                        if (keep < rows.Count)
+                            rows.RemoveRange(0, rows.Count - keep);
 
-                        until = entry.Key;
+                        until = entry.getKey();
                         found = true;
                         break;
                     }
@@ -2180,13 +2178,30 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 if (found == false)
                     yield break;
 
-                foreach (var key in map.Keys.TakeWhile(k => order.Compare(k.Key, until.Key) < 0).ToList())
-                    map.Remove(key);
+                map.headMap(until, false).clear();
             }
 
-            foreach (var rows in map.Values)
-                foreach (var row in rows)
+            for (var i = map.values().iterator(); i.hasNext();)
+                foreach (var row in (List<TSource>)i.next())
                     yield return row;
+        }
+
+        /// <summary>
+        /// Compares two keys the way the map holding them does.
+        /// </summary>
+        /// <remarks>
+        /// The comparator where there is one, which is every case Calcite reaches: <c>GenerateCollationKey</c>
+        /// always produces one. The fallback exists because the parameter is nullable and matches what a
+        /// <c>TreeMap</c> built without a comparator does — order by the keys themselves. It goes through
+        /// <see cref="IComparable"/> rather than <c>java.lang.Comparable</c>, which is a ghost interface a
+        /// cast cannot reach from C#.
+        /// </remarks>
+        static int Compare(java.util.Comparator? comparator, object? x, object? y)
+        {
+            if (comparator != null)
+                return comparator.compare(x, y);
+
+            return Comparer<object>.Default.Compare(x, y);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -1601,8 +1601,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="joinType"></param>
         /// <returns></returns>
         /// <remarks>
-        /// The counterpart of <c>EnumerableDefaults.nestedLoopJoin</c>. The inner sequence is read once and
-        /// kept, because it is walked again for every outer row.
+        /// The counterpart of <c>EnumerableDefaults.nestedLoopJoin</c>, which is one dispatch over two
+        /// bodies that are not the same walk, and they are two methods here as they are there. A join that
+        /// generates nulls on the left — RIGHT and FULL — goes to <see cref="NestedLoopJoinAsList"/>, which
+        /// buffers the inner and builds the whole result before it returns; everything else goes to
+        /// <see cref="NestedLoopJoinOptimized"/>, which buffers nothing and streams. The asymmetry is
+        /// Calcite's own and is reproduced rather than smoothed over.
         /// </remarks>
         public static IEnumerable<TResult> NestedLoopJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
@@ -1611,47 +1615,249 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType)
         {
-            var rows = inner as IReadOnlyList<TInner> ?? [.. inner];
+            if (joinType.generatesNullsOnLeft() == false)
+                return NestedLoopJoinOptimized(outer, inner, resultSelector, predicate, joinType);
+
+            return NestedLoopJoinAsList(outer, inner, resultSelector, predicate, joinType);
+        }
+
+        /// <summary>
+        /// Joins two sequences on a condition by building the whole result as a list and returning it.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TInner"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner"></param>
+        /// <param name="resultSelector"></param>
+        /// <param name="predicate"></param>
+        /// <param name="joinType"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The counterpart of <c>EnumerableDefaults.nestedLoopJoinAsList</c>. It is not an iterator, because
+        /// Calcite's is not lazy either: the join runs when the method is called and what comes back is a
+        /// list already filled, wrapped by <c>Linq4j.asEnumerable</c>. This is the only path that reads the
+        /// inner into a list, and it reads it once for every outer row from there.
+        ///
+        /// <para>The rows of the right side that never matched are held in an identity set, because Calcite
+        /// holds them in <c>Sets.newIdentityHashSet()</c>. That set deduplicates by reference, so two
+        /// unmatched right rows that are the same object are emitted once and not twice — which is not the
+        /// answer SQL wants, and is the answer Calcite gives. This is a port and Calcite's behaviour is the
+        /// specification, so the defect is reproduced.</para>
+        ///
+        /// <para>The order those trailing rows come out in is the one place this cannot follow. Java walks
+        /// the buckets of an <c>IdentityHashMap</c>, so the order is a function of
+        /// <c>System.identityHashCode</c>, which no CLR type has; the rows come out here in the order they
+        /// were added, which is the order of the inner sequence. Only the order differs — the set of rows,
+        /// deduplication included, is Calcite's.</para>
+        /// </remarks>
+        static IEnumerable<TResult> NestedLoopJoinAsList<TSource, TInner, TResult>(
+            IEnumerable<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource, TInner, bool> predicate,
+            org.apache.calcite.linq4j.JoinType joinType)
+        {
             var name = joinType.name();
-            var nullsOnRight = name is nameof(org.apache.calcite.linq4j.JoinType.LEFT) or nameof(org.apache.calcite.linq4j.JoinType.FULL);
-            var nullsOnLeft = name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL);
-            var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
-            var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
-            var matched = nullsOnLeft ? new bool[rows.Count] : null;
+            var generateNullsOnLeft = joinType.generatesNullsOnLeft();
+            var generateNullsOnRight = joinType.generatesNullsOnRight();
+            var result = new List<TResult>();
+            var rightList = new List<TInner>(inner);
+            HashSet<TInner>? rightUnmatched;
 
-            foreach (var row in outer)
+            if (generateNullsOnLeft)
             {
-                var any = false;
+                rightUnmatched = new HashSet<TInner>(IdentityComparer<TInner>.Instance);
 
-                for (int i = 0; i < rows.Count; i++)
-                {
-                    if (predicate(row, rows[i]) == false)
-                        continue;
-
-                    any = true;
-                    if (matched != null)
-                        matched[i] = true;
-
-                    if (semi || anti)
-                        break;
-
-                    yield return resultSelector(row, rows[i]);
-                }
-
-                if (semi && any)
-                    yield return resultSelector(row, default!);
-                else if (anti && any == false)
-                    yield return resultSelector(row, default!);
-                else if (any == false && nullsOnRight)
-                    yield return resultSelector(row, default!);
+                foreach (var right in rightList)
+                    rightUnmatched.Add(right);
+            }
+            else
+            {
+                rightUnmatched = null;
             }
 
-            if (matched == null)
-                yield break;
+            foreach (var left in outer)
+            {
+                var leftMatchCount = 0;
 
-            for (int i = 0; i < rows.Count; i++)
-                if (matched[i] == false)
-                    yield return resultSelector(default!, rows[i]);
+                foreach (var right in rightList)
+                {
+                    if (predicate(left, right))
+                    {
+                        ++leftMatchCount;
+
+                        if (name == nameof(org.apache.calcite.linq4j.JoinType.ANTI))
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            rightUnmatched?.Remove(right);
+
+                            // a semi join emits the matched right row, not a null one, and then stops
+                            result.Add(resultSelector(left, right));
+
+                            if (name == nameof(org.apache.calcite.linq4j.JoinType.SEMI))
+                                break;
+                        }
+                    }
+                }
+
+                if (leftMatchCount == 0 && (generateNullsOnRight || name == nameof(org.apache.calcite.linq4j.JoinType.ANTI)))
+                    result.Add(resultSelector(left, default!));
+            }
+
+            if (rightUnmatched != null)
+                foreach (var right in rightUnmatched)
+                    result.Add(resultSelector(default!, right));
+
+            return result;
+        }
+
+        /// <summary>
+        /// Joins two sequences on a condition without building the result as a list first.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TInner"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner"></param>
+        /// <param name="resultSelector"></param>
+        /// <param name="predicate"></param>
+        /// <param name="joinType"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The counterpart of <c>EnumerableDefaults.nestedLoopJoinOptimized</c>, and the same state machine:
+        /// state 0 moves the outer, state 1 moves the inner. The inner is enumerated afresh for every outer
+        /// row and never read into a list — <c>nestedLoopJoinAsList</c> is the only body that buffers, and
+        /// <c>leftMarkJoinInternal</c> re-enumerates the same way this does.
+        ///
+        /// <para>A join type that is none of the six the switch names — ASOF, LEFT_ASOF, LEFT_MARK — falls to
+        /// its default, which returns no pair and no unmatched row either, so the whole join is empty. That
+        /// is what Calcite does and it is not treated as INNER here.</para>
+        /// </remarks>
+        static IEnumerable<TResult> NestedLoopJoinOptimized<TSource, TInner, TResult>(
+            IEnumerable<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource, TInner, bool> predicate,
+            org.apache.calcite.linq4j.JoinType joinType)
+        {
+            var name = joinType.name();
+
+            // Calcite refuses before it returns its enumerable, so this method is not the iterator: the
+            // walk below is, and the refusal happens when the caller calls rather than when it enumerates
+            if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
+                throw new ArgumentException($"JoinType {name} is unsupported");
+
+            return Walk();
+
+            IEnumerable<TResult> Walk()
+            {
+                var outerEnumerator = outer.GetEnumerator();
+                IEnumerator<TInner>? innerEnumerator = null;
+                var outerMatch = false; // whether the outerValue has matched an innerValue
+                var outerValue = default(TSource)!;
+                var innerValue = default(TInner)!;
+                var state = 0; // 0 moving outer, 1 moving inner
+
+                try
+                {
+                    while (true)
+                    {
+                        switch (state)
+                        {
+                            case 0:
+                                // move outer
+                                if (outerEnumerator.MoveNext() == false)
+                                    yield break;
+
+                                outerValue = outerEnumerator.Current;
+                                innerEnumerator?.Dispose();
+                                innerEnumerator = inner.GetEnumerator();
+                                outerMatch = false;
+                                state = 1;
+                                continue;
+                            case 1:
+                                // move inner
+                                if (innerEnumerator!.MoveNext())
+                                {
+                                    innerValue = innerEnumerator.Current;
+
+                                    if (predicate(outerValue, innerValue))
+                                    {
+                                        outerMatch = true;
+
+                                        switch (name)
+                                        {
+                                            case nameof(org.apache.calcite.linq4j.JoinType.ANTI): // try next outer row
+                                                state = 0;
+                                                continue;
+                                            case nameof(org.apache.calcite.linq4j.JoinType.SEMI): // return result, and try next outer row
+                                                state = 0;
+                                                // Calcite computes the row in current() from the fields the
+                                                // enumerator holds; an iterator has to compute it at the
+                                                // yield. The fields are what they would have been there —
+                                                // for SEMI that means the matched inner row, not a null one
+                                                yield return resultSelector(outerValue, innerValue);
+                                                continue;
+                                            case nameof(org.apache.calcite.linq4j.JoinType.INNER):
+                                            case nameof(org.apache.calcite.linq4j.JoinType.LEFT): // INNER and LEFT just return result
+                                                yield return resultSelector(outerValue, innerValue);
+                                                continue;
+                                            default:
+                                                break;
+                                        }
+                                    } // else (predicate returned false) continue: move inner
+                                }
+                                else
+                                { // innerEnumerator is over
+                                    state = 0;
+                                    innerValue = default!;
+
+                                    if (outerMatch == false &&
+                                        name is nameof(org.apache.calcite.linq4j.JoinType.LEFT) or nameof(org.apache.calcite.linq4j.JoinType.ANTI))
+                                    {
+                                        // No match detected: outerValue is a result for LEFT / ANTI join
+                                        yield return resultSelector(outerValue, innerValue);
+                                        continue;
+                                    }
+                                }
+
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                finally
+                {
+                    outerEnumerator.Dispose();
+                    innerEnumerator?.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compares by reference, and hashes by the identity hash.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <remarks>
+        /// What a <c>java.util.IdentityHashMap</c> keys on, for the one place a port of Calcite's needs it:
+        /// the unmatched right rows of a RIGHT or FULL nested loop join. A row of this convention is a
+        /// reference — <c>ClrPhysType.RowType</c> is the boxed row type — so identity is defined for every
+        /// <c>TInner</c> a plan produces.
+        /// </remarks>
+        sealed class IdentityComparer<T> : IEqualityComparer<T>
+        {
+
+            public static readonly IdentityComparer<T> Instance = new();
+
+            public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
+
+            public int GetHashCode(T obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -2088,6 +2088,20 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             return Ordered(source, keySelector, comparator, offset, fetch);
         }
 
+
+        /// <summary>
+        /// A sort key, held so that it can be null.
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <param name="Key">The key, which may be null.</param>
+        /// <remarks>
+        /// <see cref="SortedDictionary{TKey, TValue}"/> rejects a null key before it consults the comparer,
+        /// where a <c>TreeMap</c> built with a comparator hands one to it. Since a SQL sort key is null
+        /// wherever its column is, and <c>Functions.nullsComparator</c> exists precisely to order those, the
+        /// key is wrapped in something that is never null and the comparer unwraps it.
+        /// </remarks>
+        readonly record struct Sorted<TKey>(TKey Key);
+
         /// <summary>
         /// Reads the input, keeping only the rows that can reach the output, and yields them in order.
         /// </summary>
@@ -2097,7 +2111,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 ? Comparer<TKey>.Default
                 : Comparer<TKey>.Create((x, y) => comparator.compare(x, y));
 
-            var map = new SortedDictionary<TKey, List<TSource>>(order);
+            // the key is wrapped in a struct, which is never null. A TreeMap built with a comparator routes
+            // a null key through that comparator -- which is the whole job of Functions.nullsComparator, and
+            // is how NULLS FIRST/LAST is expressed -- but SortedDictionary null-checks the key before it
+            // consults the comparer and throws. Wrapping is what makes ours accept what linq4j accepts.
+            //
+            // Only a single-column collation can produce a null key: a multi-field one keys on a FlatLists
+            // row, which is never null however many of its fields are.
+            var map = new SortedDictionary<Sorted<TKey>, List<TSource>>(
+                Comparer<Sorted<TKey>>.Create((x, y) => order.Compare(x.Key, y.Key)));
             var size = 0L;
             var needed = fetch == int.MaxValue ? -1L : fetch + (long)offset;
 
@@ -2109,7 +2131,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 {
                     // the current row will never appear in the output, so just skip it
                     var lastKey = map.Keys.Last();
-                    if (order.Compare(key, lastKey) >= 0)
+                    if (order.Compare(key, lastKey.Key) >= 0)
                         continue;
 
                     // remove the last entry, so that at most 'needed' rows are kept
@@ -2122,10 +2144,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     size--;
                 }
 
-                if (map.TryGetValue(key, out var held))
+                if (map.TryGetValue(new Sorted<TKey>(key), out var held))
                     held.Add(row);
                 else
-                    map[key] = [row];
+                    map[new Sorted<TKey>(key)] = [row];
 
                 size++;
             }
@@ -2135,7 +2157,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             {
                 var skipped = 0;
                 var found = false;
-                TKey until = default!;
+                var until = default(Sorted<TKey>);
 
                 foreach (var entry in map)
                 {
@@ -2158,7 +2180,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 if (found == false)
                     yield break;
 
-                foreach (var key in map.Keys.TakeWhile(k => order.Compare(k, until) < 0).ToList())
+                foreach (var key in map.Keys.TakeWhile(k => order.Compare(k.Key, until.Key) < 0).ToList())
                     map.Remove(key);
             }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -2517,45 +2517,84 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.repeatUnion</c>, which is what WITH RECURSIVE becomes. The
         /// iterative part is enumerated afresh each round, reading what the spool beneath it left behind.
+        ///
+        /// <para>Transcribed from Calcite's enumerator rather than re-expressed, because its termination test
+        /// is not the obvious one. It stops when <c>current</c> still holds the <c>DUMMY</c> sentinel after a
+        /// round -- not when the round produced nothing. Those differ, and the difference is reproduced here
+        /// deliberately: see the note at the seed/iteration boundary.</para>
+        ///
+        /// <para>The sentinel itself is a flag. Calcite casts a private <c>DUMMY</c> object to the row type and
+        /// compares by reference; a row can never be that object, so a <see cref="bool"/> decides exactly what
+        /// the reference comparison decides, without a cast that would be a lie about the row type.</para>
         /// </remarks>
         public static IEnumerable<TSource> RepeatUnion<TSource>(IEnumerable<TSource> seed, IEnumerable<TSource> iteration, int iterationLimit, bool all, EqualityComparer? comparer, Action? cleanUp)
         {
             ArgumentNullException.ThrowIfNull(seed);
             ArgumentNullException.ThrowIfNull(iteration);
 
+            var processed = all ? null : new HashSet<TSource>(JavaEqualityComparer<TSource>.Of(comparer));
+
+            // Calcite's `current == DUMMY`. Set false wherever `checkValue` passed and Calcite assigned
+            // `current`, and back to true wherever Calcite put the sentinel back.
+            var currentIsDummy = true;
+
+            // the seed enumerator is held for the whole life of the sequence, as Calcite holds it -- it is
+            // closed in `close()` and not when the seed runs out
+            var seedEnumerator = seed.GetEnumerator();
+            IEnumerator<TSource>? iterativeEnumerator = null;
+
             try
             {
-                var processed = all ? null : new HashSet<TSource>(JavaEqualityComparer<TSource>.Of(comparer));
-
-                foreach (var row in seed)
-                    if (processed == null || processed.Add(row))
-                        yield return row;
-
-                for (int i = 0; iterationLimit < 0 || i < iterationLimit; i++)
+                while (seedEnumerator.MoveNext())
                 {
-                    // a round that returned no row this sequence had not already returned is the end of it,
-                    // and not a round that read no rows. Calcite's own enumerator says the same thing by
-                    // setting `current` only where `checkValue` passed and stopping where it is still DUMMY.
-                    // Counting what was read instead is an infinite loop for every UNION rather than UNION
-                    // ALL: the iterative part re-reads the whole spool each round and so never runs dry.
-                    var any = false;
+                    var value = seedEnumerator.Current;
 
-                    foreach (var row in iteration)
+                    if (processed == null || processed.Add(value))
                     {
-                        if (processed == null || processed.Add(row))
+                        currentIsDummy = false;
+                        yield return value;
+                    }
+                }
+
+                // The sentinel is NOT put back here, and that is Calcite's, not an oversight of the
+                // transcription. A seed that emitted a row leaves `current` holding that row, so the first
+                // iterative round to produce nothing does not stop the sequence -- it goes round once more,
+                // and only the second empty round stops it. A recursive query whose step reads the working
+                // table row by row cannot tell, because an empty table gives an empty round either way; one
+                // whose step aggregates -- COUNT(*) yields a row over no rows -- can, and does.
+                for (var currentIteration = 0; ; currentIteration++)
+                {
+                    if (iterationLimit >= 0 && currentIteration == iterationLimit)
+                        yield break;
+
+                    iterativeEnumerator = iteration.GetEnumerator();
+
+                    while (iterativeEnumerator.MoveNext())
+                    {
+                        var value = iterativeEnumerator.Current;
+
+                        if (processed == null || processed.Add(value))
                         {
-                            any = true;
-                            yield return row;
+                            currentIsDummy = false;
+                            yield return value;
                         }
                     }
 
-                    if (any == false)
+                    if (currentIsDummy)
                         yield break;
+
+                    currentIsDummy = true;
+                    iterativeEnumerator.Dispose();
+                    iterativeEnumerator = null;
                 }
             }
             finally
             {
+                // Calcite's `close()` in its order: the clean-up first, then the two enumerators. A foreach
+                // would have disposed them first, which is the other way round.
                 cleanUp?.Invoke();
+                seedEnumerator.Dispose();
+                iterativeEnumerator?.Dispose();
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -1248,7 +1248,21 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                             return false;
                         }
 
-                        var c = Compare(leftKey, rightKey);
+                        int c;
+
+                        try
+                        {
+                            c = Compare(leftKey, rightKey);
+                        }
+                        catch (BothValuesAreNullException)
+                        {
+                            // take the left as the bigger, so the right advances and the algorithm carries on.
+                            // Unreachable: the null guard above returns before either key can be null. Calcite
+                            // has the same dead catch, and it is what decides the answer rather than the
+                            // comparison, so it is written here too.
+                            c = 1;
+                        }
+
                         if (c == 0)
                             break;
 
@@ -1401,16 +1415,35 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <summary>
+        /// Raised where a merge join compares two null keys, which it must not call equal.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableDefaults.BothValuesAreNullException</c>, which is private, so it is written again
+        /// rather than reused. It carries no message and is never allowed out of <c>advance</c>.
+        /// </remarks>
+        sealed class BothValuesAreNullException : Exception
+        {
+
+        }
+
+        /// <summary>
         /// Orders two keys with nulls last, refusing to call two nulls equal.
         /// </summary>
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.compareNullsLastForMergeJoin</c>, reached only where no
-        /// comparator was given. Two nulls are not equal, and the caller takes the left as the bigger.
+        /// comparator was given.
+        ///
+        /// <para>Two nulls are a throw rather than an answer, because there is no answer this method could
+        /// give that is right for both of its callers -- calling them equal would join them, and calling
+        /// either one bigger is a decision about which side to advance. Calcite leaves that decision to
+        /// <c>advance</c>, which catches this and takes 1. Returning 1 from here instead composed to the same
+        /// rows and quietly moved the decision, so a second caller would inherit an answer that was only ever
+        /// right for the first.</para>
         /// </remarks>
         static int CompareNullsLastForMergeJoin<TKey>(TKey a, TKey b)
         {
             if (a == null && b == null)
-                return 1;
+                throw new BothValuesAreNullException();
 
             if (a == null)
                 return 1;
@@ -1729,14 +1762,18 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var generateNullsOnRight = joinType.generatesNullsOnRight();
             var result = new List<TResult>();
             var rightList = new List<TInner>(inner);
-            HashSet<TInner>? rightUnmatched;
+            java.util.Set? rightUnmatched;
 
             if (generateNullsOnLeft)
             {
-                rightUnmatched = new HashSet<TInner>(IdentityComparer<TInner>.Instance);
+                // Sets.newIdentityHashSet(), which is Guava's, backed by an IdentityHashMap. Not a stand-in
+                // for it: what comes out of here is the order that map's buckets give, keyed on
+                // System.identityHashCode, and nothing written against CLR references reproduces that. We
+                // run on IKVM, so the set Calcite uses is available and is the one used.
+                rightUnmatched = com.google.common.collect.Sets.newIdentityHashSet();
 
                 foreach (var right in rightList)
-                    rightUnmatched.Add(right);
+                    rightUnmatched.add(right);
             }
             else
             {
@@ -1759,7 +1796,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                         }
                         else
                         {
-                            rightUnmatched?.Remove(right);
+                            rightUnmatched?.remove(right);
 
                             // a semi join emits the matched right row, not a null one, and then stops
                             result.Add(resultSelector(left, right));
@@ -1775,8 +1812,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             }
 
             if (rightUnmatched != null)
-                foreach (var right in rightUnmatched)
-                    result.Add(resultSelector(default!, right));
+                for (var i = rightUnmatched.iterator(); i.hasNext();)
+                    result.Add(resultSelector(default!, (TInner)i.next()));
 
             return result;
         }
@@ -1903,27 +1940,6 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     innerEnumerator?.Dispose();
                 }
             }
-        }
-
-        /// <summary>
-        /// Compares by reference, and hashes by the identity hash.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <remarks>
-        /// What a <c>java.util.IdentityHashMap</c> keys on, for the one place a port of Calcite's needs it:
-        /// the unmatched right rows of a RIGHT or FULL nested loop join. A row of this convention is a
-        /// reference — <c>ClrPhysType.RowType</c> is the boxed row type — so identity is defined for every
-        /// <c>TInner</c> a plan produces.
-        /// </remarks>
-        internal sealed class IdentityComparer<T> : IEqualityComparer<T>
-        {
-
-            public static readonly IdentityComparer<T> Instance = new();
-
-            public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
-
-            public int GetHashCode(T obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
-
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -612,13 +612,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             if (unmatched == null)
                 yield break;
 
-            for (var i = lookup.entrySet().iterator(); i.hasNext();)
+            // the set is walked and each key looked back up, which is what linq4j does and is not the same as
+            // walking the map and filtering by the set. A HashSet copied from a key set does not have the
+            // map's iteration order: HashSet(Collection) sizes its table as
+            // tableSizeFor(max((int) (n / 0.75f) + 1, 16)), while a map grown by insertion holds the smallest
+            // power of two at or above 16 that still leaves n <= 0.75 * cap. The two disagree exactly where
+            // n = 0.75 * 2^k — 12, 24, 48 — and these rows have no ORDER BY over them.
+            for (var i = unmatched.iterator(); i.hasNext();)
             {
-                var entry = (java.util.Map.Entry)i.next();
-                if (unmatched.contains(entry.getKey()) == false)
-                    continue;
+                var key = i.next();
 
-                foreach (var other in (List<TInner>)entry.getValue())
+                foreach (var other in (List<TInner>)lookup.get(key))
                     yield return resultSelector(default!, other);
             }
         }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -2162,6 +2162,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <para>The accumulator carries each aggregate's state and its last result, so a result that does not
         /// change while the frame is intact is computed once and read again, which is the whole point of the
         /// frame bookkeeping. It is made once for the whole window, as Calcite declares its variables once.</para>
+        ///
+        /// <para>The rows go into a list and the list is returned, because that is what the generated block
+        /// does: it appends each output row to an <c>ArrayList</c> and evaluates to
+        /// <c>Linq4j.asEnumerable(list)</c>, once per window group, each group's list being the next group's
+        /// source. So the whole window is computed where the expression is evaluated. Yielding instead was a
+        /// laziness Calcite does not have — the same rows in the same order, reached sooner and recomputed on
+        /// a second pass.</para>
         /// </remarks>
         public static IEnumerable<TResult> Window<TSource, TKey, TAccumulator, TResult>(
             IEnumerable<TSource> source,
@@ -2194,6 +2201,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var frame = new WindowFrame();
             var accumulator = accumulatorInitializer();
+            var list = new List<TResult>();
 
             foreach (var rows in Partitions(source, partitionSelector, comparator))
             {
@@ -2268,9 +2276,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     if (uncachedResult != null)
                         accumulator = uncachedResult(frame, accumulator);
 
-                    yield return selector(frame, accumulator);
+                    list.Add(selector(frame, accumulator));
                 }
             }
+
+            return list;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -1853,7 +1853,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// reference — <c>ClrPhysType.RowType</c> is the boxed row type — so identity is defined for every
         /// <c>TInner</c> a plan produces.
         /// </remarks>
-        sealed class IdentityComparer<T> : IEqualityComparer<T>
+        internal sealed class IdentityComparer<T> : IEqualityComparer<T>
         {
 
             public static readonly IdentityComparer<T> Instance = new();

--- a/src/Apache.Calcite.Extensions/Interop/JavaSequences.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaSequences.cs
@@ -120,7 +120,7 @@ namespace Apache.Calcite.Extensions.Interop
             /// <inheritdoc />
             public override Enumerator enumerator()
             {
-                return new JavaEnumerator<TSource>(source.GetEnumerator());
+                return new JavaEnumerator<TSource>(source);
             }
 
         }
@@ -132,30 +132,43 @@ namespace Apache.Calcite.Extensions.Interop
         /// <param name="source"></param>
         /// <remarks>
         /// linq4j positions before the first row and advances on <c>moveNext</c>, which is what
-        /// <see cref="IEnumerator"/> does, so the two agree except over <c>reset</c>, which .NET is allowed to
-        /// refuse.
+        /// <see cref="IEnumerator"/> does, so the two agree except over <c>reset</c>.
+        ///
+        /// <para><c>reset</c> means "be positioned before the first row again", and it is live: linq4j's
+        /// <c>CartesianProductEnumerator.moveNext</c> calls it to rewind the inner side once per row of the
+        /// outer, so a sequence of ours reaching a cartesian product of Calcite's is asked for it. A .NET
+        /// iterator refuses <see cref="IEnumerator.Reset"/> -- the compiler generates a throw -- so the
+        /// sequence is enumerated afresh instead. That is what the linq4j enumerable it stands for would do
+        /// when asked for a second enumerator, and it is why this holds the sequence rather than one
+        /// enumerator of it.</para>
         /// </remarks>
-        sealed class JavaEnumerator<TSource>(IEnumerator<TSource> source) : Enumerator
+        sealed class JavaEnumerator<TSource>(IEnumerable<TSource> source) : Enumerator
         {
 
-            /// <inheritdoc />
-            public object current() => source.Current!;
+            IEnumerator<TSource> enumerator = source.GetEnumerator();
 
             /// <inheritdoc />
-            public bool moveNext() => source.MoveNext();
+            public object current() => enumerator.Current!;
 
             /// <inheritdoc />
-            public void reset() => source.Reset();
+            public bool moveNext() => enumerator.MoveNext();
 
             /// <inheritdoc />
-            public void close() => source.Dispose();
+            public void reset()
+            {
+                enumerator.Dispose();
+                enumerator = source.GetEnumerator();
+            }
+
+            /// <inheritdoc />
+            public void close() => enumerator.Dispose();
 
             /// <inheritdoc />
             /// <remarks>
             /// IKVM maps <c>java.lang.AutoCloseable</c>, which a linq4j Enumerator extends, onto
             /// <see cref="IDisposable"/>, so closing one from Java arrives here.
             /// </remarks>
-            public void Dispose() => source.Dispose();
+            public void Dispose() => enumerator.Dispose();
 
         }
 

--- a/src/Apache.Calcite.Extensions/Interop/JavaValues.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaValues.cs
@@ -60,7 +60,14 @@ namespace Apache.Calcite.Extensions.Interop
             if (value == null)
                 return null!;
 
-            return typeof(T).IsValueType ? JavaValues.Box(value, typeof(T)) : value;
+            // the value's own type, not typeof(T). A boundary is crossed by a value, and the static type
+            // parameter at these sites is nearly always object or a PhysType.RowType -- and a RowType is
+            // ClrPrimitive.Box(...), a Java class -- so testing typeof(T) compiled the guard away at exactly
+            // the sites that had something to guard. Box returns what it was given where the type is not one
+            // of linq4j's primitives, so a struct of our own still passes through untouched.
+            var type = value.GetType();
+
+            return type.IsValueType ? JavaValues.Box(value, type) : value;
         }
 
 

--- a/src/Apache.Calcite.Extensions/Schema/IClrAsyncScannableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrAsyncScannableTable.cs
@@ -31,9 +31,10 @@ namespace Apache.Calcite.Extensions.Schema
     /// <c>BigDecimal</c> — exactly as a <see cref="ScannableTable"/>'s are, because everything downstream of
     /// this is Calcite's and every boundary where a value crosses between the two runtimes is an adapter. A
     /// table handing back CLR primitives leaves two representations of one value in a plan, and Calcite's own
-    /// comparators fail on them — quietly, which is the trouble:
-    /// <c>ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay</c> shows the two comparing unequal
-    /// while their hashes agree, so a set operator keeps both copies and everything else looks right.</para>
+    /// comparators fail on them — at once rather than quietly, because what reads a field is
+    /// <c>SqlFunctions.toInt</c> or a cast to the boxed type the row type declares.
+    /// <c>ShouldFailOverATableWhoseValuesAreNotTheTypeFactorys</c> holds that for the synchronous SPI, and
+    /// the contract is the same one.</para>
     /// </remarks>
     public interface IClrAsyncScannableTable : Table
     {

--- a/src/Apache.Calcite.Extensions/Schema/IClrAsyncScannableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrAsyncScannableTable.cs
@@ -31,7 +31,9 @@ namespace Apache.Calcite.Extensions.Schema
     /// <c>BigDecimal</c> — exactly as a <see cref="ScannableTable"/>'s are, because everything downstream of
     /// this is Calcite's and every boundary where a value crosses between the two runtimes is an adapter. A
     /// table handing back CLR primitives leaves two representations of one value in a plan, and Calcite's own
-    /// comparators fail on them.</para>
+    /// comparators fail on them — quietly, which is the trouble:
+    /// <c>ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay</c> shows the two comparing unequal
+    /// while their hashes agree, so a set operator keeps both copies and everything else looks right.</para>
     /// </remarks>
     public interface IClrAsyncScannableTable : Table
     {

--- a/src/Apache.Calcite.Extensions/Schema/IClrScannableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrScannableTable.cs
@@ -26,7 +26,12 @@ namespace Apache.Calcite.Extensions.Schema
     /// <para>The values in each row are Java's — <c>java.lang.Integer</c>, <c>java.lang.String</c>,
     /// <c>BigDecimal</c> — exactly as a <see cref="ScannableTable"/>'s are. What is avoided is the hop the
     /// <em>sequence</em> makes, not the conversion each value needs: everything downstream is Calcite's, and
-    /// every boundary where a value crosses between the two runtimes is an adapter.</para>
+    /// every boundary where a value crosses between the two runtimes is an adapter. This is a contract and
+    /// not a suggestion, and nothing enforces it — the scan hands these rows on unconverted, exactly as
+    /// Calcite hands on a <see cref="ScannableTable"/>'s. What goes wrong is narrow and quiet:
+    /// <c>ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay</c> shows a CLR-boxed element and
+    /// a Java-boxed one comparing unequal while their hashes agree, so a set operator keeps both copies and
+    /// the rows are otherwise in the right order.</para>
     /// </remarks>
     public interface IClrScannableTable : Table
     {

--- a/src/Apache.Calcite.Extensions/Schema/IClrScannableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrScannableTable.cs
@@ -26,12 +26,11 @@ namespace Apache.Calcite.Extensions.Schema
     /// <para>The values in each row are Java's — <c>java.lang.Integer</c>, <c>java.lang.String</c>,
     /// <c>BigDecimal</c> — exactly as a <see cref="ScannableTable"/>'s are. What is avoided is the hop the
     /// <em>sequence</em> makes, not the conversion each value needs: everything downstream is Calcite's, and
-    /// every boundary where a value crosses between the two runtimes is an adapter. This is a contract and
-    /// not a suggestion, and nothing enforces it — the scan hands these rows on unconverted, exactly as
-    /// Calcite hands on a <see cref="ScannableTable"/>'s. What goes wrong is narrow and quiet:
-    /// <c>ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay</c> shows a CLR-boxed element and
-    /// a Java-boxed one comparing unequal while their hashes agree, so a set operator keeps both copies and
-    /// the rows are otherwise in the right order.</para>
+    /// every boundary where a value crosses between the two runtimes is an adapter. The rows go on
+    /// unconverted, exactly as Calcite passes on a <see cref="ScannableTable"/>'s, and nothing checks them.
+    /// Nothing needs to: what reads a field is <c>SqlFunctions.toInt</c> or a cast to the boxed type the row
+    /// type declares, so a table that gets this wrong stops on its first row rather than going quietly wrong.
+    /// <c>ShouldFailOverATableWhoseValuesAreNotTheTypeFactorys</c> holds that.</para>
     /// </remarks>
     public interface IClrScannableTable : Table
     {

--- a/src/Apache.Calcite.Tests/AsyncTestSchema.cs
+++ b/src/Apache.Calcite.Tests/AsyncTestSchema.cs
@@ -55,6 +55,41 @@ namespace Apache.Calcite.Tests
         ];
 
         /// <summary>
+        /// Twelve distinct keys, which is the one build-side size at which a hash join's leftovers can come
+        /// out in the wrong order.
+        /// </summary>
+        /// <remarks>
+        /// <c>hashEquiJoin_</c> ends a right or a full join by copying the lookup's key set into a
+        /// <c>java.util.HashSet</c> and walking that. The copy does not have the map's iteration order:
+        /// <c>HashSet(Collection)</c> sizes its table as <c>tableSizeFor(max((int) (n / 0.75f) + 1, 16))</c>,
+        /// while a map grown by insertion holds the smallest power of two at or above 16 that still leaves
+        /// <c>n &lt;= 0.75 * cap</c>. The two disagree exactly where <c>n = 0.75 * 2^k</c> — 12, 24, 48 — and
+        /// at twelve keys the map is a table of 16 and the copy a table of 32. <c>SALES</c> has six, which
+        /// puts both at 16 and says nothing.
+        /// </remarks>
+        public static readonly object[][] Wide = BuildWide();
+
+        static object[][] BuildWide()
+        {
+            var rows = new object[12][];
+            for (var i = 0; i < rows.Length; i++)
+                rows[i] = [string.Format("K{0:D2}", i + 1), java.lang.Integer.valueOf(i + 1)];
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Returns the WIDE row type.
+        /// </summary>
+        public static RelDataType WideRowType(RelDataTypeFactory typeFactory)
+        {
+            return typeFactory.builder()
+                .add("K", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+                .add("N", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                .build();
+        }
+
+        /// <summary>
         /// Returns the SALES row type.
         /// </summary>
         public static RelDataType SalesRowType(RelDataTypeFactory typeFactory)

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -53,11 +53,13 @@ namespace Apache.Calcite.Tests
             {
                 rootSchema.add("SALES", new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false));
                 rootSchema.add("SORTED", new AsyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, true));
+                rootSchema.add("WIDE", new AsyncRowsTable(AsyncTestRows.Wide, AsyncTestRows.WideRowType, false));
             }
             else
             {
                 rootSchema.add("SALES", new SyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false));
                 rootSchema.add("SORTED", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, true));
+                rootSchema.add("WIDE", new SyncRowsTable(AsyncTestRows.Wide, AsyncTestRows.WideRowType, false));
             }
 
             // a table function, which this convention has no node for: Calcite plans it and the converter
@@ -285,6 +287,19 @@ namespace Apache.Calcite.Tests
 
         [TestMethod]
         public Task ShouldAgreeOnANestedLoopJoin() => Same("SELECT s.ID, t.V FROM SALES s JOIN SORTED t ON s.ID > t.K");
+
+        // A right and a full join over twelve build-side keys with no ORDER BY. The rows that matched nothing
+        // come out at the end, and twelve is the one size at which the collection they are walked from
+        // decides their order: the lookup is a table of 16 and the HashSet copied from its key set is a table
+        // of 32.
+
+        [TestMethod]
+        public Task ShouldAgreeOnARightJoinsOwnOrderOverTwelveKeys() =>
+            SameThrough("ClrAsyncEnumerableHashJoin", "SELECT a.N, b.K FROM (SELECT * FROM WIDE WHERE N < 3) a RIGHT JOIN WIDE b ON a.K = b.K");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAFullJoinsOwnOrderOverTwelveKeys() =>
+            SameThrough("ClrAsyncEnumerableHashJoin", "SELECT a.N, b.K FROM (SELECT * FROM WIDE WHERE N < 3) a FULL JOIN WIDE b ON a.K = b.K");
 
         [TestMethod]
         public Task ShouldAgreeOnASemiJoin() => Same("SELECT ID FROM SALES WHERE ID IN (SELECT K FROM SORTED)");

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -145,6 +145,116 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// Plans a hand-built rel in one convention and returns its rows, rendered.
+        /// </summary>
+        /// <param name="build"></param>
+        /// <param name="async"></param>
+        /// <param name="planOnly"></param>
+        /// <param name="add"></param>
+        /// <param name="remove"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>ClrEnumerableDifferentialTests.RunRel</c> for this convention: the same planning, and the rule
+        /// registration of <see cref="Run"/> next door. It exists because SQL cannot reach every shape. The
+        /// one that forced it is a recursive query whose step aggregates the working table — standard SQL
+        /// will not put an aggregate in a recursive term, and that shape is the only thing that tells
+        /// <c>repeatUnion</c>'s termination test apart from "stop after an empty round".
+        ///
+        /// <para>Each side builds against its own schema, as <see cref="Run"/> does, so the asynchronous side
+        /// reads asynchronous tables and the synchronous side reads synchronous ones. The rel is therefore
+        /// built twice rather than shared, which is also what makes the builder's own state safe.</para>
+        ///
+        /// <para>No parser, so no validator and no sub-query program: a rel built here is already the shape
+        /// the planner is given. That is the point of the route and also its limit — nothing here exercises
+        /// how SQL becomes a rel.</para>
+        /// </remarks>
+        static async Task<List<string>> RunRel(Func<RelBuilder, RelNode> build, bool async, bool planOnly = false, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            var rootSchema = Schema(async);
+
+            var rules = new java.util.ArrayList();
+            foreach (var rule in async ? ClrAsyncEnumerableRules.Rules() : ClrEnumerableRules.Rules())
+                rules.add(rule);
+
+            var calcRules = new java.util.ArrayList();
+            foreach (var rule in async ? ClrAsyncEnumerableRules.CalcRules() : ClrEnumerableRules.CalcRules())
+                calcRules.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRules.add(rule);
+
+            var config = Frameworks.newConfigBuilder().defaultSchema(rootSchema).build();
+            var logical = build(RelBuilder.create(config));
+
+            var planner = (org.apache.calcite.plan.volcano.VolcanoPlanner)logical.getCluster().getPlanner();
+            planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+            planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);
+
+            var convention = async ? (Convention)ClrAsyncEnumerableConvention.Instance : ClrEnumerableConvention.Instance;
+            var empty = new java.util.ArrayList();
+
+            var chosen = new DefaultRulesProgram(rules, false, false, false, add, remove)
+                .run(planner, logical, logical.getTraitSet().replace(convention).simplify(), empty, empty);
+
+            var physical = Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE)
+                .run(planner, chosen, chosen.getTraitSet(), empty, empty);
+
+            if (planOnly)
+                return [RelOptUtil.toString(physical)];
+
+            var parameters = new java.util.HashMap();
+            var context = new TestDataContext(rootSchema, parameters);
+
+            var rows = new List<string>();
+
+            if (async)
+            {
+                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                await foreach (var row in bindable.Bind(context))
+                    rows.Add(Render(row));
+            }
+            else
+            {
+                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                foreach (var row in bindable.Bind(context))
+                    rows.Add(Render(row));
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Requires that a hand-built rel gives the same rows in both conventions.
+        /// </summary>
+        static async Task SameRel(Func<RelBuilder, RelNode> build, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            var async = await RunRel(build, true, add: add, remove: remove);
+            var sync = await RunRel(build, false, add: add, remove: remove);
+
+            async.Should().Equal(sync, "the plan should give what ClrEnumerableConvention gives");
+        }
+
+        /// <summary>
+        /// Requires the same rows, and that the asynchronous convention really planned the node aimed at.
+        /// </summary>
+        /// <remarks>
+        /// The reason <see cref="SameThrough"/> gives, and it applies here with more force: a rel built by
+        /// hand does not have a parser's opinion about which node it wants, so a rule that fires on some
+        /// other shape than the one intended still produces rows that agree.
+        /// </remarks>
+        static async Task SameRelThrough(string node, Func<RelBuilder, RelNode> build, RelOptRule[]? add = null, RelOptRule[]? remove = null)
+        {
+            (await RunRel(build, true, planOnly: true, add: add, remove: remove))[0]
+                .Should().Contain(node, "the plan should be planned through {0}", node);
+
+            await SameRel(build, add, remove);
+        }
+
+        /// <summary>
+        /// A boxed integer, which is what a literal of a hand-built rel takes.
+        /// </summary>
+        static java.lang.Integer I(int value) => java.lang.Integer.valueOf(value);
+
+        /// <summary>
         /// The context a plan of either convention is bound with.
         /// </summary>
         /// <remarks>
@@ -448,6 +558,69 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public Task ShouldAgreeOnARecursiveQueryOfSeveralColumns() =>
             Same("WITH RECURSIVE t(n, m) AS (VALUES (1, 10) UNION ALL SELECT n + 1, m + 10 FROM t WHERE n < 4) SELECT n, m FROM t ORDER BY 1");
+
+        // ------------------------------------------------------------------ built by hand
+        //
+        // Shapes SQL cannot express, through RunRel. Each has a twin in ClrEnumerableRelTests, which checks
+        // the synchronous convention against Calcite; these check this convention against that one.
+
+        /// <summary>
+        /// A recursive query whose step aggregates the working table rather than reading it row by row.
+        /// </summary>
+        /// <remarks>
+        /// The shape this harness was built for, and the only one that tells <c>repeatUnion</c>'s termination
+        /// test apart from "stop after a round that produced nothing": the sentinel is never restored across
+        /// the seed/iteration boundary, so a seed that emitted a row leaves the first empty round
+        /// non-terminating. An aggregate step makes the extra round visible, because <c>COUNT(*)</c> yields a
+        /// row over no rows; a step that reads the table row by row cannot see it.
+        ///
+        /// <para>UNION rather than UNION ALL, and that is what makes it terminate — the spool is cleared by
+        /// the round that wrote nothing, so the step oscillates, and deduplication is what ends it. Under
+        /// UNION ALL this runs forever in every convention including Calcite's.</para>
+        /// </remarks>
+        [TestMethod]
+        public Task ShouldAgreeOnARecursiveQueryWhoseStepAggregates() =>
+            SameRel(builder => builder
+                .values(["i"], I(1))
+                .transientScan("EMPTY_FIRST")
+                .aggregate(builder.groupKey(), builder.count(false, "C"))
+                .filter(builder.equals(builder.field(0), builder.literal(java.lang.Long.valueOf(0))))
+                .project(builder.literal(I(99)))
+                .repeatUnion("EMPTY_FIRST", false)
+                .build());
+
+        /// <summary>
+        /// A recursive query whose step reads the working table a row at a time.
+        /// </summary>
+        /// <remarks>
+        /// The ordinary shape, which SQL can express and this suite already runs as
+        /// <c>ShouldAgreeOnARecursiveQuery</c>. Here to show the two routes agree on it, so that a failure of
+        /// the one above is read as being about the aggregate rather than about the harness.
+        /// </remarks>
+        [TestMethod]
+        public Task ShouldAgreeOnARecursiveQueryBuiltByHand() =>
+            SameRel(builder => builder
+                .values(["i"], I(1))
+                .transientScan("DELTA")
+                .filter(builder.call(org.apache.calcite.sql.fun.SqlStdOperatorTable.LESS_THAN, builder.field(0), builder.literal(I(4))))
+                .project(builder.call(org.apache.calcite.sql.fun.SqlStdOperatorTable.PLUS, builder.field(0), builder.literal(I(1))))
+                .repeatUnion("DELTA", true)
+                .build());
+
+        /// <summary>
+        /// A scan and a filter built by hand, planned through this convention's own nodes.
+        /// </summary>
+        /// <remarks>
+        /// The harness proving itself: that a rel built rather than parsed reaches this convention at all,
+        /// and reaches it through <c>ClrAsyncEnumerableCalc</c> rather than through a converter. Without this
+        /// a failure anywhere above is ambiguous between the shape and the route.
+        /// </remarks>
+        [TestMethod]
+        public Task ShouldPlanAHandBuiltScanThroughThisConvention() =>
+            SameRelThrough("ClrAsyncEnumerableCalc", builder => builder
+                .scan("SORTED")
+                .filter(builder.call(org.apache.calcite.sql.fun.SqlStdOperatorTable.GREATER_THAN, builder.field(0), builder.literal(I(1))))
+                .build());
 
         [TestMethod]
         public Task ShouldAgreeOnATableFunction() =>

--- a/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
+using Apache.Calcite.Extensions.Interop;
 
 using org.apache.calcite.linq4j.function;
 
@@ -214,6 +215,42 @@ namespace Apache.Calcite.Tests
             // over finished state buys and what a yield in the method itself would have lost
             rows.ToList().Should().Equal(2, 1);
             drawn.Should().Be(3);
+        }
+
+        /// <summary>
+        /// A row array holding a CLR-boxed value is not equal to one holding the Java-boxed same value, so a
+        /// set operator keeps both.
+        /// </summary>
+        /// <remarks>
+        /// The failure mode behind the SPI contract on <c>IClrScannableTable</c>, proved here rather than
+        /// left as a possibility. <c>Functions.arrayComparer</c> compares element by element with
+        /// <c>equals</c>, and a <see cref="int"/> boxed the CLR way and a <c>java.lang.Integer</c> are not
+        /// equal in either direction. Their hashes do agree — IKVM maps <c>hashCode</c> onto
+        /// <see cref="object.GetHashCode"/>, and <see cref="int"/>'s is the value, which is
+        /// <c>Integer.hashCode</c> — so the two land in the same bucket, the iteration order of the set is
+        /// undisturbed, and the only thing that breaks is the deduplication. That is why it would not show up
+        /// as rows in the wrong order.
+        ///
+        /// <para><see cref="JavaValues.From"/> does not save this and is not meant to: a row is an
+        /// <c>object[]</c>, which is not a value type, so it passes through whole and its elements are never
+        /// looked at. Calcite requires the same of a <c>ScannableTable</c> and converts nothing either.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay()
+        {
+            var comparer = org.apache.calcite.linq4j.function.Functions.arrayComparer();
+
+            object[] clr = [1, "A"];
+            object[] java = [global::java.lang.Integer.valueOf(1), "A"];
+
+            comparer.equal(clr, java).Should().BeFalse("this is what the SPI contract exists to prevent");
+            comparer.hashCode(clr).Should().Be(comparer.hashCode(java), "the hashes agree, so only dedup breaks");
+
+            ClrEnumerableDefaults.Distinct([clr, java], comparer).Should().HaveCount(2);
+
+            // and the same two rows, both boxed the way the contract requires, are one row
+            object[] other = [global::java.lang.Integer.valueOf(1), "A"];
+            ClrEnumerableDefaults.Distinct([java, other], comparer).Should().HaveCount(1);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using org.apache.calcite.linq4j.function;
+
+using JoinType = org.apache.calcite.linq4j.JoinType;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// What the operators do with the sequences they are given, against what <c>EnumerableDefaults</c> does.
+    /// </summary>
+    /// <remarks>
+    /// None of this is a property of any row a query returns, so the differential suite is no oracle for it:
+    /// how many rows an operator draws, whether it opens its input at all, when it drains it, and what it does
+    /// with a join type or a null the planner never produces. Each test is written against Calcite's body.
+    /// </remarks>
+    [TestClass]
+    public class ClrEnumerableDefaultsContractTests
+    {
+
+        /// <summary>
+        /// A satisfied fetch has drawn one row more than it returned.
+        /// </summary>
+        /// <remarks>
+        /// <c>take</c> is <c>takeWhile</c> over <c>n &lt; count</c>, and the enumerator has to draw a row
+        /// before it can test it. LINQ's own <c>Take</c> stops on the count and draws exactly n, which is why
+        /// delegating to it was a divergence.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldDrawOneRowMoreThanItTakes()
+        {
+            var drawn = 0;
+
+            IEnumerable<int> Source()
+            {
+                for (var i = 0; i < 5; i++)
+                {
+                    drawn++;
+                    yield return i;
+                }
+            }
+
+            ClrEnumerableDefaults.Take(Source(), 2).ToList().Should().Equal(0, 1);
+            drawn.Should().Be(3);
+        }
+
+        /// <summary>
+        /// A fetch of no rows still opens its input and still draws a row from it.
+        /// </summary>
+        /// <remarks>
+        /// Opening is not free. It is what runs a lazy collection spool's write-back and a repeat union's
+        /// clean-up, so returning an empty sequence without touching the input skips work Calcite does.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldOpenItsInputForAFetchOfNoRows()
+        {
+            var drawn = 0;
+
+            IEnumerable<int> Source()
+            {
+                for (var i = 0; i < 5; i++)
+                {
+                    drawn++;
+                    yield return i;
+                }
+            }
+
+            ClrEnumerableDefaults.Take(Source(), 0).ToList().Should().BeEmpty();
+            drawn.Should().Be(1);
+        }
+
+        /// <summary>
+        /// The asynchronous fetch draws the same rows as the synchronous one.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldDrawOneRowMoreThanItTakesAsync()
+        {
+            var drawn = 0;
+
+            async IAsyncEnumerable<int> Source()
+            {
+                for (var i = 0; i < 5; i++)
+                {
+                    drawn++;
+                    await Task.Yield();
+                    yield return i;
+                }
+            }
+
+            var rows = new List<int>();
+            await foreach (var row in ClrAsyncEnumerableDefaults.Take(Source(), 2))
+                rows.Add(row);
+
+            rows.Should().Equal(0, 1);
+            drawn.Should().Be(3);
+        }
+
+        /// <summary>
+        /// A semi join over an empty outer never touches its inner.
+        /// </summary>
+        /// <remarks>
+        /// CALCITE-2909. Calcite holds the inner lookup behind a <c>Suppliers.memoize</c> and only asks for it
+        /// while testing the first outer row, so an outer that has no rows never builds it. Building the
+        /// lookup first reads a whole input for an answer that was already known.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotEnumerateTheInnerOfASemiJoinOverAnEmptyOuter()
+        {
+            var enumerations = 0;
+
+            IEnumerable<int> Inner()
+            {
+                enumerations++;
+                yield return 1;
+            }
+
+            ClrEnumerableDefaults.SemiJoin(System.Array.Empty<int>(), Inner(), x => x, x => x, null, false, null).ToList().Should().BeEmpty();
+            enumerations.Should().Be(0);
+        }
+
+        /// <summary>
+        /// A semi join over a non-empty outer builds its lookup once and no more.
+        /// </summary>
+        [TestMethod]
+        public void ShouldEnumerateTheInnerOfASemiJoinOnce()
+        {
+            var enumerations = 0;
+
+            IEnumerable<int> Inner()
+            {
+                enumerations++;
+                yield return 1;
+                yield return 2;
+            }
+
+            ClrEnumerableDefaults.SemiJoin(new[] { 1, 2, 3 }, Inner(), x => x, x => x, null, false, null).ToList().Should().Equal(1, 2);
+            enumerations.Should().Be(1);
+        }
+
+        /// <summary>
+        /// A correlated join refuses RIGHT and FULL where it is built, not where it is enumerated.
+        /// </summary>
+        /// <remarks>
+        /// <c>correlateJoin</c> throws before it constructs the enumerable at all. Deferring the refusal into
+        /// an iterator would let a plan be assembled and only fail once rows were pulled; falling through and
+        /// inner-joining, which is what happened here, would let it not fail at all.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRefuseARightOrFullCorrelateWhereItIsBuilt()
+        {
+            foreach (var joinType in new[] { JoinType.RIGHT, JoinType.FULL })
+            {
+                var act = () => ClrEnumerableDefaults.CorrelateJoin<int, int, int>(new[] { 1 }, _ => [1], (a, b) => a + b, joinType);
+
+                act.Should().Throw<ArgumentException>().WithMessage("*" + joinType.name() + "*");
+            }
+        }
+
+        /// <summary>
+        /// A correlated function that answers null is read as a sequence of no rows.
+        /// </summary>
+        /// <remarks>
+        /// <c>Linq4j.emptyEnumerable()</c>, which Calcite substitutes rather than dereferencing. A LEFT join
+        /// therefore emits the outer row against null instead of throwing.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadANullCorrelatedSequenceAsEmpty()
+        {
+            ClrEnumerableDefaults.CorrelateJoin<int, string, string>(new[] { 1, 2 }, _ => null!, (a, b) => $"{a}:{b ?? "null"}", JoinType.LEFT)
+                .ToList()
+                .Should()
+                .Equal("1:null", "2:null");
+        }
+
+        /// <summary>
+        /// A grouped aggregate folds its whole input where it is called, before a row is pulled from it.
+        /// </summary>
+        /// <remarks>
+        /// <c>groupBy_</c> drains the input into the map and only then returns a <c>LookupResultEnumerable</c>
+        /// over a map that is already finished, so a second pass replays rather than folding again.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldFoldAGroupedAggregateWhereItIsCalled()
+        {
+            var drawn = 0;
+
+            IEnumerable<int> Source()
+            {
+                foreach (var i in new[] { 1, 1, 2 })
+                {
+                    drawn++;
+                    yield return i;
+                }
+            }
+
+            var rows = ClrEnumerableDefaults.GroupBy<int, int, int>(Source(), x => x, new Count(), new Add(), new Result(), null);
+
+            drawn.Should().Be(3, "the fold runs where groupBy is called, not where its result is enumerated");
+
+            rows.ToList().Should().Equal(2, 1);
+
+            // a second pass replays the map rather than folding again, which is what returning an enumerable
+            // over finished state buys and what a yield in the method itself would have lost
+            rows.ToList().Should().Equal(2, 1);
+            drawn.Should().Be(3);
+        }
+
+        /// <summary>
+        /// An accumulator of one counter.
+        /// </summary>
+        sealed class Count : Function0
+        {
+
+            public object apply() => new int[1];
+
+        }
+
+        /// <summary>
+        /// Adds a row to the counter.
+        /// </summary>
+        sealed class Add : Function2
+        {
+
+            public object apply(object accumulator, object row)
+            {
+                ((int[])accumulator)[0]++;
+                return accumulator;
+            }
+
+        }
+
+        /// <summary>
+        /// Answers the counter.
+        /// </summary>
+        sealed class Result : Function2
+        {
+
+            public object apply(object key, object accumulator) => java.lang.Integer.valueOf(((int[])accumulator)[0]);
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
-using Apache.Calcite.Extensions.Interop;
 
 using org.apache.calcite.linq4j.function;
 
@@ -215,42 +214,6 @@ namespace Apache.Calcite.Tests
             // over finished state buys and what a yield in the method itself would have lost
             rows.ToList().Should().Equal(2, 1);
             drawn.Should().Be(3);
-        }
-
-        /// <summary>
-        /// A row array holding a CLR-boxed value is not equal to one holding the Java-boxed same value, so a
-        /// set operator keeps both.
-        /// </summary>
-        /// <remarks>
-        /// The failure mode behind the SPI contract on <c>IClrScannableTable</c>, proved here rather than
-        /// left as a possibility. <c>Functions.arrayComparer</c> compares element by element with
-        /// <c>equals</c>, and a <see cref="int"/> boxed the CLR way and a <c>java.lang.Integer</c> are not
-        /// equal in either direction. Their hashes do agree — IKVM maps <c>hashCode</c> onto
-        /// <see cref="object.GetHashCode"/>, and <see cref="int"/>'s is the value, which is
-        /// <c>Integer.hashCode</c> — so the two land in the same bucket, the iteration order of the set is
-        /// undisturbed, and the only thing that breaks is the deduplication. That is why it would not show up
-        /// as rows in the wrong order.
-        ///
-        /// <para><see cref="JavaValues.From"/> does not save this and is not meant to: a row is an
-        /// <c>object[]</c>, which is not a value type, so it passes through whole and its elements are never
-        /// looked at. Calcite requires the same of a <c>ScannableTable</c> and converts nothing either.</para>
-        /// </remarks>
-        [TestMethod]
-        public void ShouldNotDeduplicateARowBoxedTheClrWayAgainstOneBoxedTheJavaWay()
-        {
-            var comparer = org.apache.calcite.linq4j.function.Functions.arrayComparer();
-
-            object[] clr = [1, "A"];
-            object[] java = [global::java.lang.Integer.valueOf(1), "A"];
-
-            comparer.equal(clr, java).Should().BeFalse("this is what the SPI contract exists to prevent");
-            comparer.hashCode(clr).Should().Be(comparer.hashCode(java), "the hashes agree, so only dedup breaks");
-
-            ClrEnumerableDefaults.Distinct([clr, java], comparer).Should().HaveCount(2);
-
-            // and the same two rows, both boxed the way the contract requires, are one row
-            object[] other = [global::java.lang.Integer.valueOf(1), "A"];
-            ClrEnumerableDefaults.Distinct([java, other], comparer).Should().HaveCount(1);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -1827,6 +1827,19 @@ namespace Apache.Calcite.Tests
         public void ShouldAgreeOnALimitSortWithNullsFirstAndAnOffset() =>
             SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS FIRST, \"ID\" OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY");
 
+        /// <remarks>
+        /// A <em>single</em>-column collation over a nullable column, which is the only shape whose sort key
+        /// can itself be null: a multi-field collation key is a FlatLists row, and a row is never null even
+        /// when a field in it is. The four tests above are all two-key and therefore cannot reach it.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortOnOneNullableKeyNullsFirst() =>
+            SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS FIRST FETCH NEXT 3 ROWS ONLY");
+
+        [TestMethod]
+        public void ShouldAgreeOnALimitSortOnOneNullableKeyTakingEverything() =>
+            SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" FETCH NEXT 100 ROWS ONLY");
+
         [TestMethod]
         public void ShouldAgreeOnALimitSortWithNullsLastAndAnOffset() =>
             SameLimitSort("SELECT \"ID\", \"AMOUNT\" FROM \"SALES\" ORDER BY \"AMOUNT\" NULLS LAST, \"ID\" OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY");

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -1198,6 +1198,34 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public void ShouldAgreeOnARangeFrameWithAnOffset() => Same("SELECT \"ID\", SUM(\"AMOUNT\") OVER (ORDER BY \"ID\" RANGE BETWEEN 2 PRECEDING AND CURRENT ROW) FROM \"SALES\" ORDER BY \"ID\"");
 
+        /// <summary>
+        /// A RANGE bound with an offset over a nullable order key fails, here as in Calcite.
+        /// </summary>
+        /// <remarks>
+        /// <c>EnumerableWindow.translateBound</c> boxes the key type only where the bound has no offset --
+        /// <c>if (bound.getOffset() == null) desiredKeyType = Primitive.box(desiredKeyType)</c> -- so with an
+        /// offset the key stays whatever the type factory gave, which for a nullable column is
+        /// <c>java.lang.Integer</c>. The <c>subtract</c> built on it then unboxes, and a null key is a
+        /// <c>NullPointerException</c>.
+        ///
+        /// <para>Ours is the same translation and fails the same way: IKVM maps that exception onto
+        /// <see cref="NullReferenceException"/>, and the unboxing an expression tree does for the same
+        /// arithmetic raises the same one. Both sides are asserted, because the point is not that ours throws
+        /// -- it is that neither convention answers a query the other answers. If Calcite ever fixes this,
+        /// this test fails and tells us to follow.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAgreeOnFailingARangeFrameWithAnOffsetOverANullableKey()
+        {
+            const string sql = "SELECT \"ID\", SUM(\"AMOUNT\") OVER (ORDER BY \"AMOUNT\" RANGE BETWEEN 2 PRECEDING AND CURRENT ROW) FROM \"SALES\" ORDER BY \"ID\"";
+
+            var calcite = () => Run(sql, false);
+            var mine = () => Run(sql, true);
+
+            calcite.Should().Throw<NullReferenceException>("Calcite unboxes a null order key");
+            mine.Should().Throw<NullReferenceException>("and so do we, from the same translation");
+        }
+
         [TestMethod]
         public void ShouldAgreeOnLeadAndLag() => Same("SELECT \"ID\", LAG(\"AMOUNT\") OVER (ORDER BY \"ID\"), LEAD(\"AMOUNT\") OVER (ORDER BY \"ID\") FROM \"SALES\" ORDER BY \"ID\"");
 

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -190,6 +190,57 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// A table of twelve distinct keys, which is the one row count at which a hash join's leftovers can
+        /// come out in the wrong order.
+        /// </summary>
+        /// <remarks>
+        /// A RIGHT or a FULL join ends by emitting the build rows nothing probed, and <c>hashEquiJoin_</c>
+        /// walks those by copying the lookup's key set into a <c>java.util.HashSet</c> and iterating
+        /// <em>that</em>. The copy does not have the map's iteration order:
+        /// <c>HashSet(Collection)</c> sizes its table as <c>tableSizeFor(max((int) (n / 0.75f) + 1, 16))</c>,
+        /// while a map grown by insertion holds the smallest power of two at or above 16 that still leaves
+        /// <c>n &lt;= 0.75 * cap</c>. The two disagree exactly where <c>n = 0.75 * 2^k</c> — 12, 24, 48 — and
+        /// at twelve keys the map is a table of 16 and the copy a table of 32.
+        ///
+        /// <para>So this is the shape no other fixture here has. <c>SALES</c> has six rows, which puts both
+        /// at 16, and a right join over it agrees whichever collection the leftovers are walked from.</para>
+        /// </remarks>
+        sealed class WideTable : AbstractTable, ScannableTable
+        {
+
+            static readonly object[][] Rows = BuildRows();
+
+            static object[][] BuildRows()
+            {
+                var rows = new object[12][];
+                for (var i = 0; i < rows.Length; i++)
+                    rows[i] = [string.Format("K{0:D2}", i + 1), java.lang.Integer.valueOf(i + 1)];
+
+                return rows;
+            }
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("K", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+                    .add("N", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .build();
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root)
+            {
+                var list = new java.util.ArrayList();
+                foreach (var row in Rows)
+                    list.add(row);
+
+                return Linq4j.asEnumerable(list);
+            }
+
+        }
+
+        /// <summary>
         /// A table with a timestamp, which is what a window table function needs and <c>SALES</c> has not.
         /// </summary>
         /// <remarks>
@@ -280,6 +331,7 @@ namespace Apache.Calcite.Tests
             rootSchema.add("EVENTS", new EventsTable());
             rootSchema.add("SORTED", new SortedTable());
             rootSchema.add("SCALARS", new ScalarsTable());
+            rootSchema.add("WIDE", new WideTable());
             rootSchema.add("FIB", org.apache.calcite.schema.impl.TableFunctionImpl.create(org.apache.calcite.util.Smalls.FIBONACCI_LIMIT_100_TABLE_METHOD));
 
             // A CUSTOM-format fixture, which every other table here is not. HrSchema's rows are instances of
@@ -870,6 +922,23 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public void ShouldAgreeOnARightJoinsOwnOrder() =>
             Same("SELECT a.\"ID\", b.\"ID\" FROM (SELECT * FROM \"SALES\" WHERE \"ID\" < 3) a RIGHT JOIN \"SALES\" b ON a.\"REGION\" = b.\"REGION\" AND a.\"LABEL\" = b.\"LABEL\"");
+
+        /// <summary>
+        /// The same question at the one build-side size where the collection the leftovers are walked from
+        /// decides the answer.
+        /// </summary>
+        /// <remarks>
+        /// <c>WIDE</c> has twelve keys, so the lookup is a table of 16 and the <c>HashSet</c> copied from its
+        /// key set is a table of 32; the two orders differ. <see cref="ShouldAgreeOnARightJoinsOwnOrder"/> is
+        /// over six keys, where both are 16 and either collection gives the same rows.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAgreeOnARightJoinsOwnOrderOverTwelveKeys() =>
+            SameThrough("ClrEnumerableHashJoin", "SELECT a.\"N\", b.\"K\" FROM (SELECT * FROM \"WIDE\" WHERE \"N\" < 3) a RIGHT JOIN \"WIDE\" b ON a.\"K\" = b.\"K\"");
+
+        [TestMethod]
+        public void ShouldAgreeOnAFullJoinsOwnOrderOverTwelveKeys() =>
+            SameThrough("ClrEnumerableHashJoin", "SELECT a.\"N\", b.\"K\" FROM (SELECT * FROM \"WIDE\" WHERE \"N\" < 3) a FULL JOIN \"WIDE\" b ON a.\"K\" = b.\"K\"");
 
         [TestMethod]
         public void ShouldAgreeOnAFullJoinsOwnOrder() =>

--- a/src/Apache.Calcite.Tests/ClrEnumerableNestedLoopJoinTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableNestedLoopJoinTests.cs
@@ -1,0 +1,250 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using JoinType = org.apache.calcite.linq4j.JoinType;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// What <c>ClrEnumerableDefaults.NestedLoopJoin</c> does, against what
+    /// <c>EnumerableDefaults.nestedLoopJoin</c> does.
+    /// </summary>
+    /// <remarks>
+    /// The oracle everywhere else is a query run through both conventions, and it cannot reach any of these.
+    /// The result selector a plan hands the join is <c>ClrEnumUtils.JoinSelector</c>, and for SEMI that
+    /// lambda declares its right parameter and never reads it — a semi join's row is the left row — so which
+    /// right row the join passes is invisible to every query, and so is a join type the planner never
+    /// produces. What the method does with a sequence it is given — how many times it enumerates it, when it
+    /// runs, and what it does with two right rows that are the same object — is not a property of any row a
+    /// query returns either. So these are direct tests of the method, and each one is written against
+    /// Calcite's body rather than against what SQL would want.
+    /// </remarks>
+    [TestClass]
+    public class ClrEnumerableNestedLoopJoinTests
+    {
+
+        /// <summary>
+        /// A right row, which is a reference, so that two of them can be the same object.
+        /// </summary>
+        sealed class Row(string value)
+        {
+
+            public readonly string Value = value;
+
+            public override string ToString() => Value;
+
+        }
+
+        /// <summary>
+        /// A sequence that counts how many times it has been enumerated.
+        /// </summary>
+        sealed class Counting<T>(IEnumerable<T> source) : IEnumerable<T>
+        {
+
+            public int Count;
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                Count++;
+                return source.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        }
+
+        static string Pair(string? left, Row? right) => (left ?? "-") + "/" + (right?.Value ?? "-");
+
+        static List<string> Join(IEnumerable<string> outer, IEnumerable<Row> inner, JoinType joinType) =>
+            [.. ClrEnumerableDefaults.NestedLoopJoin<string, Row, string>(outer, inner, Pair, (l, r) => r != null && l != null && r.Value.StartsWith(l), joinType)];
+
+        static IEnumerable<Row> Rows(params string[] values) => values.Select(v => new Row(v));
+
+        // ------------------------------------------------------------------ which right row a semi join passes
+
+        /// <summary>
+        /// A semi join passes the right row that matched, not a null one.
+        /// </summary>
+        /// <remarks>
+        /// <c>nestedLoopJoinOptimized</c> returns from state 1 with <c>innerValue</c> set to the row the
+        /// predicate accepted, and <c>current()</c> is <c>resultSelector.apply(outerValue, innerValue)</c>.
+        /// The row is therefore built from the match. Passing null instead returns the same rows for every
+        /// plan, because a semi join's selector ignores its right parameter, and a different answer for
+        /// <c>MergeJoin</c>, which calls this method for a semi merge join with a residual.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldPassTheMatchedRightRowToASemiJoin() =>
+            Join(["a", "b", "c"], Rows("a1", "a2", "b1"), JoinType.SEMI)
+                .Should().Equal("a/a1", "b/b1");
+
+        /// <summary>
+        /// An anti join passes no right row, because it never returns one that matched.
+        /// </summary>
+        [TestMethod]
+        public void ShouldPassNoRightRowToAnAntiJoin() =>
+            Join(["a", "b", "c"], Rows("a1", "a2", "b1"), JoinType.ANTI)
+                .Should().Equal("c/-");
+
+        [TestMethod]
+        public void ShouldPairEveryMatchOfAnInnerJoin() =>
+            Join(["a", "b", "c"], Rows("a1", "a2", "b1"), JoinType.INNER)
+                .Should().Equal("a/a1", "a/a2", "b/b1");
+
+        [TestMethod]
+        public void ShouldKeepTheUnmatchedLeftRowOfALeftJoin() =>
+            Join(["a", "b", "c"], Rows("a1", "a2", "b1"), JoinType.LEFT)
+                .Should().Equal("a/a1", "a/a2", "b/b1", "c/-");
+
+        [TestMethod]
+        public void ShouldKeepTheUnmatchedRightRowOfARightJoin() =>
+            Join(["a", "b"], Rows("a1", "c1", "b1"), JoinType.RIGHT)
+                .Should().Equal("a/a1", "b/b1", "-/c1");
+
+        [TestMethod]
+        public void ShouldKeepBothUnmatchedSidesOfAFullJoin() =>
+            Join(["a", "b", "d"], Rows("a1", "c1", "b1"), JoinType.FULL)
+                .Should().Equal("a/a1", "b/b1", "d/-", "-/c1");
+
+        // ------------------------------------------------------------------ a join type the switch does not name
+
+        /// <summary>
+        /// A join type none of the six cases names returns nothing at all.
+        /// </summary>
+        /// <remarks>
+        /// <c>nestedLoopJoinOptimized</c>'s switch on the join type falls to <c>default: break</c> for ASOF,
+        /// LEFT_ASOF and LEFT_MARK, which moves the inner on rather than returning the pair, and the
+        /// unmatched-left branch names only LEFT and ANTI. So a match returns nothing and a miss returns
+        /// nothing, and the join is empty. It is not an inner join.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReturnNothingForAJoinTypeTheSwitchDoesNotName()
+        {
+            Join(["a", "b"], Rows("a1", "b1"), JoinType.ASOF).Should().BeEmpty();
+            Join(["a", "b"], Rows("a1", "b1"), JoinType.LEFT_ASOF).Should().BeEmpty();
+            Join(["a", "b"], Rows("a1", "b1"), JoinType.LEFT_MARK).Should().BeEmpty();
+        }
+
+        // ------------------------------------------------------------------ what each body does with the inner
+
+        /// <summary>
+        /// The streaming body enumerates the inner once for every outer row.
+        /// </summary>
+        /// <remarks>
+        /// <c>nestedLoopJoinOptimized</c> calls <c>inner.enumerator()</c> in state 0, which it reaches once
+        /// per outer row, and never reads the inner into a list. <c>leftMarkJoinInternal</c> does the same.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldEnumerateTheInnerForEveryOuterRowOfAnInnerJoin()
+        {
+            var inner = new Counting<Row>(Rows("x1", "y1").ToList());
+
+            Join(["a", "b", "c"], inner, JoinType.INNER).Should().BeEmpty();
+            inner.Count.Should().Be(3);
+        }
+
+        /// <summary>
+        /// The list body reads the inner once and walks the list from then on.
+        /// </summary>
+        /// <remarks>
+        /// <c>nestedLoopJoinAsList</c> calls <c>inner.toList()</c>, and that asymmetry with the streaming
+        /// body is Calcite's own: it needs the right rows a second time, to emit the ones nothing matched.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldEnumerateTheInnerOnceForARightJoin()
+        {
+            var inner = new Counting<Row>(Rows("x1", "y1").ToList());
+
+            Join(["a", "b", "c"], inner, JoinType.RIGHT).Should().HaveCount(2);
+            inner.Count.Should().Be(1);
+        }
+
+        // ------------------------------------------------------------------ when each body runs
+
+        /// <summary>
+        /// A right join runs when it is called, not when its result is enumerated.
+        /// </summary>
+        /// <remarks>
+        /// <c>nestedLoopJoinAsList</c> builds the whole result and hands back
+        /// <c>Linq4j.asEnumerable(result)</c>, so the work is done before the caller has the sequence.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRunARightJoinWhenItIsCalled()
+        {
+            var outer = new Counting<string>(["a", "b"]);
+
+            ClrEnumerableDefaults.NestedLoopJoin<string, Row, string>(outer, [.. Rows("a1")], Pair, (l, r) => false, JoinType.RIGHT);
+
+            outer.Count.Should().Be(1);
+        }
+
+        /// <summary>
+        /// An inner join runs when its result is enumerated, and not before.
+        /// </summary>
+        [TestMethod]
+        public void ShouldNotRunAnInnerJoinUntilItIsEnumerated()
+        {
+            var outer = new Counting<string>(["a", "b"]);
+
+            ClrEnumerableDefaults.NestedLoopJoin<string, Row, string>(outer, [.. Rows("a1")], Pair, (l, r) => false, JoinType.INNER);
+
+            outer.Count.Should().Be(0);
+        }
+
+        // ------------------------------------------------------------------ the identity set of unmatched right rows
+
+        /// <summary>
+        /// Two unmatched right rows that are the same object are emitted once.
+        /// </summary>
+        /// <remarks>
+        /// <c>nestedLoopJoinAsList</c> holds the unmatched right rows in <c>Sets.newIdentityHashSet()</c>,
+        /// which keys on the reference, so one object added twice is one entry and comes out once. SQL wants
+        /// it twice — the right side has two rows and neither matched — and Calcite does not give that. This
+        /// is a port, so the answer here is Calcite's.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldEmitOneRowForTwoUnmatchedRightRowsThatAreTheSameObject()
+        {
+            var shared = new Row("x1");
+
+            Join(["a"], [shared, shared], JoinType.RIGHT).Should().Equal("-/x1");
+            Join(["a"], [shared, shared], JoinType.FULL).Should().Equal("a/-", "-/x1");
+        }
+
+        /// <summary>
+        /// Two unmatched right rows of equal value but different identity are both emitted.
+        /// </summary>
+        /// <remarks>
+        /// The set keys on the reference and not on the value, so equality of the rows is not what collapses
+        /// them; only being the same object is.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldEmitBothUnmatchedRightRowsThatAreEqualButNotTheSameObject() =>
+            Join(["a"], [new Row("x1"), new Row("x1")], JoinType.RIGHT)
+                .Should().Equal("-/x1", "-/x1");
+
+        /// <summary>
+        /// One match against a right row that is in the list twice takes both occurrences out.
+        /// </summary>
+        /// <remarks>
+        /// The set holds one entry for the object, so the single <c>remove</c> a match performs leaves
+        /// nothing behind for the second occurrence.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldTreatBothOccurrencesOfOneObjectAsMatched()
+        {
+            var shared = new Row("a1");
+
+            Join(["a"], [shared, shared], JoinType.RIGHT).Should().Equal("a/a1", "a/a1");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrEnumerableRelTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableRelTests.cs
@@ -315,6 +315,38 @@ namespace Apache.Calcite.Tests
                 .build());
 
         /// <summary>
+        /// A recursive query whose step aggregates the working table rather than reading it row by row.
+        /// </summary>
+        /// <remarks>
+        /// The one shape that tells Calcite's termination test apart from "stop after a round that produced
+        /// nothing". <c>EnumerableDefaults.repeatUnion</c> stops on an empty round only where its
+        /// <c>current</c> field still holds the <c>DUMMY</c> sentinel, and the sentinel is never put back
+        /// across the seed/iteration boundary -- so a seed that emitted a row leaves <c>current</c> holding
+        /// that row, and the first empty round does not stop it. It runs the iterative part once more.
+        ///
+        /// <para>Every recursive test above reads the working table row by row, and none of them can see
+        /// this: an empty table gives an empty round whether the round runs or not. The step here is
+        /// <c>COUNT(*)</c>, which yields a row over no rows, so the extra round shows up in the answer.</para>
+        ///
+        /// <para>It is a UNION rather than a UNION ALL, and that is what makes it terminate. The spool is
+        /// cleared by the round that wrote nothing, so the step oscillates: a round that counts one is empty
+        /// and empties the table, and the round after it counts zero and emits 99 again. Under UNION ALL
+        /// that runs forever -- under Calcite too, which is worth knowing before writing a recursive test.
+        /// Deduplication stops it: the second 99 is one this sequence already returned, so that round adds
+        /// nothing new, the sentinel survives it, and the query ends. Rows 1 and 99.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAgreeOnARecursiveQueryWhoseStepAggregates() =>
+            ClrEnumerableDifferentialTests.SameRel(builder => builder
+                .values(["i"], I(1))
+                .transientScan("EMPTY_FIRST")
+                .aggregate(builder.groupKey(), builder.count(false, "C"))
+                .filter(builder.equals(builder.field(0), builder.literal(java.lang.Long.valueOf(0))))
+                .project(builder.literal(I(99)))
+                .repeatUnion("EMPTY_FIRST", false)
+                .build());
+
+        /// <summary>
         /// CALCITE-4054: a repeat union whose step is a correlate with the transient scan on its right.
         /// </summary>
         /// <remarks>

--- a/src/Apache.Calcite.Tests/ClrRepeatUnionTests.cs
+++ b/src/Apache.Calcite.Tests/ClrRepeatUnionTests.cs
@@ -1,0 +1,202 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// What <c>ClrEnumerableDefaults.RepeatUnion</c> and its asynchronous twin do, against what
+    /// <c>EnumerableDefaults.repeatUnion</c> does.
+    /// </summary>
+    /// <remarks>
+    /// <c>ShouldAgreeOnARecursiveQueryWhoseStepAggregates</c> holds the same property against Calcite as the
+    /// oracle, and it only reaches the synchronous convention -- the asynchronous differential suite is
+    /// driven by SQL, and standard SQL will not put an aggregate in a recursive term. So the asymmetric
+    /// round count is pinned here instead, on both operators, by scripting the iterative part directly:
+    /// what a caller can see is how many times that sequence is enumerated, and the two must agree.
+    /// </remarks>
+    [TestClass]
+    public class ClrRepeatUnionTests
+    {
+
+        /// <summary>
+        /// An iterative part that yields a row on its first evaluation and nothing afterwards, counting how
+        /// many times it was evaluated.
+        /// </summary>
+        sealed class Rounds
+        {
+
+            public int Evaluations { get; private set; }
+
+            public IEnumerable<int> Sync()
+            {
+                var round = Evaluations++;
+                if (round == 0)
+                    yield return 100;
+            }
+
+            public async IAsyncEnumerable<int> Async()
+            {
+                var round = Evaluations++;
+                if (round == 0)
+                {
+                    await Task.Yield();
+                    yield return 100;
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// A round that produced rows puts the sentinel back, so the empty round after it does stop the
+        /// sequence.
+        /// </summary>
+        /// <remarks>
+        /// The contrast that places the extra round at the seed/iteration boundary and nowhere else. Round 0
+        /// yields 100 and, being productive, ends with the sentinel restored; round 1 yields nothing and the
+        /// sentinel is set, so it stops. Two evaluations, not three. The defect below is not "an empty round
+        /// is always retried" -- it is that the boundary is the one place the sentinel is never restored.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotRunAnExtraRoundWhereTheFirstRoundProducedRows()
+        {
+            var rounds = new Rounds();
+            var rows = ClrEnumerableDefaults.RepeatUnion(new[] { 1 }, rounds.Sync(), -1, true, null, null).ToList();
+
+            rows.Should().Equal(1, 100);
+            rounds.Evaluations.Should().Be(2);
+        }
+
+        /// <summary>
+        /// The asynchronous operator counts the same rounds as the synchronous one.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldNotRunAnExtraRoundWhereTheFirstRoundProducedRowsAsync()
+        {
+            var rounds = new Rounds();
+            var rows = new List<int>();
+
+            await foreach (var row in ClrAsyncEnumerableDefaults.RepeatUnion(AsyncOf(1), rounds.Async(), -1, true, null, null))
+                rows.Add(row);
+
+            rows.Should().Equal(1, 100);
+            rounds.Evaluations.Should().Be(2);
+        }
+
+        /// <summary>
+        /// A seed that emitted a row costs an extra evaluation of an iterative part that was never going to
+        /// yield anything at all.
+        /// </summary>
+        /// <remarks>
+        /// The cleanest statement of the defect, with the iterative part empty from the start so nothing else
+        /// is in play. Round 0 is empty, but <c>current</c> holds the seed row, so it goes round again; round
+        /// 1 is empty with the sentinel back, and that ends it. Two evaluations to discover that a sequence
+        /// which never yields anything never yields anything.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldEvaluateAnEmptyIterativePartTwiceWhereTheSeedEmittedARow()
+        {
+            var evaluations = 0;
+
+            IEnumerable<int> Empty()
+            {
+                evaluations++;
+                yield break;
+            }
+
+            ClrEnumerableDefaults.RepeatUnion(new[] { 1 }, Empty(), -1, true, null, null).ToList().Should().Equal(1);
+            evaluations.Should().Be(2);
+        }
+
+        /// <summary>
+        /// A seed that emitted nothing leaves the sentinel set, so the first empty round does stop it.
+        /// </summary>
+        /// <remarks>
+        /// The other side of the same test, and the reason the extra round is a property of the seed/iteration
+        /// boundary rather than of the loop: with no seed row there is nothing to leave in <c>current</c>, and
+        /// round 0 stops the sequence on its own. One evaluation rather than two.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldEvaluateAnEmptyIterativePartOnceWhereTheSeedWasEmpty()
+        {
+            var evaluations = 0;
+
+            IEnumerable<int> Empty()
+            {
+                evaluations++;
+                yield break;
+            }
+
+            ClrEnumerableDefaults.RepeatUnion(System.Array.Empty<int>(), Empty(), -1, true, null, null).ToList().Should().BeEmpty();
+            evaluations.Should().Be(1);
+        }
+
+        /// <summary>
+        /// A limit of zero never opens the iterative part at all.
+        /// </summary>
+        [TestMethod]
+        public void ShouldNotOpenTheIterativePartWhereTheLimitIsZero()
+        {
+            var rounds = new Rounds();
+            var rows = ClrEnumerableDefaults.RepeatUnion(new[] { 1 }, rounds.Sync(), 0, true, null, null).ToList();
+
+            rows.Should().Equal(1);
+            rounds.Evaluations.Should().Be(0);
+        }
+
+        /// <summary>
+        /// The clean-up runs before the enumerators are disposed, which is the order of Calcite's
+        /// <c>close()</c>.
+        /// </summary>
+        /// <remarks>
+        /// The caller has to abandon the sequence for this to be observable at all. Run to the end and the
+        /// seed's own <c>finally</c> has already fired -- a C# iterator runs it when its body falls off the
+        /// end, during the very <c>MoveNext</c> that reports false, not when the enumerator is later disposed.
+        /// So a drained seed logs itself before the clean-up no matter which order the two are written in, and
+        /// a test that drains it is measuring nothing. Taking one row and stopping leaves the seed suspended
+        /// at its <c>yield</c>, and then disposal is what runs its <c>finally</c>.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRunTheCleanUpBeforeDisposingTheEnumerators()
+        {
+            var order = new List<string>();
+
+            IEnumerable<int> Seed()
+            {
+                try
+                {
+                    yield return 1;
+                    yield return 2;
+                }
+                finally
+                {
+                    order.Add("seed disposed");
+                }
+            }
+
+            using (var enumerator = ClrEnumerableDefaults.RepeatUnion(Seed(), System.Array.Empty<int>(), -1, true, null, () => order.Add("clean up")).GetEnumerator())
+                enumerator.MoveNext().Should().BeTrue();
+
+            order.Should().Equal("clean up", "seed disposed");
+        }
+
+        static async IAsyncEnumerable<int> AsyncOf(params int[] values)
+        {
+            foreach (var value in values)
+            {
+                await Task.Yield();
+                yield return value;
+            }
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrTableSpiTests.cs
+++ b/src/Apache.Calcite.Tests/ClrTableSpiTests.cs
@@ -119,6 +119,57 @@ namespace Apache.Calcite.Tests
 
         }
 
+        /// <summary>
+        /// A table that breaks the SPI's contract, holding its values boxed the CLR way.
+        /// </summary>
+        /// <remarks>
+        /// What an implementer writing ordinary C# would produce, and what
+        /// <see cref="ShouldFailOverATableWhoseValuesAreNotTheTypeFactory's"/> exists to pin.
+        /// </remarks>
+        sealed class ClrBoxedRowsTable : AbstractTable, IClrScannableTable
+        {
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory) => AsyncTestRows.SortedRowType(typeFactory);
+
+            /// <inheritdoc />
+            public IEnumerable<object?[]> Scan(DataContext root) =>
+            [
+                [1, "A"],
+                [2, "B"],
+            ];
+
+        }
+
+        /// <summary>
+        /// A table whose values are not the type factory's fails, and fails at once.
+        /// </summary>
+        /// <remarks>
+        /// The contract on <see cref="IClrScannableTable"/> is Calcite's own contract on
+        /// <see cref="ScannableTable"/>: the values in a row are what the type factory says they are, which
+        /// is to say Java's. Nothing checks it, and nothing needs to -- what reads a field is
+        /// <c>SqlFunctions.toInt</c> and a cast to <c>java.lang.Integer</c>, both of them Calcite's own and
+        /// neither of them able to see a <see cref="int"/> boxed the CLR way. So the simplest query there is
+        /// over such a table stops on its first row.
+        ///
+        /// <para>Recorded as a test because the failure is the correct behaviour and should stay correct. It
+        /// would be easy to read "Cannot convert 1 to int" as a defect in the scan and to answer it by
+        /// converting every row on the way in — an adapter on a boundary that does not have one, paid for by
+        /// every table that was already right.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldFailOverATableWhoseValuesAreNotTheTypeFactorys()
+        {
+            var scan = () => Run("SELECT \"K\" FROM \"T\"", new ClrBoxedRowsTable(), false);
+            var distinct = () => Run("SELECT DISTINCT \"K\" FROM \"T\"", new ClrBoxedRowsTable(), false);
+
+            // SqlFunctions.toInt, which knows java.lang.Number and nothing else
+            scan.Should().Throw<org.apache.calcite.runtime.CalciteException>().WithMessage("*Cannot convert 1 to int*");
+
+            // and the group key, which casts the field to the boxed type the row type declares
+            distinct.Should().Throw<InvalidCastException>().WithMessage("*System.Int32*java.lang.Integer*");
+        }
+
         static (RelNode Plan, List<string> Rows) Run(string sql, Table table, bool async)
         {
             var rootSchema = Frameworks.createRootSchema(true);


### PR DESCRIPTION
An audit of all 45 operators in both conventions against `EnumerableDefaults`, method beside method, and the 17 divergences it found — each one now transcribed from Calcite's body rather than reasoned about.

None of the 17 was visible to the differential suite. Every one of them returned the right rows.

## What was wrong

**`RepeatUnion` stopped a round early.** Calcite stops where `current` still holds its `DUMMY` sentinel after a round, not where the round produced nothing. The sentinel is never restored across the seed/iteration boundary, so a seed that emitted a row leaves the first empty round non-terminating. The clean-up also ran after the enumerators closed rather than before.

**`NestedLoopJoin` was one method where Calcite has two**, and carried five defects: a SEMI join emitting a null right row, the inner buffered where the optimized body re-enumerates it, unmatched right rows tracked by position rather than identity, RIGHT and FULL streaming where Calcite builds a list, and an unnamed join type treated as INNER where Calcite yields nothing.

**`SemiJoin` was also one method doing two jobs.** Without a predicate Calcite holds the distinct inner *keys*; with one it holds a lookup of *rows*. Ours held every row either way, and built the lookup before reading the outer, where CALCITE-2909 memoizes it so an empty outer never touches the inner.

The equi path now keeps two sets, which is not redundant: `distinct(comparer)` decides duplicates by the comparer, but the `contains` that follows is `Objects.equals` over the unwrapped result.

**`Take` drew n rows.** Calcite's is `takeWhile` over `n < count`, and the enumerator draws a row before it can test it — so a satisfied fetch reads one more than it returns, and `FETCH 0` still opens its input. Opening is not nothing: it runs a spool's write-back and a repeat union's clean-up.

**`CorrelateJoin`** accepted RIGHT and FULL and silently inner-joined them, and dereferenced a null correlated sequence. Calcite throws where the enumerable is *built*, and reads null as an empty sequence.

**`Cartesian`** built the whole product into a `List` sized by an `int` multiply of two counts. `CartesianProductJoinEnumerator` holds nothing.

**`GroupBy`, `GroupByMultiple`, `AsofJoin` and `Window`** fold at call time and return a sequence over finished state; as iterators they deferred and re-folded on a second pass. `Window` also missed the `collectionExpr.clear()` the generated block does — Calcite comments it *"allows gc"*, and it is what keeps the buffered input from being alive alongside the finished output.

**`HashEquiJoin`** walked its leftover keys in the wrong order; **the limit sort** sorted its whole input where linq4j keeps a bounded `TreeMap`, and threw on a null key because `SortedDictionary` rejects one before consulting the comparer. Both now use the Java collection Calcite uses.

**`JavaSequences`' linq4j enumerator refused `reset`**, which is live — a cartesian product of Calcite's calls it once per outer row.

**`Count`, `IntersectAll` and `ExceptAll` are deleted.** Nothing called them.

## Where the CLR does not allow a copy

Four async operators cannot fold at the call, because a method returning `IAsyncEnumerable` has nowhere to await before it returns. They fold on the first `MoveNextAsync` instead; every row is still computed before the first is yielded, which is the property the ordering rests on. Stated at each site.

The unmatched-right rows of a RIGHT or FULL nested loop join *can* be copied exactly — Guava is on the classpath under IKVM, so `Sets.newIdentityHashSet()` is the set Calcite uses, not one imitated with a reference-equality comparer.

## Defects of Calcite's, reproduced and tested as such

`Window`'s EXCLUDE over an UNBOUNDED/UNBOUNDED frame never takes effect. A RANGE bound with an offset over a nullable order key throws, because `translateBound` boxes the key type only when the bound has no offset. Both conventions are asserted to fail on the second, so a fix upstream shows up here as a failing test rather than a silent divergence.

## Tests

619 → 632, all green in about 100 seconds.

New direct suites for what no query can reach — how many rows an operator draws, whether it opens its input, when it folds, what it does with a join type the planner never emits: `ClrEnumerableNestedLoopJoinTests`, `ClrRepeatUnionTests`, `ClrEnumerableDefaultsContractTests`.

`ClrAsyncEnumerableDifferentialTests` gains a rel-builder harness (`RunRel`, `SameRel`, `SameRelThrough`). It was SQL-only, and standard SQL will not put an aggregate in a recursive term — which is the one shape that tells `RepeatUnion`'s termination test apart from "stop after an empty round".

`ClrTableSpiTests` gains a table that breaks the SPI contract by holding CLR-boxed values, asserting that it fails on its first row. That failure is correct and should stay correct: it is the kind of message that later reads as a defect in the scan and gets answered with a per-row conversion every already-correct table would pay for.

## Notes

`CLAUDE.md` gains what this cost to learn: `dotnet test --filter` is silently ignored under Microsoft.Testing.Platform and runs the whole suite reporting success; a recursive query can fail to terminate under Calcite too, so `SameRel` hangs rather than fails; and three ways a port goes wrong — calling a behaviour unreproducible without checking whether the Java class is simply reachable, recording a divergence as deliberate when the CLR does not actually prevent following, and reasoning about how something fails instead of running it.

`TODO.md` is pruned of everything that landed.
