### PR TITLE
Explain a plan of either convention

### DIFF
--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -336,6 +336,14 @@ plan to bind.
 text and returns a `ClrExplainResult`; `Describe` wraps that text in a `ClrExplainBindable`, which
 yields one row.
 
+It is read by either reader, and `ClrExplainBindable` is the only bindable that is both an
+`IClrBindable` and an `IClrAsyncBindable`. Not a relaxation of the rule that each convention refuses
+the other's reader — an `EXPLAIN` is of neither convention, holding a string rather than a plan, so
+there is no pull for an awaited reader to hide. **Which convention gets explained is still decided
+by which method was called**, because the plan is optimized under that program before it is
+rendered: `ExecuteReaderAsync` on an `EXPLAIN` renders `ClrAsyncEnumerable*` nodes, and fails to
+plan wherever the query itself would.
+
 ---
 
 ## Direct Engine Access

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -471,10 +471,10 @@ namespace Apache.Calcite.Data.Internal
                     // Wire the cancellation token to the Calcite cancel flag only here, where we
                     // are synchronously enumerating and need Calcite's check-points to be able to
                     // interrupt the loop. The registration is scoped to this block only.
-                    // Because prepareSql is called with elementType=Object[], the prefer hint is
-                    // ARRAY and cursorFactory is CursorFactory.ARRAY. Calcite therefore yields a
-                    // single Object[] row whose only element [0] is the ROWCOUNT BIGINT column
-                    // defined by RelOptUtil.createDmlRowType.
+                    // RelOptUtil.createDmlRowType gives DML one ROWCOUNT column, and
+                    // Meta.CursorFactory.deduce answers OBJECT for a single column before it looks at
+                    // the element type -- measured -- so the row is the boxed count itself and not an
+                    // array holding it. The array branch below is for a plan that says otherwise.
                     recordsAffected = 0;
                     using var _ = cancellationToken.Register(() => cancelFlag.set(true));
                     using var e = signature.Bind(dataContext).GetEnumerator();

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -261,7 +261,7 @@ cmd.RegisterHook(Hook.PROGRAM, /* ... */);
 
 Overloads accept a Java `Consumer`, a .NET `Action<object>`, or a primitive value to set as the hook's property. Connection hooks run before command hooks.
 
-`EXPLAIN PLAN FOR <query>` also works, and returns the rendered plan as a single row.
+`EXPLAIN PLAN FOR <query>` also works, and returns the rendered plan as a single row. It explains the plan the reader you called would have run: `ExecuteReader` renders `ClrEnumerable*` nodes and `ExecuteReaderAsync` renders `ClrAsyncEnumerable*` ones, since nothing in the SQL says which convention is wanted.
 
 ## Accessing the Calcite engine directly
 

--- a/src/Apache.Calcite.Extensions/Prepare/ClrExplainBindable.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrExplainBindable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
 using Apache.Calcite.Extensions.Runtime;
 
 using org.apache.calcite;
@@ -19,28 +20,50 @@ namespace Apache.Calcite.Extensions.Prepare
     /// <c>Prepare.prepareSql</c> answers an <c>EXPLAIN</c> with a <c>PreparedExplain</c> rather than going
     /// through <c>implement</c>, so there is no plan of any convention to compile — the text is already in
     /// hand. This is <c>CalcitePreparedExplain.getBindable</c>, which wraps that text in a singleton
-    /// enumerable, written against <see cref="IClrBindable"/> instead.
+    /// enumerable, written against <see cref="IClrBindableBase"/> instead.
+    ///
+    /// <para><b>It answers both interfaces, and it is the only thing that does.</b> Every other prepared
+    /// result is one convention's and refuses the other's reader, because a sequence that has to be pulled
+    /// is not one that can be awaited. This one holds a string. Which convention the plan behind the text
+    /// was optimized into was settled at prepare time — <c>ExecuteReader</c> or <c>ExecuteReaderAsync</c> is
+    /// the only way that demand is stated, so an <c>EXPLAIN</c> asked for asynchronously renders the
+    /// asynchronous plan — and by the time the row is bound there is nothing left of that plan to be
+    /// faithful to. Refusing the asynchronous reader here would mean an <c>EXPLAIN</c> could not be read at
+    /// all by a caller who only has that method.</para>
     /// </remarks>
