### PR TITLE
Say what is nullable, and stop suppressing what is not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,13 @@ operator audit against linq4j — 45 methods read side by side, 17 of them diver
   | 1.42 (referenced) | `EnumerableCombine`, `EnumerableConditionalCorrelate` and their rules, `EnumUtils.markJoinSelector` and the mark-join paths, `PhysType.generateNullAwareAccessor`, `JoinInfo.nullExclusionFlags` |
   | 1.43 (unreleased) | `org.apache.calcite.rel.core.Asof`, `FetchOffsetRoundingPolicy`, `RexImplementorTable(s)`, and `EnumerableTableModify`'s five private helpers — the UPDATE/DELETE/INSERT rewrite, CALCITE-7510 |
 
-  **1.43's DELETE cannot compile over a one-column table**, and two `CalciteDdlTests` are red for it
-  rather than skipped. CALCITE-7510 emits `(int) sinkRow` from a `sinkRow` declared `Object`; javac
-  accepts that and **Janino does not** — measured. The fix is upstream's: declare `sinkRow` as the row's
-  boxed type rather than `Object`.
+  **1.43's DELETE cannot compile over a one-column table** *under Janino*. CALCITE-7510 emits
+  `(int) sinkRow` from a `sinkRow` declared `Object`; javac accepts that and **Janino does not** — measured.
+  The fix is upstream's: declare `sinkRow` as the row's boxed type rather than `Object`. It costs this
+  project nothing, because `ClrEnumerablePrepare` translates Calcite's tree instead of compiling it. The two
+  `CalciteDdlTests` this held were skipped until `fc3621e` typed a scan's rows by the physical row type;
+  **they pass, and nothing in the suite is skipped.** The claim that they are red outlived the fix by four
+  commits in this file.
 
   **`AsofJoin` is neither** — `rel.core.AsofJoin`, `EnumerableAsofJoin` and `ENUMERABLE_ASOFJOIN_RULE` are
   all in 1.41, and a claim that it was 1.42 stood in this file for a while on the strength of the wrong
@@ -267,6 +270,13 @@ differential tests cannot use Calcite as the oracle for.
   ghost conversion only for the Java it compiles itself. `IComparable` is the way in, and
   `JavaComparisons` is where the `Utilities` comparisons that take a `Comparable` go through it.
   `PhysTypeImpl.generateComparator` casts to it purely to pick an overload out of the source text.
+- **A Java `static final` field is not a CLR field of that name.** IKVM emits a *property*, over a backing
+  field it renames to `__<>NAME`, so that reading it from C# still runs the class initializer the way Java
+  guarantees. `GetField("COMPARABLE_EMPTY_LIST")` on `FlatLists` answers nothing — measured.
+  `ClrTypes.Resolve(target, PseudoField)` tries field then property for this reason, and
+  `JavaRowFormatExtensions.StaticMember` does the same for the two constants a row of no fields is. Both of
+  those were `GetField(...)!` and had been null since they were written; nothing had reached a zero-field row,
+  so the suite was green over an NRE waiting to happen. `ZeroFieldRowTests` holds it now.
 - **Java enum ordinals are not stable across versions; names are.** Dispatch on `switch (x.name())` with
   `nameof(...)` labels. Never `ordinal()`, never IKVM's `__Enum` shadow.
 - **`(java.lang.Class)typeof(X)`, never `(java.lang.reflect.Type)typeof(X)`.**

--- a/src/Apache.Calcite.Adapter.AdoNet/Extensions/FuncFunction0.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Extensions/FuncFunction0.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using org.apache.calcite.linq4j.function;
 
@@ -20,9 +20,9 @@ namespace Apache.Calcite.Adapter.AdoNet.Extensions
             _func = func ?? throw new ArgumentNullException(nameof(func));
         }
 
-        public object apply()
+        public object? apply()
         {
-            return _func()!;
+            return _func();
         }
 
     }

--- a/src/Apache.Calcite.Adapter.AdoNet/Extensions/FuncFunction1.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Extensions/FuncFunction1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using org.apache.calcite.linq4j.function;
 
@@ -20,9 +20,9 @@ namespace Apache.Calcite.Adapter.AdoNet.Extensions
             _func = func ?? throw new ArgumentNullException(nameof(func));
         }
 
-        public object apply(object obj)
+        public object? apply(object obj)
         {
-            return _func((TArg)obj)!;
+            return _func((TArg)obj);
         }
 
     }

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/AdoJoin.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/AdoJoin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using java.util;
 
@@ -42,7 +42,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             return planner.getCostFactory().makeCost(mq.getRowCount(this).doubleValue(), 0, 0);
         }
@@ -50,8 +50,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel
         /// <inheritdoc />
         public override double estimateRowCount(RelMetadataQuery mq)
         {
-            var lRowCount = mq.getRowCount(left)!;
-            var rRowCount = mq.getRowCount(right)!;
+            var lRowCount = mq.getRowCount(left);
+            var rRowCount = mq.getRowCount(right);
             return Math.Max(lRowCount.doubleValue(), rRowCount.doubleValue());
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoFilterRule.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoFilterRule.cs
@@ -50,7 +50,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var filter = (Filter)rel;
             return new AdoFilter(

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverterRule.cs
@@ -46,7 +46,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             return new AdoToClrEnumerableConverter(rel.getCluster(), rel.getTraitSet().replace(getOutConvention()), rel);
         }

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToEnumerableConverter.cs
@@ -236,7 +236,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         #region EnumerableRel
 
         /// <inheritdoc />
-        public Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             return EnumerableRel.__DefaultMethods.deriveTraits(this, childTraits, childId);
         }
@@ -248,7 +248,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         }
 
         /// <inheritdoc />
-        public Pair passThroughTraits(RelTraitSet required)
+        public Pair? passThroughTraits(RelTraitSet required)
         {
             return EnumerableRel.__DefaultMethods.passThroughTraits(this, required);
         }
@@ -258,7 +258,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         #region PhysicalNode
 
         /// <inheritdoc />
-        public RelNode derive(RelTraitSet childTraits, int childId)
+        public RelNode? derive(RelTraitSet childTraits, int childId)
         {
             return PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
         }
@@ -270,7 +270,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         }
 
         /// <inheritdoc />
-        public RelNode passThrough(RelTraitSet required)
+        public RelNode? passThrough(RelTraitSet required)
         {
             return PhysicalNode.__DefaultMethods.passThrough(this, required);
         }

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToEnumerableConverterRule.cs
@@ -37,7 +37,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             return new AdoToEnumerableConverter(rel.getCluster(), rel.getTraitSet().replace(getOutConvention()), rel);
         }

--- a/src/Apache.Calcite.Data.Tests/CalciteDdlTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDdlTests.cs
@@ -351,14 +351,14 @@ namespace Apache.Calcite.Data.Tests
         /// <para>Every test CALCITE-7510 added uses a two-column table, which is why this shape was never
         /// seen. Both of these tables are one column. They pass on 1.42.0 — where four UPDATE tests fail
         /// instead, because 1.42 is what CALCITE-7510 fixes.</para>
-        /// <para>That was the whole story while Janino compiled the plan, and it no longer does: the default
-        /// prepare is <c>ClrEnumerablePrepare</c>, which translates Calcite's tree rather than compiling it,
-        /// so the cast Janino refuses costs nothing here. Measured — what remains is a different defect, and
-        /// ours. A one-column table gives the scan a SCALAR physical type, because <c>PhysTypeImpl.of</c>
-        /// collapses ARRAY to SCALAR for a single field, while the table still yields <c>Object[]</c> rows;
-        /// an aggregate over it is built as <c>IEnumerable&lt;int&gt;</c> and handed
-        /// <c>IEnumerable&lt;object[]&gt;</c>.</para>
-        /// <para>Skipped, not deleted, and the skip message names the defect that holds it.</para>
+        /// <para><b>This passes, and the paragraphs above are why it is worth keeping rather than why it
+        /// fails.</b> That was the whole story while Janino compiled the plan, and it no longer does: the
+        /// default prepare is <c>ClrEnumerablePrepare</c>, which translates Calcite's tree rather than
+        /// compiling it, so the cast Janino refuses costs nothing here. What remained after that was a defect
+        /// of ours rather than Calcite's — a one-column table gives the scan a SCALAR physical type while
+        /// the table still yields <c>Object[]</c> rows — and the scan now types its rows by the physical row
+        /// type, which cleared it. The upstream one-liner is still owed to Calcite, for anyone running these
+        /// through <c>EnumerableConvention</c>.</para>
         /// </remarks>
         [Fact]
         public void Delete_should_return_row_count()
@@ -459,14 +459,14 @@ namespace Apache.Calcite.Data.Tests
         /// <para>Every test CALCITE-7510 added uses a two-column table, which is why this shape was never
         /// seen. Both of these tables are one column. They pass on 1.42.0 — where four UPDATE tests fail
         /// instead, because 1.42 is what CALCITE-7510 fixes.</para>
-        /// <para>That was the whole story while Janino compiled the plan, and it no longer does: the default
-        /// prepare is <c>ClrEnumerablePrepare</c>, which translates Calcite's tree rather than compiling it,
-        /// so the cast Janino refuses costs nothing here. Measured — what remains is a different defect, and
-        /// ours. A one-column table gives the scan a SCALAR physical type, because <c>PhysTypeImpl.of</c>
-        /// collapses ARRAY to SCALAR for a single field, while the table still yields <c>Object[]</c> rows;
-        /// an aggregate over it is built as <c>IEnumerable&lt;int&gt;</c> and handed
-        /// <c>IEnumerable&lt;object[]&gt;</c>.</para>
-        /// <para>Skipped, not deleted, and the skip message names the defect that holds it.</para>
+        /// <para><b>This passes, and the paragraphs above are why it is worth keeping rather than why it
+        /// fails.</b> That was the whole story while Janino compiled the plan, and it no longer does: the
+        /// default prepare is <c>ClrEnumerablePrepare</c>, which translates Calcite's tree rather than
+        /// compiling it, so the cast Janino refuses costs nothing here. What remained after that was a defect
+        /// of ours rather than Calcite's — a one-column table gives the scan a SCALAR physical type while
+        /// the table still yields <c>Object[]</c> rows — and the scan now types its rows by the physical row
+        /// type, which cleared it. The upstream one-liner is still owed to Calcite, for anyone running these
+        /// through <c>EnumerableConvention</c>.</para>
         /// </remarks>
         [Fact]
         public void MultiRow_delete_should_return_correct_row_count_for_single_column_table()

--- a/src/Apache.Calcite.Data/CalciteCommand.cs
+++ b/src/Apache.Calcite.Data/CalciteCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,6 +65,11 @@ namespace Apache.Calcite.Data
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see cref="DbCommand.CommandText"/> is declared <see cref="AllowNullAttribute"/>, so the override
+        /// says so too and turns a null into the empty text rather than refusing it.
+        /// </remarks>
+        [AllowNull]
         public override string CommandText
         {
             get => _commandText;

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -476,7 +476,7 @@ namespace Apache.Calcite.Data
             if (string.IsNullOrEmpty(value))
                 Remove(key);
             else
-                this[key] = value!;
+                this[key] = value;
         }
 
     }

--- a/src/Apache.Calcite.Data/CalciteParameter.cs
+++ b/src/Apache.Calcite.Data/CalciteParameter.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 
 using Apache.Calcite.Data.Internal;
 
@@ -85,6 +86,11 @@ namespace Apache.Calcite.Data
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see cref="DbParameter.ParameterName"/> is declared <see cref="AllowNullAttribute"/>, so the
+        /// override says so too and reads a null as no name.
+        /// </remarks>
+        [AllowNull]
         public override string ParameterName
         {
             get => _parameterName;
@@ -99,6 +105,8 @@ namespace Apache.Calcite.Data
         }
 
         /// <inheritdoc />
+        /// <inheritdoc cref="ParameterName" path="/remarks" />
+        [AllowNull]
         public override string SourceColumn
         {
             get => _sourceColumn;

--- a/src/Apache.Calcite.Data/CalciteParameterCollection.cs
+++ b/src/Apache.Calcite.Data/CalciteParameterCollection.cs
@@ -56,7 +56,7 @@ namespace Apache.Calcite.Data
                 throw new ArgumentNullException(nameof(values));
 
             foreach (var v in values)
-                Add(v!);
+                _items.Add(AsParameter(v));
         }
 
         /// <inheritdoc />
@@ -169,7 +169,7 @@ namespace Apache.Calcite.Data
         /// </summary>
         internal IReadOnlyList<CalciteParameter> Items => _items;
 
