### PR TITLE
Make ClrPhysTypeImpl public, as PhysTypeImpl is

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysTypeImpl.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysTypeImpl.cs
@@ -29,7 +29,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
     /// <para>The format arrives already through <c>JavaRowFormat.optimize</c>, and every question about
     /// how a row is laid out is the format's to answer.</para>
     /// </remarks>
-    class ClrPhysTypeImpl : ClrPhysType
+    public class ClrPhysTypeImpl : ClrPhysType
     {
 
         readonly JavaTypeFactory typeFactory;


### PR DESCRIPTION
`ClrPhysType` is a public interface, and every method that *takes* one is public — `ClrEnumerableRelImplementor.Result`, `ClrAsyncEnumerableRelImplementor.Result`, `ClrEnumUtils.JoinSelector`, `ClrEnumUtils.GeneratePredicate`. Only the way to *make* one was closed: `ClrPhysTypeImpl` is internal, and its `Of` factories are the sole means of obtaining a `ClrPhysType`.

`Result` will not build a result without one. So an adapter outside this assembly cannot implement a node of either convention at all — it can declare a `ClrAsyncEnumerableRel`, and then has nothing to return from `Implement`. `Apache.Calcite.Adapter.AdoNet` does not notice, because it is on the `InternalsVisibleTo` list; that is also why it has been the only adapter that could exist.

Calcite's `PhysTypeImpl` is public for precisely this reason, and calling `PhysTypeImpl.of` is the first thing every out-of-tree converter does:

| adapter | |
|---|---|
| arrow | `ArrowToEnumerableConverter.java:69` |
| cassandra | `CassandraToEnumerableConverter.java:84` |
| elasticsearch | `ElasticsearchToEnumerableConverter.java:74` |
| geode | `GeodeToEnumerableConverter.java:101` |
| innodb | `InnodbToEnumerableConverter.java:90` |
| core (jdbc) | `JdbcToEnumerableConverter.java:103` |

The constructor is untouched — `PhysTypeImpl`'s is package-private and this one is private. What becomes reachable is the factory, which alone applies `JavaRowFormat.optimize`, and not the ability to assemble one by hand.

## Verification

`dotnet build Apache.Calcite.sln` succeeds. No new warnings: the CS1591s in the output are pre-existing and all in `Apache.Calcite.Adapter.AdoNet.Tests`, and nothing in the build output names `ClrPhysType`. Widening accessibility on a type whose public members already use public types has no other effect in-tree.

## How it was found

Writing a Cosmos DB adapter against `ClrAsyncEnumerableConvention`. `CosmosToClrAsyncEnumerableConverter.Implement` needs a physical type for its rows and there is no public way to get one; with this change the adapter compiles, plans and returns rows.
