### PR TITLE
Converters between the two Clr calling conventions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -151,9 +151,13 @@ tree is smaller than the CLR's, so going the other way means deciding what to do
 no node for, and the answer for some of it will be "nothing". Worth doing when the boundary starts to
 matter; not before.
 
-Note the asynchronous convention needs none of this. It reads a Calcite sub-plan and never feeds one — no
-plan can put a Calcite node above an asynchronous one, because Calcite cannot read an
-`IClrAsyncScannableTable` — so it has no converter out and nothing to translate.
+Note the asynchronous convention needs none of this. It reads a Calcite sub-plan and never feeds one — there
+is no converter from it to `EnumerableConvention` and there cannot be, because Janino compiles generated
+source and generated source cannot await — so there is nothing on that side to translate. Its converters to
+and from `ClrEnumerableConvention` need no translation either: both sides are `System.Linq.Expressions` and
+both share `ClrPhysType`, so the sub-plan's expression is spliced into the tree being built and wrapped in
+one call. `ClrAsyncEnumerableToClrEnumerableConverter` is the one that costs something, and what it costs is
+a blocked thread per row rather than a compilation boundary.
 
 ## Audit findings: 45 operators, twelve agents, one method group each
 

--- a/src/Apache.Calcite.Data/CalciteCommand.cs
+++ b/src/Apache.Calcite.Data/CalciteCommand.cs
@@ -294,7 +294,9 @@ namespace Apache.Calcite.Data
         /// <inheritdoc />
         /// <remarks>
         /// Asks for a synchronous plan, because the reader it returns will be read with
-        /// <c>DbDataReader.Read</c>, which refuses to block on an asynchronous one.
+        /// <c>DbDataReader.Read</c>. A reader over an asynchronous plan answers that too, by blocking --
+        /// <c>CalciteResult</c> says why it has to -- and asking for the synchronous plan here is what keeps
+        /// a caller who never touched an <c>Async</c> method off that path.
         /// </remarks>
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
@@ -305,10 +307,16 @@ namespace Apache.Calcite.Data
         /// <inheritdoc />
         /// <remarks>
         /// Prepares into the asynchronous convention, and <b>throws where the query cannot be planned into