-        static CalciteParameter AsParameter(object value)
+        static CalciteParameter AsParameter(object? value)
         {
             if (value is null)
                 throw new ArgumentNullException(nameof(value));

--- a/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
@@ -68,9 +68,10 @@ namespace Apache.Calcite.Data.Internal
             ThrowIfDisposed();
             cancellationToken.ThrowIfCancellationRequested();
 
-            var moved = _enumerator is not null && await _enumerator.MoveNextAsync().ConfigureAwait(false);
+            if (_enumerator is null || await _enumerator.MoveNextAsync().ConfigureAwait(false) == false)
+                return Accept(null, false);
 
-            return Accept(moved ? _enumerator!.Current : null, moved);
+            return Accept(_enumerator.Current, true);
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Data/Internal/CalciteEnumerableResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteEnumerableResult.cs
@@ -37,9 +37,10 @@ namespace Apache.Calcite.Data.Internal
         {
             ThrowIfDisposed();
 
-            var moved = _enumerator is not null && _enumerator.MoveNext();
+            if (_enumerator is null || _enumerator.MoveNext() == false)
+                return Accept(null, false);
 
-            return Accept(moved ? _enumerator!.Current : null, moved);
+            return Accept(_enumerator.Current, true);
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Data/Internal/CalciteResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResult.cs
@@ -91,7 +91,7 @@ namespace Apache.Calcite.Data.Internal
         /// <returns>Whether there was a row.</returns>
         protected bool Accept(object? row, bool moved)
         {
-            _current = moved ? new CalciteResultRow(_columns, _signature.CursorFactory, row!) : null;
+            _current = moved ? new CalciteResultRow(_columns, _signature.CursorFactory, row) : null;
             return moved;
         }
 

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -110,7 +110,8 @@ namespace Apache.Calcite.Data.Internal
                 _rootSchemaPlus = _rootSchema.plus();
                 _config = new CalciteConnectionConfigImpl(BuildEngineProperties(options));
                 _typeFactory = new JavaTypeFactoryImpl();
-                _defaultSchemaPath = string.IsNullOrEmpty(modelDefaultSchema ?? options.Schema) ? [] : [modelDefaultSchema ?? options.Schema];
+                var defaultSchema = modelDefaultSchema ?? options.Schema;
+                _defaultSchemaPath = string.IsNullOrEmpty(defaultSchema) ? [] : [defaultSchema];
             }
             catch (Exception e) when (e is not CalciteException)
             {

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateBase.cs
@@ -252,7 +252,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 var adderList = Expression.Variable(typeof(java.util.List), "accumulatorAdders");
                 var adderBody = new System.Collections.Generic.List<Expression>
                 {
-                    Expression.Assign(adderList, Expression.New(typeof(java.util.LinkedList).GetConstructor([])!)),
+                    Expression.Assign(adderList, Expression.New(LinkedListConstructor)),
                 };
 
                 for (int i = 0; i < adders.size(); i++)
@@ -266,7 +266,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var lazyList = Expression.Variable(typeof(java.util.List), "lazyAccumulators");
             var body = new System.Collections.Generic.List<Expression>
             {
-                Expression.Assign(lazyList, Expression.New(typeof(java.util.LinkedList).GetConstructor([])!)),
+                Expression.Assign(lazyList, Expression.New(LinkedListConstructor)),
             };
 
             for (int i = 0; i < aggs.size(); i++)
@@ -341,22 +341,32 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         protected static readonly System.Reflection.ConstructorInfo SourceSorter = typeof(SourceSorter).GetConstructors()[0];
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])!;
+        protected static readonly System.Reflection.ConstructorInfo LinkedListConstructor = typeof(java.util.LinkedList).GetConstructor([])
+            ?? throw new InvalidOperationException("java.util.LinkedList has no no-arg constructor.");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo AccInitializer = typeof(AggregateLambdaFactory).GetMethod("accumulatorInitializer")!;
+        protected static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])
+            ?? throw new InvalidOperationException("java.util.List has no add(Object).");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo AccAdder = typeof(AggregateLambdaFactory).GetMethod("accumulatorAdder")!;
+        protected static readonly System.Reflection.MethodInfo AccInitializer = typeof(AggregateLambdaFactory).GetMethod("accumulatorInitializer")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no accumulatorInitializer().");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo ResultSelector = typeof(AggregateLambdaFactory).GetMethod("resultSelector")!;
+        protected static readonly System.Reflection.MethodInfo AccAdder = typeof(AggregateLambdaFactory).GetMethod("accumulatorAdder")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no accumulatorAdder().");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo SingleGroupResultSelector = typeof(AggregateLambdaFactory).GetMethod("singleGroupResultSelector")!;
+        protected static readonly System.Reflection.MethodInfo ResultSelector = typeof(AggregateLambdaFactory).GetMethod("resultSelector")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no resultSelector().");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo Function0Apply = typeof(Function0).GetMethod("apply")!;
+        protected static readonly System.Reflection.MethodInfo SingleGroupResultSelector = typeof(AggregateLambdaFactory).GetMethod("singleGroupResultSelector")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no singleGroupResultSelector().");
+
+        /// <inheritdoc cref="BasicFactory" />
+        protected static readonly System.Reflection.MethodInfo Function0Apply = typeof(Function0).GetMethod("apply")
+            ?? throw new InvalidOperationException("Function0 has no apply().");
 
         /// <summary>
         /// What an aggregate implementor is told about the call it is implementing.
@@ -419,9 +429,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             }
 
             /// <inheritdoc />
-            public override RexNode rexFilterArgument()
+            public override RexNode? rexFilterArgument()
             {
-                return agg.call.filterArg < 0 ? null! : RexInputRef.of(agg.call.filterArg, inputPhysType.getRowType());
+                return agg.call.filterArg < 0 ? null : RexInputRef.of(agg.call.filterArg, inputPhysType.getRowType());
             }
 
             /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateRule.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var aggregate = (Aggregate)rel;
             var traitSet = rel.getCluster().traitSet().replace(ClrAsyncEnumerableConvention.Instance);
@@ -59,7 +59,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             {
                 // an aggregate this convention cannot implement is left for another rule, exactly as Calcite
                 // leaves one: refusing here rather than in Implement, which runs after a plan has been chosen
-                return null!;
+                return null;
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAsofJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAsofJoin.cs
@@ -89,20 +89,20 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             // should only derive traits (limited to collation for now) from the left join input
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             return planner.getCostFactory().makeCost(mq.getRowCount(this).doubleValue(), 0, 0);
         }

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAsofJoinRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAsofJoinRule.cs
@@ -39,7 +39,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var join = (LogicalAsofJoin)rel;
             var newInputs = new java.util.ArrayList();

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableBatchNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableBatchNestedLoopJoin.cs
@@ -77,15 +77,15 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
@@ -98,7 +98,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCalc.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCalc.cs
@@ -84,18 +84,18 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             return ClrEnumerableTraitsUtils.PassThroughTraitsForProject(
                 required,
                 Exps(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             return ClrEnumerableTraitsUtils.DeriveTraitsForProject(
                 childTraits,
@@ -103,7 +103,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 Exps(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCalcRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCalcRule.cs
@@ -46,7 +46,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var calc = (Calc)rel;
             var input = calc.getInput();

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCollectRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCollectRules.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var collect = (Collect)rel;
             var input = collect.getInput();
@@ -81,7 +81,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var uncollect = (Uncollect)rel;
             var traitSet = uncollect.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCombineRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCombineRule.cs
@@ -39,7 +39,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var combine = (Combine)rel;
             var traitSet = combine.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConditionalCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConditionalCorrelate.cs
@@ -91,15 +91,15 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// Only a collation on the left input passes down, because the left input is always the outer loop
         /// and only it can keep an order.
         /// </remarks>
-        public Pair passThroughTraits(RelTraitSet required)
+        public Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConditionalCorrelateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConditionalCorrelateRule.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var c = (LogicalConditionalCorrelate)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCorrelate.cs
@@ -70,16 +70,16 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// A correlate passes a collation to its left input and to no other: the left is always the outer
         /// loop, so only it can preserve an ordering.
         /// </remarks>
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             // should only derive traits (limited to collation for now) from the left input
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCorrelateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCorrelateRule.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var c = (Correlate)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -498,11 +498,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             Func<TSource, TNsKey>? outerNullSafeKeySelector,
             Func<TInner, TNsKey>? innerNullSafeKeySelector,
             bool atMostOneNotNullSafeKey,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
             EqualityComparer? comparer,
             EqualityComparer? nullSafeComparer,
-            Func<TSource, TInner, java.lang.Boolean>? nonEquiPredicate,
-            Func<TSource, TInner, java.lang.Boolean> equiPredicate,
+            Func<TSource, TInner, java.lang.Boolean?>? nonEquiPredicate,
+            Func<TSource, TInner, java.lang.Boolean?> equiPredicate,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
 {
             ArgumentNullException.ThrowIfNull(outer);
@@ -531,7 +531,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             await foreach (var row in (outer).WithCancellation(cancellationToken))
             {
-                var marker = java.lang.Boolean.FALSE;
+                java.lang.Boolean? marker = java.lang.Boolean.FALSE;
 
                 if (outerNullSafeKeySelector != null
                     && nullSafeKeys.contains(JavaWrapped.Of(nullSafeComparer, JavaValues.From(outerNullSafeKeySelector(row)))) == false)
@@ -549,7 +549,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     if (atMostOneNotNullSafeKey)
                     {
                         // the one EQUALS key is null on this row, so every comparison it makes is unknown
-                        marker = null!;
+                        marker = null;
                     }
                     else
                     {
@@ -561,7 +561,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                             {
                                 if (equiPredicate(row, other) == null)
                                 {
-                                    marker = null!;
+                                    marker = null;
                                     break;
                                 }
                             }
@@ -584,7 +584,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                             var matched = nonEquiPredicate(row, other);
 
                             if (matched == null)
-                                marker = null!;
+                                marker = null;
                             else if (matched.booleanValue())
                             {
                                 marker = java.lang.Boolean.TRUE;
@@ -598,7 +598,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     // nothing hashed to this key, but the build side holds rows whose key is null
                     if (atMostOneNotNullSafeKey)
                     {
-                        marker = null!;
+                        marker = null;
                     }
                     else
                     {
@@ -606,7 +606,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                         {
                             if (equiPredicate(row, other) == null)
                             {
-                                marker = null!;
+                                marker = null;
                                 break;
                             }
                         }
@@ -671,7 +671,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
@@ -699,7 +699,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
@@ -748,7 +748,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 }
 
                 if (any == false && generateNullsOnRight)
-                    yield return resultSelector(row, default!);
+                    yield return resultSelector(row, default);
             }
 
             if (unmatched == null)
@@ -765,7 +765,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 var key = i.next();
 
                 foreach (var other in (List<TInner>)lookup.get(key))
-                    yield return resultSelector(default!, other);
+                    yield return resultSelector(default, other);
             }
         }
 
@@ -786,7 +786,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
@@ -833,14 +833,14 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 }
 
                 if (any == false && generateNullsOnRight)
-                    yield return resultSelector(row, default!);
+                    yield return resultSelector(row, default);
             }
 
             if (unmatched == null)
                 yield break;
 
             foreach (var other in unmatched)
-                yield return resultSelector(default!, other);
+                yield return resultSelector(default, other);
         }
 
         /// <summary>
@@ -1016,7 +1016,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> matchComparator,
             java.util.Comparator timestampComparator,
             bool emitNullsOnRight,
@@ -1087,7 +1087,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             }
 
             foreach (var row in (outerWithNullKeys))
-                yield return resultSelector(row, default!);
+                yield return resultSelector(row, default);
         }
 
 
@@ -1322,7 +1322,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
             Func<TSource, TInner, bool>? predicate,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             org.apache.calcite.linq4j.JoinType joinType,
             java.util.Comparator? comparator,
             EqualityComparer? comparer,
@@ -1558,7 +1558,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
                 if (remainingLeft)
                 {
-                    yield return resultSelector(leftEnumerator.Current, default!);
+                    yield return resultSelector(leftEnumerator.Current, default);
 
                     if (await LeftMoveNext() == false)
                     {
@@ -1670,7 +1670,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             org.apache.calcite.linq4j.JoinType joinType,
             IAsyncEnumerable<TSource> outer,
             Func<java.util.List, IAsyncEnumerable<TInner>> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             int batchSize,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -1761,7 +1761,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                         }
 
                         if (any == false && (isLeft || isAnti))
-                            yield return resultSelector(left, default!);
+                            yield return resultSelector(left, default);
                     }
                 }
             }
@@ -1795,8 +1795,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         public static async IAsyncEnumerable<TResult> LeftMarkNestedLoopJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
-            Func<TSource, TInner, java.lang.Boolean> predicate,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
 {
             ArgumentNullException.ThrowIfNull(inner);
@@ -1824,9 +1824,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// </remarks>
         public static async IAsyncEnumerable<TResult> CorrelateLeftMarkJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
-            Func<TSource, IAsyncEnumerable<TInner>> inner,
-            Func<TSource, TInner, java.lang.Boolean> predicate,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector,
+            Func<TSource, IAsyncEnumerable<TInner>?> inner,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
 {
             await foreach (var row in LeftMarkJoin(outer, inner, predicate, resultSelector, cancellationToken).WithCancellation(cancellationToken))
@@ -1850,9 +1850,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// </remarks>
         static async IAsyncEnumerable<TResult> LeftMarkJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
-            Func<TSource, IAsyncEnumerable<TInner>> inner,
-            Func<TSource, TInner, java.lang.Boolean> predicate,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector,
+            Func<TSource, IAsyncEnumerable<TInner>?> inner,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(outer);
@@ -1862,7 +1862,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             await foreach (var left in outer.WithCancellation(cancellationToken))
             {
-                var marker = java.lang.Boolean.FALSE;
+                java.lang.Boolean? marker = java.lang.Boolean.FALSE;
                 var rows = inner(left);
 
                 if (rows != null)
@@ -1872,7 +1872,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                         var matched = predicate(left, right);
 
                         if (matched == null)
-                            marker = null!;
+                            marker = null;
                         else if (matched.booleanValue())
                         {
                             marker = java.lang.Boolean.TRUE;
@@ -1912,7 +1912,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         public static IAsyncEnumerable<TResult> NestedLoopJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType,
             CancellationToken cancellationToken = default)
@@ -1945,7 +1945,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         static async IAsyncEnumerable<TResult> NestedLoopJoinAsList<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -2001,12 +2001,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 }
 
                 if (leftMatchCount == 0 && (generateNullsOnRight || name == nameof(org.apache.calcite.linq4j.JoinType.ANTI)))
-                    result.Add(resultSelector(left, default!));
+                    result.Add(resultSelector(left, default));
             }
 
             if (rightUnmatched != null)
                 for (var i = rightUnmatched.iterator(); i.hasNext();)
-                    result.Add(resultSelector(default!, (TInner)i.next()));
+                    result.Add(resultSelector(default, (TInner)i.next()));
 
             foreach (var row in result)
                 yield return row;
@@ -2030,7 +2030,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         static IAsyncEnumerable<TResult> NestedLoopJoinOptimized<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType,
             CancellationToken cancellationToken = default)
@@ -2151,8 +2151,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// </remarks>
         public static IAsyncEnumerable<TResult> CorrelateJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
-            Func<TSource, IAsyncEnumerable<TInner>> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource, IAsyncEnumerable<TInner>?> inner,
+            Func<TSource?, TInner?, TResult> resultSelector,
             org.apache.calcite.linq4j.JoinType joinType,
             CancellationToken cancellationToken = default)
         {
@@ -2184,11 +2184,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     }
 
                     if (semi && any)
-                        yield return resultSelector(row, default!);
+                        yield return resultSelector(row, default);
                     else if (anti && any == false)
-                        yield return resultSelector(row, default!);
+                        yield return resultSelector(row, default);
                     else if (any == false && nullsOnRight)
-                        yield return resultSelector(row, default!);
+                        yield return resultSelector(row, default);
                 }
             }
         }
@@ -2592,7 +2592,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // nothing about reading it can block. Awaiting it would mean an adapter over a Java sequence,
             // which is the async-over-sync this convention exists to refuse.
             await foreach (var row in source.WithCancellation(cancellationToken))
