### PR TITLE
Call every linq4j method through its method handle

### DIFF
--- a/src/Apache.Calcite.Extensions/Interop/JavaDelegates.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaDelegates.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Reflection;
+
+using IKVM.Runtime;
+
+namespace Apache.Calcite.Extensions.Interop
+{
+
+    /// <summary>
+    /// Creates a delegate that calls a Java method, resolved by IKVM rather than searched for by name.
+    /// </summary>
+    /// <remarks>
+    /// A <c>java.lang.reflect.Method</c> is a Java answer, and the CLR method IKVM compiled for it is not
+    /// always reachable from the name and the erased signature Java reports: a remapped class keeps its Java
+    /// methods on a static <c>Helper</c> class, a ghost interface declares nothing at all, and a name can
+    /// differ in case. <see cref="Linq4j.Tree.ClrTypes"/> reconstructs those, and a reconstruction is a guess.
+    /// A method handle is not: <c>unreflect</c> is IKVM's own resolution of the same member, and a delegate
+    /// over the handle calls whatever IKVM would have called.
+    ///
+    /// <para>This is <c>ikvm.runtime.Util.getDelegateFromMethodHandle</c>, written against what IKVM 8.15.0
+    /// makes public. <c>ByteCodeHelper.GetDelegateForInvokeExact&lt;T&gt;</c> is not "give me a delegate of
+    /// type T" — it hands back the canonical <c>MH</c>/<c>MHV</c> delegate IKVM built for the
+    /// handle's own method type and throws <c>WrongMethodTypeException</c> if T is not that type, and the two
+    /// members that would say which type that is are internal. So the canonical type is rebuilt here by
+    /// <see cref="CreateDelegateType"/>, which is <c>MethodHandleUtil.CreateDelegateType</c> ported, and the
+    /// method type the requested delegate stands for is asked of <c>ByteCodeHelper.LoadMethodType</c> rather
+    /// than derived. A rebuild that is wrong fails loudly in <c>GetDelegateForInvokeExact</c> rather than
+    /// binding something else.</para>
+    ///
+    /// <para>When IKVM ships the method this class goes away, and each caller becomes one call to it.</para>
+    /// </remarks>
+    static class JavaDelegates
+    {
+
+        /// <summary>
+        /// Number of parameters a canonical delegate carries before the rest are packed into containers.
+        /// </summary>
+        const int MaxArity = 8;
+
+        static readonly Type MHA = typeof(MHA<,,,,,,,>);
+
+        static readonly Type[] MHVTypes = [
+            typeof(MHV),
+            typeof(MHV<>),
+            typeof(MHV<,>),
+            typeof(MHV<,,>),
+            typeof(MHV<,,,>),
+            typeof(MHV<,,,,>),
+            typeof(MHV<,,,,,>),
+            typeof(MHV<,,,,,,>),
+            typeof(MHV<,,,,,,,>)];
+
+        static readonly Type?[] MHTypes = [
+            null,
+            typeof(MH<>),
+            typeof(MH<,>),
+            typeof(MH<,,>),
+            typeof(MH<,,,>),
+            typeof(MH<,,,,>),
+            typeof(MH<,,,,,>),
+            typeof(MH<,,,,,,>),
+            typeof(MH<,,,,,,,>),
+            typeof(MH<,,,,,,,,>)];
+
+        static readonly MethodInfo LoadMethodType = typeof(ByteCodeHelper).GetMethod(nameof(ByteCodeHelper.LoadMethodType))!;
+
+        static readonly MethodInfo GetDelegateForInvokeExact = typeof(ByteCodeHelper).GetMethod(nameof(ByteCodeHelper.GetDelegateForInvokeExact))!;
+
+        /// <summary>
+        /// Returns a delegate of the given type that calls the given method or constructor.
+        /// </summary>
+        /// <param name="delegateType"></param>
+        /// <param name="executable"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Access is checked as <c>Lookup.unreflect</c> checks it, against the public lookup. Nothing a linq4j
+        /// tree names can be out of its reach — Janino compiles that tree as Java source in an anonymous
+        /// package, so every member it reaches is public on a public class — and a member that is not is the
+        /// caller's to mark accessible, as it is for the IKVM method this stands in for.
+        /// </remarks>
+        public static Delegate FromMethod(Type delegateType, java.lang.reflect.Executable executable)
+        {
+            ArgumentNullException.ThrowIfNull(delegateType);
+            ArgumentNullException.ThrowIfNull(executable);
+
+            var lookup = java.lang.invoke.MethodHandles.publicLookup();
+            var handle = executable is java.lang.reflect.Constructor constructor
+                ? lookup.unreflectConstructor(constructor)
+                : lookup.unreflect((java.lang.reflect.Method)executable);
+
+            return FromMethodHandle(delegateType, handle);
+        }
+
+        /// <summary>
+        /// Returns a delegate that calls the given method or constructor, taking the receiver first where it
+        /// has one.
+        /// </summary>
+        /// <param name="executable"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The signature is the method's own, with every reference type left as <see cref="object"/> and every
+        /// primitive kept as itself. Keeping the primitives is the point: a primitive passed as an object is a
+        /// <c>java.lang.Integer</c> rather than a boxed CLR int, and the two are not the same value. Leaving
+        /// the references as objects costs nothing — a reference conversion either way — and keeps the
+        /// signature to types that are certainly the ones IKVM signs with, which a ghost interface is not.
+        ///
+        /// <para>The type built here is the canonical one, so the delegate returned is IKVM's own rather than
+        /// a second delegate wrapping it.</para>
+        /// </remarks>
+        public static Delegate FromMethod(java.lang.reflect.Executable executable)
+        {
+            ArgumentNullException.ThrowIfNull(executable);
+
+            var parameterClasses = executable.getParameterTypes();
+            var receiver = executable is java.lang.reflect.Method && (executable.getModifiers() & java.lang.reflect.Modifier.STATIC) == 0 ? 1 : 0;
+
+            var types = new Type[parameterClasses.Length + receiver];
+            if (receiver == 1)
+                types[0] = typeof(object);
+            for (int i = 0; i < parameterClasses.Length; i++)
+                types[i + receiver] = Erase(parameterClasses[i]);
+
+            var returnType = executable is java.lang.reflect.Method method ? Erase(method.getReturnType()) : typeof(object);
+
+            return FromMethod(CreateDelegateType(types, returnType), executable);
+        }
+
+        /// <summary>
+        /// Returns the type a value of the given class crosses a delegate boundary as.
+        /// </summary>
+        /// <param name="clazz"></param>
+        /// <returns></returns>
+        static Type Erase(java.lang.Class clazz)
+        {
+            return clazz.isPrimitive() ? Linq4j.Tree.ClrTypes.FromClass(clazz) : typeof(object);
+        }
+
+        /// <summary>
+        /// Returns a delegate of the given type that invokes the given method handle.
+        /// </summary>
+        /// <param name="delegateType"></param>
+        /// <param name="methodHandle"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The handle is adapted to the delegate's own signature, which is what performs the conversions a
+        /// call needs — boxing, primitive widening, receiver binding — and what rejects a handle that cannot
+        /// be called through this delegate.
+        /// </remarks>
+        public static Delegate FromMethodHandle(Type delegateType, java.lang.invoke.MethodHandle methodHandle)
+        {
+            ArgumentNullException.ThrowIfNull(delegateType);
+            ArgumentNullException.ThrowIfNull(methodHandle);
+
+            var invoke = Invoke(delegateType);
+
+            foreach (var parameter in invoke.GetParameters())
+                if (parameter.ParameterType.IsByRef || parameter.ParameterType.IsPointer)
+                    throw new ArgumentException($"'{delegateType}' has a by-ref or pointer parameter.", nameof(delegateType));
+
+            // what the delegate's signature is as a method type is IKVM's answer rather than one derived here,
+            // and adapting the handle to it is what makes the delegate callable
+            var methodType = (java.lang.invoke.MethodType)LoadMethodType.MakeGenericMethod(delegateType).Invoke(null, null)!;
+            methodHandle = methodHandle.asType(methodType).asFixedArity();
+
+            // the adapted handle materializes as its canonical delegate, which by construction has exactly the
+            // signature asked for; where that is the type asked for there is nothing further to do
+            var canonical = CreateDelegateType(Array.ConvertAll(invoke.GetParameters(), p => p.ParameterType), invoke.ReturnType);
+            var inner = (Delegate)GetDelegateForInvokeExact.MakeGenericMethod(canonical).Invoke(null, [methodHandle])!;
+            if (canonical == delegateType)
+                return inner;
+
+            return Delegate.CreateDelegate(delegateType, inner, Invoke(canonical), false)
+                ?? throw new ArgumentException($"Cannot create a '{delegateType}' for a method handle of type {methodType}.", nameof(delegateType));
+        }
+
+        /// <summary>
+        /// Returns the <c>Invoke</c> of a delegate type.
+        /// </summary>
+        /// <param name="delegateType"></param>
+        /// <returns></returns>
+        static MethodInfo Invoke(Type delegateType)
+        {
+            return (delegateType.BaseType == typeof(MulticastDelegate) ? delegateType.GetMethod("Invoke") : null)
+                ?? throw new ArgumentException($"'{delegateType}' is not a delegate type.", nameof(delegateType));
+        }
+
+        /// <summary>
+        /// Returns the canonical delegate type IKVM builds for a signature.
+        /// </summary>
+        /// <param name="types"></param>
+        /// <param name="returnType"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>MethodHandleUtil.CreateDelegateType</c>. Past eight parameters the tail is packed into nested
+        /// <see cref="MHA"/> containers, seven at a time.
+        /// </remarks>
+        static Type CreateDelegateType(Type[] types, Type returnType)
+        {
+            if (types.Length == 0 && returnType == typeof(void))
+                return MHVTypes[0];
+
+            if (types.Length > MaxArity)
+            {
+                var arity = types.Length;
+                var remainder = (arity - 8) % 7;
+                var count = (arity - 8) / 7;
+                if (remainder == 0)
+                {
+                    remainder = 7;
+                    count--;
+                }
+
+                var last = MHA.MakeGenericType(SubArray(types, types.Length - 8, 8));
+                for (int i = 0; i < count; i++)
+                {
+                    var temp = SubArray(types, types.Length - 8 - 7 * (i + 1), 8);
+                    temp[7] = last;
+                    last = MHA.MakeGenericType(temp);
+                }
+
+                types = SubArray(types, 0, remainder + 1);
+                types[remainder] = last;
+            }
+
+            if (returnType == typeof(void))
+                return MHVTypes[types.Length].MakeGenericType(types);
+
+            types = [.. types, returnType];
+            return MHTypes[types.Length]!.MakeGenericType(types);
+        }
+
+        /// <summary>
+        /// Returns a range of an array.
+        /// </summary>
+        /// <param name="array"></param>
+        /// <param name="start"></param>
+        /// <param name="length"></param>
+        /// <returns></returns>
+        static Type[] SubArray(Type[] array, int start, int length)
+        {
+            var result = new Type[length];
+            Array.Copy(array, start, result, 0, length);
+            return result;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/ClrTypes.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/ClrTypes.cs
@@ -95,12 +95,6 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
 
         /// <summary>
-        /// Assembly IKVM compiles the Java class library into, and so where a remapped class keeps the methods
-        /// its CLR counterpart does not have.
-        /// </summary>
-        static readonly Assembly JavaAssembly = typeof(java.lang.Class).Assembly;
-
-        /// <summary>
         /// Resolves a Java method to its CLR method.
         /// </summary>
         /// <param name="method"></param>
@@ -108,24 +102,42 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// <exception cref="NotSupportedException"></exception>
         public static MethodInfo Resolve(java.lang.reflect.Method method)
         {
+            return TryResolve(method)
+                ?? throw new NotSupportedException($"No CLR method matches '{method}'.");
+        }
+
+        /// <summary>
+        /// Resolves a Java method to the CLR method of that name and signature, or answers
+        /// <see langword="null"/> where there is none.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// One question, asked once: is there a method of this name whose parameters are exactly these. Where
+        /// there is, it is the method IKVM compiled and nothing further needs deciding; where there is not,
+        /// there is no second question worth asking here. A name that differs, a receiver that moved to a
+        /// static <c>Helper</c>, a ghost interface that declares nothing — those were four more searches, and
+        /// each was a reconstruction of what IKVM did rather than an answer from it. Across all 597 of
+        /// Calcite's <c>BuiltInMethod</c>s they resolved three: <c>String.toUpperCase</c>,
+        /// <c>Object.toString</c> and <c>Comparable.compareTo</c>.
+        ///
+        /// <para>Answering <see langword="null"/> is therefore not a claim that no such method exists. It says
+        /// the CLR type system cannot be asked, and the question goes to IKVM instead — <c>JavaDelegates</c>
+        /// unreflects the member into a method handle, which is IKVM's own resolution of it and cannot be
+        /// wrong. A caller that can invoke a delegate rather than emit a call should do that.</para>
+        /// </remarks>
+        public static MethodInfo? TryResolve(java.lang.reflect.Method method)
+        {
             ArgumentNullException.ThrowIfNull(method);
 
             var declaring = ClrTypes.FromClass(method.getDeclaringClass());
-            var name = method.getName();
 
             var parameterTypes = method.getParameterTypes();
             var parameters = new Type[parameterTypes.Length];
             for (int i = 0; i < parameterTypes.Length; i++)
                 parameters[i] = ClrTypes.FromClass(parameterTypes[i]);
 
-            return declaring.GetMethod(name, All, null, parameters, null)
-                ?? Search(declaring, name, parameters, StringComparison.Ordinal)
-                ?? FromRemappedClass(method.getDeclaringClass(), declaring, name, parameters)
-                // a remapped class keeps its methods but not their Java names: java.lang.Comparable is
-                // System.IComparable, whose method is CompareTo. Last, because a name that differs by more
-                // than case is a resolution to fail on rather than to guess at
-                ?? Search(declaring, name, parameters, StringComparison.OrdinalIgnoreCase)
-                ?? throw new NotSupportedException($"No CLR method matches '{method}'.");
+            return declaring.GetMethod(method.getName(), All, null, parameters, null);
         }
 
         /// <summary>
@@ -166,10 +178,17 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// <param name="arguments"></param>
         /// <returns></returns>
         /// <remarks>
-        /// A linq4j tree records a Method, but Janino never uses it: the tree is written out as source and the
-        /// Java compiler resolves the overload from the argument expressions. So the recorded method is only
-        /// what the code that built the tree happened to name. Calcite writes Linq4j.asEnumerable(list) against
-        /// BuiltInMethod.AS_ENUMERABLE, whose parameter is an array, and Java binds the List overload.
+        /// A linq4j tree records a Method, but Janino never uses it: <c>MethodCallExpression</c> writes itself
+        /// out as <c>target.name(args)</c> and the Java compiler resolves the overload from the argument
+        /// expressions. So the recorded method is only what the code that built the tree happened to name.
+        ///
+        /// <para>It is very nearly always the method to call, and measuring says how nearly: across the whole
+        /// test suite one call in the plans this convention builds names a method that is not the one, and it
+        /// is Calcite's own — <c>EnumerableWindow</c> names <c>BINARY_SEARCH5_UPPER</c>, whose method takes
+        /// five parameters, and passes it six arguments. Janino writes the name and javac binds the six-parameter
+        /// overload. Nothing derived from the recorded method can find that, a method handle over it included:
+        /// the handle would take five arguments. Choosing needs the candidates of that name, which is what this
+        /// walks.</para>
         /// </remarks>
         public static MethodInfo Rebind(MethodInfo method, Type[] arguments)
         {
@@ -235,6 +254,14 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// <param name="method"></param>
         /// <param name="arguments"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// Fitting includes the box and the primitive of one another, because the call being composed converts
+        /// each argument to its parameter anyway and that conversion is one of the ones it makes. Counting it
+        /// as a misfit sends <see cref="Rebind"/> looking for another method where there was nothing wrong
+        /// with this one: <c>SqlFunctions.greater(int, int)</c> handed an <c>int</c> and a
+        /// <c>java.lang.Integer</c> is the method Calcite named and the method whose return type the tree
+        /// carries, and the second argument wants unboxing rather than a different overload.
+        /// </remarks>
         static bool Accepts(MethodInfo method, Type[] arguments)
         {
             var parameters = method.GetParameters();
@@ -242,118 +269,17 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
                 return false;
 
             for (int i = 0; i < parameters.Length; i++)
-                if (parameters[i].ParameterType.IsAssignableFrom(arguments[i]) == false)
-                    return false;
-
-            return true;
-        }
-
-        /// <summary>
-        /// Finds a method that a remapped Java class keeps outside the CLR type it was remapped onto.
-        /// </summary>
-        /// <param name="clazz"></param>
-        /// <param name="declaring"></param>
-        /// <param name="name"></param>
-        /// <param name="parameters"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// IKVM remaps a handful of Java classes onto the CLR type that already means the same thing, so
-        /// <c>java.lang.String</c> is <see cref="string"/>. The methods only Java has cannot go there, and
-        /// land on a static <c>Helper</c> class taking the receiver as the first parameter:
-        /// <c>String.toUpperCase()</c> is <c>java.lang.StringHelper.toUpperCase(string)</c>.
-        ///
-        /// <para>The returned method is therefore static where the Java one was not, and a caller composing a
-        /// call must pass the receiver as the first argument rather than as the call's target.</para>
-        /// </remarks>
-        static MethodInfo? FromRemappedClass(java.lang.Class clazz, Type declaring, string name, Type[] parameters)
-        {
-            var helper = JavaAssembly.GetType(clazz.getName() + "Helper");
-            if (helper == null)
-                return null;
-
-            var withReceiver = new Type[parameters.Length + 1];
-            withReceiver[0] = declaring;
-            parameters.CopyTo(withReceiver, 1);
-
-            return helper.GetMethod(name, All, null, withReceiver, null)
-                ?? helper.GetMethod(name, All, null, parameters, null)
-                ?? Search(helper, name, withReceiver, StringComparison.Ordinal)
-                ?? Search(helper, name, parameters, StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Finds a method by name and parameter types when an exact binder match fails.
-        /// </summary>
-        /// <param name="declaring"></param>
-        /// <param name="name"></param>
-        /// <param name="parameters"></param>
-        /// <param name="comparison"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// A method the binder will not match on exact types is still reachable by walking the candidates:
-        /// an interface method is declared on a base interface rather than the one asked about, and a
-        /// method IKVM generates for a Java class can differ from the erased signature Java reports.
-        /// </remarks>
-        static MethodInfo? Search(Type declaring, string name, Type[] parameters, StringComparison comparison)
-        {
-            var found = SearchDeclared(declaring, name, parameters, comparison);
-            if (found != null)
-                return found;
-
-            // an interface does not report the members it inherits, and IKVM leaves a Java interface empty
-            // when a CLR interface already carries its method: java.lang.Comparable extends System.IComparable
-            // and declares nothing itself
-            if (declaring.IsInterface)
-                foreach (var inherited in declaring.GetInterfaces())
-                    if ((found = SearchDeclared(inherited, name, parameters, comparison)) != null)
-                        return found;
-
-            return null;
-        }
-
-        /// <summary>
-        /// Finds a method declared on one type by name and parameter types.
-        /// </summary>
-        /// <param name="declaring"></param>
-        /// <param name="name"></param>
-        /// <param name="parameters"></param>
-        /// <param name="comparison"></param>
-        /// <returns></returns>
-        static MethodInfo? SearchDeclared(Type declaring, string name, Type[] parameters, StringComparison comparison)
-        {
-            MethodInfo? found = null;
-
-            foreach (var candidate in declaring.GetMethods(All))
             {
-                if (string.Equals(candidate.Name, name, comparison) == false)
+                var parameter = parameters[i].ParameterType;
+                if (parameter.IsAssignableFrom(arguments[i]))
+                    continue;
+                if (ClrPrimitive.Box(parameter) == ClrPrimitive.Box(arguments[i]))
                     continue;
 
-                var candidateParameters = candidate.GetParameters();
-                if (candidateParameters.Length != parameters.Length)
-                    continue;
-
-                var match = true;
-                for (int i = 0; i < parameters.Length; i++)
-                {
-                    if (candidateParameters[i].ParameterType.IsAssignableFrom(parameters[i]) == false)
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-
-                if (match == false)
-                    continue;
-
-                // an ambiguous name and arity is a resolution this cannot make, and silently taking the first
-                // would put the wrong method in the tree
-                if (found != null)
-                    throw new NotSupportedException($"'{name}' on '{declaring}' is ambiguous for the given parameter types.");
-
-                found = candidate;
+                return false;
             }
 
-            return found;
+            return true;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/LixToClrTranslator.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/LixToClrTranslator.cs
@@ -698,10 +698,15 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// <returns></returns>
         Expression Call(J.MethodCallExpression expression)
         {
-            var method = ClrTypes.Resolve(expression.method);
+            var method = ClrTypes.TryResolve(expression.method);
             var target = expression.targetExpression == null ? null : Visit(expression.targetExpression);
 
             var arguments = expression.expressions;
+
+            // no CLR method of that name and signature is on that type at all, which is what a remapped class
+            // or a ghost interface leaves behind. IKVM knows which method it compiled; a name search does not
+            if (method == null)
+                return Invoke(expression.method, target, arguments);
 
             // a method IKVM moved off a remapped class is static and takes the receiver first, so what Java
             // called the target is argument zero
@@ -733,6 +738,40 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
                 return Expression.Call(null, method, resolved);
 
             return Expression.Call(ClrEnumUtils.Convert(target!, method.DeclaringType!), method, resolved);
+        }
+
+        /// <summary>
+        /// Translates a method call as an invocation of a delegate over the method.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="target"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The route for a method the CLR type system cannot be asked about — one of a remapped class, whose
+        /// Java methods went elsewhere, or of a ghost interface, which declares nothing. The delegate is
+        /// IKVM's own resolution of the member and takes the receiver first where the method has one, so the
+        /// receiver moves the same way it does for a method that landed on a <c>Helper</c> class.
+        ///
+        /// <para>Its signature is objects and primitives — see <c>JavaDelegates.FromMethod</c> — so the
+        /// conversions here are reference conversions and the boxing of a primitive argument, both of which
+        /// <see cref="Coerce"/> already does. A primitive never crosses as an object, which is the one thing
+        /// that would put a <c>java.lang.Integer</c> where a CLR int belongs.</para>
+        /// </remarks>
+        Expression Invoke(java.lang.reflect.Method method, Expression? target, java.util.List arguments)
+        {
+            var del = JavaDelegates.FromMethod(method);
+            var parameters = del.GetType().GetMethod("Invoke")!.GetParameters();
+
+            var offset = target != null ? 1 : 0;
+            var resolved = new Expression[arguments.size() + offset];
+            if (offset == 1)
+                resolved[0] = Coerce(target!, parameters[0].ParameterType);
+
+            for (int i = 0; i < arguments.size(); i++)
+                resolved[i + offset] = Coerce(Visit((J.Node)arguments.get(i)), parameters[i + offset].ParameterType);
+
+            return Expression.Invoke(Expression.Constant(del, del.GetType()), resolved);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/Interop/JavaDelegatesTests.cs
+++ b/src/Apache.Calcite.Tests/Interop/JavaDelegatesTests.cs
@@ -1,0 +1,228 @@
+using System;
+
+using Apache.Calcite.Extensions.Interop;
+
+using FluentAssertions;
+
+using IKVM.Runtime;
+
+using java.lang;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.util;
+
+namespace Apache.Calcite.Tests.Interop
+{
+
+    [TestClass]
+    public class JavaDelegatesTests
+    {
+
+        static java.lang.reflect.Method Method(Type declaring, string name, params Class[] parameters)
+        {
+            return ((Class)declaring).getMethod(name, parameters);
+        }
+
+        [TestMethod]
+        public void ShouldCallInstanceMethod()
+        {
+            var m = Method(typeof(java.util.ArrayList), "size");
+            var d = (Func<object, int>)JavaDelegates.FromMethod(typeof(Func<object, int>), m);
+
+            var list = new java.util.ArrayList();
+            list.add("a");
+            list.add("b");
+
+            d(list).Should().Be(2);
+        }
+
+        [TestMethod]
+        public void ShouldCallInstanceMethodWithArgument()
+        {
+            var m = Method(typeof(StringBuilder), "append", (Class)typeof(java.lang.String));
+            var d = (Func<object, object, object>)JavaDelegates.FromMethod(typeof(Func<object, object, object>), m);
+
+            var sb = new StringBuilder("a");
+            d(sb, "b").Should().BeSameAs(sb);
+            sb.toString().Should().Be("ab");
+        }
+
+        [TestMethod]
+        public void ShouldCallStaticMethod()
+        {
+            var m = Method(typeof(Integer), "parseInt", (Class)typeof(java.lang.String));
+            var d = (Func<object, int>)JavaDelegates.FromMethod(typeof(Func<object, int>), m);
+
+            d("42").Should().Be(42);
+        }
+
+        [TestMethod]
+        public void ShouldCallVoidMethod()
+        {
+            var m = Method(typeof(java.util.ArrayList), "clear");
+            var d = (Action<object>)JavaDelegates.FromMethod(typeof(Action<object>), m);
+
+            var list = new java.util.ArrayList();
+            list.add("a");
+            d(list);
+
+            list.size().Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ShouldCallConstructor()
+        {
+            var c = ((Class)typeof(java.util.ArrayList)).getConstructor([]);
+            var d = (Func<object>)JavaDelegates.FromMethod(typeof(Func<object>), c);
+
+            d().Should().BeOfType<java.util.ArrayList>();
+        }
+
+        /// <summary>
+        /// The case a name search cannot answer and this exists for: java.lang.Object is remapped onto
+        /// System.Object, and its Java methods have no CLR method of that name on that type at all.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCallMethodOnRemappedType()
+        {
+            var m = Method(typeof(java.lang.Object), "hashCode");
+            var d = (Func<object, int>)JavaDelegates.FromMethod(typeof(Func<object, int>), m);
+
+            var o = new object();
+            d(o).Should().Be(java.lang.System.identityHashCode(o));
+        }
+
+        /// <summary>
+        /// The other half of it: String is remapped onto System.String, and toUpperCase lands on
+        /// java.lang.StringHelper taking the receiver first. The delegate hides that the receiver moved.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCallMethodMovedToAHelperClass()
+        {
+            var m = Method(typeof(java.lang.String), "toUpperCase");
+            var d = (Func<string, string>)JavaDelegates.FromMethod(typeof(Func<string, string>), m);
+
+            d("abc").Should().Be("ABC");
+        }
+
+        /// <summary>
+        /// A ghost interface declares nothing the CLR type system can see, and a cast to one throws. The
+        /// handle does not cast.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCallMethodOnGhostInterface()
+        {
+            var m = Method(typeof(java.lang.Comparable), "compareTo", (Class)typeof(java.lang.Object));
+            var d = (Func<object, object, int>)JavaDelegates.FromMethod(typeof(Func<object, object, int>), m);
+
+            d("a", "b").Should().BeNegative();
+        }
+
+        /// <summary>
+        /// A delegate typed in the runtime's own terms rather than in objects, which is what a translated
+        /// tree wants: no value crosses a boxing boundary on the way in or out.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCallThroughATypedDelegate()
+        {
+            var m = Method(typeof(Integer), "parseInt", (Class)typeof(java.lang.String));
+            var d = (Func<string, int>)JavaDelegates.FromMethod(typeof(Func<string, int>), m);
+
+            d("42").Should().Be(42);
+        }
+
+        /// <summary>
+        /// The canonical delegate is what IKVM hands back, so asking for it directly is the one signature
+        /// that costs nothing at all — no second delegate wrapping the first.
+        /// </summary>
+        [TestMethod]
+        public void ShouldReturnTheCanonicalDelegateUnwrapped()
+        {
+            var m = Method(typeof(Integer), "parseInt", (Class)typeof(java.lang.String));
+            var d = (MH<string, int>)JavaDelegates.FromMethod(typeof(MH<string, int>), m);
+
+            d("42").Should().Be(42);
+            d.Target.Should().BeAssignableTo<java.lang.invoke.MethodHandle>();
+        }
+
+        /// <summary>
+        /// A method of Calcite's own, reached the way the convention reaches one.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCallACalciteBuiltInMethod()
+        {
+            var d = (Func<object, int, object>)JavaDelegates.FromMethod(typeof(Func<object, int, object>), BuiltInMethod.LIST_GET.method);
+
+            var list = new java.util.ArrayList();
+            list.add("a");
+            list.add("b");
+
+            d(list, 1).Should().Be("b");
+        }
+
+        /// <summary>
+        /// A primitive crossing as an object is a java.lang.Integer rather than a boxed CLR int, and the
+        /// adaptation the handle performs is Java's own. This is the boundary the whole port turns on.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBoxAPrimitiveReturnTheJavaWay()
+        {
+            var m = Method(typeof(Integer), "parseInt", (Class)typeof(java.lang.String));
+            var d = (Func<object, object>)JavaDelegates.FromMethod(typeof(Func<object, object>), m);
+
+            d("42").Should().BeOfType<Integer>();
+        }
+
+        /// <summary>
+        /// Access is checked as Lookup.unreflect checks it, and marking the member accessible is the caller's
+        /// to do. java.lang.Runtime's constructor is private.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseAnInaccessibleMemberUntilMarkedAccessible()
+        {
+            var c = ((Class)typeof(Runtime)).getDeclaredConstructor([]);
+
+            var act = () => JavaDelegates.FromMethod(typeof(Func<object>), c);
+            act.Should().Throw<java.lang.IllegalAccessException>();
+
+            c.setAccessible(true);
+            var d = (Func<object>)JavaDelegates.FromMethod(typeof(Func<object>), c);
+
+            d().Should().BeOfType<Runtime>();
+        }
+
+        [TestMethod]
+        public void ShouldRefuseATypeThatIsNotADelegate()
+        {
+            var m = Method(typeof(java.util.ArrayList), "size");
+
+            var act = () => JavaDelegates.FromMethod(typeof(string), m);
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [TestMethod]
+        public void ShouldRefuseAnIncompatibleSignature()
+        {
+            var m = Method(typeof(Integer), "parseInt", (Class)typeof(java.lang.String));
+
+            // parseInt takes one argument; this delegate supplies three
+            var act = () => JavaDelegates.FromMethod(typeof(Func<object, object, object, int>), m);
+            act.Should().Throw<java.lang.invoke.WrongMethodTypeException>();
+        }
+
+        [TestMethod]
+        public void ShouldRefuseNullArguments()
+        {
+            var m = Method(typeof(java.util.ArrayList), "size");
+
+            var nullType = () => JavaDelegates.FromMethod(null!, m);
+            nullType.Should().Throw<ArgumentNullException>();
+
+            var nullMethod = () => JavaDelegates.FromMethod(typeof(Func<object, int>), null!);
+            nullMethod.Should().Throw<ArgumentNullException>();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/Tree/ClrTypesMethodTests.cs
+++ b/src/Apache.Calcite.Tests/Tree/ClrTypesMethodTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 
+using Apache.Calcite.Extensions.Interop;
 using Apache.Calcite.Extensions.Linq4j.Tree;
 
 using FluentAssertions;
@@ -66,28 +67,22 @@ namespace Apache.Calcite.Tests.Tree
             m.Invoke(null, [7]).Should().Be(Integer.valueOf(7));
         }
 
+        /// <summary>
+        /// The three methods of Calcite's whole table that have no CLR method of their name and signature.
+        /// </summary>
+        /// <remarks>
+        /// Each was reachable by a search that reconstructed what IKVM had done — java.lang.String is
+        /// System.String and its Java methods went to a static helper; java.lang.Comparable is left empty and
+        /// extends System.IComparable, whose method is spelled CompareTo. Both reconstructions happened to
+        /// land, and neither was an answer from IKVM. They go to a delegate over the method handle instead,
+        /// which is one.
+        /// </remarks>
         [TestMethod]
-        public void ShouldResolveMethodOfRemappedClass()
+        public void ShouldNotResolveWhatOnlyASearchWouldFind()
         {
-            // java.lang.String is System.String, which has no toUpperCase, so the method is static on a helper
-            // and takes the receiver first. A translated call has to pass the target as argument zero.
-            var m = ClrTypes.Resolve(((Class)typeof(java.lang.String)).getDeclaredMethod("toUpperCase", []));
-
-            m.IsStatic.Should().BeTrue();
-            m.GetParameters().Should().ContainSingle()
-                .Which.ParameterType.Should().Be(typeof(string));
-            m.Invoke(null, ["abc"]).Should().Be("ABC");
-        }
-
-        [TestMethod]
-        public void ShouldResolveMethodInheritedFromClrInterface()
-        {
-            // IKVM leaves java.lang.Comparable empty and extends System.IComparable, and an interface does not
-            // report what it inherits, so this only resolves if the base interfaces are walked
-            var m = ClrTypes.Resolve(((Class)typeof(java.lang.Comparable)).getDeclaredMethod("compareTo", [typeof(object)]));
-
-            m.Name.Should().Be("CompareTo");
-            m.DeclaringType.Should().Be(typeof(IComparable));
+            ClrTypes.TryResolve(((Class)typeof(java.lang.String)).getDeclaredMethod("toUpperCase", [])).Should().BeNull();
+            ClrTypes.TryResolve(((Class)typeof(java.lang.Object)).getDeclaredMethod("toString", [])).Should().BeNull();
+            ClrTypes.TryResolve(((Class)typeof(java.lang.Comparable)).getDeclaredMethod("compareTo", [typeof(object)])).Should().BeNull();
         }
 
         [TestMethod]
@@ -117,18 +112,24 @@ namespace Apache.Calcite.Tests.Tree
         public static string Describe(DbConnection connection, string label) => label;
 
         /// <summary>
-        /// Resolves every method Calcite names in <c>BuiltInMethod</c>.
+        /// Reaches every method Calcite names in <c>BuiltInMethod</c>, by one route or the other.
         /// </summary>
         /// <remarks>
         /// The whole port rests on this direction of the interop working, and it either works for a signature
         /// shape or it does not. Sweeping the table says which shapes are the exceptions instead of finding
         /// them one at a time, node by node, much later.
+        ///
+        /// <para>Reaching one is either resolving it to a CLR method or building a delegate over it, which is
+        /// what a translated call does. The count of each is asserted rather than only the total: a method
+        /// moving from the first route to the second is a call becoming an invoke, and that should not happen
+        /// unnoticed.</para>
         /// </remarks>
         [TestMethod]
-        public void ShouldResolveEveryBuiltInMethod()
+        public void ShouldReachEveryBuiltInMethod()
         {
             var failures = new List<string>();
-            var resolved = 0;
+            var invoked = new List<string>();
+            var called = 0;
 
             foreach (BuiltInMethod value in BuiltInMethod.values())
             {
@@ -138,8 +139,10 @@ namespace Apache.Calcite.Tests.Tree
 
                 try
                 {
-                    ClrTypes.Resolve(method);
-                    resolved++;
+                    if (ClrTypes.TryResolve(method) != null)
+                        called++;
+                    else if (JavaDelegates.FromMethod(method) != null)
+                        invoked.Add($"{value.name()}: {method}");
                 }
                 catch (System.Exception e)
                 {
@@ -147,8 +150,13 @@ namespace Apache.Calcite.Tests.Tree
                 }
             }
 
-            resolved.Should().BeGreaterThan(0);
-            Assert.IsTrue(failures.Count == 0, $"{resolved} resolved, {failures.Count} failed:{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+            Assert.IsTrue(failures.Count == 0, $"{called} called, {invoked.Count} invoked, {failures.Count} failed:{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+
+            called.Should().Be(594);
+            invoked.Should().BeEquivalentTo([
+                "STRING_TO_UPPER: public java.lang.String java.lang.String.toUpperCase()",
+                "OBJECT_TO_STRING: public java.lang.String java.lang.Object.toString()",
+                "COMPARE_TO: public abstract int java.lang.Comparable.compareTo(java.lang.Object)"]);
         }
 
     }

--- a/src/Apache.Calcite.Tests/Tree/LixToClrTranslatorTests.cs
+++ b/src/Apache.Calcite.Tests/Tree/LixToClrTranslatorTests.cs
@@ -196,6 +196,48 @@ namespace Apache.Calcite.Tests.Tree
             Run<string>(e).Should().Be("ABC");
         }
 
+        /// <summary>
+        /// A method with no CLR method to call at all. IKVM answered String.length() with a property, so
+        /// nothing of that name and arity is on the type, on a helper, or on anything the search reaches —
+        /// ClrTypes.TryResolve says so, and the call goes through a delegate over the method instead.
+        /// </summary>
+        [TestMethod]
+        public void ShouldTranslateCallToMethodWithNoClrMethod()
+        {
+            var method = ((Class)typeof(java.lang.String)).getDeclaredMethod("length", []);
+            ClrTypes.TryResolve(method).Should().BeNull();
+
+            Run<int>(J.Expressions.call(J.Expressions.constant("abc"), method)).Should().Be(3);
+        }
+
+        /// <summary>
+        /// The same, for a method whose receiver is the one type the CLR does not keep Java's methods on, and
+        /// which returns a primitive: the value comes back as an int rather than as a java.lang.Integer.
+        /// </summary>
+        [TestMethod]
+        public void ShouldTranslateCallToMethodOfObject()
+        {
+            var method = ((Class)typeof(java.lang.Object)).getDeclaredMethod("hashCode", []);
+            ClrTypes.TryResolve(method).Should().BeNull();
+
+            var value = new java.util.ArrayList();
+            value.add("a");
+
+            Run<int>(J.Expressions.call(J.Expressions.constant(value), method)).Should().Be(value.hashCode());
+        }
+
+        /// <summary>
+        /// One with an argument, so the delegate's parameters are being filled in the right order.
+        /// </summary>
+        [TestMethod]
+        public void ShouldTranslateCallToMethodWithNoClrMethodAndAnArgument()
+        {
+            var method = ((Class)typeof(java.lang.String)).getDeclaredMethod("charAt", [Integer.TYPE]);
+            ClrTypes.TryResolve(method).Should().BeNull();
+
+            Run<char>(J.Expressions.call(J.Expressions.constant("abc"), method, J.Expressions.constant(Integer.valueOf(1)))).Should().Be('b');
+        }
+
         [TestMethod]
         public void ShouldTranslateTernary()
         {


### PR DESCRIPTION
A linq4j call carries a `java.lang.reflect.Method`, which already names the member. `ClrTypes` searched for the CLR method that member stands for, by name and erased signature. IKVM can be asked instead — `unreflect` is its own resolution of the same member — so a search can only agree with that answer or be wrong, and there are members it cannot reach at all.

`LixToClrTranslator.Call` now builds a delegate for every call and emits an invoke. `ClrTypes.TryResolve`, `Rebind` and `RebindReceiver` are gone, along with the case-insensitive name match, the `Helper` class assembled from the class name, and the walk of base interfaces matching parameters by assignability.

## Is the recorded method the method?

Nearly always, and measuring says how nearly. Of 6395 calls that reached `Rebind`, sixteen carried a signature the arguments did not fit and six changed the method.

Five of the six were this port's defect. `Accepts` counted an unboxing as a misfit:

```
NAMED SqlFunctions.greater(Int32,Int32)  ARGS (Int32,Integer)  CHOSE (IComparable,IComparable)
```

`greater(int, int)` is what Calcite named and what the tree's declared return type comes from — `MethodCallExpression`'s constructor asserts `Types.toClass(returnType) == method.getReturnType()`. The second argument wanted unboxing. It was abandoned for an overload that boxes, compares through `compareTo`, and returns `Object`.

The sixth is upstream's, and is why `FromMethod` takes an argument count. [`EnumerableWindow`](https://github.com/apache/calcite/blob/calcite-1.42.0/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableWindow.java#L966) in 1.42:

```java
Expressions.call((lower ? BINARY_SEARCH5_LOWER : BINARY_SEARCH5_UPPER).method,
    rows_, row_, searchLower, searchUpper, keySelector, keyComparator);
```

Five-parameter method, six arguments. It works only because Janino writes the name as text and javac binds the six-parameter overload; `MethodCallExpression.evaluate`, which calls `method.invoke`, would throw on the same expression. Nothing derived from the recorded method can find what was meant — a handle over it takes five arguments — so the overload is looked up by name and arity, and only where the count disagrees.

## The delegate's signature

It is the method's own, each class resolved to the type IKVM compiled it as. Erasing the references to `object` was tried and is wrong twice over, and both showed up as differential-test failures rather than as an argument:

- the return type is what a caller reads to know what it has — a scan asking whether there is an `Enumerable` to convert, above all;
- the parameter types are what each argument is converted to, so against `object` nothing converts and values arrive in whatever shape they were already in.

## Two shapes that need more than the plain route

Both were measured, not predicted:

- **Ghost interfaces.** A ghost's CLR type is not the type IKVM signs with, and no public member says which type is. Eleven of Calcite's comparison methods have one in their signature — `LESSER`, `GREATER`, `COMPARE`, `COMPARE_TO` and the rest. The exact signature throws `WrongMethodTypeException`, which is loud, and the retry erases the references and lets the handle convert into them.
- **Non-public declaring classes.** The public lookup cannot reach a public method of a non-public class, and Calcite names one: `QUERYABLE_SELECT` is `ExtendedQueryable.select`. It is retried through a copy of the member marked accessible, so the one the caller holds is untouched. I had removed this retry as speculative; the sweep put it back.

## JavaDelegates

`ikvm.runtime.Util.getDelegateFromMethodHandle`, written against what IKVM 8.15.0 makes public, and it goes away when IKVM ships that method.

`ByteCodeHelper.GetDelegateForInvokeExact<T>` is not "give me a delegate of type T" — it hands back the canonical `MH`/`MHV` delegate IKVM built for the handle's own method type and throws if `T` is not that type, and the two members that would say which type that is are internal. So the canonical type is rebuilt from `MethodHandleUtil.CreateDelegateType`, and the method type a requested delegate stands for is asked of the public `ByteCodeHelper.LoadMethodType`. A rebuild that is wrong fails there rather than binding something else — which is what makes the ghost retry safe.

## Tests

- `JavaDelegatesTests` — 19, covering instance, static, void, constructor, the remapped receiver (`Object.hashCode`), the method moved to a helper (`String.toUpperCase`), a ghost interface in the signature (`Utilities.compare`), a public method of a non-public class (`QUERYABLE_SELECT`), an inaccessible member, the typed and canonical delegate forms, Java-side boxing of a primitive return, and the refusals.
- `ClrTypesMethodTests.ShouldBuildADelegateForEveryBuiltInMethod` — all 597 go through the route a translated call takes.
- `LixToClrTranslatorTests` — three calls whose method has no CLR method of that name at all (`String.length`, `charAt`, `Object.hashCode`), which threw before.

`Apache.Calcite.Tests` 612, `Apache.Calcite.Data.Tests` 281, `Apache.Calcite.Adapter.AdoNet.Tests` 103, all passing.

## Not done, and unproven

`ClrTypes.Resolve` still searches by name, for two callers that are not translating a tree: the Calcite methods this convention names itself, read once into static fields and called on every row, and `Resolve(Type, name, arguments)`, where Calcite named a class and a method and there is no `Method` to unreflect. Converting the first costs throughput — IKVM's `invokeExact` delegate body is three field loads, a `castclass`, a second delegate call and a `checkcast` against one `call` instruction — so it wants an IKVM API returning the `MethodBase` for an `Executable` rather than a delegate.

The per-call cost of this change is that same delegate body, now on every translated call rather than on three of them. It has not been benchmarked; the differential tests say the answers are the same, not that they arrive as fast.

The six-argument `upperBound` was found by measuring the plans these tests build, not by auditing Calcite, so it is not established to be the only place upstream does this.