-        /// it</b> — where it touches a table that is not an <c>IClrAsyncScannableTable</c>, there being no
-        /// converter to carry those rows. Preparing the synchronous plan instead would hand back a reader
-        /// that looks asynchronous and blocks a thread per row, which a caller cannot tell from the outside.
-        /// <see cref="ExecuteReader()"/> is how a caller asks for that plan deliberately.
+        /// it</b>. The prepare pipeline puts one convention's rules on the planner and not the other's, so
+        /// although converters exist between the two Clr conventions, no plan prepared here mixes them and a
+        /// query the asynchronous rules cannot cover has nowhere to go. Preparing the synchronous plan
+        /// instead would hand back a reader that looks asynchronous and blocks a thread per row, which a
+        /// caller cannot tell from the outside. <see cref="ExecuteReader()"/> is how a caller asks for that
+        /// plan deliberately.
+        ///
+        /// <para>A table Calcite can scan is not that case: it is planned in <c>EnumerableConvention</c> and
+        /// <c>EnumerableToClrAsyncEnumerableConverter</c> carries its rows, which costs a state machine and
+        /// no thread.</para>
         /// </remarks>
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {

--- a/src/Apache.Calcite.Data/CalciteDataReader.cs
+++ b/src/Apache.Calcite.Data/CalciteDataReader.cs
@@ -108,10 +108,12 @@ namespace Apache.Calcite.Data
 
         /// <inheritdoc />
         /// <remarks>
-        /// Refuses where the rows come from a plan of the asynchronous convention, rather than blocking on
-        /// it. That block is the sync-over-async this convention exists to avoid — it deadlocks on a
-        /// synchronization context and wastes a thread everywhere else — and this is the one place a caller
-        /// could reach it by accident. A reader over an asynchronous plan has <see cref="ReadAsync"/>.
+        /// Blocks where the rows come from a plan of the asynchronous convention, and does not refuse:
+        /// <c>DbDataReader.Read</c> is a contract a generic consumer calls, and a provider whose reader
+        /// throws there is not a provider. <c>CalciteResult</c> has the argument, and
+        /// <c>CalciteAsyncEnumerableResult.Read</c> is where the block happens. The usual caution applies — a
+        /// synchronization context can deadlock on it — and a reader over an asynchronous plan has
+        /// <see cref="ReadAsync"/>.
         /// </remarks>
         public override bool Read()
         {

--- a/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
@@ -35,11 +35,13 @@ namespace Apache.Calcite.Data.Internal
         /// consumer that knows nothing but the ADO.NET interface calls it, and a provider whose reader
         /// throws there is not one.
         ///
-        /// <para>This is not the sync-over-async the convention refuses. That rule is about what a plan
-        /// does inside itself, where a converter would insert blocking nobody chose; a caller reaching for
-        /// <c>Read</c> on a reader they asked to be asynchronous is choosing it in the open. The usual
-        /// caution applies -- a synchronization context can deadlock on it -- and <see cref="ReadAsync"/>
-        /// is how to avoid that.</para>
+        /// <para>This is not the sync-over-async the surface refuses, and the line is about who chose. A
+        /// plan can block inside itself too -- <c>ClrAsyncEnumerableToClrEnumerableConverter</c> does, once
+        /// per row -- and what makes that refusable is that the planner would be choosing it for a caller
+        /// who could not see it, which is why the prepare pipeline never registers the rules that would put
+        /// one on a plan. A caller reaching for <c>Read</c> on a reader they asked to be asynchronous is
+        /// choosing it in the open. The usual caution applies -- a synchronization context can deadlock on
+        /// it -- and <see cref="ReadAsync"/> is how to avoid that.</para>
         /// </remarks>
         public override bool Read()
         {

--- a/src/Apache.Calcite.Data/Internal/CalciteResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResult.cs
@@ -26,10 +26,13 @@ namespace Apache.Calcite.Data.Internal
     /// throws there is not a provider. So a synchronous plan answers <c>ReadAsync</c> with a completed
     /// task, and an asynchronous plan blocks in <c>Read</c>.</para>
     ///
-    /// <para>Neither is the sync-over-async this convention refuses. That rule is about a <em>plan's</em>
-    /// internals, where a converter would insert blocking nobody asked for and nobody could see. Here the
-    /// caller is choosing, in the open, at the boundary -- which is where every ADO.NET provider blocks and
-    /// what <c>Read</c> on an asynchronous source means.</para>
+    /// <para>Neither is the sync-over-async this surface refuses, and the line is about who chose. A
+    /// <em>plan's</em> internals can block too — <c>ClrAsyncEnumerableToClrEnumerableConverter</c> is exactly
+    /// that, one blocked thread per row — and what makes it refusable there is that the planner would be
+    /// choosing it, invisibly, on behalf of a caller who asked for nothing of the sort. That is why the
+    /// prepare pipeline registers one convention's rules and not both, and so never produces a plan holding
+    /// one. Here the caller is choosing, in the open, at the boundary -- which is where every ADO.NET
+    /// provider blocks and what <c>Read</c> on an asynchronous source means.</para>
     /// </remarks>
     internal abstract class CalciteResult : IDisposable, IAsyncDisposable
     {

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -376,15 +376,18 @@ namespace Apache.Calcite.Data.Internal
         /// <exception cref="CalciteException">Thrown when planning or execution fails, <b>including where the
         /// query cannot be planned asynchronously at all</b>.</exception>
         /// <remarks>
-        /// <b>There is no fallback.</b> <c>ClrAsyncEnumerableConvention</c> has no converter to any other, so
-        /// a query touching a table that is not an <c>IClrAsyncScannableTable</c> cannot be planned and this
-        /// throws. Preparing the synchronous plan instead would hand back a reader that looks asynchronous
-        /// and blocks a thread per row, which is the one thing this convention exists to refuse -- and a
-        /// caller cannot tell the difference from the outside, so the failure has to be visible.
+        /// <b>There is no fallback.</b> The planner this goes to carries the asynchronous convention's rules
+        /// and not the synchronous one's, so a query touching a table that is not an
+        /// <c>IClrAsyncScannableTable</c> cannot be planned and this throws. Preparing the synchronous plan
+        /// instead would hand back a reader that looks asynchronous and blocks a thread per row, which is the
+        /// one thing this convention exists to refuse -- and a caller cannot tell the difference from the
+        /// outside, so the failure has to be visible.
         ///
-        /// <para>If a fallback is ever wanted it will come from a converter, which would make the mixed plan
-        /// one the planner chose and costed rather than a second plan substituted behind the caller's
-        /// back.</para>
+        /// <para><c>ClrEnumerableToClrAsyncEnumerableConverter</c> is what a fallback would be built from,
+        /// and it exists; what does not exist is a decision to register both rule sets here. Doing so would
+        /// make the mixed plan one the planner chose and costed rather than a second plan substituted behind
+        /// the caller's back — but it would also let a plan block a thread per row without saying so, which
+        /// is why it is not the default.</para>
         ///
         /// <para>A caller that wants the synchronous plan asks for it: <see cref="ExecuteReader"/>.</para>
         /// </remarks>
@@ -435,9 +438,9 @@ namespace Apache.Calcite.Data.Internal
         /// <remarks>
         /// Synchronous, and <see cref="ExecuteNonQueryAsync"/> is this method in a completed task. There is
         /// no asynchronous DML and there cannot be one: a table modification is not a node either of these
-        /// conventions implements -- the synchronous one reaches Calcite's across a converter, and the
-        /// asynchronous one has no converter -- so a write is planned into <c>ClrEnumerableConvention</c>
-        /// whichever entry point asked for it.
+        /// conventions implements, and only the synchronous one reaches Calcite's across a converter -- there
+        /// is no converter to <c>EnumerableConvention</c> from the asynchronous one and cannot be -- so a
+        /// write is planned into <c>ClrEnumerableConvention</c> whichever entry point asked for it.
         /// </remarks>
         public CalciteEnumerableResult ExecuteNonQuery(CalciteExecuteRequest request, CancellationToken cancellationToken)
         {

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConvention.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConvention.cs
@@ -22,12 +22,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
     /// of the plan that comes out is a <see cref="ClrAsyncEnumerableRel"/>, and
     /// <see cref="ClrAsyncEnumerableRelImplementor.ImplementRoot"/> turns it into a lambda to compile.</para>
     ///
-    /// <para><b>A plan cannot hold nodes of any other convention.</b> There is no converter to
-    /// <c>EnumerableConvention</c> or to <see cref="ClrEnumerableConvention"/> and there will not be: an
-    /// <see cref="System.Collections.Generic.IEnumerable{T}"/> behind an awaited interface is a blocking
-    /// pull, and the reverse is sync over async. So a query this convention cannot cover whole does not plan
-    /// at all, and the planner throws rather than quietly falling back to a plan that would block a thread
-    /// per row. Its leaves are <see cref="Schema.IClrAsyncScannableTable"/> and nothing else.</para>
+    /// <para><b>A plan may hold nodes of another convention, and what that costs depends on the
+    /// direction.</b> Reading a <c>EnumerableConvention</c> or a <see cref="ClrEnumerableConvention"/>
+    /// sub-plan as one of these costs a state machine and no thread — the sub-plan is pulled, so nothing
+    /// suspends, and it is simply not asynchronous over that part of itself. Reading one of <em>these</em> as
+    /// a <see cref="ClrEnumerableConvention"/> sub-plan blocks a thread once per row, because an
+    /// <see cref="System.Collections.Generic.IEnumerable{T}"/> has nowhere to suspend; that converter is
+    /// registered with the convention it produces.</para>
+    ///
+    /// <para>There is no converter to <c>EnumerableConvention</c> and there will not be. Calcite compiles its
+    /// side with Janino from generated source, which cannot await, so a Calcite node above an asynchronous
+    /// one would have to block inside a block this convention does not write.</para>
     /// </remarks>
     public sealed class ClrAsyncEnumerableConvention : Convention.Impl
     {

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRelImplementor.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRelImplementor.cs
@@ -43,12 +43,31 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="rexBuilder">The builder for row expressions, from the plan's cluster.</param>
         /// <param name="internalParameters">The map values are stashed into, which must be the one the
         /// <see cref="DataContext"/> will serve at run time.</param>
-        public ClrAsyncEnumerableRelImplementor(RexBuilder rexBuilder, java.util.Map internalParameters)
+        public ClrAsyncEnumerableRelImplementor(RexBuilder rexBuilder, java.util.Map internalParameters) :
+            this(rexBuilder, internalParameters, Expression.Parameter(typeof(DataContext), "root"))
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance implementing a sub-plan of a plan already being implemented.
+        /// </summary>
+        /// <param name="rexBuilder">The builder for row expressions, from the plan's cluster.</param>
+        /// <param name="internalParameters">The map values are stashed into, which must be the one the
+        /// <see cref="DataContext"/> will serve at run time.</param>
+        /// <param name="root">The parameter the <see cref="DataContext"/> arrives by, which must be the one
+        /// the enclosing plan's lambda declares.</param>
+        /// <remarks>
+        /// <c>ClrEnumerableRelImplementor</c>'s overload of the same shape, and for the same reason: a
+        /// converter between the two Clr conventions splices the sub-plan into the tree it is building, so
+        /// the sub-plan has to read the <see cref="DataContext"/> by the parameter that tree already has.
+        /// </remarks>
+        public ClrAsyncEnumerableRelImplementor(RexBuilder rexBuilder, java.util.Map internalParameters, ParameterExpression root)
         {
             this.rexBuilder = rexBuilder ?? throw new ArgumentNullException(nameof(rexBuilder));
             this.map = internalParameters ?? throw new ArgumentNullException(nameof(internalParameters));
 
-            Root = Expression.Parameter(typeof(DataContext), "root");
+            Root = root ?? throw new ArgumentNullException(nameof(root));
             Translator = new LixToClrTranslator(map);
             Translator.Bind(DataContext.ROOT, Root);
 
@@ -213,6 +232,37 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <summary>
+        /// Registers on Calcite's implementor every correlation variable in scope here.
+        /// </summary>
+        /// <param name="enumerable"></param>
+        /// <remarks>
+        /// <c>ClrEnumerableRelImplementor.ReplayCorrelVariables</c>, which says why: a sub-plan run on a
+        /// second implementor finds that implementor's correlation variables, and they are none, so
+        /// <c>RexToLixTranslator.visitFieldAccess</c> reads a null getter. A sub-plan of Calcite's under a
+        /// correlate of this convention is exactly that case.
+        /// </remarks>
+        internal void ReplayCorrelVariables(EnumerableRelImplementor enumerable)
+        {
+            foreach (var pair in corrVars)
+                enumerable.registerCorrelVariable(pair.Key, pair.Value.Parameter, pair.Value.Block, pair.Value.PhysType);
+        }
+
+        /// <summary>
+        /// Registers on the synchronous convention's implementor every correlation variable in scope here.
+        /// </summary>
+        /// <param name="clr"></param>
+        /// <remarks>
+        /// <see cref="ReplayCorrelVariables(EnumerableRelImplementor)"/> across the other converter. Here the
+        /// registration really is the same one — both implementors hold the same kind of getter over the same
+        /// block — so nothing is rebuilt.
+        /// </remarks>
+        internal void ReplayCorrelVariables(ClrEnumerableRelImplementor clr)
+        {
+            foreach (var pair in corrVars)
+                clr.RegisterCorrelVariable(pair.Key, pair.Value.Parameter, pair.Value.Block, pair.Value.PhysType);
+        }
+
+        /// <summary>
         /// Creates the result a node's <c>Implement</c> returns.
         /// </summary>
         /// <param name="physType">How the rows are represented.</param>
@@ -237,8 +287,10 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// there: a check with a way out is a check only for the shapes that already pass.
         ///
         /// <para>Requiring the asynchronous interface specifically is also what keeps the two conventions
-        /// from meeting by accident. A synchronous sequence reaching a node of this convention is a
-        /// converter nobody wrote, and this is where it is caught.</para>
+        /// from meeting by accident. There is a converter between them —
+        /// <see cref="ClrEnumerableToClrAsyncEnumerableConverter"/> — and a synchronous sequence reaching a
+        /// node of this convention by any other route is a crossing the planner did not make and nobody
+        /// costed. This is where that is caught.</para>
         /// </remarks>
         static void RequireRowType(ClrPhysType physType, Expression expression)
         {

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableRules.cs
@@ -164,12 +164,6 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         public static readonly RelOptRule ClrAsyncEnumerableProjectToCalcRule = Apache.Calcite.Extensions.Adapter.AsyncEnumerable.ClrAsyncEnumerableProjectToCalcRule.Create();
 
         /// <summary>
-        /// Rule that reads a plan of <c>EnumerableConvention</c> as one of this convention.
-        /// </summary>
-        public static readonly RelOptRule EnumerableToClrEnumerableConverterRule = Apache.Calcite.Extensions.Adapter.Enumerable.EnumerableToClrEnumerableConverterRule.Create();
-
-
-        /// <summary>
         /// Rule that converts an aggregate over a sorted input to a
         /// <see cref="ClrAsyncEnumerableSortedAggregate"/>.
         /// </summary>
@@ -195,37 +189,54 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// Rule that reads a plan of <c>EnumerableConvention</c> as one of this convention.
         /// </summary>
         /// <remarks>
-        /// The only converter this convention has, and it goes one way. It lets a query be planned partly
-        /// here and partly by Calcite, which is what stops a node this convention has none of — a table
-        /// function, a MATCH_RECOGNIZE, an interpreted transient scan — from making the whole query
-        /// unplannable.
+        /// It lets a query be planned partly here and partly by Calcite, which is what stops a node this
+        /// convention has none of — a table function, a MATCH_RECOGNIZE, an interpreted transient scan — from
+        /// making the whole query unplannable. The sub-plan under it is not asynchronous and nothing can make
+        /// it so; that is a fact about the sub-plan rather than about the converter.
         ///
-        /// <para>There is no converter out. Calcite cannot read an
-        /// <see cref="Schema.IClrAsyncScannableTable"/> by any route, so a Calcite node can never sit above
-        /// an asynchronous one; a query that would need it does not plan, and that is the right answer
-        /// rather than a gap, because the alternative blocks once per row.</para>
+        /// <para>There is no converter out to <c>EnumerableConvention</c>, and there cannot be: Calcite
+        /// compiles its side with Janino from generated source, which cannot await. A Calcite node above an
+        /// asynchronous one would have to block, and it would have to do so inside a block this convention
+        /// does not write.</para>
         /// </remarks>
         public static readonly RelOptRule EnumerableToClrAsyncEnumerableConverterRule = Apache.Calcite.Extensions.Adapter.AsyncEnumerable.EnumerableToClrAsyncEnumerableConverterRule.Create();
+
+        /// <summary>
+        /// Rule that reads a plan of <see cref="ClrEnumerableConvention"/> as one of this convention.
+        /// </summary>
+        /// <remarks>
+        /// The cheap crossing between the two Clr conventions: the sub-plan's expression is spliced into the
+        /// tree being built and wrapped in a sequence that never suspends, so it costs a state machine and no
+        /// thread. The way back is
+        /// <c>ClrEnumerableRules.ClrAsyncEnumerableToClrEnumerableConverterRule</c>, which blocks, and which
+        /// is registered with the convention it produces rather than here.
+        /// </remarks>
+        public static readonly RelOptRule ClrEnumerableToClrAsyncEnumerableConverterRule = Apache.Calcite.Extensions.Adapter.AsyncEnumerable.ClrEnumerableToClrAsyncEnumerableConverterRule.Create();
 
         /// <summary>
         /// The rules registered by default.
         /// </summary>
         /// <remarks>
         /// The counterpart of <c>EnumerableRules.ENUMERABLE_RULES</c>, holding what that holds for the nodes
-        /// this convention has, plus the two converters that let one plan hold both conventions. Read through
-        /// <see cref="Rules"/>, as Calcite's is read through <c>rules()</c>.
+        /// this convention has, plus the two converters that read another convention's sub-plan as one of
+        /// these. Read through <see cref="Rules"/>, as Calcite's is read through <c>rules()</c>.
         ///
         /// <para>Membership is the synchronous convention's list less what this one cannot cover. Gone are
-        /// the two converters -- an IEnumerable behind an awaited interface is async over sync and the
-        /// reverse is sync over async, so this convention has none in either direction and a query it cannot
-        /// plan whole throws rather than falling back. Gone with them are the interpreter rule, whose
-        /// Interpreter is a pull based Enumerable, and the table function scan, whose two paths both hand a
-        /// linq4j Enumerable through a generator of Calcite's.</para>
+        /// the interpreter rule, whose Interpreter is a pull based Enumerable, and the table function scan,
+        /// whose two paths both hand a linq4j Enumerable through a generator of Calcite's; both are covered
+        /// by leaving the node in <c>EnumerableConvention</c> under the converter in.</para>
+        ///
+        /// <para><b>Both converters here go one way, into this convention.</b> A rule producing another
+        /// convention's node belongs to that convention's list, and the way back to
+        /// <see cref="ClrEnumerableConvention"/> is registered there, in
+        /// <c>ClrEnumerableRules.ClrAsyncEnumerableToClrEnumerableConverterRule</c>. There is no way back to
+        /// <c>EnumerableConvention</c> at all, for the reason
+        /// <see cref="EnumerableToClrAsyncEnumerableConverterRule"/> gives.</para>
         ///
         /// <para>The repeat union and the table spool are left out although both nodes exist. The spool's
         /// write is fine; the iterative side scans the TransientTable it filled, only Calcite's interpreter
-        /// reads one, and with no converter there is nothing to carry those rows. WITH RECURSIVE therefore
-        /// does not plan here, and will not until there is an asynchronous transient table.</para>
+        /// reads one, and nothing carries those rows back. WITH RECURSIVE therefore does not plan here, and
+        /// will not until there is an asynchronous transient table.</para>
         ///
         /// <para>What is left is Calcite's list less the match and table modify
         /// rules. Match cannot be written at all; modification is out of scope, so a
@@ -257,7 +268,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             ClrAsyncEnumerableCollectRule,
             ClrAsyncEnumerableUncollectRule,
             EnumerableToClrAsyncEnumerableConverterRule,
-            EnumerableToClrEnumerableConverterRule,
+            ClrEnumerableToClrAsyncEnumerableConverterRule,
         ];
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverter.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+using Apache.Calcite.Extensions.Runtime;
+
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+
+namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
+{
+
+    /// <summary>
+    /// Relational operator that reads the result of a <see cref="ClrEnumerableConvention"/> sub-plan as a
+    /// <see cref="ClrAsyncEnumerableConvention"/> one.
+    /// </summary>
+    /// <remarks>
+    /// The cheap direction, and the exact counterpart of
+    /// <see cref="EnumerableToClrAsyncEnumerableConverter"/> over a sub-plan that is already
+    /// <see cref="System.Linq.Expressions"/>: <see cref="ClrSequences.ToAsyncEnumerable{TSource}"/> costs a
+    /// state machine and no thread, because nothing under it ever suspends.
+    ///
+    /// <para><b>The sub-plan is not asynchronous and this does not make it so.</b> A sequence that always
+    /// completes synchronously is not the sync-over-async the convention refuses — that is a caller blocked
+    /// waiting, which is <see cref="ClrAsyncEnumerableToClrEnumerableConverter"/>. A plan reading a
+    /// synchronous sub-plan this way is simply not asynchronous over that part of itself, and the part above
+    /// it still is.</para>
+    ///
+    /// <para>Nothing is translated, stashed or rebuilt. Both sides are
+    /// <see cref="System.Linq.Expressions"/> and both share <c>ClrPhysType</c>, so the sub-plan's expression
+    /// is spliced into the tree being built — which is why the sub-implementor is given the enclosing plan's
+    /// <c>Root</c>.</para>
+    /// </remarks>
+    public class ClrEnumerableToClrAsyncEnumerableConverter : ConverterImpl, ClrAsyncEnumerableRel
+    {
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <param name="traits"></param>
+        /// <param name="input"></param>
+        public ClrEnumerableToClrAsyncEnumerableConverter(RelOptCluster cluster, RelTraitSet traits, RelNode input) :
+            base(cluster, ConventionTraitDef.INSTANCE, traits, input)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode copy(RelTraitSet traitSet, java.util.List inputs)
+        {
+            return new ClrEnumerableToClrAsyncEnumerableConverter(getCluster(), traitSet, (RelNode)sole(inputs));
+        }
+
+        /// <inheritdoc />
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        {
+            var cost = base.computeSelfCost(planner, mq);
+
+            return cost?.multiplyBy(ClrAsyncEnumerableConvention.CostMultiplier);
+        }
+
+        /// <inheritdoc />
+        public ClrAsyncEnumerableResult Implement(ClrAsyncEnumerableRelImplementor implementor, ClrEnumerablePrefer pref)
+        {
+            // the same map, so a value the sub-plan stashes reaches the DataContext this plan is bound with,
+            // and the same root, so the spliced expression reads the parameter this plan's lambda declares
+            var clr = new ClrEnumerableRelImplementor(implementor.RexBuilder, implementor.Map, implementor.Root);
+
+            // and the same correlation variables, because a synchronous sub-plan under a correlate of this
+            // convention reads the outer row through them
+            implementor.ReplayCorrelVariables(clr);
+
+            var result = clr.VisitChild(null, 0, (ClrEnumerableRel)getInput(), pref);
+
+            // the physical type crosses unchanged. It is not merely equivalent -- ClrPhysType is one class,
+            // shared by both conventions, because a row is the same thing in each
+            var physType = result.PhysType;
+
+            return implementor.Result(physType,
+                ClrAsyncBuiltInMethod.Call(ToAsyncEnumerableMethod.MakeGenericMethod(physType.RowType), result.Expression));
+        }
+
+        /// <summary>
+        /// <see cref="ClrSequences.ToAsyncEnumerable{TSource}"/>, which yields the sub-plan's rows without
+        /// suspending.
+        /// </summary>
+        /// <remarks>
+        /// Called through <see cref="ClrAsyncBuiltInMethod.Call"/> rather than
+        /// <c>Expression.Call</c>, because it ends in a <see cref="System.Threading.CancellationToken"/> like
+        /// every other operator of this convention, and that is what appends the <c>default</c> the
+        /// <c>[EnumeratorCancellation]</c> attribute reads.
+        /// </remarks>
+        static readonly MethodInfo ToAsyncEnumerableMethod = typeof(ClrSequences).GetMethod(nameof(ClrSequences.ToAsyncEnumerable), BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"'{nameof(ClrSequences.ToAsyncEnumerable)}' is missing from {nameof(ClrSequences)}.");
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverterRule.cs
@@ -1,0 +1,55 @@
+using java.util.function;
+
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+
+namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
+{
+
+    /// <summary>
+    /// Rule that converts a <see cref="ClrEnumerableConvention"/> node to a
+    /// <see cref="ClrAsyncEnumerableConvention"/> one.
+    /// </summary>
+    public class ClrEnumerableToClrAsyncEnumerableConverterRule : ConverterRule
+    {
+
+        /// <summary>
+        /// Creates a <see cref="ClrEnumerableToClrAsyncEnumerableConverterRule"/>.
+        /// </summary>
+        /// <returns></returns>
+        public static ClrEnumerableToClrAsyncEnumerableConverterRule Create()
+        {
+            return (ClrEnumerableToClrAsyncEnumerableConverterRule)Config.INSTANCE
+                .withConversion(
+                    (java.lang.Class)typeof(RelNode),
+                    ClrEnumerableConvention.Instance,
+                    ClrAsyncEnumerableConvention.Instance,
+                    "ClrEnumerableToClrAsyncEnumerableConverterRule")
+                .withRuleFactory(new DelegateFunction<Config, ClrEnumerableToClrAsyncEnumerableConverterRule>(c => new ClrEnumerableToClrAsyncEnumerableConverterRule(c)))
+                .toRule(typeof(ClrEnumerableToClrAsyncEnumerableConverterRule));
+        }
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="config"></param>
+        public ClrEnumerableToClrAsyncEnumerableConverterRule(Config config) :
+            base(config)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode? convert(RelNode rel)
+        {
+            return new ClrEnumerableToClrAsyncEnumerableConverter(
+                rel.getCluster(),
+                rel.getTraitSet().replace(ClrAsyncEnumerableConvention.Instance),
+                rel);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverter.cs
@@ -66,6 +66,10 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the same map, so a value Calcite stashes reaches the DataContext this plan is bound with
             var enumerable = new EnumerableRelImplementor(implementor.RexBuilder, implementor.Map);
 
+            // and the same correlation variables, because a sub-plan of Calcite's under a correlate of this
+            // convention reads the outer row through them
+            implementor.ReplayCorrelVariables(enumerable);
+
             var result = enumerable.visitChild(null, 0, (EnumerableRel)getInput(), pref.ToCalcite());
 
             // a physical type is a type factory, a row type and a format, and theirs answers all three

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverter.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Runtime;
+
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+
+namespace Apache.Calcite.Extensions.Adapter.Enumerable
+{
+
+    /// <summary>
+    /// Relational operator that reads the result of a <see cref="ClrAsyncEnumerableConvention"/> sub-plan as
+    /// a <see cref="ClrEnumerableConvention"/> one.
+    /// </summary>
+    /// <remarks>
+    /// The expensive direction, and the one the asynchronous convention was written to make unnecessary:
+    /// <see cref="ClrSequences.ToEnumerable{TSource}"/> blocks the calling thread once per row, because an
+    /// <see cref="IEnumerable{T}"/> has nowhere to suspend. Nothing about the node hides that — a plan
+    /// holding one is a plan that blocks, and the cost model does not know it.
+    ///
+    /// <para><b>It is nonetheless the cheapest converter in the tree to build.</b> Both sides are
+    /// <see cref="System.Linq.Expressions"/> and both sides share <c>ClrPhysType</c>, so there is no
+    /// translation, no stash, no callback and no physical type to rebuild: the sub-plan's expression is
+    /// spliced into the tree being built and wrapped in one call. That is why the sub-implementor is given
+    /// the enclosing plan's <c>Root</c> — the two trees are one tree.</para>
+    ///
+    /// <para>What it buys is that a query whose leaves are asynchronous can still be read by a caller that
+    /// wants an <see cref="IEnumerable{T}"/> — an ADO.NET reader driven synchronously, most of all — instead
+    /// of failing to plan.</para>
+    /// </remarks>
+    public class ClrAsyncEnumerableToClrEnumerableConverter : ConverterImpl, ClrEnumerableRel
+    {
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <param name="traits"></param>
+        /// <param name="input"></param>
+        public ClrAsyncEnumerableToClrEnumerableConverter(RelOptCluster cluster, RelTraitSet traits, RelNode input) :
+            base(cluster, ConventionTraitDef.INSTANCE, traits, input)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode copy(RelTraitSet traitSet, java.util.List inputs)
+        {
+            return new ClrAsyncEnumerableToClrEnumerableConverter(getCluster(), traitSet, (RelNode)sole(inputs));
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// What a converter costs is what the convention it produces costs against a typical one, which is
+        /// what every other converter here charges. The blocking is not in the cost, and cannot honestly be
+        /// put there: <c>VolcanoCost.isLt</c> compares the row count and nothing else — cpu and io are dead
+        /// code behind <c>if (true)</c> — so a multiplier is the only lever, and one large enough to express
+        /// "this blocks a thread" would also stop the planner choosing the converter where it is the only way
+        /// to plan the query at all.
+        /// </remarks>
+        public override RelOptCost? computeSelfCost(RelOptPlanner planner, org.apache.calcite.rel.metadata.RelMetadataQuery mq)
+        {
+            var cost = base.computeSelfCost(planner, mq);
+
+            return cost?.multiplyBy(ClrEnumerableConvention.CostMultiplier);
+        }
+
+        /// <inheritdoc />
+        public ClrEnumerableResult Implement(ClrEnumerableRelImplementor implementor, ClrEnumerablePrefer pref)
+        {
+            // the same map, so a value the sub-plan stashes reaches the DataContext this plan is bound with,
+            // and the same root, so the spliced expression reads the parameter this plan's lambda declares
+            var async = new ClrAsyncEnumerableRelImplementor(implementor.RexBuilder, implementor.Map, implementor.Root);
+
+            // and the same correlation variables, because an asynchronous sub-plan under a correlate of this
+            // convention reads the outer row through them
+            implementor.ReplayCorrelVariables(async);
+
+            var result = async.VisitChild(null, 0, (ClrAsyncEnumerableRel)getInput(), pref);
+
+            // the physical type crosses unchanged. It is not merely equivalent -- ClrPhysType is one class,
+            // shared by both conventions, because a row is the same thing in each
+            var physType = result.PhysType;
+
+            return implementor.Result(physType,
+                Expression.Call(null, ToEnumerableMethod.MakeGenericMethod(physType.RowType), result.Expression));
+        }
+
+        /// <summary>
+        /// <see cref="ClrSequences.ToEnumerable{TSource}"/>, which blocks on each row of the sub-plan.
+        /// </summary>
+        static readonly MethodInfo ToEnumerableMethod = typeof(ClrSequences).GetMethod(nameof(ClrSequences.ToEnumerable), BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"'{nameof(ClrSequences.ToEnumerable)}' is missing from {nameof(ClrSequences)}.");
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverterRule.cs
@@ -1,0 +1,55 @@
+using java.util.function;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+
+namespace Apache.Calcite.Extensions.Adapter.Enumerable
+{
+
+    /// <summary>
+    /// Rule that converts a <see cref="ClrAsyncEnumerableConvention"/> node to a
+    /// <see cref="ClrEnumerableConvention"/> one.
+    /// </summary>
+    public class ClrAsyncEnumerableToClrEnumerableConverterRule : ConverterRule
+    {
+
+        /// <summary>
+        /// Creates a <see cref="ClrAsyncEnumerableToClrEnumerableConverterRule"/>.
+        /// </summary>
+        /// <returns></returns>
+        public static ClrAsyncEnumerableToClrEnumerableConverterRule Create()
+        {
+            return (ClrAsyncEnumerableToClrEnumerableConverterRule)Config.INSTANCE
+                .withConversion(
+                    (java.lang.Class)typeof(RelNode),
+                    ClrAsyncEnumerableConvention.Instance,
+                    ClrEnumerableConvention.Instance,
+                    "ClrAsyncEnumerableToClrEnumerableConverterRule")
+                .withRuleFactory(new DelegateFunction<Config, ClrAsyncEnumerableToClrEnumerableConverterRule>(c => new ClrAsyncEnumerableToClrEnumerableConverterRule(c)))
+                .toRule(typeof(ClrAsyncEnumerableToClrEnumerableConverterRule));
+        }
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="config"></param>
+        public ClrAsyncEnumerableToClrEnumerableConverterRule(Config config) :
+            base(config)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode? convert(RelNode rel)
+        {
+            return new ClrAsyncEnumerableToClrEnumerableConverter(
+                rel.getCluster(),
+                rel.getTraitSet().replace(ClrEnumerableConvention.Instance),
+                rel);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRelImplementor.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRelImplementor.cs
@@ -44,12 +44,33 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="rexBuilder">The builder for row expressions, from the plan's cluster.</param>
         /// <param name="internalParameters">The map values are stashed into, which must be the one the
         /// <see cref="DataContext"/> will serve at run time.</param>
-        public ClrEnumerableRelImplementor(RexBuilder rexBuilder, java.util.Map internalParameters)
+        public ClrEnumerableRelImplementor(RexBuilder rexBuilder, java.util.Map internalParameters) :
+            this(rexBuilder, internalParameters, Expression.Parameter(typeof(DataContext), "root"))
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance implementing a sub-plan of a plan already being implemented.
+        /// </summary>
+        /// <param name="rexBuilder">The builder for row expressions, from the plan's cluster.</param>
+        /// <param name="internalParameters">The map values are stashed into, which must be the one the
+        /// <see cref="DataContext"/> will serve at run time.</param>
+        /// <param name="root">The parameter the <see cref="DataContext"/> arrives by, which must be the one
+        /// the enclosing plan's lambda declares.</param>
+        /// <remarks>
+        /// A converter whose two sides are both <see cref="System.Linq.Expressions"/> splices the sub-plan
+        /// into the tree it is building rather than compiling it separately, so the sub-plan has to read the
+        /// <see cref="DataContext"/> by the parameter that tree already has. An implementor that made its own
+        /// would produce an expression referring to a parameter the enclosing lambda does not declare, which
+        /// fails at <c>Compile</c> rather than here.
+        /// </remarks>
+        public ClrEnumerableRelImplementor(RexBuilder rexBuilder, java.util.Map internalParameters, ParameterExpression root)
         {
             this.rexBuilder = rexBuilder ?? throw new ArgumentNullException(nameof(rexBuilder));
             this.map = internalParameters ?? throw new ArgumentNullException(nameof(internalParameters));
 
-            Root = Expression.Parameter(typeof(DataContext), "root");
+            Root = root ?? throw new ArgumentNullException(nameof(root));
             Translator = new LixToClrTranslator(map);
             Translator.Bind(DataContext.ROOT, Root);
 
@@ -247,6 +268,22 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         {
             foreach (var pair in corrVars)
                 enumerable.registerCorrelVariable(pair.Key, pair.Value.Parameter, pair.Value.Block, pair.Value.PhysType);
+        }
+
+        /// <summary>
+        /// Registers on the asynchronous convention's implementor every correlation variable in scope here.
+        /// </summary>
+        /// <param name="async"></param>
+        /// <remarks>
+        /// <see cref="ReplayCorrelVariables(EnumerableRelImplementor)"/> across the other converter, and for
+        /// the same reason: a sub-plan run on a second implementor finds that implementor's correlation
+        /// variables, which are none. Here the registration really is the same one — both implementors hold
+        /// the same kind of getter over the same block — so nothing is rebuilt.
+        /// </remarks>
+        internal void ReplayCorrelVariables(AsyncEnumerable.ClrAsyncEnumerableRelImplementor async)
+        {
+            foreach (var pair in corrVars)
+                async.RegisterCorrelVariable(pair.Key, pair.Value.Parameter, pair.Value.Block, pair.Value.PhysType);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRules.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableRules.cs
@@ -176,6 +176,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         public static readonly RelOptRule ClrEnumerableToEnumerableConverterRule = Apache.Calcite.Extensions.Adapter.Enumerable.ClrEnumerableToEnumerableConverterRule.Create();
 
         /// <summary>
+        /// Rule that reads a plan of <see cref="ClrAsyncEnumerableConvention"/> as one of this convention.
+        /// </summary>
+        /// <remarks>
+        /// The converter it produces blocks a thread once per row, because an <c>IEnumerable</c> has nowhere
+        /// to suspend. It is in the list all the same: the alternative to a plan that blocks is a query that
+        /// does not plan, and the caller who asked for this convention over an asynchronous table asked for
+        /// the rows synchronously.
+        /// </remarks>
+        public static readonly RelOptRule ClrAsyncEnumerableToClrEnumerableConverterRule = Apache.Calcite.Extensions.Adapter.Enumerable.ClrAsyncEnumerableToClrEnumerableConverterRule.Create();
+
+        /// <summary>
         /// Rule that converts an aggregate over a sorted input to a
         /// <see cref="ClrEnumerableSortedAggregate"/>.
         /// </summary>
@@ -212,11 +223,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </summary>
         /// <remarks>
         /// The counterpart of <c>EnumerableRules.ENUMERABLE_RULES</c>, holding what that holds for the nodes
-        /// this convention has, plus the two converters that let one plan hold both conventions. Read through
-        /// <see cref="Rules"/>, as Calcite's is read through <c>rules()</c>.
+        /// this convention has, plus the three converters that let one plan hold this convention and another.
+        /// Read through <see cref="Rules"/>, as Calcite's is read through <c>rules()</c>.
         ///
         /// <para>Membership is Calcite's list, member for member: its 26 less the match and table modify
-        /// rules, plus the two converters. Match cannot be written at all; modification is out of scope, so a
+        /// rules, plus the three converters — both directions against <c>EnumerableConvention</c>, and the
+        /// one way in from <see cref="ClrAsyncEnumerableConvention"/>. Match cannot be written at all;
+        /// modification is out of scope, so a
         /// plan that writes is left to <c>EnumerableConvention</c>. The three rules Calcite declares as fields
         /// and leaves out of the list — limit-sort, sorted aggregate and batch nested loop join — are left out
         /// here too, and a caller who wants one adds it.</para>
@@ -249,6 +262,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ClrEnumerableUncollectRule,
             EnumerableToClrEnumerableConverterRule,
             ClrEnumerableToEnumerableConverterRule,
+            ClrAsyncEnumerableToClrEnumerableConverterRule,
         ];
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Interop/JavaPlans.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaPlans.cs
@@ -18,12 +18,16 @@ namespace Apache.Calcite.Extensions.Interop
     /// the static below. At run time the generated Java calls it with the stashed delegate and the context,
     /// and gets back a linq4j <c>Enumerable</c>.
     ///
-    /// <para>There is one such converter and there is only going to be one.
-    /// <c>ClrAsyncEnumerableConvention</c> reads a Calcite sub-plan but never feeds one: a sequence going
-    /// that way would have to become a linq4j <c>Enumerator</c>, whose <c>moveNext</c> returns a
-    /// <c>boolean</c> with nowhere to await, so it would block once per row. Nothing requires it — Calcite
-    /// cannot read an <c>IClrAsyncScannableTable</c> by any route, so no plan can put a Calcite node above
-    /// an asynchronous one.</para>
+    /// <para>There is one such converter and there is only going to be one, because there is only one
+    /// boundary where Janino is on the other side. <c>ClrAsyncEnumerableConvention</c> reads a Calcite
+    /// sub-plan but never feeds one: a sequence going that way would have to become a linq4j
+    /// <c>Enumerator</c>, whose <c>moveNext</c> returns a <c>boolean</c> with nowhere to await, and the
+    /// generated source it would be called from cannot await either.</para>
+    ///
+    /// <para>That is not a claim that the asynchronous convention has no converter out.
+    /// <c>ClrAsyncEnumerableToClrEnumerableConverter</c> is one, and it blocks a thread per row -- but both
+    /// its sides are <see cref="System.Linq.Expressions"/>, so it splices rather than compiling separately
+    /// and leaves nothing here to call back into.</para>
     ///
     /// <para>Separate from <see cref="JavaSequences"/>, which carries a sequence between the two runtimes
     /// and nothing else. This takes a <em>plan</em> — a function of a <see cref="DataContext"/> — and

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
@@ -86,10 +86,13 @@ namespace Apache.Calcite.Extensions.Prepare
         /// is. Parsing, DDL, the statement kind, the parameter and column metadata and the cursor factory
         /// are shared, and this is the same method for both rather than a second copy of it.
         ///
-        /// <para><b>An asynchronous plan has no fallback.</b> That convention has no converter to any other,
-        /// so a query touching a table that cannot produce rows asynchronously does not plan and the planner
-        /// throws. A caller that wants the synchronous plan in that case asks for it, rather than being
-        /// handed one that would block a thread per row while looking asynchronous.</para>
+        /// <para><b>Neither plan can fall through to the other convention here</b>, and that is a matter of
+        /// which rules are registered rather than of what exists. <see cref="CreatePlanner"/> puts one
+        /// convention's rules on the planner and not the other's, so although a converter exists in each
+        /// direction, no node of the other convention is ever produced for one to match. A query touching a
+        /// table that cannot produce rows asynchronously therefore does not plan asynchronously — the planner
+        /// throws, rather than the caller being handed a plan that would block a thread per row while looking
+        /// asynchronous. A caller that wants the synchronous plan asks for it.</para>
         /// </remarks>
         public ClrSignature Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount, bool async)
         {

--- a/src/Apache.Calcite.Extensions/Runtime/ClrSequences.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/ClrSequences.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Apache.Calcite.Extensions.Runtime
+{
+
+    /// <summary>
+    /// Carries a sequence of rows between an <see cref="IEnumerable{T}"/> and an
+    /// <see cref="IAsyncEnumerable{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the whole of what a converter between <c>ClrEnumerableConvention</c> and
+    /// <c>ClrAsyncEnumerableConvention</c> does. The rows are not touched, and there is nothing to touch: the
+    /// two conventions share <c>ClrPhysType</c>, so a row of one already is a row of the other. Only the
+    /// sequence around it differs.
+    ///
+    /// <para>The two directions are not the same cost, and the asymmetry is the point.
+    /// <see cref="ToAsyncEnumerable{TSource}"/> costs a state machine and no thread; nothing it produces ever
+    /// suspends. <see cref="ToEnumerable{TSource}"/> blocks the calling thread once per row, which is the
+    /// sync-over-async the asynchronous convention was written to avoid. Both exist because a plan that
+    /// cannot be assembled is worse than one that is slow.</para>
+    /// </remarks>
+    static class ClrSequences
+    {
+
+        /// <summary>
+        /// Reads an asynchronous sequence as a synchronous one, blocking on each row.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <b>This blocks a thread per row, and there is no version of it that does not.</b> An
+        /// <see cref="IEnumerable{T}"/> has nowhere to suspend, so a caller that wants rows from an
+        /// asynchronous plan through this interface waits for them. That is a fact about
+        /// <see cref="IEnumerator{T}.MoveNext"/> rather than about this method.
+        ///
+        /// <para>The token is <see cref="CancellationToken.None"/> because the synchronous convention has no
+        /// token to give: a plan of it is a <c>Func&lt;DataContext, IEnumerable&lt;object&gt;&gt;</c>, and the
+        /// consumer's only way out is to stop enumerating. Abandoning the sequence disposes the enumerator,
+        /// which is what ends the asynchronous plan under it.</para>
+        ///
+        /// <para><b>The synchronization context is suppressed for the length of each wait</b>, and that is
+        /// load bearing rather than tidy. The operators of the asynchronous convention await without
+        /// <c>ConfigureAwait(false)</c> — <c>await foreach (var row in source.WithCancellation(token))</c>
+        /// continues on the captured context — so a caller that blocked a thread carrying one would wait for
+        /// a continuation that can only run on the thread it is blocking. Nulling the context before the call
+        /// means there is nothing to capture and the continuation goes to the thread pool. Where there is no
+        /// context, which is every thread a query is normally read on, this costs one read.</para>
+        /// </remarks>
+        public static IEnumerable<TSource> ToEnumerable<TSource>(IAsyncEnumerable<TSource> source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            var enumerator = source.GetAsyncEnumerator(CancellationToken.None);
+
+            try
+            {
+                while (Block(enumerator.MoveNextAsync()))
+                    yield return enumerator.Current;
+            }
+            finally
+            {
+                Block(enumerator.DisposeAsync());
+            }
+        }
+
+        /// <summary>
+        /// Waits for a <see cref="ValueTask{TResult}"/> the calling thread cannot await.
+        /// </summary>
+        /// <param name="task"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A <see cref="ValueTask{TResult}"/> that has not completed cannot be blocked on directly — its
+        /// awaiter is backed by an <see cref="System.Threading.Tasks.Sources.IValueTaskSource{TResult}"/>
+        /// that may be recycled the moment it is read once — so it goes through
+        /// <see cref="ValueTask{TResult}.AsTask"/>, which allocates. The completed case is the common one and
+        /// skips that.
+        /// </remarks>
+        static bool Block(ValueTask<bool> task)
+        {
+            if (task.IsCompletedSuccessfully)
+                return task.Result;
+
+            var context = SynchronizationContext.Current;
+            if (context == null)
+                return task.AsTask().GetAwaiter().GetResult();
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                return task.AsTask().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
+            }
+        }
+
+        /// <summary>
+        /// Waits for a <see cref="ValueTask"/> the calling thread cannot await.
+        /// </summary>
+        /// <param name="task"></param>
+        /// <remarks>
+        /// <see cref="Block(ValueTask{bool})"/> for the disposal, which has no value. The completed case is
+        /// still awaited rather than dropped, because that is what observes a failure.
+        /// </remarks>
+        static void Block(ValueTask task)
+        {
+            if (task.IsCompletedSuccessfully)
+            {
+                task.GetAwaiter().GetResult();
+                return;
+            }
+
+            var context = SynchronizationContext.Current;
+            if (context == null)
+            {
+                task.AsTask().GetAwaiter().GetResult();
+                return;
+            }
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                task.AsTask().GetAwaiter().GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
+            }
+        }
+
+        /// <summary>
+        /// Reads a synchronous sequence as an asynchronous one.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>JavaSequences.FromJavaAsync</c> over a .NET sequence rather than a linq4j one, and the same
+        /// honest shape: nothing here suspends, because the source is pulled. Producing an asynchronous
+        /// sequence that always completes synchronously costs a state machine and no thread — it is not the
+        /// sync-over-async of <see cref="ToEnumerable{TSource}"/>, which is a caller blocked waiting. A plan
+        /// reading a synchronous sub-plan this way is simply not asynchronous over that part of itself.
+        ///
+        /// <para>The token is checked per row rather than awaited on, which is the only way an operator that
+        /// never suspends can honour one.</para>
+        ///
+        /// <para>The trailing <c>await</c> is what makes the compiler accept an async iterator that has
+        /// nothing to await, as <c>FromJavaAsync</c> does for the same reason.</para>
+        /// </remarks>
+        public static async IAsyncEnumerable<TSource> ToAsyncEnumerable<TSource>(IEnumerable<TSource> source, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            foreach (var row in source)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                yield return row;
+            }
+
+            await Task.CompletedTask;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Schema/IClrAsyncScannableTable.cs
+++ b/src/Apache.Calcite.Extensions/Schema/IClrAsyncScannableTable.cs
@@ -11,11 +11,16 @@ namespace Apache.Calcite.Extensions.Schema
     /// </summary>
     /// <remarks>
     /// The counterpart of <see cref="ScannableTable"/>, member for member, with the sequence swapped. It is
-    /// the only leaf a plan of the <c>ClrAsyncEnumerableConvention</c> calling convention can read: that
-    /// convention has no converter to any other, because one would be a synchronous pull behind an awaited
-    /// interface or the reverse. A query touching a <see cref="ScannableTable"/>, a
-    /// <see cref="QueryableTable"/> or a <see cref="FilterableTable"/> is still planned -- Calcite reads it
-    /// and a converter carries the rows across -- but that part of it is not asynchronous and cannot be.
+    /// the only leaf a plan of the <c>ClrAsyncEnumerableConvention</c> calling convention scans <em>itself</em>.
+    /// A query touching a <see cref="ScannableTable"/>, a <see cref="QueryableTable"/> or a
+    /// <see cref="FilterableTable"/> is still planned -- Calcite reads it and a converter carries the rows
+    /// across -- but that part of it is not asynchronous and cannot be.
+    ///
+    /// <para>The converse does not hold. A plan asked for in <c>ClrEnumerableConvention</c> can read one of
+    /// these, across <c>ClrAsyncEnumerableToClrEnumerableConverter</c>, and it blocks a thread once per row
+    /// doing so. Whether that converter is available is a matter of which rules the planner was given: the
+    /// prepare pipeline registers one convention's rules and not the other's, so a query asked for
+    /// synchronously over one of these tables fails to plan rather than blocking.</para>
     ///
     /// <para>There is no cancellation parameter, and that is not an omission. A token enters an
     /// <see cref="IAsyncEnumerable{T}"/> at <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator"/>, which is

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
@@ -80,9 +80,12 @@ namespace Apache.Calcite.Tests
         /// <remarks>
         /// Not a limitation to work around — it is the convention's whole premise arriving at the surface.
         /// An <c>IClrAsyncScannableTable</c> is not a <c>ScannableTable</c>, so neither the synchronous
-        /// convention nor Calcite's own has a scan for it, and there is no converter that could carry its
-        /// rows into one. <c>ExecuteReader</c> therefore fails to plan rather than blocking a thread per row,
-        /// which is the trade this whole convention exists to make.
+        /// convention nor Calcite's own has a scan for it, and the synchronous planner is given no rule that
+        /// would put the scan in the asynchronous convention for
+        /// <c>ClrAsyncEnumerableToClrEnumerableConverter</c> to carry. <c>ExecuteReader</c> therefore fails to
+        /// plan rather than blocking a thread per row, which is the trade this whole convention exists to
+        /// make — and it is a trade the prepare pipeline makes by choosing rules, not one the planner is
+        /// incapable of unmaking.
         ///
         /// <para>A schema may hold both kinds of table; it is the individual query that is one or the
         /// other.</para>
@@ -139,9 +142,11 @@ namespace Apache.Calcite.Tests
         /// micro-ORM, <c>DataTable.Load</c> — calls <c>Read</c>. A provider whose reader throws there is not
         /// a provider, so the asynchronous result blocks instead.
         ///
-        /// <para>That is not the sync-over-async the convention refuses. That rule governs what a plan does
-        /// inside itself, where a converter would insert blocking nobody chose and nobody could see; here
-        /// the caller is choosing it in the open at the boundary.</para>
+        /// <para>That is not the sync-over-async the surface refuses, and the line is about who chose. A
+        /// plan can block inside itself too — <c>ClrAsyncEnumerableToClrEnumerableConverter</c> does, once
+        /// per row — and what makes that refusable is that the planner would be choosing it for a caller who
+        /// could not see it, which is why the prepare pipeline registers one convention's rules and not
+        /// both. Here the caller is choosing it in the open at the boundary.</para>
         /// </remarks>
         [TestMethod]
         public async Task ShouldReadAnAsyncPlanSynchronouslyWhenAskedTo()

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -326,9 +326,10 @@ namespace Apache.Calcite.Tests
         /// </summary>
         /// <remarks>
         /// The plan assertion is what stops a test from comparing something against itself. It matters more
-        /// here than in the synchronous harness, not less: there is no converter to fall through to, so a
-        /// rule that fails to fire does not quietly produce a plan of the other convention — it produces no
-        /// plan at all — but a node reached by a route nobody intended still looks like a pass.
+        /// here than in the synchronous harness, not less: this harness registers one convention's rules
+        /// only, so there is nothing for a converter to carry and a rule that fails to fire does not quietly
+        /// produce a plan of the other convention — it produces no plan at all — but a node reached by a
+        /// route nobody intended still looks like a pass.
         /// </remarks>
         static async Task SameThrough(string node, string sql, bool sortedAggregate = false, bool batchNestedLoopJoin = false, bool limitSort = false, bool excludeHashJoin = false, bool excludeMergeJoin = false)
         {

--- a/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
+++ b/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
@@ -1,0 +1,283 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite;
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.schema;
+using org.apache.calcite.tools;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Runs a plan that holds nodes of both Clr calling conventions.
+    /// </summary>
+    /// <remarks>
+    /// A row crosses untouched, and here that is not an argument about type factories agreeing: the two
+    /// conventions share <c>ClrPhysType</c>, so a row of one already is a row of the other. Only the sequence
+    /// around it changes, and the two directions do not cost the same —
+    /// <c>ClrEnumerableToClrAsyncEnumerableConverter</c> never suspends, and
+    /// <c>ClrAsyncEnumerableToClrEnumerableConverter</c> blocks a thread once per row.
+    ///
+    /// <para><b>The schema is what forces a crossing.</b> <c>SALES</c> is an
+    /// <c>IClrAsyncScannableTable</c> and nothing else, so only the asynchronous convention has a scan rule
+    /// that matches it; <c>SORTED</c> is a Calcite <c>ScannableTable</c>, which only the synchronous one
+    /// reads. A query naming either against the wrong root convention has to cross, and a query naming both
+    /// has to cross whichever root it is given.</para>
+    ///
+    /// <para>The <c>AcrossConverter</c> tests exist for the reason
+    /// <c>ClrEnumerableMixedConventionTests.ShouldCarryACalcAcrossTheConverter</c> gives: with both rule sets
+    /// registered the planner puts nearly everything on the root's side, so the converter only ever sees a
+    /// bare scan. Registering one convention's rules plus the single converter rule is what makes the
+    /// converter meet a real generated node.</para>
+    /// </remarks>
+    [TestClass]
+    public class ClrConventionCrossingTests
+    {
+
+        static ClrConventionCrossingTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.CalciteJdbc41Factory).Assembly);
+        }
+
+        /// <summary>
+        /// A schema whose two tables can each be scanned in one convention only.
+        /// </summary>
+        static SchemaPlus Schema(AsyncRowsTable? sales = null)
+        {
+            var rootSchema = Frameworks.createRootSchema(true);
+            rootSchema.add("SALES", sales ?? new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false));
+            rootSchema.add("SORTED", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, true));
+
+            return rootSchema;
+        }
+
+        /// <summary>
+        /// The context a plan is bound with.
+        /// </summary>
+        sealed class TestDataContext(SchemaPlus rootSchema, java.util.Map parameters) : DataContext
+        {
+
+            /// <inheritdoc />
+            public SchemaPlus getRootSchema() => rootSchema;
+
+            /// <inheritdoc />
+            public org.apache.calcite.adapter.java.JavaTypeFactory getTypeFactory() => new org.apache.calcite.jdbc.JavaTypeFactoryImpl();
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.QueryProvider getQueryProvider() => null!;
+
+            /// <inheritdoc />
+            public object get(string name) => parameters.get(name);
+
+        }
+
+        /// <summary>
+        /// Plans a statement to the given root convention with the given rules.
+        /// </summary>
+        static RelNode Plan(string sql, SchemaPlus rootSchema, Convention root, IReadOnlyList<RelOptRule> rules, IReadOnlyList<RelOptRule> calcRules)
+        {
+            var ruleList = new java.util.ArrayList();
+            foreach (var rule in rules)
+                ruleList.add(rule);
+
+            var calcRuleList = new java.util.ArrayList();
+            foreach (var rule in calcRules)
+                calcRuleList.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRuleList.add(rule);
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(rootSchema)
+                .programs(
+                    Programs.subQuery(org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE),
+                    new DefaultRulesProgram(ruleList, false, false, false, null, null),
+                    Programs.hep(calcRuleList, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE))
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+            var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+            var expanded = planner.transform(0, logical.getTraitSet(), logical);
+            var chosen = planner.transform(1, expanded.getTraitSet().replace(root).simplify(), expanded);
+
+            return planner.transform(2, chosen.getTraitSet(), chosen);
+        }
+
+        /// <summary>
+        /// Both rule sets, so the planner may put a node in either convention and bridge between them.
+        /// </summary>
+        static (IReadOnlyList<RelOptRule> Rules, IReadOnlyList<RelOptRule> CalcRules) Both()
+        {
+            var rules = new List<RelOptRule>();
+            rules.AddRange(ClrEnumerableRules.Rules());
+            rules.AddRange(ClrAsyncEnumerableRules.Rules());
+
+            var calcRules = new List<RelOptRule>();
+            calcRules.AddRange(ClrEnumerableRules.CalcRules());
+            calcRules.AddRange(ClrAsyncEnumerableRules.CalcRules());
+
+            return (rules, calcRules);
+        }
+
+        /// <summary>
+        /// Runs a plan rooted in the synchronous convention, blocking as its caller would.
+        /// </summary>
+        static List<string> RunSync(string sql, SchemaPlus rootSchema, IReadOnlyList<RelOptRule> rules, IReadOnlyList<RelOptRule> calcRules)
+        {
+            var physical = Plan(sql, rootSchema, ClrEnumerableConvention.Instance, rules, calcRules);
+            var parameters = new java.util.HashMap();
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+            var rows = new List<string>();
+            foreach (var row in bindable.Bind(new TestDataContext(rootSchema, parameters)))
+                rows.Add(Render(row));
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Runs a plan rooted in the asynchronous convention.
+        /// </summary>
+        static async Task<List<string>> RunAsync(string sql, SchemaPlus rootSchema, IReadOnlyList<RelOptRule> rules, IReadOnlyList<RelOptRule> calcRules)
+        {
+            var physical = Plan(sql, rootSchema, ClrAsyncEnumerableConvention.Instance, rules, calcRules);
+            var parameters = new java.util.HashMap();
+            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+            var rows = new List<string>();
+            await foreach (var row in bindable.Bind(new TestDataContext(rootSchema, parameters)))
+                rows.Add(Render(row));
+
+            return rows;
+        }
+
+        static string Render(object? row)
+        {
+            return row is object?[] array
+                ? string.Join("|", array.Select(v => v?.ToString() ?? "NULL"))
+                : row?.ToString() ?? "NULL";
+        }
+
+        /// <summary>
+        /// A plan asked for synchronously over a table only the asynchronous convention can scan still runs,
+        /// and returns every row in order.
+        /// </summary>
+        /// <remarks>
+        /// <c>AsyncRowsTable</c> awaits on every row, so each <c>MoveNextAsync</c> here really is incomplete
+        /// when it is blocked on. A fixture that completed synchronously would exercise the fast path only
+        /// and say nothing about the wait.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadAnAsynchronousPlanSynchronously()
+        {
+            var (rules, calcRules) = Both();
+            var rows = RunSync("SELECT ID, LABEL FROM SALES WHERE ID > 3", Schema(), rules, calcRules);
+
+            rows.Should().Equal(["4|D", "5|E", "6|F"]);
+        }
+
+        /// <summary>
+        /// A plan asked for asynchronously over a table only the synchronous convention can scan still runs.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldReadASynchronousPlanAsynchronously()
+        {
+            var (rules, calcRules) = Both();
+            var rows = await RunAsync("SELECT K, V FROM SORTED WHERE K >= 2", Schema(), rules, calcRules);
+
+            rows.Should().Equal(["2|B", "2|C", "4|D"]);
+        }
+
+        /// <summary>
+        /// A join whose two sides can only be scanned in different conventions runs, whichever convention the
+        /// root is asked for.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldJoinAcrossTheConventions()
+        {
+            var (rules, calcRules) = Both();
+
+            const string sql = "SELECT S.LABEL, T.V FROM SALES S JOIN SORTED T ON S.ID = T.K";
+
+            var sync = RunSync(sql, Schema(), rules, calcRules);
+            var async = await RunAsync(sql, Schema(), rules, calcRules);
+
+            sync.Should().BeEquivalentTo(["A|A", "B|B", "B|C", "D|D"]);
+            async.Should().BeEquivalentTo(sync);
+        }
+
+        /// <summary>
+        /// The blocking converter carries a generated node of the asynchronous convention, not merely a scan.
+        /// </summary>
+        /// <remarks>
+        /// Only the asynchronous rules are registered, plus the one converter that produces a synchronous
+        /// node, so the whole plan below the root is asynchronous and the calc under the converter is a
+        /// <c>ClrAsyncEnumerableCalc</c>.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCarryAnAsynchronousCalcAcrossTheConverter()
+        {
+            var rules = new List<RelOptRule>(ClrAsyncEnumerableRules.Rules()) { ClrEnumerableRules.ClrAsyncEnumerableToClrEnumerableConverterRule };
+            var calcRules = new List<RelOptRule>(ClrAsyncEnumerableRules.CalcRules());
+
+            var rows = RunSync("SELECT ID, LABEL FROM SALES WHERE ID > 3", Schema(), rules, calcRules);
+
+            rows.Should().Equal(["4|D", "5|E", "6|F"]);
+        }
+
+        /// <summary>
+        /// The non-suspending converter carries a generated node of the synchronous convention.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldCarryASynchronousCalcAcrossTheConverter()
+        {
+            var rules = new List<RelOptRule>(ClrEnumerableRules.Rules()) { ClrAsyncEnumerableRules.ClrEnumerableToClrAsyncEnumerableConverterRule };
+            var calcRules = new List<RelOptRule>(ClrEnumerableRules.CalcRules());
+
+            var rows = await RunAsync("SELECT K, V FROM SORTED WHERE K >= 2", Schema(), rules, calcRules);
+
+            rows.Should().Equal(["2|B", "2|C", "4|D"]);
+        }
+
+        /// <summary>
+        /// A synchronous caller that stops reading disposes the asynchronous plan under the converter, and
+        /// waits for the disposal rather than dropping it.
+        /// </summary>
+        /// <remarks>
+        /// <c>AsyncRowsTable</c> sets <c>DisposedAsynchronously</c> after an <c>await</c> in its
+        /// <c>finally</c>, so the flag is only set if the awaited part of the disposal ran to completion. A
+        /// converter that called <c>DisposeAsync</c> and discarded the <c>ValueTask</c> would leave it false.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldDisposeTheAsynchronousPlanWhenTheReaderStops()
+        {
+            var (rules, calcRules) = Both();
+            var sales = new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false);
+            var rootSchema = Schema(sales);
+
+            var physical = Plan("SELECT ID, LABEL FROM SALES", rootSchema, ClrEnumerableConvention.Instance, rules, calcRules);
+            var parameters = new java.util.HashMap();
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+            using (var enumerator = bindable.Bind(new TestDataContext(rootSchema, parameters)).GetEnumerator())
+            {
+                enumerator.MoveNext().Should().BeTrue();
+                Render(enumerator.Current).Should().Be("1|A");
+            }
+
+            sales.Produced.Should().BeLessThan(AsyncTestRows.Sales.Length);
+            sales.DisposedAsynchronously.Should().BeTrue();
+        }
+
+    }
+
+}


### PR DESCRIPTION
`ClrAsyncEnumerableConvention` had one converter, going in from `EnumerableConvention`. It now has one each way against `ClrEnumerableConvention` as well.

## The converters

**`ClrAsyncEnumerableToClrEnumerableConverter`** — asynchronous sub-plan read synchronously. **It blocks a thread once per row**, and nothing about the node hides that: an `IEnumerable<T>` has nowhere to suspend, so a caller that wants rows from an asynchronous plan through that interface waits for them. The cost model does not know it, and cannot honestly be made to — `VolcanoCost.isLt` compares the row count and nothing else, so the only lever is a multiplier, and one large enough to say "this blocks" would also stop the planner choosing the converter where it is the only way to plan the query at all.

**`ClrEnumerableToClrAsyncEnumerableConverter`** — synchronous sub-plan read asynchronously. Costs a state machine and no thread, because nothing under it ever suspends. This is not sync-over-async; it is simply a plan that is not asynchronous over that part of itself.

Each rule is registered with the convention it *produces*: the blocking one in `ClrEnumerableRules.Rules()`, the cheap one in `ClrAsyncEnumerableRules.Rules()`.

Neither translates or stashes anything. Both sides are `System.Linq.Expressions` and both share `ClrPhysType` — a row of one convention already *is* a row of the other — so the sub-plan's expression is spliced into the tree being built and wrapped in one call. That is why both implementors gained a root-parameter constructor, and why correlation variables are replayed across the boundary the way `EnumerableToClrEnumerableConverter` already did.

There is still no converter to `EnumerableConvention`, and there cannot be: Janino compiles generated source, and generated source cannot await.

## Two decisions worth reviewing

`ClrSequences.ToEnumerable` **suppresses the synchronization context around each blocking wait**. The asynchronous operators await without `ConfigureAwait(false)` — `await foreach (row in source.WithCancellation(token))` continues on the captured context — so blocking a thread that carries one would wait for a continuation that can only run on the thread being blocked. Nulling it before the call means there is nothing to capture. Where there is no context, which is every thread a query is normally read on, it costs one read.

The token is `CancellationToken.None`. The synchronous convention has none to give — a plan of it is a `Func<DataContext, IEnumerable<object>>` — and the consumer's only way out is to stop enumerating, which disposes the enumerator and ends the asynchronous plan under it.

## Corrections carried along

`EnumerableToClrAsyncEnumerableConverter` never called `ReplayCorrelVariables`. Its synchronous twin does, and without it a Calcite sub-plan under a correlate of the asynchronous convention reads a null getter.

The asynchronous rule list carried `EnumerableToClrEnumerableConverterRule` — the *synchronous* convention's converter in, left over from when `ClrAsyncEnumerableRules` was copied from `ClrEnumerableRules`; `9f60d6c` added the asynchronous one beside it rather than replacing it. It was live on the prepare planner and produced `ClrEnumerableConvention` subtrees nothing could consume. Removed.

`CalciteDataReader.Read` does not refuse an asynchronous plan and had not for some time — it calls `ActiveResult.Read`, and `CalciteAsyncEnumerableResult` blocks on `ReadAsync`. `CalciteResult`'s own remark says so and `ShouldReadAnAsyncPlanSynchronouslyWhenAskedTo` asserts it; the reader's remark and `CalciteCommand.ExecuteDbDataReader`'s contradicted both.

## Docs

Eleven remarks gave "there is no converter" as the reason a plan cannot mix the conventions. The conclusion still holds for `Apache.Calcite.Data`, but for a different reason: `ClrPrepareImpl.CreatePlanner` registers one convention's rules and not the other's, so no prepared plan mixes the two Clr conventions and neither converter fires there. That is a choice about rule registration now, not a fact about what exists, and the remarks say so.

The line the surface docs draw is no longer "a converter would insert blocking nobody chose" — one does — but **who chose**: a caller reaching for `Read` on a reader they asked to be asynchronous is choosing in the open; a planner splicing the blocking converter into a plan would be choosing for someone who cannot see it.

## Tests

`ClrConventionCrossingTests`, six tests. The schema forces the crossing: `SALES` is an `IClrAsyncScannableTable` and nothing else, `SORTED` is a Calcite `ScannableTable`, so each table has exactly one convention that can scan it and a query naming either against the wrong root convention has to cross.

Two of them register one convention's rules plus the single converter rule, so the converter meets a real generated calc rather than a bare scan — the trap `ShouldCarryACalcAcrossTheConverter` exists for. One checks that a reader stopping part-way disposes the asynchronous plan and *waits* for the disposal: `AsyncRowsTable` sets its flag after an `await` in its `finally`, so a converter that called `DisposeAsync` and discarded the `ValueTask` would leave it false.

`AsyncRowsTable` awaits on every row, so the blocking path is exercised with genuinely incomplete `MoveNextAsync` calls rather than the synchronous fast path.

659 pass in `Apache.Calcite.Tests`, 316 in `Apache.Calcite.Data.Tests`, 105 in `Apache.Calcite.Adapter.AdoNet.Tests`. Nothing failed, nothing skipped.