-                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(row!)))
+                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(row)))
                     yield return item;
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableFilter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableFilter.cs
@@ -54,11 +54,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             var collation = required.getCollation();
             if (collation == null || collation == RelCollations.EMPTY)
-                return null!;
+                return null;
 
             var traits = getTraitSet().replace(collation);
 
@@ -66,11 +66,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             var collation = childTraits.getCollation();
             if (collation == null || collation == RelCollations.EMPTY)
-                return null!;
+                return null;
 
             var traits = getTraitSet().replace(collation);
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableFilterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableFilterRule.cs
@@ -46,7 +46,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var filter = (Filter)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableHashJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableHashJoin.cs
@@ -64,16 +64,16 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             // should only derive traits (limited to collation for now) from the left join input
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
@@ -86,7 +86,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableJoinRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableJoinRule.cs
@@ -47,7 +47,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var join = (Join)rel;
             var newInputs = new java.util.ArrayList();

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableMergeJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableMergeJoin.cs
@@ -160,10 +160,10 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <c>TopDownRuleDriver.convert</c> asserts cannot happen. Refusing a foreign convention outright is
         /// the guard; everything after it is the port.</para>
         /// </remarks>
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             if (required.getConvention() != getConvention())
-                return null!;
+                return null;
 
             // the required collation keys can be a subset or a superset of the merge join keys
             var collation = GetCollation(required);
@@ -243,7 +243,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     com.google.common.collect.ImmutableList.of(required.replace(leftCollation), required.replace(rightCollation)));
             }
 
-            return null!;
+            return null;
         }
 
         static bool AllLessThan(java.util.List keys, int bound)
@@ -265,13 +265,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             var keyCount = joinInfo.leftKeys.size();
             var collation = GetCollation(childTraits);
             var colCount = collation.getFieldCollations().size();
             if (colCount < keyCount || keyCount == 0)
-                return null!;
+                return null;
 
             if (colCount > keyCount)
                 collation = RelCollations.of(collation.getFieldCollations().subList(0, keyCount));
@@ -280,7 +280,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var keySet = ImmutableBitSet.of(sourceKeys);
             var childCollationKeys = ImmutableBitSet.of(RelCollations.ordinals(collation));
             if (childCollationKeys.equals(keySet) == false)
-                return null!;
+                return null;
 
             var mapping = BuildMapping(childId == 0);
             var targetCollation = RexUtil.apply(mapping, collation);
@@ -373,7 +373,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableMergeJoinRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableMergeJoinRule.cs
@@ -46,24 +46,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var join = (Join)rel;
 
             // a merge join stops at a null, and IS NOT DISTINCT FROM says two nulls are equal, so a
             // condition carrying one cannot be a merge join key
             if (RexUtil.findOperatorCall(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM, join.getCondition()) != null)
-                return null!;
+                return null;
 
             var info = JoinInfo.createWithStrictEquality(join.getLeft(), join.getRight(), join.getCondition());
 
             // a merge join answers only some join types
             if (ClrAsyncEnumerableMergeJoin.IsMergeJoinSupported(join.getJoinType()) == false)
-                return null!;
+                return null;
 
             // a cartesian join could be merged too, and Calcite leaves it off for now
             if (info.pairs().isEmpty())
-                return null!;
+                return null;
 
             var newInputs = new java.util.ArrayList();
             var collations = new java.util.ArrayList();

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableMergeUnion.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableMergeUnion.cs
@@ -87,7 +87,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var sources = Expression.Variable(typeof(java.util.List), "mergeUnionInputs");
             var body = new List<Expression>
             {
-                Expression.Assign(sources, Expression.New(typeof(java.util.ArrayList).GetConstructor([])!)),
+                Expression.Assign(sources, Expression.New(ArrayListConstructor)),
             };
 
             for (int i = 0; i < getInputs().size(); i++)
@@ -116,7 +116,14 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             return implementor.Result(physType, Expression.Block(body[^1].Type, [sources], body));
         }
 
-        static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])!;
+        static readonly System.Reflection.ConstructorInfo ArrayListConstructor = typeof(java.util.ArrayList).GetConstructor([])
+            ?? throw new System.InvalidOperationException("java.util.ArrayList has no no-arg constructor.");
+
+        /// <summary>
+        /// <c>java.util.List.add</c>, which fills the list above.
+        /// </summary>
+        static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])
+            ?? throw new System.InvalidOperationException("java.util.List has no add(Object).");
 
     }
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableNestedLoopJoin.cs
@@ -71,15 +71,15 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// preserve an ordering. Pushing a sort to the right does not help a right outer join either, because
         /// the unmatched right rows are produced together at the end.
         /// </remarks>
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
@@ -92,7 +92,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableProject.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableProject.cs
@@ -55,18 +55,18 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             return ClrEnumerableTraitsUtils.PassThroughTraitsForProject(
                 required,
                 getProjects(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             return ClrEnumerableTraitsUtils.DeriveTraitsForProject(
                 childTraits,
@@ -74,7 +74,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 getProjects(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableProjectRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableProjectRule.cs
@@ -56,7 +56,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var project = (Project)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRecursionRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRecursionRules.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var union = (RepeatUnion)rel;
             var traitSet = union.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance);
@@ -88,7 +88,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var spool = (TableSpool)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRel.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRel.cs
@@ -35,19 +35,19 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         ClrAsyncEnumerableResult Implement(ClrAsyncEnumerableRelImplementor implementor, ClrEnumerablePrefer pref);
 
         /// <inheritdoc cref="PhysicalNode.passThroughTraits" />
-        Pair PhysicalNode.passThroughTraits(RelTraitSet required) => null!;
+        Pair? PhysicalNode.passThroughTraits(RelTraitSet required) => null;
 
         /// <inheritdoc cref="PhysicalNode.deriveTraits" />
-        Pair PhysicalNode.deriveTraits(RelTraitSet childTraits, int childId) => null!;
+        Pair? PhysicalNode.deriveTraits(RelTraitSet childTraits, int childId) => null;
 
         /// <inheritdoc cref="PhysicalNode.getDeriveMode" />
         DeriveMode PhysicalNode.getDeriveMode() => DeriveMode.LEFT_FIRST;
 
         /// <inheritdoc cref="PhysicalNode.passThrough" />
-        RelNode PhysicalNode.passThrough(RelTraitSet required) => PhysicalNode.__DefaultMethods.passThrough(this, required);
+        RelNode? PhysicalNode.passThrough(RelTraitSet required) => PhysicalNode.__DefaultMethods.passThrough(this, required);
 
         /// <inheritdoc cref="PhysicalNode.derive(RelTraitSet, int)" />
-        RelNode PhysicalNode.derive(RelTraitSet childTraits, int childId) => PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
+        RelNode? PhysicalNode.derive(RelTraitSet childTraits, int childId) => PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
 
         /// <inheritdoc cref="PhysicalNode.derive(java.util.List)" />
         java.util.List PhysicalNode.derive(java.util.List inputTraits) => PhysicalNode.__DefaultMethods.derive(this, inputTraits);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSetOpRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSetOpRules.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var union = (Union)rel;
             var traitSet = rel.getCluster().traitSet().replace(ClrAsyncEnumerableConvention.Instance);
@@ -83,7 +83,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var intersect = (Intersect)rel;
             var traitSet = intersect.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance);
@@ -122,7 +122,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var minus = (Minus)rel;
             var traitSet = rel.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortRule.cs
@@ -43,13 +43,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var sort = (Sort)rel;
 
             // a sort carrying an offset or a fetch belongs to ClrAsyncEnumerableLimitRule, not to this one
             if (sort.offset != null || sort.fetch != null)
-                return null!;
+                return null;
 
             var input = sort.getInput();
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
@@ -56,15 +56,15 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             if (isSimple(this) == false)
-                return null!;
+                return null;
 
             // a required trait set of another convention is refused rather than copied onto, for the reason
             // ClrAsyncEnumerableMergeJoin gives at more length
             if (required.getConvention() != getConvention())
-                return null!;
+                return null;
 
             var inputTraits = getInput().getTraitSet();
             var collation = required.getCollation() ?? throw new java.lang.NullPointerException($"collation trait is null, required traits are {required}");
@@ -95,7 +95,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             // the group keys do not cover the required keys, as in GROUP BY a, b ORDER BY a, b, c, and
             // nothing can be pushed down
-            return null!;
+            return null;
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregateRule.cs
@@ -54,13 +54,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// collation is empty; Calcite's rule builds the node anyway and its <c>implement</c> then fails. A
         /// global aggregate has nothing to sort by and belongs to <see cref="ClrAsyncEnumerableAggregate"/>.
         /// </remarks>
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var agg = (Aggregate)rel;
             if (Aggregate.isSimple(agg) == false)
-                return null!;
+                return null;
             if (agg.getGroupSet().isEmpty())
-                return null!;
+                return null;
 
             var inputTraits = rel.getCluster().traitSet()
                 .replace(ClrAsyncEnumerableConvention.Instance)

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableTableScan.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableTableScan.cs
@@ -193,9 +193,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// Where a table had an index on the required collation keys this is where an index scan would be
         /// returned. There is none, and Calcite's own answer here is the same null.
         /// </remarks>
-        public RelNode passThrough(RelTraitSet required)
+        public RelNode? passThrough(RelTraitSet required)
         {
-            return null!;
+            return null;
         }
 
         /// <inheritdoc />
@@ -274,7 +274,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 var names = table.getQualifiedName();
 
                 return queryable.GetAsyncExpression(
-                    ((org.apache.calcite.jdbc.CalciteSchema)table.unwrap(typeof(org.apache.calcite.jdbc.CalciteSchema)))?.plus()!,
+                    ((org.apache.calcite.jdbc.CalciteSchema)table.unwrap(typeof(org.apache.calcite.jdbc.CalciteSchema)))?.plus(),
                     (string)names.get(names.size() - 1))
                     ?? throw new java.lang.IllegalStateException($"{table}.GetExpression returned null");
             }

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableTableScanRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableTableScanRule.cs
@@ -57,7 +57,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// and an asynchronous table is exactly that, so the question the synchronous rule asks safely is one
         /// this one cannot ask at all.</para>
         /// </remarks>
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var scan = (TableScan)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableValues.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableValues.cs
@@ -61,11 +61,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public RelNode passThrough(RelTraitSet required)
+        public RelNode? passThrough(RelTraitSet required)
         {
             var collation = required.getCollation();
             if (collation == null || collation.isDefault())
-                return null!;
+                return null;
 
             // a VALUES of 0 or 1 rows can be ordered by any collation
             if (tuples.size() > 1)
@@ -81,7 +81,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
                 // check whether the tuples are sorted by the required collations
                 if (ordering!.isOrdered(tuples) == false)
-                    return null!;
+                    return null;
             }
 
             // the tuples' order satisfies the collation, so a node carrying it is all that is needed

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableValuesRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableValuesRule.cs
@@ -52,7 +52,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// a <c>RelCompositeTrait to RelCollation</c> cast failure. That failure is
         /// <see cref="ClrAsyncEnumerableValues.passThrough"/> having been missing, not this.</para>
         /// </remarks>
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var values = (Values)rel;
             var enumerableValues = ClrAsyncEnumerableValues.Create(values.getCluster(), values.getRowType(), values.getTuples());

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
@@ -76,11 +76,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
         {
             var cost = base.computeSelfCost(planner, mq);
             if (cost == null)
-                return null!;
+                return null;
 
             return cost.multiplyBy(ClrAsyncEnumerableConvention.CostMultiplier);
         }
@@ -1002,7 +1002,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             public override java.util.List rexArguments() => rexArgs;
 
             /// <inheritdoc />
-            public override RexNode rexFilterArgument() => null!;
+            public override RexNode? rexFilterArgument() => null;
 
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindowRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindowRule.cs
@@ -39,7 +39,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var window = (Window)rel;
             var traitSet = window.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverter.cs
@@ -53,11 +53,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
         {
             var cost = base.computeSelfCost(planner, mq);
 
-            return cost == null ? null! : cost.multiplyBy(ClrAsyncEnumerableConvention.CostMultiplier);
+            return cost?.multiplyBy(ClrAsyncEnumerableConvention.CostMultiplier);
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverterRule.cs
@@ -41,7 +41,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             return new EnumerableToClrAsyncEnumerableConverter(
                 rel.getCluster(),

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumUtils.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumUtils.cs
@@ -483,11 +483,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </remarks>
         public static Expression? GenerateCollatorExpression(org.apache.calcite.sql.SqlCollation? collation)
         {
-            var collator = collation?.getCollator();
-            if (collator == null)
+            if (collation == null || collation.getCollator() is not java.text.Collator collator)
                 return null;
 
-            var locale = collation!.getLocale();
+            var locale = collation.getLocale();
 
             return Expression.Call(null, GenerateCollator,
                 Expression.New(LocaleConstructor,
@@ -501,11 +500,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <c>Utilities.generateCollator</c>, and the locale it takes.
         /// </summary>
         static readonly MethodInfo GenerateCollator = typeof(org.apache.calcite.runtime.Utilities)
-            .GetMethod("generateCollator", BindingFlags.Public | BindingFlags.Static)!;
+            
+            .GetMethod("generateCollator", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Utilities has no generateCollator().");
 
         /// <inheritdoc cref="GenerateCollator" />
         static readonly System.Reflection.ConstructorInfo LocaleConstructor = typeof(java.util.Locale)
-            .GetConstructor([typeof(string), typeof(string), typeof(string)])!;
+            
+            .GetConstructor([typeof(string), typeof(string), typeof(string)])
+            ?? throw new InvalidOperationException("java.util.Locale has no (String, String, String) constructor.");
 
         /// <summary>
         /// Converts between two primitives, and returns <paramref name="expression"/> when they agree.

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateBase.cs
@@ -250,7 +250,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 var adderList = Expression.Variable(typeof(java.util.List), "accumulatorAdders");
                 var adderBody = new System.Collections.Generic.List<Expression>
                 {
-                    Expression.Assign(adderList, Expression.New(typeof(java.util.LinkedList).GetConstructor([])!)),
+                    Expression.Assign(adderList, Expression.New(LinkedListConstructor)),
                 };
 
                 for (int i = 0; i < adders.size(); i++)
@@ -264,7 +264,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var lazyList = Expression.Variable(typeof(java.util.List), "lazyAccumulators");
             var body = new System.Collections.Generic.List<Expression>
             {
-                Expression.Assign(lazyList, Expression.New(typeof(java.util.LinkedList).GetConstructor([])!)),
+                Expression.Assign(lazyList, Expression.New(LinkedListConstructor)),
             };
 
             for (int i = 0; i < aggs.size(); i++)
@@ -339,22 +339,32 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         protected static readonly System.Reflection.ConstructorInfo SourceSorter = typeof(SourceSorter).GetConstructors()[0];
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])!;
+        protected static readonly System.Reflection.ConstructorInfo LinkedListConstructor = typeof(java.util.LinkedList).GetConstructor([])
+            ?? throw new InvalidOperationException("java.util.LinkedList has no no-arg constructor.");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo AccInitializer = typeof(AggregateLambdaFactory).GetMethod("accumulatorInitializer")!;
+        protected static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])
+            ?? throw new InvalidOperationException("java.util.List has no add(Object).");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo AccAdder = typeof(AggregateLambdaFactory).GetMethod("accumulatorAdder")!;
+        protected static readonly System.Reflection.MethodInfo AccInitializer = typeof(AggregateLambdaFactory).GetMethod("accumulatorInitializer")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no accumulatorInitializer().");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo ResultSelector = typeof(AggregateLambdaFactory).GetMethod("resultSelector")!;
+        protected static readonly System.Reflection.MethodInfo AccAdder = typeof(AggregateLambdaFactory).GetMethod("accumulatorAdder")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no accumulatorAdder().");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo SingleGroupResultSelector = typeof(AggregateLambdaFactory).GetMethod("singleGroupResultSelector")!;
+        protected static readonly System.Reflection.MethodInfo ResultSelector = typeof(AggregateLambdaFactory).GetMethod("resultSelector")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no resultSelector().");
 
         /// <inheritdoc cref="BasicFactory" />
-        protected static readonly System.Reflection.MethodInfo Function0Apply = typeof(Function0).GetMethod("apply")!;
+        protected static readonly System.Reflection.MethodInfo SingleGroupResultSelector = typeof(AggregateLambdaFactory).GetMethod("singleGroupResultSelector")
+            ?? throw new InvalidOperationException("AggregateLambdaFactory has no singleGroupResultSelector().");
+
+        /// <inheritdoc cref="BasicFactory" />
+        protected static readonly System.Reflection.MethodInfo Function0Apply = typeof(Function0).GetMethod("apply")
+            ?? throw new InvalidOperationException("Function0 has no apply().");
 
         /// <summary>
         /// What an aggregate implementor is told about the call it is implementing.
@@ -417,9 +427,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             }
 
             /// <inheritdoc />
-            public override RexNode rexFilterArgument()
+            public override RexNode? rexFilterArgument()
             {
-                return agg.call.filterArg < 0 ? null! : RexInputRef.of(agg.call.filterArg, inputPhysType.getRowType());
+                return agg.call.filterArg < 0 ? null : RexInputRef.of(agg.call.filterArg, inputPhysType.getRowType());
             }
 
             /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateRule.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var aggregate = (Aggregate)rel;
             var traitSet = rel.getCluster().traitSet().replace(ClrEnumerableConvention.Instance);
@@ -57,7 +57,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             {
                 // an aggregate this convention cannot implement is left for another rule, exactly as Calcite
                 // leaves one: refusing here rather than in Implement, which runs after a plan has been chosen
-                return null!;
+                return null;
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAsofJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAsofJoin.cs
@@ -87,20 +87,20 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             // should only derive traits (limited to collation for now) from the left join input
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             return planner.getCostFactory().makeCost(mq.getRowCount(this).doubleValue(), 0, 0);
         }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAsofJoinRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAsofJoinRule.cs
@@ -37,7 +37,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var join = (LogicalAsofJoin)rel;
             var newInputs = new java.util.ArrayList();

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableBatchNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableBatchNestedLoopJoin.cs
@@ -75,15 +75,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
@@ -96,7 +96,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCalc.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCalc.cs
@@ -82,18 +82,18 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             return ClrEnumerableTraitsUtils.PassThroughTraitsForProject(
                 required,
                 Exps(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             return ClrEnumerableTraitsUtils.DeriveTraitsForProject(
                 childTraits,
@@ -101,7 +101,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 Exps(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCalcRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCalcRule.cs
@@ -44,7 +44,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var calc = (Calc)rel;
             var input = calc.getInput();

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCollectRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCollectRules.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var collect = (Collect)rel;
             var input = collect.getInput();
@@ -79,7 +79,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var uncollect = (Uncollect)rel;
             var traitSet = uncollect.getTraitSet().replace(ClrEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCombineRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCombineRule.cs
@@ -37,7 +37,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var combine = (Combine)rel;
             var traitSet = combine.getTraitSet().replace(ClrEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableConditionalCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableConditionalCorrelate.cs
@@ -89,15 +89,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// Only a collation on the left input passes down, because the left input is always the outer loop
         /// and only it can keep an order.
         /// </remarks>
-        public Pair passThroughTraits(RelTraitSet required)
+        public Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableConditionalCorrelateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableConditionalCorrelateRule.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var c = (LogicalConditionalCorrelate)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCorrelate.cs
@@ -68,16 +68,16 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// A correlate passes a collation to its left input and to no other: the left is always the outer
         /// loop, so only it can preserve an ordering.
         /// </remarks>
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, getJoinType(), getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             // should only derive traits (limited to collation for now) from the left input
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, getJoinType(), getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCorrelateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCorrelateRule.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var c = (Correlate)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -320,11 +320,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             Func<TSource, TNsKey>? outerNullSafeKeySelector,
             Func<TInner, TNsKey>? innerNullSafeKeySelector,
             bool atMostOneNotNullSafeKey,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
             EqualityComparer? comparer,
             EqualityComparer? nullSafeComparer,
-            Func<TSource, TInner, java.lang.Boolean>? nonEquiPredicate,
-            Func<TSource, TInner, java.lang.Boolean> equiPredicate)
+            Func<TSource, TInner, java.lang.Boolean?>? nonEquiPredicate,
+            Func<TSource, TInner, java.lang.Boolean?> equiPredicate)
         {
             ArgumentNullException.ThrowIfNull(outer);
             ArgumentNullException.ThrowIfNull(inner);
@@ -352,7 +352,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             foreach (var row in outer)
             {
-                var marker = java.lang.Boolean.FALSE;
+                java.lang.Boolean? marker = java.lang.Boolean.FALSE;
 
                 if (outerNullSafeKeySelector != null
                     && nullSafeKeys.contains(JavaWrapped.Of(nullSafeComparer, JavaValues.From(outerNullSafeKeySelector(row)))) == false)
@@ -370,7 +370,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     if (atMostOneNotNullSafeKey)
                     {
                         // the one EQUALS key is null on this row, so every comparison it makes is unknown
-                        marker = null!;
+                        marker = null;
                     }
                     else
                     {
@@ -382,7 +382,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                             {
                                 if (equiPredicate(row, other) == null)
                                 {
-                                    marker = null!;
+                                    marker = null;
                                     break;
                                 }
                             }
@@ -405,7 +405,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                             var matched = nonEquiPredicate(row, other);
 
                             if (matched == null)
-                                marker = null!;
+                                marker = null;
                             else if (matched.booleanValue())
                             {
                                 marker = java.lang.Boolean.TRUE;
@@ -419,7 +419,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     // nothing hashed to this key, but the build side holds rows whose key is null
                     if (atMostOneNotNullSafeKey)
                     {
-                        marker = null!;
+                        marker = null;
                     }
                     else
                     {
@@ -427,7 +427,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                         {
                             if (equiPredicate(row, other) == null)
                             {
-                                marker = null!;
+                                marker = null;
                                 break;
                             }
                         }
@@ -491,7 +491,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             IEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
@@ -514,7 +514,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             IEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight)
@@ -562,7 +562,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
 
                 if (any == false && generateNullsOnRight)
-                    yield return resultSelector(row, default!);
+                    yield return resultSelector(row, default);
             }
 
             if (unmatched == null)
@@ -579,7 +579,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 var key = i.next();
 
                 foreach (var other in (List<TInner>)lookup.get(key))
-                    yield return resultSelector(default!, other);
+                    yield return resultSelector(default, other);
             }
         }
 
@@ -600,7 +600,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             IEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
@@ -646,14 +646,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
 
                 if (any == false && generateNullsOnRight)
-                    yield return resultSelector(row, default!);
+                    yield return resultSelector(row, default);
             }
 
             if (unmatched == null)
                 yield break;
 
             foreach (var other in unmatched)
-                yield return resultSelector(default!, other);
+                yield return resultSelector(default, other);
         }
 
         /// <summary>
@@ -833,7 +833,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             IEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> matchComparator,
             java.util.Comparator timestampComparator,
             bool emitNullsOnRight)
@@ -907,7 +907,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
 
                 foreach (var row in outerWithNullKeys)
-                    yield return resultSelector(row, default!);
+                    yield return resultSelector(row, default);
             }
         }
 
@@ -1137,7 +1137,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
             Func<TSource, TInner, bool>? predicate,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             org.apache.calcite.linq4j.JoinType joinType,
             java.util.Comparator? comparator,
             EqualityComparer? comparer)
@@ -1372,7 +1372,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
                 if (remainingLeft)
                 {
-                    yield return resultSelector(leftEnumerator.Current, default!);
+                    yield return resultSelector(leftEnumerator.Current, default);
 
                     if (LeftMoveNext() == false)
                     {
@@ -1483,7 +1483,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             org.apache.calcite.linq4j.JoinType joinType,
             IEnumerable<TSource> outer,
             Func<java.util.List, IEnumerable<TInner>> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             int batchSize)
         {
@@ -1572,7 +1572,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                         }
 
                         if (any == false && (isLeft || isAnti))
-                            yield return resultSelector(left, default!);
+                            yield return resultSelector(left, default);
                     }
                 }
             }