-    sealed class ClrExplainBindable(string explanation, Meta.CursorFactory cursorFactory) : IClrBindable
+    sealed class ClrExplainBindable(string explanation, Meta.CursorFactory cursorFactory) : IClrBindable, IClrAsyncBindable
     {
 
         readonly string explanation = explanation ?? throw new ArgumentNullException(nameof(explanation));
         readonly Meta.CursorFactory cursorFactory = cursorFactory ?? throw new ArgumentNullException(nameof(cursorFactory));
 
         /// <inheritdoc />
-        public IEnumerable<object> Bind(DataContext root)
+        IEnumerable<object> IClrBindable.Bind(DataContext root)
         {
             ArgumentNullException.ThrowIfNull(root);
 
-            yield return IsArray ? new[] { explanation } : explanation;
+            return [Row];
+        }
+
+        /// <inheritdoc />
+        IAsyncEnumerable<object> IClrAsyncBindable.Bind(DataContext root)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+
+            return ClrAsyncEnumerableDefaults.Singleton(Row);
         }
 
         /// <inheritdoc />
         /// <remarks>
-        /// A CLR type, as the interface says, and the rows really are these: <see cref="Bind"/> yields a
+        /// A CLR type, as the interface says, and the rows really are these: <see cref="Row"/> is a
         /// <see cref="string"/> or a <c>string[]</c> and nothing here goes near the type factory.
         /// </remarks>
         public Type ElementType => IsArray ? typeof(string[]) : typeof(string);
+
+        /// <summary>
+        /// Returns the row, which is the text or an array holding it.
+        /// </summary>
+        object Row => IsArray ? new[] { explanation } : explanation;
 
         /// <summary>
         /// Returns whether the row is an array holding the text rather than the text itself.

--- a/src/Apache.Calcite.Extensions/Prepare/ClrSignature.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrSignature.cs
@@ -127,6 +127,10 @@ namespace Apache.Calcite.Extensions.Prepare
         /// Either convention's, because a statement is described the same way whichever prepared it and this
         /// type reads nothing of the plan but its element type. <see cref="Bind"/> and
         /// <see cref="BindAsync"/> are where the two part company, and each refuses the other's.
+        ///
+        /// <para>An <c>EXPLAIN</c> is neither, and answers both: it never reached <c>implement</c>, so what
+        /// is held is a rendered string rather than a plan, and there is no pull behind it for an awaited
+        /// reader to hide.</para>
         /// </remarks>
         public IClrBindableBase? Bindable { get; }
 
@@ -172,6 +176,9 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <see cref="Bind"/> for a statement prepared into the asynchronous convention. It refuses a
         /// synchronous plan rather than wrapping one: an <see cref="IEnumerable{T}"/> behind an awaited
         /// interface is a blocking pull, and a caller that asked for this method asked not to have one.