@@ -1604,8 +1604,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         public static IEnumerable<TResult> LeftMarkNestedLoopJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
             IEnumerable<TInner> inner,
-            Func<TSource, TInner, java.lang.Boolean> predicate,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector)
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector)
         {
             ArgumentNullException.ThrowIfNull(inner);
 
@@ -1630,9 +1630,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </remarks>
         public static IEnumerable<TResult> CorrelateLeftMarkJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
-            Func<TSource, IEnumerable<TInner>> inner,
-            Func<TSource, TInner, java.lang.Boolean> predicate,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector)
+            Func<TSource, IEnumerable<TInner>?> inner,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector)
         {
             return LeftMarkJoin(outer, inner, predicate, resultSelector);
         }
@@ -1653,9 +1653,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </remarks>
         static IEnumerable<TResult> LeftMarkJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
-            Func<TSource, IEnumerable<TInner>> inner,
-            Func<TSource, TInner, java.lang.Boolean> predicate,
-            Func<TSource, java.lang.Boolean, TResult> resultSelector)
+            Func<TSource, IEnumerable<TInner>?> inner,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector)
         {
             ArgumentNullException.ThrowIfNull(outer);
             ArgumentNullException.ThrowIfNull(inner);
@@ -1664,7 +1664,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             foreach (var left in outer)
             {
-                var marker = java.lang.Boolean.FALSE;
+                java.lang.Boolean? marker = java.lang.Boolean.FALSE;
                 var rows = inner(left);
 
                 if (rows != null)
@@ -1674,7 +1674,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                         var matched = predicate(left, right);
 
                         if (matched == null)
-                            marker = null!;
+                            marker = null;
                         else if (matched.booleanValue())
                         {
                             marker = java.lang.Boolean.TRUE;
@@ -1710,7 +1710,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         public static IEnumerable<TResult> NestedLoopJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
             IEnumerable<TInner> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType)
         {
@@ -1753,7 +1753,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         static IEnumerable<TResult> NestedLoopJoinAsList<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
             IEnumerable<TInner> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType)
         {
@@ -1808,12 +1808,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
 
                 if (leftMatchCount == 0 && (generateNullsOnRight || name == nameof(org.apache.calcite.linq4j.JoinType.ANTI)))
-                    result.Add(resultSelector(left, default!));
+                    result.Add(resultSelector(left, default));
             }
 
             if (rightUnmatched != null)
                 for (var i = rightUnmatched.iterator(); i.hasNext();)
-                    result.Add(resultSelector(default!, (TInner)i.next()));
+                    result.Add(resultSelector(default, (TInner)i.next()));
 
             return result;
         }
@@ -1843,7 +1843,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         static IEnumerable<TResult> NestedLoopJoinOptimized<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
             IEnumerable<TInner> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             org.apache.calcite.linq4j.JoinType joinType)
         {
@@ -1968,8 +1968,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </remarks>
         public static IEnumerable<TResult> CorrelateJoin<TSource, TInner, TResult>(
             IEnumerable<TSource> outer,
-            Func<TSource, IEnumerable<TInner>> inner,
-            Func<TSource, TInner, TResult> resultSelector,
+            Func<TSource, IEnumerable<TInner>?> inner,
+            Func<TSource?, TInner?, TResult> resultSelector,
             org.apache.calcite.linq4j.JoinType joinType)
         {
             var name = joinType.name();
@@ -2000,11 +2000,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     }
 
                     if (semi && any)
-                        yield return resultSelector(row, default!);
+                        yield return resultSelector(row, default);
                     else if (anti && any == false)
-                        yield return resultSelector(row, default!);
+                        yield return resultSelector(row, default);
                     else if (any == false && nullsOnRight)
-                        yield return resultSelector(row, default!);
+                        yield return resultSelector(row, default);
                 }
             }
         }
@@ -2423,7 +2423,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(selector);
 
             foreach (var row in source)
-                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(row!)))
+                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(row)))
                     yield return item;
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableFilter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableFilter.cs
@@ -52,11 +52,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             var collation = required.getCollation();
             if (collation == null || collation == RelCollations.EMPTY)
-                return null!;
+                return null;
 
             var traits = getTraitSet().replace(collation);
 
@@ -64,11 +64,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             var collation = childTraits.getCollation();
             if (collation == null || collation == RelCollations.EMPTY)
-                return null!;
+                return null;
 
             var traits = getTraitSet().replace(collation);
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableFilterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableFilterRule.cs
@@ -44,7 +44,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var filter = (Filter)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableHashJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableHashJoin.cs
@@ -62,16 +62,16 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             // should only derive traits (limited to collation for now) from the left join input
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
@@ -84,7 +84,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableInterpreter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableInterpreter.cs
@@ -61,11 +61,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var cost = base.computeSelfCost(planner, mq);
 
-            return cost == null ? null! : cost.multiplyBy(factor);
+            return cost?.multiplyBy(factor);
         }
 
         /// <inheritdoc />
@@ -105,7 +105,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <c>Interpreter(DataContext, RelNode)</c>, which is what runs the input.
         /// </summary>
         static readonly System.Reflection.ConstructorInfo InterpreterConstructor =
-            typeof(Interpreter).GetConstructor([typeof(org.apache.calcite.DataContext), typeof(RelNode)])!;
+            typeof(Interpreter).GetConstructor([typeof(org.apache.calcite.DataContext), typeof(RelNode)])
+            ?? throw new System.InvalidOperationException("Interpreter has no (DataContext, RelNode) constructor.");
 
         /// <summary>
         /// <c>Linq4j.slice0</c>, which reads a sequence of one-column rows as a sequence of their values.

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableInterpreterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableInterpreterRule.cs
@@ -46,7 +46,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             return ClrEnumerableInterpreter.Create(rel, 0.5d);
         }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableJoinRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableJoinRule.cs
@@ -45,7 +45,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var join = (Join)rel;
             var newInputs = new java.util.ArrayList();

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableMergeJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableMergeJoin.cs
@@ -158,10 +158,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <c>TopDownRuleDriver.convert</c> asserts cannot happen. Refusing a foreign convention outright is
         /// the guard; everything after it is the port.</para>
         /// </remarks>
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             if (required.getConvention() != getConvention())
-                return null!;
+                return null;
 
             // the required collation keys can be a subset or a superset of the merge join keys
             var collation = GetCollation(required);
@@ -241,7 +241,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     com.google.common.collect.ImmutableList.of(required.replace(leftCollation), required.replace(rightCollation)));
             }
 
-            return null!;
+            return null;
         }
 
         static bool AllLessThan(java.util.List keys, int bound)
@@ -263,13 +263,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             var keyCount = joinInfo.leftKeys.size();
             var collation = GetCollation(childTraits);
             var colCount = collation.getFieldCollations().size();
             if (colCount < keyCount || keyCount == 0)
-                return null!;
+                return null;
 
             if (colCount > keyCount)
                 collation = RelCollations.of(collation.getFieldCollations().subList(0, keyCount));
@@ -278,7 +278,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var keySet = ImmutableBitSet.of(sourceKeys);
             var childCollationKeys = ImmutableBitSet.of(RelCollations.ordinals(collation));
             if (childCollationKeys.equals(keySet) == false)
-                return null!;
+                return null;
 
             var mapping = BuildMapping(childId == 0);
             var targetCollation = RexUtil.apply(mapping, collation);
@@ -371,7 +371,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableMergeJoinRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableMergeJoinRule.cs
@@ -44,24 +44,24 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var join = (Join)rel;
 
             // a merge join stops at a null, and IS NOT DISTINCT FROM says two nulls are equal, so a
             // condition carrying one cannot be a merge join key
             if (RexUtil.findOperatorCall(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM, join.getCondition()) != null)
-                return null!;
+                return null;
 
             var info = JoinInfo.createWithStrictEquality(join.getLeft(), join.getRight(), join.getCondition());
 
             // a merge join answers only some join types
             if (ClrEnumerableMergeJoin.IsMergeJoinSupported(join.getJoinType()) == false)
-                return null!;
+                return null;
 
             // a cartesian join could be merged too, and Calcite leaves it off for now
             if (info.pairs().isEmpty())
-                return null!;
+                return null;
 
             var newInputs = new java.util.ArrayList();
             var collations = new java.util.ArrayList();

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableMergeUnion.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableMergeUnion.cs
@@ -85,7 +85,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var sources = Expression.Variable(typeof(java.util.List), "mergeUnionInputs");
             var body = new List<Expression>
             {
-                Expression.Assign(sources, Expression.New(typeof(java.util.ArrayList).GetConstructor([])!)),
+                Expression.Assign(sources, Expression.New(ArrayListConstructor)),
             };
 
             for (int i = 0; i < getInputs().size(); i++)
@@ -115,7 +115,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             return implementor.Result(physType, Expression.Block(body[^1].Type, [sources], body));
         }
 
-        static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])!;
+        static readonly System.Reflection.ConstructorInfo ArrayListConstructor = typeof(java.util.ArrayList).GetConstructor([])
+            ?? throw new System.InvalidOperationException("java.util.ArrayList has no no-arg constructor.");
+
+        /// <summary>
+        /// <c>java.util.List.add</c>, which fills the list above.
+        /// </summary>
+        static readonly System.Reflection.MethodInfo CollectionAdd = typeof(java.util.List).GetMethod("add", [typeof(object)])
+            ?? throw new System.InvalidOperationException("java.util.List has no add(Object).");
 
     }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableNestedLoopJoin.cs
@@ -69,15 +69,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// preserve an ordering. Pushing a sort to the right does not help a right outer join either, because
         /// the unmatched right rows are produced together at the end.
         /// </remarks>
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
-            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet())!;
+            return ClrEnumerableTraitsUtils.PassThroughTraitsForJoin(required, joinType, getLeft().getRowType().getFieldCount(), getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
-            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet())!;
+            return ClrEnumerableTraitsUtils.DeriveTraitsForJoin(childTraits, childId, joinType, getTraitSet(), getRight().getTraitSet());
         }
 
         /// <inheritdoc />