+        ///
+        /// <para>An <c>EXPLAIN</c> passes, because <c>ClrExplainBindable</c> is both. Not an exception to
+        /// that rule — there is no plan behind it to pull.</para>
         /// </remarks>
         public IAsyncEnumerable<object> BindAsync(DataContext root)
         {

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
@@ -101,6 +101,110 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// An EXPLAIN of a query over an asynchronous table renders the asynchronous plan, and is read
+        /// asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// An <c>EXPLAIN</c> leaves <c>Prepare.prepareSql</c> before <c>implement</c>, so what the signature
+        /// carries is a rendered string and not a plan of either convention — but the plan it rendered was
+        /// optimized under whichever program was asked for, and <c>ExecuteReaderAsync</c> is the only way
+        /// that demand is stated. So the text names this convention's nodes.
+        ///
+        /// <para>It used to throw: <c>ClrExplainBindable</c> was an <c>IClrBindable</c> alone and
+        /// <c>ClrSignature.BindAsync</c> refused it as "prepared into a synchronous convention", which was
+        /// never true of an <c>EXPLAIN</c> and left a caller holding only <c>ExecuteReaderAsync</c> unable to
+        /// explain anything at all.</para>
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldExplainAnAsyncPlanAsynchronously()
+        {
+            var (c, table) = Open();
+            using (c)
+            {
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "EXPLAIN PLAN FOR SELECT ID FROM SALES WHERE REGION = 'EAST'";
+
+                using var reader = await cmd.ExecuteReaderAsync();
+
+                (await reader.ReadAsync()).Should().BeTrue();
+                reader.GetString(0).Should().Contain("ClrAsyncEnumerable");
+                (await reader.ReadAsync()).Should().BeFalse("an EXPLAIN is one row");
+
+                table.Produced.Should().Be(0, "explaining a query does not run it");
+            }
+        }
+
+        /// <summary>
+        /// The same EXPLAIN over the same table renders a different plan depending on which reader asked
+        /// for it.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="SyncRowsTable"/> can be planned either way, so this is the whole of the point:
+        /// nothing in the SQL says which convention to explain, and <c>ExecuteReader</c> against
+        /// <c>ExecuteReaderAsync</c> is where that is decided — for an <c>EXPLAIN</c> exactly as for the
+        /// query it explains.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldExplainTheConventionThatWasAskedFor()
+        {
+            using var c = new CalciteConnection(Model);
+            c.Open();
+            c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+
+            const string Sql = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
+
+            string synchronous;
+            using (var cmd = c.CreateCommand())
+            {
+                cmd.CommandText = Sql;
+                using var reader = cmd.ExecuteReader();
+                reader.Read().Should().BeTrue();
+                synchronous = reader.GetString(0);
+            }
+
+            string asynchronous;
+            using (var cmd = c.CreateCommand())
+            {
+                cmd.CommandText = Sql;
+                using var reader = await cmd.ExecuteReaderAsync();
+                (await reader.ReadAsync()).Should().BeTrue();
+                asynchronous = reader.GetString(0);
+            }
+
+            synchronous.Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
+            asynchronous.Should().Contain("ClrAsyncEnumerable");
+        }
+
+        /// <summary>
+        /// An EXPLAIN read as a scalar is the plan, by either method.
+        /// </summary>
+        /// <remarks>
+        /// <c>ExecuteScalar</c> and <c>ExecuteScalarAsync</c> are the reader path with one row and one column
+        /// taken off it — the same two demands for a convention, so the same two answers. A caller reaching
+        /// for the plan as a string is the likely one, and it is a column of a result set like any other:
+        /// <c>Meta.CursorFactory.deduce</c> makes a single column <c>OBJECT</c>, so the row <i>is</i> the
+        /// text.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldExplainThroughExecuteScalar()
+        {
+            using var c = new CalciteConnection(Model);
+            c.Open();
+            c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
+
+            var synchronous = cmd.ExecuteScalar();
+            var asynchronous = await cmd.ExecuteScalarAsync();
+
+            synchronous.Should().BeOfType<string>()
+                .Which.Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
+            asynchronous.Should().BeOfType<string>()
+                .Which.Should().Contain("ClrAsyncEnumerable");
+        }
+
+        /// <summary>
         /// A query over an ordinary Calcite table plans asynchronously.
         /// </summary>
         /// <remarks>

--- a/src/Apache.Calcite.Tests/ClrPrepareBehaviourTests.cs
+++ b/src/Apache.Calcite.Tests/ClrPrepareBehaviourTests.cs
@@ -45,6 +45,27 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// A one-column result is the value and a wider one is an array, whatever element type the caller
+        /// asked to prefer.
+        /// </summary>
+        /// <remarks>
+        /// <c>Meta.CursorFactory.deduce</c> answers <c>OBJECT</c> for a single column before it looks at the
+        /// class at all, so preparing with <c>Object[]</c> — which every caller here does — does not make a
+        /// one-column row an array. An <c>EXPLAIN</c> is one column, and so is DML's <c>ROWCOUNT</c>.
+        /// </remarks>
+        [TestMethod]
+        [DataRow("SELECT ID FROM SALES", "OBJECT")]
+        [DataRow("SELECT ID, REGION FROM SALES", "ARRAY")]
+        [DataRow("EXPLAIN PLAN FOR SELECT ID FROM SALES", "OBJECT")]
+        public void Cursor_style_should_follow_the_column_count(string sql, string expected)
+        {
+            var style = ClrPrepareFixture.WithContext(sql, (context, _) =>
+                new ClrPrepareImpl().Prepare(context, sql, (java.lang.Class)typeof(object[]), -1).CursorFactory.style.name());
+
+            Assert.AreEqual(expected, style, sql);
+        }
+
+        /// <summary>
         /// <c>getTypeName</c> rewrites seven interval names and renders the collection types by
         /// <c>toString</c>. Everything else is the SQL type's own name.
         /// </summary>


### PR DESCRIPTION
An `EXPLAIN` leaves `Prepare.prepareSql` before `implement`, so what the signature carries is a rendered string rather than a plan of any convention. `ClrExplainBindable` was an `IClrBindable` alone, and `ClrSignature.BindAsync` refused it as *"prepared into a synchronous convention"* — which was never true of an `EXPLAIN`, and left a caller holding only `ExecuteReaderAsync` or `ExecuteScalarAsync` unable to explain anything at all. Measured before the change:

```
CalciteException: Failed to execute Calcite statement.
 ---> InvalidOperationException: EXPLAIN PLAN FOR SELECT ID FROM SALES was prepared into a
      synchronous convention; read it with Bind.
      at ClrSignature.BindAsync(DataContext root) ClrSignature.cs:183
```

The plan was optimized and rendered correctly; it was thrown away on the way out.

`ClrExplainBindable` now answers both interfaces. That is not a relaxation of the rule that each convention refuses the other's reader — the rule exists because an `IEnumerable` behind an awaited interface is a blocking pull, and there is no pull behind a string rendered at prepare time.

**Which convention gets explained is still decided by which method was called**, because nothing in the SQL says: `ExecuteReader` renders `ClrEnumerable*` nodes, `ExecuteReaderAsync` renders `ClrAsyncEnumerable*` ones, and an `EXPLAIN` fails to plan wherever the query it explains would. `ExecuteScalar` / `ExecuteScalarAsync` needed no code change — they are the reader path with one row and one column taken off it — but were unproven, so they are tested rather than assumed.

Tests are in `ClrAsyncEnumerableAdoNetTests`, whose rule is to assert which convention ran:

- `ShouldExplainAnAsyncPlanAsynchronously` — over the async-only table: one row, names `ClrAsyncEnumerable`, leaf produced nothing.
- `ShouldExplainTheConventionThatWasAskedFor` — over a table plannable both ways, the same SQL through the two readers renders the two plans.
- `ShouldExplainThroughExecuteScalar` — the same pair through the scalar methods.

Found on the way: the comment on DML's row in `CalciteSession.ExecuteNonQuery` said the cursor factory is `ARRAY` because prepare is called with `Object[]`. It is `OBJECT` — `deduce` answers `OBJECT` for a single column before it looks at the element type, and DML's row type is one `ROWCOUNT` column, so that branch is dead there. No behaviour change; the measurement is now `Cursor_style_should_follow_the_column_count` rather than a comment.

659 + 316 + 105 pass, nothing skipped.