@@ -90,7 +90,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
         {
             var rowCount = mq.getRowCount(this).doubleValue();
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableProject.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableProject.cs
@@ -53,18 +53,18 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             return ClrEnumerableTraitsUtils.PassThroughTraitsForProject(
                 required,
                 getProjects(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair deriveTraits(RelTraitSet childTraits, int childId)
+        public org.apache.calcite.util.Pair? deriveTraits(RelTraitSet childTraits, int childId)
         {
             return ClrEnumerableTraitsUtils.DeriveTraitsForProject(
                 childTraits,
@@ -72,7 +72,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 getProjects(),
                 getInput().getRowType(),
                 getInput().getCluster().getTypeFactory(),
-                getTraitSet())!;
+                getTraitSet());
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableProjectRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableProjectRule.cs
@@ -54,7 +54,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var project = (Project)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRecursionRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRecursionRules.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var union = (RepeatUnion)rel;
             var traitSet = union.getTraitSet().replace(ClrEnumerableConvention.Instance);
@@ -86,7 +86,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var spool = (TableSpool)rel;
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRel.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRel.cs
@@ -35,19 +35,19 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         ClrEnumerableResult Implement(ClrEnumerableRelImplementor implementor, ClrEnumerablePrefer pref);
 
         /// <inheritdoc cref="PhysicalNode.passThroughTraits" />
-        Pair PhysicalNode.passThroughTraits(RelTraitSet required) => null!;
+        Pair? PhysicalNode.passThroughTraits(RelTraitSet required) => null;
 
         /// <inheritdoc cref="PhysicalNode.deriveTraits" />
-        Pair PhysicalNode.deriveTraits(RelTraitSet childTraits, int childId) => null!;
+        Pair? PhysicalNode.deriveTraits(RelTraitSet childTraits, int childId) => null;
 
         /// <inheritdoc cref="PhysicalNode.getDeriveMode" />
         DeriveMode PhysicalNode.getDeriveMode() => DeriveMode.LEFT_FIRST;
 
         /// <inheritdoc cref="PhysicalNode.passThrough" />
-        RelNode PhysicalNode.passThrough(RelTraitSet required) => PhysicalNode.__DefaultMethods.passThrough(this, required);
+        RelNode? PhysicalNode.passThrough(RelTraitSet required) => PhysicalNode.__DefaultMethods.passThrough(this, required);
 
         /// <inheritdoc cref="PhysicalNode.derive(RelTraitSet, int)" />
-        RelNode PhysicalNode.derive(RelTraitSet childTraits, int childId) => PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
+        RelNode? PhysicalNode.derive(RelTraitSet childTraits, int childId) => PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
 
         /// <inheritdoc cref="PhysicalNode.derive(java.util.List)" />
         java.util.List PhysicalNode.derive(java.util.List inputTraits) => PhysicalNode.__DefaultMethods.derive(this, inputTraits);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSetOpRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSetOpRules.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var union = (Union)rel;
             var traitSet = rel.getCluster().traitSet().replace(ClrEnumerableConvention.Instance);
@@ -81,7 +81,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var intersect = (Intersect)rel;
             var traitSet = intersect.getTraitSet().replace(ClrEnumerableConvention.Instance);
@@ -120,7 +120,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var minus = (Minus)rel;
             var traitSet = rel.getTraitSet().replace(ClrEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortRule.cs
@@ -41,13 +41,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var sort = (Sort)rel;
 
             // a sort carrying an offset or a fetch belongs to ClrEnumerableLimitRule, not to this one
             if (sort.offset != null || sort.fetch != null)
-                return null!;
+                return null;
 
             var input = sort.getInput();
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
@@ -54,15 +54,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public org.apache.calcite.util.Pair passThroughTraits(RelTraitSet required)
+        public org.apache.calcite.util.Pair? passThroughTraits(RelTraitSet required)
         {
             if (isSimple(this) == false)
-                return null!;
+                return null;
 
             // a required trait set of another convention is refused rather than copied onto, for the reason
             // ClrEnumerableMergeJoin gives at more length
             if (required.getConvention() != getConvention())
-                return null!;
+                return null;
 
             var inputTraits = getInput().getTraitSet();
             var collation = required.getCollation() ?? throw new java.lang.NullPointerException($"collation trait is null, required traits are {required}");
@@ -93,7 +93,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             // the group keys do not cover the required keys, as in GROUP BY a, b ORDER BY a, b, c, and
             // nothing can be pushed down
-            return null!;
+            return null;
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregateRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregateRule.cs
@@ -52,13 +52,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// collation is empty; Calcite's rule builds the node anyway and its <c>implement</c> then fails. A
         /// global aggregate has nothing to sort by and belongs to <see cref="ClrEnumerableAggregate"/>.
         /// </remarks>
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var agg = (Aggregate)rel;
             if (Aggregate.isSimple(agg) == false)
-                return null!;
+                return null;
             if (agg.getGroupSet().isEmpty())
-                return null!;
+                return null;
 
             var inputTraits = rel.getCluster().traitSet()
                 .replace(ClrEnumerableConvention.Instance)

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableFunctionScanRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableFunctionScanRule.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var scan = (TableFunctionScan)rel;
             var traitSet = rel.getTraitSet().replace(ClrEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableScan.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableScan.cs
@@ -175,9 +175,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// Where a table had an index on the required collation keys this is where an index scan would be
         /// returned. There is none, and Calcite's own answer here is the same null.
         /// </remarks>
-        public RelNode passThrough(RelTraitSet required)
+        public RelNode? passThrough(RelTraitSet required)
         {
-            return null!;
+            return null;
         }
 
         /// <inheritdoc />
@@ -256,7 +256,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 var names = table.getQualifiedName();
 
                 return queryable.GetExpression(
-                    ((org.apache.calcite.jdbc.CalciteSchema)table.unwrap(typeof(org.apache.calcite.jdbc.CalciteSchema)))?.plus()!,
+                    ((org.apache.calcite.jdbc.CalciteSchema)table.unwrap(typeof(org.apache.calcite.jdbc.CalciteSchema)))?.plus(),
                     (string)names.get(names.size() - 1))
                     ?? throw new java.lang.IllegalStateException($"{table}.GetExpression returned null");
             }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableScanRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableScanRule.cs
@@ -50,7 +50,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <c>QueryableTable</c> passes regardless, because Calcite's own test tables leave
         /// <c>getExpression</c> unimplemented and are still readable.
         /// </remarks>
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var scan = (TableScan)rel;
             var relOptTable = scan.getTable();
@@ -65,7 +65,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             if (table is QueryableTable || relOptTable.getExpression(typeof(object)) != null)
                 return ClrEnumerableTableScan.Create(scan.getCluster(), relOptTable);
 
-            return null!;
+            return null;
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableToEnumerableConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableToEnumerableConverter.cs
@@ -71,11 +71,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// The same multiplier the other direction applies, for the same reason: what a converter costs is
         /// what the convention it produces costs against a typical one.
         /// </remarks>
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
         {
             var cost = base.computeSelfCost(planner, mq);
 
-            return cost == null ? null! : cost.multiplyBy(EnumerableConvention.COST_MULTIPLIER);
+            return cost?.multiplyBy(EnumerableConvention.COST_MULTIPLIER);
         }
 
         /// <inheritdoc />
@@ -109,22 +109,22 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             .getDeclaredMethod(nameof(JavaPlans.Bind), [typeof(ClrPlan<IEnumerable>), typeof(DataContext)]);
 
         /// <inheritdoc />
-        public Pair deriveTraits(RelTraitSet childTraits, int childId) => EnumerableRel.__DefaultMethods.deriveTraits(this, childTraits, childId);
+        public Pair? deriveTraits(RelTraitSet childTraits, int childId) => EnumerableRel.__DefaultMethods.deriveTraits(this, childTraits, childId);
 
         /// <inheritdoc />
         public DeriveMode getDeriveMode() => EnumerableRel.__DefaultMethods.getDeriveMode(this);
 
         /// <inheritdoc />
-        public Pair passThroughTraits(RelTraitSet required) => EnumerableRel.__DefaultMethods.passThroughTraits(this, required);
+        public Pair? passThroughTraits(RelTraitSet required) => EnumerableRel.__DefaultMethods.passThroughTraits(this, required);
 
         /// <inheritdoc />
-        public RelNode derive(RelTraitSet childTraits, int childId) => PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
+        public RelNode? derive(RelTraitSet childTraits, int childId) => PhysicalNode.__DefaultMethods.derive(this, childTraits, childId);
 
         /// <inheritdoc />
         public java.util.List derive(java.util.List inputTraits) => PhysicalNode.__DefaultMethods.derive(this, inputTraits);
 
         /// <inheritdoc />
-        public RelNode passThrough(RelTraitSet required) => PhysicalNode.__DefaultMethods.passThrough(this, required);
+        public RelNode? passThrough(RelTraitSet required) => PhysicalNode.__DefaultMethods.passThrough(this, required);
 
     }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableToEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableToEnumerableConverterRule.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             return new ClrEnumerableToEnumerableConverter(
                 rel.getCluster(),

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableValues.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableValues.cs
@@ -59,11 +59,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public RelNode passThrough(RelTraitSet required)
+        public RelNode? passThrough(RelTraitSet required)
         {
             var collation = required.getCollation();
             if (collation == null || collation.isDefault())
-                return null!;
+                return null;
 
             // a VALUES of 0 or 1 rows can be ordered by any collation
             if (tuples.size() > 1)
@@ -79,7 +79,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
                 // check whether the tuples are sorted by the required collations
                 if (ordering!.isOrdered(tuples) == false)
-                    return null!;
+                    return null;
             }
 
             // the tuples' order satisfies the collation, so a node carrying it is all that is needed

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableValuesRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableValuesRule.cs
@@ -50,7 +50,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// a <c>RelCompositeTrait to RelCollation</c> cast failure. That failure is
         /// <see cref="ClrEnumerableValues.passThrough"/> having been missing, not this.</para>
         /// </remarks>
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var values = (Values)rel;
             var enumerableValues = ClrEnumerableValues.Create(values.getCluster(), values.getRowType(), values.getTuples());

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
@@ -74,11 +74,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
         {
             var cost = base.computeSelfCost(planner, mq);
             if (cost == null)
-                return null!;
+                return null;
 
             return cost.multiplyBy(ClrEnumerableConvention.CostMultiplier);
         }
@@ -1001,7 +1001,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             public override java.util.List rexArguments() => rexArgs;
 
             /// <inheritdoc />
-            public override RexNode rexFilterArgument() => null!;
+            public override RexNode? rexFilterArgument() => null;
 
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindowRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindowRule.cs
@@ -37,7 +37,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             var window = (Window)rel;
             var traitSet = window.getTraitSet().replace(ClrEnumerableConvention.Instance);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysTypeImpl.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysTypeImpl.cs
@@ -482,7 +482,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             switch (fields.size())
             {
                 case 0:
-                    return Expression.Lambda(Expression.Field(null, JavaRowFormatExtensions.ComparableEmptyList), v1);
+                    return Expression.Lambda(JavaRowFormatExtensions.ComparableEmptyList, v1);
 
                 case 1:
                     var field0 = JavaLists.Int(fields, 0);
@@ -523,7 +523,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var v1 = Expression.Parameter(javaRowClass, "v1");
             if (fields.isEmpty())
-                return Expression.Lambda(Expression.Field(null, JavaRowFormatExtensions.ComparableEmptyList), v1);
+                return Expression.Lambda(JavaRowFormatExtensions.ComparableEmptyList, v1);
 
             var list = FieldReferences(v1, fields);
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverter.cs
@@ -44,11 +44,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelOptCost computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
         {
             var cost = base.computeSelfCost(planner, mq);
 
-            return cost == null ? null! : cost.multiplyBy(ClrEnumerableConvention.CostMultiplier);
+            return cost?.multiplyBy(ClrEnumerableConvention.CostMultiplier);
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverterRule.cs
@@ -40,7 +40,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
-        public override RelNode convert(RelNode rel)
+        public override RelNode? convert(RelNode rel)
         {
             return new EnumerableToClrEnumerableConverter(
                 rel.getCluster(),

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/JavaRowFormatExtensions.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/JavaRowFormatExtensions.cs
@@ -216,7 +216,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             public override Expression Record(Type rowClass, IReadOnlyList<Expression> expressions)
             {
                 if (expressions.Count == 0)
-                    return Expression.Field(null, UnitInstance);
+                    return UnitInstance;
 
                 var constructor = Constructor(rowClass, expressions.Count);
                 var parameters = constructor.GetParameters();
@@ -306,7 +306,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             public override Expression Record(Type rowClass, IReadOnlyList<Expression> expressions)
             {
                 if (expressions.Count == 0)
-                    return Expression.Field(null, ComparableEmptyList);
+                    return ComparableEmptyList;
 
                 return ClrEnumUtils.Convert(FlatList(expressions), typeof(java.util.List));
             }
@@ -458,16 +458,47 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ClrTypes.Resolve(BuiltInMethod.LIST6.method)];
 
         /// <summary>
+        /// Returns the expression reading a Java <c>static final</c> field.
+        /// </summary>
+        /// <param name="declaring"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        /// <remarks>
+        /// <b>IKVM does not compile one to a field of that name.</b> It emits a property, over a backing field
+        /// it renames — <c>FlatLists.COMPARABLE_EMPTY_LIST</c> is a <c>COMPARABLE_EMPTY_LIST</c> property over
+        /// a <c>__&lt;&gt;COMPARABLE_EMPTY_LIST</c> field — so that reading it from C# still runs the class
+        /// initializer, which is what Java guarantees and what a bare field read would skip. Measured:
+        /// <c>GetField("COMPARABLE_EMPTY_LIST")</c> answers nothing.
+        ///
+        /// <para>So a static member is read as an expression rather than held as a <see cref="FieldInfo"/>,
+        /// and the two are tried in the order <see cref="ClrTypes.Resolve(Expression, J.PseudoField)"/> tries
+        /// them — field first, because a CLR field of ours is a field.</para>
+        /// </remarks>
+        static Expression StaticMember(Type declaring, string name)
+        {
+            const BindingFlags Static = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+            if (declaring.GetField(name, Static) is FieldInfo field)
+                return Expression.Field(null, field);
+
+            if (declaring.GetProperty(name, Static) is PropertyInfo property)
+                return Expression.Property(null, property);
+
+            throw new InvalidOperationException($"'{declaring}' has no static field or property '{name}'.");
+        }
+
+        /// <summary>
         /// <c>FlatLists.COMPARABLE_EMPTY_LIST</c>, which is the row of a type with no fields.
         /// </summary>
-        public static readonly FieldInfo ComparableEmptyList = ClrTypes.FromClass(BuiltInMethod.COMPARABLE_EMPTY_LIST.field.getDeclaringClass())
-            .GetField(BuiltInMethod.COMPARABLE_EMPTY_LIST.field.getName(), BindingFlags.Public | BindingFlags.Static)!;
+        public static readonly Expression ComparableEmptyList = StaticMember(
+            ClrTypes.FromClass(BuiltInMethod.COMPARABLE_EMPTY_LIST.field.getDeclaringClass()),
+            BuiltInMethod.COMPARABLE_EMPTY_LIST.field.getName());
 
         /// <summary>
         /// <c>Unit.INSTANCE</c>, which is the row of a custom type with no fields.
         /// </summary>
-        static readonly FieldInfo UnitInstance = typeof(org.apache.calcite.runtime.Unit)
-            .GetField("INSTANCE", BindingFlags.Public | BindingFlags.Static)!;
+        static readonly Expression UnitInstance = StaticMember(typeof(org.apache.calcite.runtime.Unit), "INSTANCE");
 
     }
 

--- a/src/Apache.Calcite.Extensions/Interop/JavaDelegates.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaDelegates.cs
@@ -62,9 +62,11 @@ namespace Apache.Calcite.Extensions.Interop
             typeof(MH<,,,,,,,>),
             typeof(MH<,,,,,,,,>)];
 
-        static readonly MethodInfo LoadMethodType = typeof(ByteCodeHelper).GetMethod(nameof(ByteCodeHelper.LoadMethodType))!;
+        static readonly MethodInfo LoadMethodType = typeof(ByteCodeHelper).GetMethod(nameof(ByteCodeHelper.LoadMethodType))
+            ?? throw new InvalidOperationException($"'{nameof(ByteCodeHelper.LoadMethodType)}' is missing from {nameof(ByteCodeHelper)}.");
 
-        static readonly MethodInfo GetDelegateForInvokeExact = typeof(ByteCodeHelper).GetMethod(nameof(ByteCodeHelper.GetDelegateForInvokeExact))!;
+        static readonly MethodInfo GetDelegateForInvokeExact = typeof(ByteCodeHelper).GetMethod(nameof(ByteCodeHelper.GetDelegateForInvokeExact))
+            ?? throw new InvalidOperationException($"'{nameof(ByteCodeHelper.GetDelegateForInvokeExact)}' is missing from {nameof(ByteCodeHelper)}.");
 
         /// <summary>
         /// Returns a delegate of the given type that calls the given method or constructor.

--- a/src/Apache.Calcite.Extensions/Interop/JavaSequences.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaSequences.cs
@@ -148,7 +148,7 @@ namespace Apache.Calcite.Extensions.Interop
             IEnumerator<TSource> enumerator = source.GetEnumerator();
 
             /// <inheritdoc />
-            public object current() => enumerator.Current!;
+            public object? current() => enumerator.Current;
 
             /// <inheritdoc />
             public bool moveNext() => enumerator.MoveNext();

--- a/src/Apache.Calcite.Extensions/Interop/JavaValues.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaValues.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Apache.Calcite.Extensions.Adapter.Enumerable;
@@ -27,7 +28,7 @@ namespace Apache.Calcite.Extensions.Interop
         /// <typeparam name="T"></typeparam>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static T As<T>(object value)
+        public static T As<T>(object? value)
         {
             if (value is T typed)
                 return typed;
@@ -54,11 +55,15 @@ namespace Apache.Calcite.Extensions.Interop
         /// The other direction, and the one that matters more: handing back a boxed CLR int where the type
         /// factory says java.lang.Integer leaves two representations of one value loose in a plan, and whatever
         /// compares them fails.
+        ///
+        /// <para>Null is the one value it passes through, so a caller that has already ruled null out keeps
+        /// that knowledge across the call.</para>
         /// </remarks>
-        public static object From<T>(T value)
+        [return: NotNullIfNotNull(nameof(value))]
+        public static object? From<T>(T value)
         {
             if (value == null)
-                return null!;
+                return null;
 
             // the value's own type, not typeof(T). A boundary is crossed by a value, and the static type
             // parameter at these sites is nearly always object or a PhysType.RowType -- and a RowType is

--- a/src/Apache.Calcite.Extensions/Interop/JavaWrapped.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaWrapped.cs
@@ -15,7 +15,7 @@ namespace Apache.Calcite.Extensions.Interop
     /// </remarks>
     /// <param name="comparer"></param>
     /// <param name="element"></param>
-    sealed class JavaWrapped(EqualityComparer comparer, object element) : java.lang.Object
+    sealed class JavaWrapped(EqualityComparer comparer, object? element) : java.lang.Object
     {
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace Apache.Calcite.Extensions.Interop
         /// <param name="comparer"></param>
         /// <param name="element"></param>
         /// <returns></returns>
-        public static object Of(EqualityComparer? comparer, object element)
+        public static object? Of(EqualityComparer? comparer, object? element)
         {
             return comparer == null ? element : new JavaWrapped(comparer, element);
         }
@@ -34,7 +34,7 @@ namespace Apache.Calcite.Extensions.Interop
         /// </summary>
         /// <param name="element"></param>
         /// <returns></returns>
-        public static object Unwrap(object element)
+        public static object? Unwrap(object? element)
         {
             return element is JavaWrapped wrapped ? wrapped.Element : element;
         }
@@ -42,7 +42,7 @@ namespace Apache.Calcite.Extensions.Interop
         /// <summary>
         /// Gets the value wrapped.
         /// </summary>
-        public object Element => element;
+        public object? Element => element;
 
         /// <inheritdoc />
         public override int hashCode()
@@ -51,7 +51,7 @@ namespace Apache.Calcite.Extensions.Interop
         }
 
         /// <inheritdoc />
-        public override bool equals(object obj)
+        public override bool equals(object? obj)
         {
             return ReferenceEquals(this, obj) || (obj is JavaWrapped other && comparer.equal(element, other.Element));
         }

--- a/src/Apache.Calcite.Extensions/Linq4j/Function/DelegateFunction1.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Function/DelegateFunction1.cs
@@ -22,7 +22,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Function
         readonly Func<TArg, TResult> function = function ?? throw new ArgumentNullException(nameof(function));
 
         /// <inheritdoc />
-        public object apply(object arg)
+        public object? apply(object? arg)
         {
             return JavaValues.From(function(JavaValues.As<TArg>(arg)));
         }

--- a/src/Apache.Calcite.Extensions/Linq4j/Function/DelegateFunctions.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Function/DelegateFunctions.cs
@@ -21,7 +21,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Function
         readonly Func<TResult> function = function ?? throw new ArgumentNullException(nameof(function));
 
         /// <inheritdoc />
-        public object apply() => JavaValues.From(function());
+        public object? apply() => JavaValues.From(function());
 
     }
 
@@ -39,7 +39,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Function
         readonly Func<T0, T1, TResult> function = function ?? throw new ArgumentNullException(nameof(function));
 
         /// <inheritdoc />
-        public object apply(object arg0, object arg1) => JavaValues.From(function(JavaValues.As<T0>(arg0), JavaValues.As<T1>(arg1)));
+        public object? apply(object? arg0, object? arg1) => JavaValues.From(function(JavaValues.As<T0>(arg0), JavaValues.As<T1>(arg1)));
 
     }
 
@@ -56,7 +56,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Function
         readonly Func<T0, TResult> function = function ?? throw new ArgumentNullException(nameof(function));
 
         /// <inheritdoc />
-        public object apply(object arg0) => JavaValues.From(function(JavaValues.As<T0>(arg0)));
+        public object? apply(object? arg0) => JavaValues.From(function(JavaValues.As<T0>(arg0)));
 
     }
 

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/LixToClrTranslator.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/LixToClrTranslator.cs
@@ -576,13 +576,13 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
 
             return Expression.Block(typeof(void), [iterator, element],
                 Expression.Assign(iterator,
-                    Expression.Call(ClrEnumUtils.Convert(source, typeof(java.lang.Iterable)), typeof(java.lang.Iterable).GetMethod("iterator")!)),
+                    Expression.Call(ClrEnumUtils.Convert(source, typeof(java.lang.Iterable)), IterableIterator)),
                 Expression.Loop(
                     Expression.IfThenElse(
-                        Expression.Call(iterator, typeof(java.util.Iterator).GetMethod("hasNext")!),
+                        Expression.Call(iterator, IteratorHasNext),
                         Expression.Block(typeof(void),
                             Expression.Assign(element,
-                                ClrEnumUtils.Convert(Expression.Call(iterator, typeof(java.util.Iterator).GetMethod("next")!), element.Type)),
+                                ClrEnumUtils.Convert(Expression.Call(iterator, IteratorNext), element.Type)),
                             body),
                         Expression.Break(loop.Break)),
                     loop.Break,
@@ -1018,7 +1018,22 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// <summary>
         /// Concatenation, which is what Java's <c>+</c> means when either side is a string.
         /// </summary>
-        static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(object), typeof(object)])!;
+        static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(object), typeof(object)])
+            ?? throw new InvalidOperationException("String has no Concat(object, object).");
+
+        /// <summary>
+        /// The three members a for-each over a <c>java.lang.Iterable</c> is written against.
+        /// </summary>
+        static readonly MethodInfo IterableIterator = typeof(java.lang.Iterable).GetMethod("iterator")
+            ?? throw new InvalidOperationException("java.lang.Iterable has no iterator().");
+
+        /// <inheritdoc cref="IterableIterator" />
+        static readonly MethodInfo IteratorHasNext = typeof(java.util.Iterator).GetMethod("hasNext")
+            ?? throw new InvalidOperationException("java.util.Iterator has no hasNext().");
+
+        /// <inheritdoc cref="IterableIterator" />
+        static readonly MethodInfo IteratorNext = typeof(java.util.Iterator).GetMethod("next")
+            ?? throw new InvalidOperationException("java.util.Iterator has no next().");
 
         /// <summary>
         /// The operators that assign to their left operand, which therefore must be left alone rather than
@@ -1129,6 +1144,9 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
 
                 default:
                     var op = Operator(expression.getNodeType());
+
+                    // null is the documented way to say "no conversion type", and these operators take none.
+                    // The parameter is annotated non-nullable all the same, so the suppression is the BCL's
                     return Expression.MakeUnary(op, Widen(operand), null!);
             }
         }

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/SyntheticRecordEmitter.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/SyntheticRecordEmitter.cs
@@ -109,7 +109,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
             var il = constructor.GetILGenerator();
 
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, typeof(SyntheticRecord).GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, [])!);
+            il.Emit(OpCodes.Call, SyntheticRecordConstructor);
 
             for (int i = 0; i < parameters.Length; i++)
             {
@@ -120,6 +120,12 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
 
             il.Emit(OpCodes.Ret);
         }
+
+        /// <summary>
+        /// The base constructor every emitted record chains to.
+        /// </summary>
+        static readonly ConstructorInfo SyntheticRecordConstructor = typeof(SyntheticRecord).GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, [])
+            ?? throw new InvalidOperationException($"{nameof(SyntheticRecord)} has no no-arg constructor.");
 
     }
 

--- a/src/Apache.Calcite.Extensions/Prepare/PrepareContext.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PrepareContext.cs
@@ -72,9 +72,12 @@ namespace Apache.Calcite.Extensions.Prepare
             return list;
         }
 
-        public List getObjectPath()
+        /// <remarks>
+        /// <c>@Nullable</c>, and null is what a context that is not preparing a view returns.
+        /// </remarks>
+        public List? getObjectPath()
         {
-            return null!;
+            return null;
         }
 
         public CalciteConnectionConfig config()

--- a/src/Apache.Calcite.Extensions/Runtime/SyntheticRecord.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/SyntheticRecord.cs
@@ -33,10 +33,10 @@ namespace Apache.Calcite.Extensions.Runtime
         Members Of() => ByType.GetOrAdd(GetType(), Members.For);
 
         /// <inheritdoc />
-        public bool equals(object other) => Of().IsEqual(this, other);
+        public bool equals(object? other) => Of().IsEqual(this, other);
 
         /// <inheritdoc />
-        public override bool Equals(object? other) => Of().IsEqual(this, other!);
+        public override bool Equals(object? other) => Of().IsEqual(this, other);
 
         /// <inheritdoc />
         public int hashCode() => Of().HashOf(this);
@@ -48,10 +48,10 @@ namespace Apache.Calcite.Extensions.Runtime
         public override string ToString() => Of().PrintOf(this);
 
         /// <inheritdoc />
-        public int compareTo(object other) => Of().CompareOf(this, other);
+        public int compareTo(object? other) => Of().CompareOf(this, other);
 
         /// <inheritdoc />
-        public int CompareTo(object? other) => Of().CompareOf(this, other!);
+        public int CompareTo(object? other) => Of().CompareOf(this, other);
 
         /// <summary>
         /// The four members of one record type.
@@ -60,17 +60,17 @@ namespace Apache.Calcite.Extensions.Runtime
         /// <param name="hash"></param>
         /// <param name="compare"></param>
         /// <param name="print"></param>
-        sealed class Members(Func<object, object, bool> isEqual, Func<object, int> hash, Func<object, object, int> compare, Func<object, string> print)
+        sealed class Members(Func<object, object?, bool> isEqual, Func<object, int> hash, Func<object, object?, int> compare, Func<object, string> print)
         {
 
             /// <summary>Compares two records field by field.</summary>
-            public Func<object, object, bool> IsEqual { get; } = isEqual;
+            public Func<object, object?, bool> IsEqual { get; } = isEqual;
 
             /// <summary>Accumulates a hash over the fields.</summary>
             public Func<object, int> HashOf { get; } = hash;
 
             /// <summary>Orders two records field by field.</summary>
-            public Func<object, object, int> CompareOf { get; } = compare;
+            public Func<object, object?, int> CompareOf { get; } = compare;
 
             /// <summary>Renders a record.</summary>
             public Func<object, string> PrintOf { get; } = print;
@@ -99,7 +99,7 @@ namespace Apache.Calcite.Extensions.Runtime
             /// <param name="type"></param>
             /// <param name="fields"></param>
             /// <returns></returns>
-            static Func<object, object, bool> BuildEquals(Type type, FieldInfo[] fields)
+            static Func<object, object?, bool> BuildEquals(Type type, FieldInfo[] fields)
             {
                 var left = Expression.Parameter(typeof(object), "o0");
                 var right = Expression.Parameter(typeof(object), "o1");
@@ -123,13 +123,14 @@ namespace Apache.Calcite.Extensions.Runtime
                         Expression.Block([that], Expression.Assign(that, Expression.Convert(right, type)), body),
                         Expression.Constant(false)));
 
-                return Expression.Lambda<Func<object, object, bool>>(test, left, right).Compile();
+                return Expression.Lambda<Func<object, object?, bool>>(test, left, right).Compile();
             }
 
             /// <summary>
             /// <c>Objects.equal</c>, which Calcite's generated equals uses for a reference field.
             /// </summary>
-            static readonly MethodInfo ObjectsEqual = typeof(com.google.common.@base.Objects).GetMethod("equal", [typeof(object), typeof(object)])!;
+            static readonly MethodInfo ObjectsEqual = typeof(com.google.common.@base.Objects).GetMethod("equal", [typeof(object), typeof(object)])
+                ?? throw new InvalidOperationException("Guava's Objects has no equal(Object, Object).");
 
             /// <summary>
             /// Builds <c>hashCode</c>, accumulating one field at a time.
@@ -191,7 +192,7 @@ namespace Apache.Calcite.Extensions.Runtime
             /// <param name="type"></param>
             /// <param name="fields"></param>
             /// <returns></returns>
-            static Func<object, object, int> BuildCompare(Type type, FieldInfo[] fields)
+            static Func<object, object?, int> BuildCompare(Type type, FieldInfo[] fields)
             {
                 var left = Expression.Parameter(typeof(object), "o0");
                 var right = Expression.Parameter(typeof(object), "o1");
@@ -220,14 +221,16 @@ namespace Apache.Calcite.Extensions.Runtime
 
                 body.Add(Expression.Label(end, Expression.Constant(0)));
 
-                return Expression.Lambda<Func<object, object, int>>(Expression.Block([self, that, c], body), left, right).Compile();
+                return Expression.Lambda<Func<object, object?, int>>(Expression.Block([self, that, c], body), left, right).Compile();
             }
 
             /// <summary>
             /// <c>Utilities.compare(Comparable, Comparable)</c>, reached by a method taking objects.
             /// </summary>
             static readonly MethodInfo ComparableCompare = typeof(Apache.Calcite.Extensions.Interop.JavaComparisons)
-                .GetMethod(nameof(Apache.Calcite.Extensions.Interop.JavaComparisons.Compare), [typeof(object), typeof(object)])!;
+                
+                .GetMethod(nameof(Apache.Calcite.Extensions.Interop.JavaComparisons.Compare), [typeof(object), typeof(object)])
+                ?? throw new InvalidOperationException("JavaComparisons has no Compare(object, object).");
 
             /// <summary>
             /// Brings a field to the type the comparison takes.
@@ -301,9 +304,11 @@ namespace Apache.Calcite.Extensions.Runtime
                     Expression.Block([self], Expression.Assign(self, Expression.Convert(value, type)), text), value).Compile();
             }
 
-            static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(string), typeof(string)])!;
+            static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(string), typeof(string)])
+                ?? throw new InvalidOperationException("String has no Concat(string, string).");
             // Objects.toString rather than String.valueOf, whose helper IKVM keeps internal; both render a null as "null"
-            static readonly MethodInfo ValueOf = typeof(java.util.Objects).GetMethod("toString", [typeof(object)])!;
+            static readonly MethodInfo ValueOf = typeof(java.util.Objects).GetMethod("toString", [typeof(object)])
+                ?? throw new InvalidOperationException("java.util.Objects has no toString(Object).");
 
         }
 

--- a/src/Apache.Calcite.Extensions/Schema/IClrAsyncQueryableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrAsyncQueryableTable.cs
@@ -41,7 +41,8 @@ namespace Apache.Calcite.Extensions.Schema
         /// <summary>
         /// Returns the expression by which the plan reaches this table's rows.
         /// </summary>
-        /// <param name="schema">The schema the table was resolved in.</param>
+        /// <param name="schema">The schema the table was resolved in, which may be null for a table that
+        /// was not resolved through a catalog reader.</param>
         /// <param name="tableName">The name it was resolved by.</param>
         /// <returns>An expression whose type is
         /// <c>IAsyncEnumerable&lt;<see cref="ElementType"/>&gt;</c>.</returns>
@@ -60,7 +61,7 @@ namespace Apache.Calcite.Extensions.Schema
         /// downstream is Calcite's, and every boundary where a value crosses between the two runtimes is an
         /// adapter.</para>
         /// </remarks>
-        Expression GetAsyncExpression(SchemaPlus schema, string tableName);
+        Expression GetAsyncExpression(SchemaPlus? schema, string tableName);
 
     }
 

--- a/src/Apache.Calcite.Extensions/Schema/IClrQueryableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrQueryableTable.cs
@@ -48,7 +48,7 @@ namespace Apache.Calcite.Extensions.Schema
         ///
         /// <para>The values in a row are Java's, as they are for every table Calcite reads.</para>
         /// </remarks>
-        Expression GetExpression(SchemaPlus schema, string tableName);
+        Expression GetExpression(SchemaPlus? schema, string tableName);
 
     }
 

--- a/src/Apache.Calcite.Tests/AsyncTestSchema.cs
+++ b/src/Apache.Calcite.Tests/AsyncTestSchema.cs
@@ -32,7 +32,7 @@ namespace Apache.Calcite.Tests
         /// <summary>
         /// Partitions, ties, nulls and an order, so that a window has something to disagree over.
         /// </summary>
-        public static readonly object[][] Sales =
+        public static readonly object?[][] Sales =
         [
             [java.lang.Integer.valueOf(1), "EAST", java.lang.Integer.valueOf(10), "A"],
             [java.lang.Integer.valueOf(2), "EAST", java.lang.Integer.valueOf(20), "B"],
@@ -46,7 +46,7 @@ namespace Apache.Calcite.Tests
         /// Rows that arrive sorted by their first field, which is where a merge join and a merge union get
         /// the collation they are only ever chosen for.
         /// </summary>
-        public static readonly object[][] Sorted =
+        public static readonly object?[][] Sorted =
         [
             [java.lang.Integer.valueOf(1), "A"],
             [java.lang.Integer.valueOf(2), "B"],
@@ -67,11 +67,11 @@ namespace Apache.Calcite.Tests
         /// at twelve keys the map is a table of 16 and the copy a table of 32. <c>SALES</c> has six, which
         /// puts both at 16 and says nothing.
         /// </remarks>
-        public static readonly object[][] Wide = BuildWide();
+        public static readonly object?[][] Wide = BuildWide();
 
-        static object[][] BuildWide()
+        static object?[][] BuildWide()
         {
-            var rows = new object[12][];
+            var rows = new object?[12][];
             for (var i = 0; i < rows.Length; i++)
                 rows[i] = [string.Format("K{0:D2}", i + 1), java.lang.Integer.valueOf(i + 1)];
 
@@ -118,7 +118,7 @@ namespace Apache.Calcite.Tests
     /// <summary>
     /// A table of the synchronous convention over one of the shared row sets.
     /// </summary>
-    sealed class SyncRowsTable(object[][] rows, System.Func<RelDataTypeFactory, RelDataType> rowType, bool sorted) : AbstractTable, ScannableTable
+    sealed class SyncRowsTable(object?[][] rows, System.Func<RelDataTypeFactory, RelDataType> rowType, bool sorted) : AbstractTable, ScannableTable
     {
 
         /// <inheritdoc />
@@ -153,7 +153,7 @@ namespace Apache.Calcite.Tests
     /// this convention from the other one — every test would pass over a sequence that is asynchronous in
     /// name only, and an operator that dropped its continuation would look correct.
     /// </remarks>
-    sealed class AsyncRowsTable(object[][] rows, System.Func<RelDataTypeFactory, RelDataType> rowType, bool sorted) : AbstractTable, IClrAsyncScannableTable
+    sealed class AsyncRowsTable(object?[][] rows, System.Func<RelDataTypeFactory, RelDataType> rowType, bool sorted) : AbstractTable, IClrAsyncScannableTable
     {
 
         /// <summary>
@@ -198,9 +198,9 @@ namespace Apache.Calcite.Tests
         }
 
         /// <inheritdoc />
-        public IAsyncEnumerable<object[]> ScanAsync(DataContext root) => Rows();
+        public IAsyncEnumerable<object?[]> ScanAsync(DataContext root) => Rows();
 
-        async IAsyncEnumerable<object[]> Rows([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        async IAsyncEnumerable<object?[]> Rows([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             SawCancellableToken = cancellationToken.CanBeCanceled;
 

--- a/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDefaultsContractTests.cs
@@ -177,7 +177,7 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public void ShouldReadANullCorrelatedSequenceAsEmpty()
         {
-            ClrEnumerableDefaults.CorrelateJoin<int, string, string>(new[] { 1, 2 }, _ => null!, (a, b) => $"{a}:{b ?? "null"}", JoinType.LEFT)
+            ClrEnumerableDefaults.CorrelateJoin<int, string, string>(new[] { 1, 2 }, _ => null, (a, b) => $"{a}:{b ?? "null"}", JoinType.LEFT)
                 .ToList()
                 .Should()
                 .Equal("1:null", "2:null");

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -59,7 +59,7 @@ namespace Apache.Calcite.Tests
         sealed class SalesTable : AbstractTable, ScannableTable
         {
 
-            static readonly object[][] Rows =
+            static readonly object?[][] Rows =
             [
                 [java.lang.Integer.valueOf(1), "EAST", java.lang.Integer.valueOf(10), "A"],
                 [java.lang.Integer.valueOf(2), "EAST", java.lang.Integer.valueOf(20), "B"],
@@ -105,7 +105,7 @@ namespace Apache.Calcite.Tests
         sealed class SortedTable : AbstractTable, ScannableTable
         {
 
-            static readonly object[][] Rows =
+            static readonly object?[][] Rows =
             [
                 [java.lang.Integer.valueOf(1), "A"],
                 [java.lang.Integer.valueOf(2), "B"],
@@ -208,7 +208,7 @@ namespace Apache.Calcite.Tests
         sealed class WideTable : AbstractTable, ScannableTable
         {
 
-            static readonly object[][] Rows = BuildRows();
+            static readonly object?[][] Rows = BuildRows();
 
             static object[][] BuildRows()
             {
@@ -253,7 +253,7 @@ namespace Apache.Calcite.Tests
             const long Hour = 3600000L;
             const long Base = 1704067200000L;
 
-            static readonly object[][] Rows =
+            static readonly object?[][] Rows =
             [
                 [java.lang.Long.valueOf(Base), java.lang.Integer.valueOf(1)],
                 [java.lang.Long.valueOf(Base + (Hour / 6)), java.lang.Integer.valueOf(2)],

--- a/src/Apache.Calcite.Tests/ClrEnumerableQueryTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableQueryTests.cs
@@ -52,7 +52,7 @@ namespace Apache.Calcite.Tests
         sealed class PeopleTable : AbstractTable, ScannableTable
         {
 
-            static readonly object[][] Rows =
+            static readonly object?[][] Rows =
             [
                 [java.lang.Integer.valueOf(1), "SMITH", java.lang.Integer.valueOf(30), java.lang.Integer.valueOf(5)],
                 [java.lang.Integer.valueOf(2), "JONES", java.lang.Integer.valueOf(40), null],

--- a/src/Apache.Calcite.Tests/ClrPrepareFixture.cs
+++ b/src/Apache.Calcite.Tests/ClrPrepareFixture.cs
@@ -32,7 +32,7 @@ namespace Apache.Calcite.Tests
         sealed class SalesTable : AbstractTable, ScannableTable
         {
 
-            static readonly object[][] Rows =
+            static readonly object?[][] Rows =
             [
                 [java.lang.Integer.valueOf(1), "EAST", java.lang.Integer.valueOf(10), "A"],
                 [java.lang.Integer.valueOf(2), "EAST", java.lang.Integer.valueOf(20), "B"],
@@ -65,7 +65,7 @@ namespace Apache.Calcite.Tests
         sealed class OneColumnTable : AbstractTable, ScannableTable
         {
 
-            static readonly object[][] Rows =
+            static readonly object?[][] Rows =
             [
                 [java.lang.Integer.valueOf(3)],
                 [java.lang.Integer.valueOf(1)],

--- a/src/Apache.Calcite.Tests/ClrTableSpiTests.cs
+++ b/src/Apache.Calcite.Tests/ClrTableSpiTests.cs
@@ -71,7 +71,7 @@ namespace Apache.Calcite.Tests
             public override RelDataType getRowType(RelDataTypeFactory typeFactory) => AsyncTestRows.SortedRowType(typeFactory);
 
             /// <inheritdoc />
-            public Type ElementType => typeof(object[]);
+            public Type ElementType => typeof(object?[]);
 
             /// <inheritdoc />
             /// <remarks>
@@ -79,8 +79,8 @@ namespace Apache.Calcite.Tests
             /// through an interface call. Here it is a constant, which is the simplest expression that
             /// yields rows; a real table would inline a provider read.
             /// </remarks>
-            public Expression GetExpression(SchemaPlus schema, string tableName) =>
-                Expression.Constant(AsyncTestRows.Sorted, typeof(IEnumerable<object[]>));
+            public Expression GetExpression(SchemaPlus? schema, string tableName) =>
+                Expression.Constant(AsyncTestRows.Sorted, typeof(IEnumerable<object?[]>));
 
         }
 
@@ -94,10 +94,10 @@ namespace Apache.Calcite.Tests
             public override RelDataType getRowType(RelDataTypeFactory typeFactory) => AsyncTestRows.SortedRowType(typeFactory);
 
             /// <inheritdoc />
-            public Type ElementType => typeof(object[]);
+            public Type ElementType => typeof(object?[]);
 
             /// <inheritdoc />
-            public Expression GetAsyncExpression(SchemaPlus schema, string tableName) =>
+            public Expression GetAsyncExpression(SchemaPlus? schema, string tableName) =>
                 Expression.Call(null, RowsMethod, Expression.Default(typeof(CancellationToken)));
 
             static readonly System.Reflection.MethodInfo RowsMethod =
@@ -106,7 +106,7 @@ namespace Apache.Calcite.Tests
             /// <summary>
             /// The rows, suspending on each, so that a plan reading this really is asynchronous.
             /// </summary>
-            public static async IAsyncEnumerable<object[]> Rows([EnumeratorCancellation] CancellationToken cancellationToken = default)
+            public static async IAsyncEnumerable<object?[]> Rows([EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
                 foreach (var row in AsyncTestRows.Sorted)
                 {

--- a/src/Apache.Calcite.Tests/ZeroFieldRowTests.cs
+++ b/src/Apache.Calcite.Tests/ZeroFieldRowTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq.Expressions;
+
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.adapter.enumerable;
+using org.apache.calcite.jdbc;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Holds the two constants a row of no fields is, and the fact about IKVM that had them resolving to
+    /// nothing.
+    /// </summary>
+    /// <remarks>
+    /// <c>FlatLists.COMPARABLE_EMPTY_LIST</c> and <c>Unit.INSTANCE</c> are Java <c>static final</c> fields,
+    /// and <b>IKVM does not compile one to a CLR field of that name</b> — it emits a property over a backing
+    /// field it renames to <c>__&lt;&gt;NAME</c>, so that reading it from C# runs the class initializer the
+    /// way Java guarantees. <c>GetField</c> by the Java name answers nothing, and both of these were looked
+    /// up that way behind a <c>!</c>: null since they were written, and an NRE waiting for the first query
+    /// whose row type has no fields.
+    ///
+    /// <para>Nothing had ever reached that shape, which is why the suite was green over a null. These
+    /// evaluate the expressions rather than assert on their node type, because what was wrong was the
+    /// resolution and only running it settles that.</para>
+    /// </remarks>
+    [TestClass]
+    public class ZeroFieldRowTests
+    {
+
+        /// <summary>
+        /// The row a LIST format builds for a type with no fields.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBuildAnEmptyComparableListRow()
+        {
+            var row = Evaluate(JavaRowFormat.LIST.Record(typeof(java.util.List), []));
+
+            row.Should().BeSameAs(org.apache.calcite.runtime.FlatLists.COMPARABLE_EMPTY_LIST);
+            ((java.util.List)row).size().Should().Be(0);
+        }
+
+        /// <summary>
+        /// The row a CUSTOM format builds for a type with no fields, which is Calcite's unit value rather
+        /// than an instance of the record class.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBuildAUnitRow()
+        {
+            var row = Evaluate(JavaRowFormat.CUSTOM.Record(typeof(object), []));
+
+            row.Should().BeSameAs(org.apache.calcite.runtime.Unit.INSTANCE);
+        }
+
+        /// <summary>
+        /// The selector a physical type of no fields generates, which is the path a plan actually reaches
+        /// the constant through.
+        /// </summary>
+        [TestMethod]
+        public void ShouldGenerateASelectorForARowOfNoFields()
+        {
+            // two fields, so that the optimising overload leaves the format ARRAY rather than collapsing it
+            // to the field's own type
+            var typeFactory = new JavaTypeFactoryImpl();
+            var rowType = typeFactory.builder()
+                .add("A", typeFactory.createSqlType(org.apache.calcite.sql.type.SqlTypeName.INTEGER))
+                .add("B", typeFactory.createSqlType(org.apache.calcite.sql.type.SqlTypeName.VARCHAR))
+                .build();
+
+            var physType = ClrPhysTypeImpl.Of(typeFactory, rowType, JavaRowFormat.ARRAY);
+            var parameter = Expression.Parameter(physType.RowType, "v1");
+            var selector = physType.GenerateSelector(parameter, new java.util.ArrayList(), JavaRowFormat.LIST);
+
+            var row = selector.Compile().DynamicInvoke([new object[] { java.lang.Integer.valueOf(1), "x" }]);
+
+            row.Should().BeSameAs(org.apache.calcite.runtime.FlatLists.COMPARABLE_EMPTY_LIST);
+        }
+
+        /// <summary>
+        /// Runs an expression that takes nothing.
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        static object Evaluate(Expression expression)
+        {
+            return Expression.Lambda<Func<object>>(Expression.Convert(expression, typeof(object))).Compile()();
+        }
+
+    }
+
+}


### PR DESCRIPTION
`Nullable` is enabled across the tree, but IKVM-imported Java signatures are **oblivious** — the compiler
sees `Pair`, not `@Nullable Pair`. So every override of a Calcite member that may answer null was declared
non-nullable and then lied with `null!` at the return. That accounted for most of the 221 suppressions in
non-test code, now **45**.

## Declarations widened to what Calcite declares

Checked against `calcite-1.42.0` source, not the tree.

| member | Calcite |
|---|---|
| `PhysicalNode.passThroughTraits` / `deriveTraits` | `@Nullable Pair` |
| `PhysicalNode.passThrough` / `derive` | `@Nullable RelNode` |
| `ConverterRule.convert` | `@Nullable RelNode` |
| `RelNode.computeSelfCost` | `@Nullable RelOptCost` |
| `AggAddContext.rexFilterArgument` | `@Nullable RexNode` |
| `CalcitePrepare.Context.getObjectPath` | `@Nullable List<String>` |

## Our own declarations that were wrong

- **The three-valued mark join.** The marker, and the equi/non-equi predicates behind it, are `null` for
  UNKNOWN — that is the whole point of the operator — and all three were declared non-nullable.
- **Outer joins.** The result selector of ten join families is called with a row that is not there.
  `Cartesian` is the one join that cannot, and keeps its signature.
- **The correlate joins**, whose bodies already `?? []`-guarded an inner sequence they declared non-null.
- **`IClrQueryableTable.GetExpression`** — the doc comment already said the schema may be null; the
  signature said otherwise, and the scan passed `?.plus()!`.
- **The adapter boundary** — `JavaValues`, `JavaWrapped`, `JavaSequences`, the `DelegateFunction`s,
  `FuncFunction0/1` — carries whatever Calcite had, null included. `JavaValues.From` got
  `[return: NotNullIfNotNull]`, so a caller that has already ruled null out keeps that.
- **`DbCommand.CommandText`, `DbParameter.ParameterName`/`SourceColumn`** are `[AllowNull]` in the BCL; the
  overrides now carry it.
- **Test row arrays** holding a null value are `object?[][]`, matching `IClrScannableTable.Scan`, which was
  already right.

`CS8601`, `CS8604`, `CS8625` and `CS8765` go to zero, and no warning of any other code appears.

## Reflection lookups fail fast

`GetMethod(…)!` on a named member of a named type is exactly what goes null when an upgrade renames
something, and `!` turns that into an `NullReferenceException` somewhere unrelated. All 37 now use the
`?? throw` idiom this codebase already had in `ClrBuiltInMethod` and `AdoToClrEnumerableConverter`, so a
missing member fails at type init with its name. The six that ran per plan inside a method body are
`static readonly` fields, resolved once.

## Which found a live bug

Two of the 37 were **null, and had been since they were written**:

```
FlatLists has no COMPARABLE_EMPTY_LIST
```

**IKVM does not compile a Java `static final` field to a CLR field of that name.** It emits a *property*,
over a backing field renamed `__<>COMPARABLE_EMPTY_LIST`, so that reading it from C# still runs the class
initializer the way Java guarantees. `GetField("COMPARABLE_EMPTY_LIST")` answers nothing — measured.

So `JavaRowFormatExtensions.ComparableEmptyList` and `UnitInstance` were both null, and the four sites that
build a row of no fields — `ClrPhysTypeImpl.GenerateSelector`, `GenerateNullAwareAccessor`, and the `LIST`
and `CUSTOM` record builders — would have thrown on the first query whose row type has no fields. Nothing
had ever reached that shape, which is why the suite was green over it.

`ClrTypes.Resolve(target, PseudoField)` already tried field then property for this reason;
`JavaRowFormatExtensions` now does the same, and holds the two as `Expression` rather than `FieldInfo`.
`ZeroFieldRowTests` **evaluates** them and the zero-field selector rather than asserting on node types,
because what was wrong was the resolution — all three tests fail against the old code. The trap is written
into `CLAUDE.md`.

## Stale claims corrected

`CLAUDE.md` said two `CalciteDdlTests` were red for the 1.43 one-column DELETE. They were *skipped*, not
red, and `fc3621e` cleared them four commits before that claim was last edited — the tests' own `<remarks>`
still ended "Skipped, not deleted". Both corrected. The Janino fact underneath (CALCITE-7510 emits
`(int) sinkRow`, which Janino rejects) is still true and kept, now marked as a debt owed upstream that costs
this project nothing, because `ClrEnumerablePrepare` translates Calcite's tree rather than compiling it.

## What the remaining 45 are

`default!` on an unconstrained `T`; flow the compiler cannot follow (the `NestedLoopJoinOptimized` state
machine, `ordering!` after a loop guaranteed to run); three results of `MethodInfo.Invoke` /
`Activator.CreateInstance`, which really do return `object?`; `MHTypes[0]`, a deliberate null placeholder;
`Expression.MakeUnary(…, null!)`, where the BCL annotates non-null a parameter its own docs say to pass null
as; and the two `RexLiteral.bigDecimalValue(fetch)!`, which are the faithful port — Calcite's own
`EnumerableMergeUnionRule` dereferences the same `@Nullable` in the same place.

## Testing

653 core, 103 adapter, 281 data, on net8.0 and net10.0. Nothing skipped, no new build warnings of any code.
