### PR TITLE
Make the AdoNet adapter work against SQL Server, ODBC and OLE DB

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -140,6 +140,11 @@ surface whether or not the operation succeeds.
   that proves least: an ODBC driver over Oracle or DB2 reports its catalog differently in ways only that
   driver will show. The type-code tables are from ODBC's `sql.h` and OLE DB's `oledb.h` rather than from
   one driver, but only SQL Server's codes have been seen.
+- A temporal correlation value is now decoded before binding — a `DATE` left the plan as a day count and
+  SQL Server answered "Operand type clash: date is incompatible with int" through all three drivers; only
+  SQLite had tolerated the raw count. Two driver limits remain, pinned by tests: `System.Data.OleDb` cannot
+  bind a `DateTimeOffset` (Variant marshal refuses it) and binds a `TimeSpan` through `DBTIME`, which drops
+  fractional seconds — measured, `01:02:03.500` compares equal to `01:02:03` and unequal to itself.
 - **Upstream, and worth reporting**: `MssqlSqlDialect` does not override `supportsGroupByLiteral`, and SQL
   Server cannot group by a constant in either form — `GROUP BY (1 = 1)` is "Incorrect syntax near '='" and
   `GROUP BY 1` is "Each GROUP BY expression must contain at least one column that is not an outer

--- a/TODO.md
+++ b/TODO.md
@@ -112,8 +112,8 @@ Listed worst-first by uncovered lines.
 - **`AdoInformationSchemaDatabaseMetadata`** — was 130 lines at 0%, and the whole of it was wrong:
   `DataRow.Field<int?>` on SQL Server's `tinyint` precision threw on every table with a numeric column, so
   no query against SQL Server had ever run. `SqlServerQueryTests` covers it now, on a Windows machine with
-  LocalDB; Odbc and OleDb still reach it through nothing, and their `ParseDbType` and `Dialect` are stubs
-  that throw.
+  LocalDB. It is no longer shared with Odbc and OleDb: neither driver's collections have the information
+  schema's shape, and both now read their own.
 - **Connection strings, parameters, batches** — `CalciteConnectionStringBuilder` 35% (148 uncovered),
   `CalciteParameterCollection` 55% (78), `CalciteBatchCommandCollection` 21% (62). Mechanical, high
   line yield.
@@ -132,11 +132,15 @@ surface whether or not the operation succeeds.
   rather than saying a parent schema is required. First thing anyone calling the API by hand hits.
 - `AdoSetOpFactory.createSetOp` is covered only indirectly, through `UNION` / `INTERSECT` / `EXCEPT`
   queries. Direct tests need a planner fixture that does not exist yet.
-- `OdbcDatabaseMetadata` and `OleDbDatabaseMetadata` have no coverage, and neither can be given any as
-  written: `GetDefaultSchema`, `Dialect` and `ParseDbType` all throw `NotImplementedException`. The README's
-  provider table lists both as supported. `SqlServerDatabaseMetadata` is covered as of `SqlServerQueryTests`,
-  which needs a Windows machine with LocalDB and skips everywhere else — so the Linux and macOS legs of the
-  matrix still see SQLite alone.
+- The SQL Server, ODBC and OLE DB suites all need a Windows machine with LocalDB and skip everywhere else,
+  so the Linux and macOS legs of the matrix still see SQLite alone. `AdoSqlDialectsTests` is the part of it
+  that runs everywhere.
+- Both generic providers are covered against SQL Server and against nothing else, which is the one backend
+  that proves least: an ODBC driver over Oracle or DB2 reports its catalog differently in ways only that
+  driver will show. The type-code tables are from ODBC's `sql.h` and OLE DB's `oledb.h` rather than from
+  one driver, but only SQL Server's codes have been seen.
+- Correlated sub-queries against ODBC and OLE DB are untested. Both bind `?` by position, which is a
+  different path from the named binding every covered provider uses.
 
 ## Translate a CLR expression tree into a linq4j one
 

--- a/TODO.md
+++ b/TODO.md
@@ -101,10 +101,11 @@ when several schemas point at one database. Lowest priority; measure before assu
 Sized against measured coverage: `Apache.Calcite.Data` 69.9%, `Apache.Calcite.Adapter.AdoNet` ~60%.
 Listed worst-first by uncovered lines.
 
-- **`AdoEnumerable.ToProviderValue`** — `Boolean`, `Double`, `BigDecimal` and `ByteString` are unexercised.
-  SQLite has no column of those types in the fixture. The second provider now exists — `SqlServerFixture`'s
-  `TYPES` table has one column of each — but no correlated sub-query runs against it, which is what reaches
-  this. All that is left of the correlated sub-query work.
+- **`AdoEnumerable.ToProviderValue`** — done. `Boolean`, `Double`, `BigDecimal` and `ByteString` were
+  unexercised because SQLite's fixture has no column of those types;
+  `GenericProviderCorrelationTests.CorrelatingOnAColumnConvertsItsValueForTheProvider` correlates on one of
+  each in `SqlServerFixture`'s `TYPES`, through all three drivers. `Character` is still unreached, Calcite
+  having no type that arrives as one.
 - **`CalciteResultValue`** — 56%, **282 uncovered**, the largest single gap anywhere. It is the whole
   type-conversion surface, and the `DATE`-as-milliseconds bug lived in exactly this kind of code.
 - **`AdoSchemaFactory` from a Calcite model** — 0%. The operand-driven path is the primary documented
@@ -139,8 +140,13 @@ surface whether or not the operation succeeds.
   that proves least: an ODBC driver over Oracle or DB2 reports its catalog differently in ways only that
   driver will show. The type-code tables are from ODBC's `sql.h` and OLE DB's `oledb.h` rather than from
   one driver, but only SQL Server's codes have been seen.
-- Correlated sub-queries against ODBC and OLE DB are untested. Both bind `?` by position, which is a
-  different path from the named binding every covered provider uses.
+- **Upstream, and worth reporting**: `MssqlSqlDialect` does not override `supportsGroupByLiteral`, and SQL
+  Server cannot group by a constant in either form — `GROUP BY (1 = 1)` is "Incorrect syntax near '='" and
+  `GROUP BY 1` is "Each GROUP BY expression must contain at least one column that is not an outer
+  reference". It costs every correlated sub-query, because `EXISTS` becomes an aggregate over a constant
+  true and `SqlImplementor.visitRoot` only runs `AggregateProjectConstantToDummyJoinRule` when the dialect
+  has asked for it. Postgres, Redshift and Informix each override it. `AdoSqlDialects.Mssql` says it here;
+  the fix belongs in Calcite.
 
 ## Translate a CLR expression tree into a linq4j one
 

--- a/TODO.md
+++ b/TODO.md
@@ -102,14 +102,18 @@ Sized against measured coverage: `Apache.Calcite.Data` 69.9%, `Apache.Calcite.Ad
 Listed worst-first by uncovered lines.
 
 - **`AdoEnumerable.ToProviderValue`** — `Boolean`, `Double`, `BigDecimal` and `ByteString` are unexercised.
-  SQLite has no column of those types in the fixture, so covering them needs a wider fixture or a second
-  provider. All that is left of the correlated sub-query work.
+  SQLite has no column of those types in the fixture. The second provider now exists — `SqlServerFixture`'s
+  `TYPES` table has one column of each — but no correlated sub-query runs against it, which is what reaches
+  this. All that is left of the correlated sub-query work.
 - **`CalciteResultValue`** — 56%, **282 uncovered**, the largest single gap anywhere. It is the whole
   type-conversion surface, and the `DATE`-as-milliseconds bug lived in exactly this kind of code.
 - **`AdoSchemaFactory` from a Calcite model** — 0%. The operand-driven path is the primary documented
   way anyone configures an adapter, and nothing proves it works.
-- **`AdoInformationSchemaDatabaseMetadata`** — 130 lines at 0%, shared by the SqlServer, Odbc and
-  OleDb providers, so one suite lifts four.
+- **`AdoInformationSchemaDatabaseMetadata`** — was 130 lines at 0%, and the whole of it was wrong:
+  `DataRow.Field<int?>` on SQL Server's `tinyint` precision threw on every table with a numeric column, so
+  no query against SQL Server had ever run. `SqlServerQueryTests` covers it now, on a Windows machine with
+  LocalDB; Odbc and OleDb still reach it through nothing, and their `ParseDbType` and `Dialect` are stubs
+  that throw.
 - **Connection strings, parameters, batches** — `CalciteConnectionStringBuilder` 35% (148 uncovered),
   `CalciteParameterCollection` 55% (78), `CalciteBatchCommandCollection` 21% (62). Mechanical, high
   line yield.
@@ -128,8 +132,11 @@ surface whether or not the operation succeeds.
   rather than saying a parent schema is required. First thing anyone calling the API by hand hits.
 - `AdoSetOpFactory.createSetOp` is covered only indirectly, through `UNION` / `INTERSECT` / `EXCEPT`
   queries. Direct tests need a planner fixture that does not exist yet.
-- The AdoNet adapter is tested against SQLite only. `SqlServerDatabaseMetadata`,
-  `OdbcDatabaseMetadata` and `OleDbDatabaseMetadata` have no coverage.
+- `OdbcDatabaseMetadata` and `OleDbDatabaseMetadata` have no coverage, and neither can be given any as
+  written: `GetDefaultSchema`, `Dialect` and `ParseDbType` all throw `NotImplementedException`. The README's
+  provider table lists both as supported. `SqlServerDatabaseMetadata` is covered as of `SqlServerQueryTests`,
+  which needs a Windows machine with LocalDB and skips everywhere else — so the Linux and macOS legs of the
+  matrix still see SQLite alone.
 
 ## Translate a CLR expression tree into a linq4j one
 

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoReaderUtilTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoReaderUtilTests.cs
@@ -92,6 +92,19 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             Assert.AreEqual((byte)7, ((java.lang.Byte)value!).byteValue());
         }
 
+        /// <summary>
+        /// Calcite's TINYINT is signed, and Java's <c>byte</c> is IKVM's unsigned one, so the sign has to
+        /// travel in the bits rather than in the type.
+        /// </summary>
+        [TestMethod]
+        public void ANegativeTinyIntKeepsItsSign()
+        {
+            using var reader = Row("-1");
+            var value = (java.lang.Byte)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.TINYINT)!;
+
+            Assert.AreEqual("-1", value.ToString());
+        }
+
         [TestMethod]
         public void SmallIntIsReadAsAJavaShort()
         {

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoReaderUtilTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoReaderUtilTests.cs
@@ -137,6 +137,73 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         #endregion
 
+        #region Unsigned types
+
+        /// <summary>
+        /// Calcite's unsigned types are not a variation on the signed ones: <c>getJavaClass</c> answers a
+        /// joou value for each, and <c>CalciteResultValue</c> is written to decode exactly those. Every one
+        /// of them threw <c>Unsupported SQL type mapping</c> until there was a case for it, so
+        /// <c>AdoTable</c>'s mapping of <c>UInt16</c>, <c>UInt32</c> and <c>UInt64</c> could type a column
+        /// and never read one.
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <param name="typeName"></param>
+        /// <param name="expected"></param>
+        [TestMethod]
+        [DataRow("0", nameof(SqlTypeName.UTINYINT), "0")]
+        [DataRow("200", nameof(SqlTypeName.UTINYINT), "200")]
+        [DataRow("255", nameof(SqlTypeName.UTINYINT), "255")]
+        [DataRow("65535", nameof(SqlTypeName.USMALLINT), "65535")]
+        [DataRow("4294967295", nameof(SqlTypeName.UINTEGER), "4294967295")]
+        [DataRow("'18446744073709551615'", nameof(SqlTypeName.UBIGINT), "18446744073709551615")]
+        public void AnUnsignedValueKeepsTheWholeOfItsRange(string expression, string typeName, string expected)
+        {
+            using var reader = Row(expression);
+            var value = AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.valueOf(typeName));
+
+            Assert.AreEqual(expected, value!.ToString());
+        }
+
+        /// <summary>
+        /// The class matters as much as the value: <c>CalciteResultValue</c> decodes a <c>UTINYINT</c> by
+        /// asking whether the value is a joou <c>UByte</c>, and a <see cref="java.lang.Short"/> holding the
+        /// same number is not one.
+        /// </summary>
+        [TestMethod]
+        public void AnUnsignedValueIsAJoouValue()
+        {
+            using var reader = Row("200");
+
+            Assert.IsInstanceOfType<org.joou.UByte>(AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.UTINYINT));
+        }
+
+        /// <summary>
+        /// The distinction the whole mapping turns on. 200 in a signed <c>TINYINT</c> is -56, which is why
+        /// an unsigned tiny integer is a <c>UTINYINT</c> and not a <c>TINYINT</c>.
+        /// </summary>
+        [TestMethod]
+        public void TheSameByteSignedAndUnsignedAreDifferentNumbers()
+        {
+            using var signed = Row("-56");
+            using var unsigned = Row("200");
+
+            Assert.AreEqual("-56", AdoReaderUtil.GetDbReaderValue(signed, 0, SqlTypeName.TINYINT)!.ToString());
+            Assert.AreEqual("200", AdoReaderUtil.GetDbReaderValue(unsigned, 0, SqlTypeName.UTINYINT)!.ToString());
+        }
+
+        /// <summary>
+        /// An unsigned value is null-safe like every other, the joou types being references.
+        /// </summary>
+        [TestMethod]
+        public void AnUnsignedNullIsNull()
+        {
+            using var reader = Row("CAST(NULL AS INTEGER)");
+
+            Assert.IsNull(AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.UTINYINT));
+        }
+
+        #endregion
+
         #region Approximate types
 
         [TestMethod]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
@@ -1,0 +1,139 @@
+using Apache.Calcite.Adapter.AdoNet.Metadata;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.parser;
+using org.apache.calcite.sql.pretty;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers working out a dialect from the only thing a generic driver can be asked: the name of the
+    /// product behind it.
+    /// </summary>
+    /// <remarks>
+    /// No database, so this runs everywhere, which matters: the ODBC and OLE DB suites that reach the same
+    /// code end to end need a Windows machine with LocalDB and skip on the rest of the matrix.
+    /// </remarks>
+    [TestClass]
+    public class AdoSqlDialectsTests
+    {
+
+        /// <summary>
+        /// Returns what a dialect writes for an <c>OFFSET</c> / <c>FETCH</c> pair.
+        /// </summary>
+        /// <param name="dialect"></param>
+        /// <returns></returns>
+        static string OffsetFetch(SqlDialect dialect)
+        {
+            var writer = new SqlPrettyWriter(SqlPrettyWriter.config().withDialect(dialect));
+            dialect.unparseOffsetFetch(
+                writer,
+                SqlLiteral.createExactNumeric("1", SqlParserPos.ZERO),
+                SqlLiteral.createExactNumeric("2", SqlParserPos.ZERO));
+
+            return writer.toSqlString().getSql();
+        }
+
+        #region Product
+
+        [TestMethod]
+        [DataRow("Microsoft SQL Server", "MssqlSqlDialect")]
+        [DataRow("PostgreSQL", "PostgresqlSqlDialect")]
+        [DataRow("Oracle", "OracleSqlDialect")]
+        [DataRow("MySQL", "MysqlSqlDialect")]
+        [DataRow("Apache Derby", "DerbySqlDialect")]
+        [DataRow("ACCESS", "AccessSqlDialect")]
+        // the DB2 driver reports its platform, and Calcite matches the prefix rather than the word
+        [DataRow("DB2/LINUXX8664", "Db2SqlDialect")]
+        [DataRow("Teradata Database", "TeradataSqlDialect")]
+        [DataRow("SQLite", "SqliteSqlDialect")]
+        public void AProductNameSelectsItsDialect(string productName, string expected)
+        {
+            Assert.AreEqual(expected, AdoSqlDialects.For(productName, "1.0").GetType().Name);
+        }
+
+        /// <summary>
+        /// Calcite matches the name case-insensitively and after trimming, so this does too.
+        /// </summary>
+        [TestMethod]
+        [DataRow("microsoft sql server")]
+        [DataRow("  Microsoft SQL Server  ")]
+        [DataRow("Microsoft SQL Server Enterprise Edition")]
+        public void TheProductNameIsMatchedLoosely(string productName)
+        {
+            Assert.AreEqual("MssqlSqlDialect", AdoSqlDialects.For(productName, "15.0").GetType().Name);
+        }
+
+        /// <summary>
+        /// A driver that will not say what is behind it still has to get a dialect, and the generic one is
+        /// what Calcite's own factory ends at.
+        /// </summary>
+        [TestMethod]
+        public void AnUnknownProductGetsTheGenericDialect()
+        {
+            Assert.AreEqual("AnsiSqlDialect", AdoSqlDialects.For(null, null).GetType().Name);
+            Assert.AreEqual("AnsiSqlDialect", AdoSqlDialects.For("Some Database Nobody Has Heard Of", "1.2.3").GetType().Name);
+        }
+
+        [TestMethod]
+        public void AnUnknownProductIsTheUnknownProduct()
+        {
+            Assert.AreEqual(
+                SqlDialect.DatabaseProduct.UNKNOWN,
+                AdoSqlDialects.ProductFor("Some Database Nobody Has Heard Of"));
+        }
+
+        #endregion
+
+        #region Version
+
+        [TestMethod]
+        [DataRow("15.00.4382", 15, 0)]
+        [DataRow("10.50.1600.1", 10, 50)]
+        [DataRow("9", 9, 0)]
+        [DataRow("", 0, 0)]
+        [DataRow(null, 0, 0)]
+        public void AVersionIsSplitIntoItsComponents(string? version, int major, int minor)
+        {
+            Assert.AreEqual(major, AdoSqlDialects.MajorVersion(version));
+            Assert.AreEqual(minor, AdoSqlDialects.MinorVersion(version));
+        }
+
+        /// <summary>
+        /// The reason the version is carried at all. <c>MssqlSqlDialect</c> writes <c>TOP(n)</c> below major
+        /// version 11 and <em>discards the offset</em> — a paged query then returns the first page for every
+        /// page — so a dialect built without a version is not merely conservative, it is wrong.
+        /// </summary>
+        [TestMethod]
+        public void SqlServerPastTwentyTwelveGetsOffsetFetch()
+        {
+            StringAssert.Contains(OffsetFetch(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382")), "OFFSET");
+        }
+
+        /// <summary>
+        /// And below it, Calcite's own answer, reproduced rather than corrected.
+        /// </summary>
+        [TestMethod]
+        public void SqlServerBeforeTwentyTwelveDoesNot()
+        {
+            Assert.AreEqual("", OffsetFetch(AdoSqlDialects.For("Microsoft SQL Server", "10.50.1600")).Trim());
+        }
+
+        /// <summary>
+        /// A version that could not be read is the same case as no version at all, and lands on the
+        /// conservative side rather than throwing.
+        /// </summary>
+        [TestMethod]
+        public void AnUnreadableVersionIsNotAnError()
+        {
+            Assert.AreEqual("MssqlSqlDialect", AdoSqlDialects.For("Microsoft SQL Server", "not a version").GetType().Name);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
@@ -3,6 +3,7 @@ using Apache.Calcite.Adapter.AdoNet.Metadata;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using org.apache.calcite.sql;
+using org.apache.calcite.sql.dialect;
 using org.apache.calcite.sql.parser;
 using org.apache.calcite.sql.pretty;
 
@@ -39,8 +40,11 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         #region Product
 
+        /// <remarks>
+        /// SQL Server is absent because its dialect is not Calcite's own instance — see
+        /// <see cref="TheCorrectedDialectIsStillTheSqlServerOne"/>.
+        /// </remarks>
         [TestMethod]
-        [DataRow("Microsoft SQL Server", "MssqlSqlDialect")]
         [DataRow("PostgreSQL", "PostgresqlSqlDialect")]
         [DataRow("Oracle", "OracleSqlDialect")]
         [DataRow("MySQL", "MysqlSqlDialect")]
@@ -64,7 +68,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("Microsoft SQL Server Enterprise Edition")]
         public void TheProductNameIsMatchedLoosely(string productName)
         {
-            Assert.AreEqual("MssqlSqlDialect", AdoSqlDialects.For(productName, "15.0").GetType().Name);
+            Assert.IsInstanceOfType<MssqlSqlDialect>(AdoSqlDialects.For(productName, "15.0"));
         }
 
         /// <summary>
@@ -129,7 +133,43 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [TestMethod]
         public void AnUnreadableVersionIsNotAnError()
         {
-            Assert.AreEqual("MssqlSqlDialect", AdoSqlDialects.For("Microsoft SQL Server", "not a version").GetType().Name);
+            Assert.IsInstanceOfType<MssqlSqlDialect>(AdoSqlDialects.For("Microsoft SQL Server", "not a version"));
+        }
+
+        #endregion
+
+        #region Group by a constant
+
+        /// <summary>
+        /// SQL Server cannot group by a constant and <c>MssqlSqlDialect</c> does not say so, which costs
+        /// every correlated sub-query: <c>EXISTS</c> becomes an aggregate over a constant true, and the
+        /// statement generated for it is <c>SELECT 1 AS [i] GROUP BY (1 = 1)</c> — "Incorrect syntax near
+        /// '='", measured. <c>SqlImplementor.visitRoot</c> only runs the rule that rewrites it away when
+        /// the dialect has asked for it.
+        /// </summary>
+        [TestMethod]
+        public void SqlServerSaysItCannotGroupByAConstant()
+        {
+            Assert.IsFalse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382").supportsGroupByLiteral());
+        }
+
+        /// <summary>
+        /// And it is still the SQL Server dialect, rather than a generic one that happens to say the same.
+        /// </summary>
+        [TestMethod]
+        public void TheCorrectedDialectIsStillTheSqlServerOne()
+        {
+            Assert.IsInstanceOfType<MssqlSqlDialect>(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"));
+        }
+
+        /// <summary>
+        /// The correction is to SQL Server alone: a dialect Calcite already had right is left as it is.
+        /// </summary>
+        [TestMethod]
+        public void AnotherProductKeepsCalcitesOwnAnswer()
+        {
+            Assert.IsFalse(AdoSqlDialects.For("PostgreSQL", "16.0").supportsGroupByLiteral(), "Postgres says so itself");
+            Assert.IsTrue(AdoSqlDialects.For("MySQL", "8.0").supportsGroupByLiteral(), "MySQL can");
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -18,6 +18,8 @@
         <PackageReference Include="FluentAssertions" Version="8.10.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
         <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+        <PackageReference Include="System.Data.Odbc" Version="8.0.0" />
+        <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -17,6 +17,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="8.10.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
@@ -256,6 +256,19 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow(SqlClient, "C_TINYINT")]
         [DataRow(Odbc, "C_TINYINT")]
         [DataRow(OleDb, "C_TINYINT")]
+        // the temporal types leave the plan as counts — a DATE as days since the epoch, a TIMESTAMP as
+        // milliseconds — and a count bound raw against a typed column is a type clash on a real backend
+        [DataRow(SqlClient, "C_DATE")]
+        [DataRow(Odbc, "C_DATE")]
+        [DataRow(OleDb, "C_DATE")]
+        [DataRow(SqlClient, "C_DATETIME2")]
+        [DataRow(Odbc, "C_DATETIME2")]
+        [DataRow(OleDb, "C_DATETIME2")]
+        // no ODBC rows for these two — System.Data.Odbc cannot read a time or datetimeoffset column at all,
+        // which TheDriverCannotReadSqlServersOwnTimeTypes already pins — and no OLE DB rows either, for the
+        // driver limitations the two tests below this one pin
+        [DataRow(SqlClient, "C_TIME")]
+        [DataRow(SqlClient, "C_DATETIMEOFFSET")]
         public void CorrelatingOnAColumnConvertsItsValueForTheProvider(string provider, string columnName)
         {
             CollectionAssert.AreEqual(
@@ -264,6 +277,39 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
                     SELECT T.ID FROM ADO.TYPES T
                     WHERE EXISTS (SELECT 1 FROM ADO.TYPES T2 WHERE T2.{columnName} = T.{columnName})
                     """));
+        }
+
+        /// <summary>
+        /// A limitation of the driver rather than of the adapter, pinned so that it is a stated fact rather
+        /// than a surprise: <c>System.Data.OleDb</c> cannot marshal a <see cref="DateTimeOffset"/> to a
+        /// Variant at all, so a zoned timestamp cannot be a parameter through OLE DB. It fails on the
+        /// client, before the server ever sees the statement.
+        /// </summary>
+        [TestMethod]
+        public void TheOleDbDriverCannotBindAZonedTimestamp()
+        {
+            var thrown = Assert.ThrowsException<NotSupportedException>(() => CorrelatedRows(OleDb, """
+                SELECT T.ID FROM ADO.TYPES T
+                WHERE EXISTS (SELECT 1 FROM ADO.TYPES T2 WHERE T2.C_DATETIMEOFFSET = T.C_DATETIMEOFFSET)
+                """));
+
+            StringAssert.Contains(thrown.Message, "Variant");
+        }
+
+        /// <summary>
+        /// The worse kind of driver limitation: not an error but a wrong answer.
+        /// <c>System.Data.OleDb</c> binds a <see cref="TimeSpan"/> through OLE DB's <c>DBTIME</c> structure,
+        /// which has no fractional seconds, so <c>01:02:03.500</c> reaches the server as <c>01:02:03</c> —
+        /// measured: the fractional value compares equal to the whole-second literal and unequal to itself.
+        /// An equality against a fractional <c>time</c> column therefore silently matches nothing.
+        /// </summary>
+        [TestMethod]
+        public void TheOleDbDriverTruncatesABoundTimeToWholeSeconds()
+        {
+            Assert.AreEqual(0, CorrelatedRows(OleDb, """
+                SELECT T.ID FROM ADO.TYPES T
+                WHERE EXISTS (SELECT 1 FROM ADO.TYPES T2 WHERE T2.C_TIME = T.C_TIME)
+                """).Count);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
@@ -252,6 +252,10 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow(SqlClient, "C_BIGINT")]
         [DataRow(Odbc, "C_BIGINT")]
         [DataRow(OleDb, "C_BIGINT")]
+        // the one unsigned type a real backend reports: a tinyint leaves the plan as a joou UByte
+        [DataRow(SqlClient, "C_TINYINT")]
+        [DataRow(Odbc, "C_TINYINT")]
+        [DataRow(OleDb, "C_TINYINT")]
         public void CorrelatingOnAColumnConvertsItsValueForTheProvider(string provider, string columnName)
         {
             CollectionAssert.AreEqual(

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
@@ -1,0 +1,288 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers correlated sub-queries against SQL Server through each of the three drivers that reach it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ODBC and OLE DB write the parameter marker as a bare <c>?</c>, so every parameter in a statement has
+    /// the same name and the only thing distinguishing them is the order they were added in. SqlClient names
+    /// them <c>@P0</c>, so a mistake in the ordering shows up there as an unfilled parameter and in the
+    /// other two as the wrong answer — which is why SqlClient is here too, as the control.
+    /// </para>
+    /// <para>
+    /// Nothing reaches a parameter but a correlated sub-query, and nothing reaches one of those but
+    /// <c>forceDecorrelate=false</c>: Calcite rewrites a correlation into a join wherever it can, and by
+    /// default it always tries.
+    /// </para>
+    /// <para>
+    /// Every one of these failed identically on all three drivers before <c>AdoSqlDialects</c> told the
+    /// dialect that SQL Server cannot group by a constant — not a parameter fault at all, and not one the
+    /// generic providers introduced. Keeping SqlClient in the table is what said so.
+    /// </para>
+    /// <para>
+    /// All three run against the shared LocalDB database, and skip where the driver is not installed.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class GenericProviderCorrelationTests
+    {
+
+        const string SqlClient = "sqlclient";
+        const string Odbc = "odbc";
+        const string OleDb = "oledb";
+
+        static GenericProviderCorrelationTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
+            java.lang.Class.forName("org.apache.calcite.jdbc.Driver");
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            if (SqlServerFixture.IsAvailable == false)
+                Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+        }
+
+        /// <summary>
+        /// Returns the data source for a provider, skipping the test where it is not installed.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        static DbDataSource DataSourceFor(string provider)
+        {
+            switch (provider)
+            {
+                case SqlClient:
+                    return SqlServerFixture.Shared.DataSource;
+                case Odbc:
+                    if (SqlServerFixture.OdbcDriver is null)
+                        Assert.Inconclusive("No SQL Server ODBC driver is installed on this machine.");
+
+                    return SqlServerFixture.Shared.OdbcDataSource;
+                case OleDb:
+                    if (SqlServerFixture.OleDbProvider is null)
+                        Assert.Inconclusive("No SQL Server OLE DB provider is registered for this process architecture.");
+
+                    return SqlServerFixture.Shared.OleDbDataSource;
+                default:
+                    throw new ArgumentException($"unknown provider {provider}", nameof(provider));
+            }
+        }
+
+        /// <summary>
+        /// Runs a query on a connection that leaves the correlate in the plan.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static List<string> CorrelatedRows(string provider, string sql)
+        {
+            var dataSource = DataSourceFor(provider);
+
+            var properties = new java.util.Properties();
+            properties.setProperty("lex", "JAVA");
+            properties.setProperty("caseSensitive", "false");
+            properties.setProperty("forceDecorrelate", "false");
+
+            using var connection = java.sql.DriverManager.getConnection("jdbc:calcite:", properties);
+            var root = ((CalciteConnection)connection).getRootSchema();
+            root.add("ADO", AdoSchema.Create(root, "ADO", dataSource, null, "dbo"));
+
+            using var statement = connection.createStatement();
+            var results = statement.executeQuery(sql);
+
+            var rows = new List<string>();
+            var columns = results.getMetaData().getColumnCount();
+
+            while (results.next())
+            {
+                var values = new string[columns];
+                for (int i = 0; i < columns; i++)
+                    values[i] = results.getObject(i + 1)?.ToString() ?? "NULL";
+
+                rows.Add(string.Join("|", values));
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// One parameter, which is the least that has to work before any of the rest can.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ACorrelatedExistsBindsItsParameter(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Sales", "Engineering" },
+                CorrelatedRows(provider, "SELECT D.DNAME FROM ADO.DEPTS D WHERE EXISTS (SELECT 1 FROM ADO.EMPS E WHERE E.DEPTNO = D.DEPTNO)"));
+        }
+
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ACorrelatedScalarSubQueryYieldsAValuePerRow(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Sales|2", "Engineering|2", "Empty|0" },
+                CorrelatedRows(provider, "SELECT D.DNAME, (SELECT COUNT(*) FROM ADO.EMPS E WHERE E.DEPTNO = D.DEPTNO) FROM ADO.DEPTS D"));
+        }
+
+        /// <summary>
+        /// The case a positional marker can get wrong and a named one cannot: two parameters of different
+        /// types in one statement. Swapping them compares a department against a salary, which gives a
+        /// different answer rather than an error. Only Alice has a colleague in her own department earning
+        /// more.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void TwoCorrelationVariablesAreBoundInOrder(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice" },
+                CorrelatedRows(provider, """
+                    SELECT E.NAME FROM ADO.EMPS E
+                    WHERE EXISTS (SELECT 1 FROM ADO.EMPS E2 WHERE E2.DEPTNO = E.DEPTNO AND E2.SALARY > E.SALARY)
+                    """));
+        }
+
+        /// <summary>
+        /// One variable read twice is two markers carrying one value, so the count of markers and the count
+        /// of variables are not the same number.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void OneVariableReadTwiceFillsBothParameters(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice", "Bob", "Carol" },
+                CorrelatedRows(provider, """
+                    SELECT E.NAME FROM ADO.EMPS E
+                    WHERE EXISTS (SELECT 1 FROM ADO.EMPS E2 WHERE E2.EMPNO > E.EMPNO AND E2.EMPNO <= E.EMPNO + 2)
+                    """));
+        }
+
+        /// <summary>
+        /// Correlating on a <c>DECIMAL</c>, which leaves the plan as a <c>java.math.BigDecimal</c> and has to
+        /// reach the parameter as something the driver will bind.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void CorrelatingOnADecimal(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice", "Bob" },
+                CorrelatedRows(provider, "SELECT E.NAME FROM ADO.EMPS E WHERE EXISTS (SELECT 1 FROM ADO.EMPS E2 WHERE E2.SALARY > E.SALARY)"));
+        }
+
+        /// <summary>
+        /// Correlating on a character column: everyone but the last name in order has one after them.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void CorrelatingOnAString(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice", "Bob", "Carol" },
+                CorrelatedRows(provider, "SELECT E.NAME FROM ADO.EMPS E WHERE EXISTS (SELECT 1 FROM ADO.EMPS E2 WHERE E2.NAME > E.NAME)"));
+        }
+
+        /// <summary>
+        /// A null correlation value is bound rather than skipped: Dave's salary is null, so his marker takes
+        /// <see cref="DBNull"/> and the inner comparison is unknown for every row, giving zero rather than
+        /// an unfilled parameter.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ANullCorrelationValueIsBound(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice|1", "Bob|1", "Carol|1", "Dave|0" },
+                CorrelatedRows(provider, "SELECT E.NAME, (SELECT COUNT(*) FROM ADO.EMPS E2 WHERE E2.SALARY = E.SALARY) FROM ADO.EMPS E"));
+        }
+
+        /// <summary>
+        /// The remaining conversions <c>AdoEnumerable.ToProviderValue</c> performs on the way out of the
+        /// plan and into a parameter, each reached by correlating on a column of that type.
+        /// </summary>
+        /// <remarks>
+        /// A correlation value leaves the plan as the boxed Java type Calcite holds it in — a
+        /// <c>java.lang.Boolean</c>, a <c>java.lang.Double</c>, an <c>avatica ByteString</c> — and no
+        /// provider knows what any of those are. The row of <c>TYPES</c> that holds values matches itself
+        /// and the row of nulls matches nothing, so the answer is the same shape whichever column is used
+        /// and a conversion that did not happen shows up as an exception rather than as a wrong row.
+        /// </remarks>
+        /// <param name="provider"></param>
+        /// <param name="columnName"></param>
+        [TestMethod]
+        [DataRow(SqlClient, "C_BIT")]
+        [DataRow(Odbc, "C_BIT")]
+        [DataRow(OleDb, "C_BIT")]
+        [DataRow(SqlClient, "C_FLOAT")]
+        [DataRow(Odbc, "C_FLOAT")]
+        [DataRow(OleDb, "C_FLOAT")]
+        [DataRow(SqlClient, "C_VARBINARY")]
+        [DataRow(Odbc, "C_VARBINARY")]
+        [DataRow(OleDb, "C_VARBINARY")]
+        [DataRow(SqlClient, "C_BIGINT")]
+        [DataRow(Odbc, "C_BIGINT")]
+        [DataRow(OleDb, "C_BIGINT")]
+        public void CorrelatingOnAColumnConvertsItsValueForTheProvider(string provider, string columnName)
+        {
+            CollectionAssert.AreEqual(
+                new[] { "1" },
+                CorrelatedRows(provider, $"""
+                    SELECT T.ID FROM ADO.TYPES T
+                    WHERE EXISTS (SELECT 1 FROM ADO.TYPES T2 WHERE T2.{columnName} = T.{columnName})
+                    """));
+        }
+
+        /// <summary>
+        /// A correlated sub-query inside a correlated sub-query: two contexts live at once, each closed over
+        /// a different outer row, and both filling markers in the same statement.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void NestedCorrelation(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Sales", "Engineering" },
+                CorrelatedRows(provider, """
+                    SELECT D.DNAME FROM ADO.DEPTS D
+                    WHERE EXISTS (
+                        SELECT 1 FROM ADO.EMPS E
+                        WHERE E.DEPTNO = D.DEPTNO
+                          AND EXISTS (SELECT 1 FROM ADO.EMPS E2 WHERE E2.DEPTNO = E.DEPTNO AND E2.EMPNO <> E.EMPNO))
+                    """));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
@@ -147,7 +147,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         {
             var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.OdbcDataSource);
 
-            Assert.AreEqual("MssqlSqlDialect", metadata.Dialect.GetType().Name);
+            Assert.IsInstanceOfType<org.apache.calcite.sql.dialect.MssqlSqlDialect>(metadata.Dialect);
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
@@ -182,7 +182,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         [TestMethod]
         [DataRow("C_BIT", nameof(SqlTypeName.BOOLEAN))]
-        [DataRow("C_TINYINT", nameof(SqlTypeName.SMALLINT))]
+        [DataRow("C_TINYINT", nameof(SqlTypeName.UTINYINT))]
         [DataRow("C_SMALLINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_BIGINT", nameof(SqlTypeName.BIGINT))]
         [DataRow("C_DECIMAL", nameof(SqlTypeName.DECIMAL))]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
@@ -6,33 +6,33 @@ using org.apache.calcite.sql.type;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Data.Odbc;
 
 namespace Apache.Calcite.Adapter.AdoNet.Tests
 {
 
     /// <summary>
-    /// Covers the adapter against a real SQL Server, which is the only thing that exercises the information
-    /// schema path and the SQL Server type mapping.
+    /// Covers the adapter over an <see cref="OdbcConnection"/>, against the same LocalDB database
+    /// <see cref="SqlServerQueryTests"/> uses.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Every query against SQL Server failed with <c>InvalidCastException: Unable to cast object of type
-    /// 'System.Byte' to type 'System.Int32'</c> and nothing here said so, because the suite had only ever
-    /// been pointed at SQLite, whose metadata comes from <c>PRAGMA table_xinfo</c> rather than from
-    /// <c>INFORMATION_SCHEMA</c>. A provider's own description of itself is not something one provider can
-    /// stand in for.
+    /// The ODBC catalog is not the information schema — <c>TABLE_CAT</c>, <c>TABLE_SCHEM</c>, a numeric
+    /// <c>DATA_TYPE</c>, no <c>NUMERIC_PRECISION</c> — so nothing about the SQL Server metadata provider
+    /// carries over, and the whole of <see cref="Metadata.OdbcDatabaseMetadata"/> threw
+    /// <see cref="NotImplementedException"/> until it was written against the shape the driver actually
+    /// returns.
     /// </para>
     /// <para>
-    /// LocalDB is Windows only, and a Windows machine need not have it either, so these skip where there is
-    /// no server to talk to.
+    /// Pointing it at the same database as the SqlClient suite is the point: the answers have to be the
+    /// same, and a metadata provider that has misread its own driver's collections says something different.
     /// </para>
     /// </remarks>
     [TestClass]
-    public class SqlServerQueryTests
+    public class OdbcQueryTests
     {
 
-        static SqlServerQueryTests()
+        static OdbcQueryTests()
         {
             ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
             ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
@@ -49,6 +49,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         {
             if (SqlServerFixture.IsAvailable == false)
                 Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+            if (SqlServerFixture.OdbcDriver is null)
+                Assert.Inconclusive("No SQL Server ODBC driver is installed on this machine.");
 
             _server = SqlServerFixture.Shared;
             _types = new JavaTypeFactoryImpl();
@@ -61,7 +63,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
             var calcite = (CalciteConnection)_connection;
             var root = calcite.getRootSchema();
-            _schema = AdoSchema.Create(root, "ADO", _server.DataSource, null, "dbo");
+            _schema = AdoSchema.Create(root, "ADO", _server.OdbcDataSource, null, "dbo");
             root.add("ADO", _schema);
         }
 
@@ -72,8 +74,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// Runs a query and returns its rows as strings, so a comparison does not depend on which numeric
-        /// type a provider chose.
+        /// Runs a query and returns its rows as strings.
         /// </summary>
         /// <param name="sql"></param>
         /// <returns></returns>
@@ -110,39 +111,16 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// Returns a table by name.
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <returns></returns>
-        org.apache.calcite.schema.Table Table(string tableName)
-        {
-            return (org.apache.calcite.schema.Table?)_schema.tables().get(tableName)
-                ?? throw new AssertFailedException($"no table {tableName}; found {string.Join(", ", TableNames())}");
-        }
-
-        /// <summary>
-        /// Returns every table name the schema exposes.
-        /// </summary>
-        /// <returns></returns>
-        List<string> TableNames()
-        {
-            var names = _schema.tables().getNames(org.apache.calcite.schema.lookup.LikePattern.any());
-
-            var result = new List<string>();
-            for (var i = names.iterator(); i.hasNext();)
-                result.Add((string)i.next());
-
-            return result;
-        }
-
-        /// <summary>
         /// Returns the fields of a table's row type, by name.
         /// </summary>
         /// <param name="tableName"></param>
         /// <returns></returns>
         Dictionary<string, RelDataType> Fields(string tableName)
         {
-            var fields = Table(tableName).getRowType(_types).getFieldList();
+            var table = (org.apache.calcite.schema.Table?)_schema.tables().get(tableName)
+                ?? throw new AssertFailedException($"no table {tableName}");
+
+            var fields = table.getRowType(_types).getFieldList();
 
             var result = new Dictionary<string, RelDataType>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < fields.size(); i++)
@@ -151,67 +129,44 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             return result;
         }
 
-        /// <summary>
-        /// Returns the Calcite type name of a named column of a table.
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        string TypeOf(string tableName, string columnName)
-        {
-            if (Fields(tableName).TryGetValue(columnName, out var type) == false)
-                throw new AssertFailedException($"no column {columnName} on {tableName}");
-
-            return type.getSqlTypeName().name();
-        }
-
-        #region The report
-
-        /// <summary>
-        /// The query from the report, verbatim in shape: three columns, one of them the <c>INT</c> whose
-        /// <c>tinyint</c> precision in the information schema was read as an <c>int</c> and threw.
-        /// </summary>
-        [TestMethod]
-        public void ScanningATableWithAnIntegerColumnReturnsItsRows()
-        {
-            CollectionAssert.AreEquivalent(
-                new[] { "Widget|Acme|3", "Gadget|Globex|10", "Doohickey|Initech|1" },
-                Rows("SELECT * FROM ADO.SUPPLIERS"));
-        }
-
-        /// <summary>
-        /// Projecting the two <c>VARCHAR</c> columns failed the same way, because the row type is derived
-        /// from every column of the table whatever the query asks for.
-        /// </summary>
-        [TestMethod]
-        public void ProjectingOnlyTheCharacterColumnsAlsoWorks()
-        {
-            CollectionAssert.AreEquivalent(
-                new[] { "Widget|Acme", "Gadget|Globex", "Doohickey|Initech" },
-                Rows("SELECT PRODUCT, SUPPLIER FROM ADO.SUPPLIERS"));
-        }
-
-        #endregion
-
         #region Discovery
 
         [TestMethod]
-        public void ASqlServerConnectionSelectsTheSqlServerMetadata()
+        public void AnOdbcConnectionSelectsTheOdbcMetadata()
         {
-            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.DataSource);
-            Assert.AreEqual("SqlServerDatabaseMetadata", metadata.GetType().Name);
+            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.OdbcDataSource);
+            Assert.AreEqual("OdbcDatabaseMetadata", metadata.GetType().Name);
+        }
+
+        /// <summary>
+        /// ODBC fronts anything, so the dialect can only come from what the driver says is behind it, which
+        /// here is SQL Server. That the version came with it is <see cref="AnOffsetIsHonoured"/>.
+        /// </summary>
+        [TestMethod]
+        public void TheDialectIsTheOneTheDriverReports()
+        {
+            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.OdbcDataSource);
+
+            Assert.AreEqual("MssqlSqlDialect", metadata.Dialect.GetType().Name);
         }
 
         [TestMethod]
         public void TheSchemaFindsTheTables()
         {
-            var names = TableNames();
+            var names = new List<string>();
+            var found = _schema.tables().getNames(org.apache.calcite.schema.lookup.LikePattern.any());
+            for (var i = found.iterator(); i.hasNext();)
+                names.Add((string)i.next());
 
             CollectionAssert.Contains(names, "SUPPLIERS");
             CollectionAssert.Contains(names, "EMPS");
             CollectionAssert.Contains(names, "DEPTS");
         }
 
+        /// <summary>
+        /// The ODBC catalog spells nullability as <c>NULLABLE</c>, an integer, where the information schema
+        /// spells it <c>IS_NULLABLE</c> and <c>YES</c>.
+        /// </summary>
         [TestMethod]
         public void NullabilityIsCarriedOntoTheType()
         {
@@ -225,26 +180,15 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         #region Types
 
-        /// <summary>
-        /// Every column of the fixture's wide table has to reach a Calcite type: a name the mapping does not
-        /// know throws, and takes the whole table with it.
-        /// </summary>
-        [TestMethod]
-        public void EveryColumnTypeIsMapped()
-        {
-            Assert.AreEqual(26, Fields("TYPES").Count);
-        }
-
         [TestMethod]
         [DataRow("C_BIT", nameof(SqlTypeName.BOOLEAN))]
-        // the server's tinyint is unsigned 0..255 and Calcite's TINYINT is signed, so SMALLINT is what holds it
         [DataRow("C_TINYINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_SMALLINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_BIGINT", nameof(SqlTypeName.BIGINT))]
         [DataRow("C_DECIMAL", nameof(SqlTypeName.DECIMAL))]
         [DataRow("C_NUMERIC", nameof(SqlTypeName.DECIMAL))]
+        // ODBC reports money as SQL_DECIMAL with its precision and scale, so it arrives as the decimal it is
         [DataRow("C_MONEY", nameof(SqlTypeName.DECIMAL))]
-        [DataRow("C_SMALLMONEY", nameof(SqlTypeName.DECIMAL))]
         [DataRow("C_FLOAT", nameof(SqlTypeName.DOUBLE))]
         [DataRow("C_REAL", nameof(SqlTypeName.REAL))]
         [DataRow("C_CHAR", nameof(SqlTypeName.CHAR))]
@@ -254,7 +198,6 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_DATE", nameof(SqlTypeName.DATE))]
         [DataRow("C_TIME", nameof(SqlTypeName.TIME))]
         [DataRow("C_DATETIME", nameof(SqlTypeName.TIMESTAMP))]
-        [DataRow("C_SMALLDATETIME", nameof(SqlTypeName.TIMESTAMP))]
         [DataRow("C_DATETIME2", nameof(SqlTypeName.TIMESTAMP))]
         [DataRow("C_DATETIMEOFFSET", nameof(SqlTypeName.TIMESTAMP_TZ))]
         [DataRow("C_BINARY", nameof(SqlTypeName.VARBINARY))]
@@ -263,50 +206,44 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_XML", nameof(SqlTypeName.VARCHAR))]
         public void AColumnGetsItsCalciteType(string columnName, string expected)
         {
-            Assert.AreEqual(expected, TypeOf("TYPES", columnName));
+            Assert.AreEqual(expected, Fields("TYPES")[columnName].getSqlTypeName().name());
+        }
+
+        [TestMethod]
+        public void EveryColumnTypeIsMapped()
+        {
+            Assert.AreEqual(26, Fields("TYPES").Count);
         }
 
         /// <summary>
-        /// Reading the wide table is a separate claim from typing it: the reader picks its accessor from the
-        /// Calcite type, and a mapping that types a column plausibly can still refuse to read one.
+        /// Every column the driver can read, read. <c>C_TIME</c> and <c>C_DATETIMEOFFSET</c> are left out:
+        /// see <see cref="TheDriverCannotReadSqlServersOwnTimeTypes"/>.
         /// </summary>
         [TestMethod]
-        public void EveryColumnTypeCanBeRead()
+        public void EveryReadableColumnTypeCanBeRead()
         {
-            Assert.AreEqual(2, Rows("SELECT * FROM ADO.TYPES").Count);
-        }
-
-        [TestMethod]
-        public void ANullOfEveryTypeComesBackNull()
-        {
-            var row = Scalar("SELECT * FROM ADO.TYPES WHERE ID = 2");
-            var values = row.Split('|');
-
-            Assert.AreEqual("2", values[0]);
-            for (int i = 1; i < values.Length; i++)
-                Assert.AreEqual("NULL", values[i], $"column {i} of the all-null row");
-        }
-
-        [TestMethod]
-        public void ADecimalKeepsItsScale()
-        {
-            Assert.AreEqual("123456789.125", Scalar("SELECT C_DECIMAL FROM ADO.TYPES WHERE ID = 1"));
-        }
-
-        [TestMethod]
-        public void AVarcharMaxIsReadable()
-        {
-            Assert.AreEqual("unbounded", Scalar("SELECT C_VARCHARMAX FROM ADO.TYPES WHERE ID = 1"));
+            Assert.AreEqual(2, Rows("""
+                SELECT ID, C_BIT, C_TINYINT, C_SMALLINT, C_BIGINT, C_DECIMAL, C_NUMERIC, C_MONEY, C_SMALLMONEY,
+                       C_FLOAT, C_REAL, C_CHAR, C_VARCHAR, C_VARCHARMAX, C_NCHAR, C_NVARCHAR, C_DATE,
+                       C_DATETIME, C_SMALLDATETIME, C_DATETIME2, C_BINARY, C_VARBINARY, C_GUID, C_XML
+                FROM ADO.TYPES
+                """).Count);
         }
 
         /// <summary>
-        /// A <c>uniqueidentifier</c> is a <see cref="Guid"/> to the provider and a <c>CHAR(36)</c> to
-        /// Calcite, so what the reader hands over has to be the text.
+        /// A limitation of the driver rather than of the adapter, pinned so that it is a stated fact rather
+        /// than a surprise: <c>System.Data.Odbc</c> has no mapping for <c>SQL_SS_TIME2</c> or
+        /// <c>SQL_SS_TIMESTAMPOFFSET</c>, and <c>TypeMap.FromSqlType</c> throws on either. The columns are
+        /// still typed — the metadata comes from the catalog, not from a reader — and only reading one
+        /// fails.
         /// </summary>
         [TestMethod]
-        public void AUniqueIdentifierComesBackAsItsText()
+        public void TheDriverCannotReadSqlServersOwnTimeTypes()
         {
-            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", Scalar("SELECT C_GUID FROM ADO.TYPES WHERE ID = 1"));
+            Assert.AreEqual(nameof(SqlTypeName.TIME), Fields("TYPES")["C_TIME"].getSqlTypeName().name());
+
+            var thrown = Assert.ThrowsException<ArgumentException>(() => Rows("SELECT C_TIME FROM ADO.TYPES"));
+            StringAssert.Contains(thrown.Message, "SS_TIME_EX");
         }
 
         [TestMethod]
@@ -314,11 +251,15 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_TINYINT", "200")]
         [DataRow("C_SMALLINT", "-300")]
         [DataRow("C_BIGINT", "9000000000")]
+        [DataRow("C_DECIMAL", "123456789.125")]
         [DataRow("C_FLOAT", "1.5")]
         [DataRow("C_REAL", "2.5")]
         [DataRow("C_CHAR", "abcd")]
+        [DataRow("C_VARCHAR", "varchar")]
+        [DataRow("C_VARCHARMAX", "unbounded")]
         [DataRow("C_NCHAR", "wxyz")]
         [DataRow("C_NVARCHAR", "nvarchar")]
+        [DataRow("C_GUID", "3f2504e0-4f89-11d3-9a0c-0305e82c3301")]
         public void AScalarValueComesBackAsWritten(string columnName, string expected)
         {
             Assert.AreEqual(expected, Scalar($"SELECT {columnName} FROM ADO.TYPES WHERE ID = 1"));
@@ -327,6 +268,14 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         #endregion
 
         #region Query
+
+        [TestMethod]
+        public void ScanningATableReturnsItsRows()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Widget|Acme|3", "Gadget|Globex|10", "Doohickey|Initech|1" },
+                Rows("SELECT * FROM ADO.SUPPLIERS"));
+        }
 
         [TestMethod]
         public void AFilterIsApplied()
@@ -350,12 +299,15 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
                 Rows("SELECT E.NAME, D.DNAME FROM ADO.EMPS E JOIN ADO.DEPTS D ON E.DEPTNO = D.DEPTNO"));
         }
 
+        /// <summary>
+        /// The dialect has to know the server is past 2012 for this to be right: under that,
+        /// <c>MssqlSqlDialect</c> writes <c>TOP(1)</c> and drops the offset, and the answer is the first row
+        /// rather than the second.
+        /// </summary>
         [TestMethod]
-        public void AnOrderByIsHonoured()
+        public void AnOffsetIsHonoured()
         {
-            CollectionAssert.AreEqual(
-                new[] { "Doohickey", "Widget", "Gadget" },
-                Rows("SELECT PRODUCT FROM ADO.SUPPLIERS ORDER BY LEAD_DAYS"));
+            Assert.AreEqual("Widget", Scalar("SELECT PRODUCT FROM ADO.SUPPLIERS ORDER BY LEAD_DAYS OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY"));
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
@@ -140,7 +140,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         {
             var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.OleDbDataSource);
 
-            Assert.AreEqual("MssqlSqlDialect", metadata.Dialect.GetType().Name);
+            Assert.IsInstanceOfType<org.apache.calcite.sql.dialect.MssqlSqlDialect>(metadata.Dialect);
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
@@ -175,7 +175,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         [TestMethod]
         [DataRow("C_BIT", nameof(SqlTypeName.BOOLEAN))]
-        [DataRow("C_TINYINT", nameof(SqlTypeName.SMALLINT))]
+        [DataRow("C_TINYINT", nameof(SqlTypeName.UTINYINT))]
         [DataRow("C_SMALLINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_BIGINT", nameof(SqlTypeName.BIGINT))]
         [DataRow("C_DECIMAL", nameof(SqlTypeName.DECIMAL))]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
@@ -6,33 +6,27 @@ using org.apache.calcite.sql.type;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Data.OleDb;
 
 namespace Apache.Calcite.Adapter.AdoNet.Tests
 {
 
     /// <summary>
-    /// Covers the adapter against a real SQL Server, which is the only thing that exercises the information
-    /// schema path and the SQL Server type mapping.
+    /// Covers the adapter over an <see cref="OleDbConnection"/>, against the same LocalDB database
+    /// <see cref="SqlServerQueryTests"/> uses.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// Every query against SQL Server failed with <c>InvalidCastException: Unable to cast object of type
-    /// 'System.Byte' to type 'System.Int32'</c> and nothing here said so, because the suite had only ever
-    /// been pointed at SQLite, whose metadata comes from <c>PRAGMA table_xinfo</c> rather than from
-    /// <c>INFORMATION_SCHEMA</c>. A provider's own description of itself is not something one provider can
-    /// stand in for.
-    /// </para>
-    /// <para>
-    /// LocalDB is Windows only, and a Windows machine need not have it either, so these skip where there is
-    /// no server to talk to.
-    /// </para>
+    /// OLE DB's schema rowsets borrow the information schema's column names without its types — a numeric
+    /// <c>DATA_TYPE</c>, a <see cref="bool"/> <c>IS_NULLABLE</c>, a <see cref="decimal"/>
+    /// <c>CHARACTER_MAXIMUM_LENGTH</c> — which is close enough to look like it should have worked and did
+    /// not: the whole of <see cref="Metadata.OleDbDatabaseMetadata"/> threw
+    /// <see cref="NotImplementedException"/>.
     /// </remarks>
     [TestClass]
-    public class SqlServerQueryTests
+    public class OleDbQueryTests
     {
 
-        static SqlServerQueryTests()
+        static OleDbQueryTests()
         {
             ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
             ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
@@ -49,6 +43,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         {
             if (SqlServerFixture.IsAvailable == false)
                 Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+            if (SqlServerFixture.OleDbProvider is null)
+                Assert.Inconclusive("No SQL Server OLE DB provider is registered for this process architecture.");
 
             _server = SqlServerFixture.Shared;
             _types = new JavaTypeFactoryImpl();
@@ -61,7 +57,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
             var calcite = (CalciteConnection)_connection;
             var root = calcite.getRootSchema();
-            _schema = AdoSchema.Create(root, "ADO", _server.DataSource, null, "dbo");
+            _schema = AdoSchema.Create(root, "ADO", _server.OleDbDataSource, null, "dbo");
             root.add("ADO", _schema);
         }
 
@@ -72,8 +68,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// Runs a query and returns its rows as strings, so a comparison does not depend on which numeric
-        /// type a provider chose.
+        /// Runs a query and returns its rows as strings.
         /// </summary>
         /// <param name="sql"></param>
         /// <returns></returns>
@@ -110,39 +105,16 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// Returns a table by name.
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <returns></returns>
-        org.apache.calcite.schema.Table Table(string tableName)
-        {
-            return (org.apache.calcite.schema.Table?)_schema.tables().get(tableName)
-                ?? throw new AssertFailedException($"no table {tableName}; found {string.Join(", ", TableNames())}");
-        }
-
-        /// <summary>
-        /// Returns every table name the schema exposes.
-        /// </summary>
-        /// <returns></returns>
-        List<string> TableNames()
-        {
-            var names = _schema.tables().getNames(org.apache.calcite.schema.lookup.LikePattern.any());
-
-            var result = new List<string>();
-            for (var i = names.iterator(); i.hasNext();)
-                result.Add((string)i.next());
-
-            return result;
-        }
-
-        /// <summary>
         /// Returns the fields of a table's row type, by name.
         /// </summary>
         /// <param name="tableName"></param>
         /// <returns></returns>
         Dictionary<string, RelDataType> Fields(string tableName)
         {
-            var fields = Table(tableName).getRowType(_types).getFieldList();
+            var table = (org.apache.calcite.schema.Table?)_schema.tables().get(tableName)
+                ?? throw new AssertFailedException($"no table {tableName}");
+
+            var fields = table.getRowType(_types).getFieldList();
 
             var result = new Dictionary<string, RelDataType>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < fields.size(); i++)
@@ -151,67 +123,43 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             return result;
         }
 
-        /// <summary>
-        /// Returns the Calcite type name of a named column of a table.
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        string TypeOf(string tableName, string columnName)
-        {
-            if (Fields(tableName).TryGetValue(columnName, out var type) == false)
-                throw new AssertFailedException($"no column {columnName} on {tableName}");
-
-            return type.getSqlTypeName().name();
-        }
-
-        #region The report
-
-        /// <summary>
-        /// The query from the report, verbatim in shape: three columns, one of them the <c>INT</c> whose
-        /// <c>tinyint</c> precision in the information schema was read as an <c>int</c> and threw.
-        /// </summary>
-        [TestMethod]
-        public void ScanningATableWithAnIntegerColumnReturnsItsRows()
-        {
-            CollectionAssert.AreEquivalent(
-                new[] { "Widget|Acme|3", "Gadget|Globex|10", "Doohickey|Initech|1" },
-                Rows("SELECT * FROM ADO.SUPPLIERS"));
-        }
-
-        /// <summary>
-        /// Projecting the two <c>VARCHAR</c> columns failed the same way, because the row type is derived
-        /// from every column of the table whatever the query asks for.
-        /// </summary>
-        [TestMethod]
-        public void ProjectingOnlyTheCharacterColumnsAlsoWorks()
-        {
-            CollectionAssert.AreEquivalent(
-                new[] { "Widget|Acme", "Gadget|Globex", "Doohickey|Initech" },
-                Rows("SELECT PRODUCT, SUPPLIER FROM ADO.SUPPLIERS"));
-        }
-
-        #endregion
-
         #region Discovery
 
         [TestMethod]
-        public void ASqlServerConnectionSelectsTheSqlServerMetadata()
+        public void AnOleDbConnectionSelectsTheOleDbMetadata()
         {
-            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.DataSource);
-            Assert.AreEqual("SqlServerDatabaseMetadata", metadata.GetType().Name);
+            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.OleDbDataSource);
+            Assert.AreEqual("OleDbDatabaseMetadata", metadata.GetType().Name);
+        }
+
+        /// <summary>
+        /// That the version came with it is <see cref="AnOffsetIsHonoured"/>.
+        /// </summary>
+        [TestMethod]
+        public void TheDialectIsTheOneTheProviderReports()
+        {
+            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.OleDbDataSource);
+
+            Assert.AreEqual("MssqlSqlDialect", metadata.Dialect.GetType().Name);
         }
 
         [TestMethod]
         public void TheSchemaFindsTheTables()
         {
-            var names = TableNames();
+            var names = new List<string>();
+            var found = _schema.tables().getNames(org.apache.calcite.schema.lookup.LikePattern.any());
+            for (var i = found.iterator(); i.hasNext();)
+                names.Add((string)i.next());
 
             CollectionAssert.Contains(names, "SUPPLIERS");
             CollectionAssert.Contains(names, "EMPS");
             CollectionAssert.Contains(names, "DEPTS");
         }
 
+        /// <summary>
+        /// OLE DB states nullability as a <see cref="bool"/>, where the information schema and ODBC both
+        /// state it otherwise.
+        /// </summary>
         [TestMethod]
         public void NullabilityIsCarriedOntoTheType()
         {
@@ -225,26 +173,14 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         #region Types
 
-        /// <summary>
-        /// Every column of the fixture's wide table has to reach a Calcite type: a name the mapping does not
-        /// know throws, and takes the whole table with it.
-        /// </summary>
-        [TestMethod]
-        public void EveryColumnTypeIsMapped()
-        {
-            Assert.AreEqual(26, Fields("TYPES").Count);
-        }
-
         [TestMethod]
         [DataRow("C_BIT", nameof(SqlTypeName.BOOLEAN))]
-        // the server's tinyint is unsigned 0..255 and Calcite's TINYINT is signed, so SMALLINT is what holds it
         [DataRow("C_TINYINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_SMALLINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_BIGINT", nameof(SqlTypeName.BIGINT))]
         [DataRow("C_DECIMAL", nameof(SqlTypeName.DECIMAL))]
         [DataRow("C_NUMERIC", nameof(SqlTypeName.DECIMAL))]
         [DataRow("C_MONEY", nameof(SqlTypeName.DECIMAL))]
-        [DataRow("C_SMALLMONEY", nameof(SqlTypeName.DECIMAL))]
         [DataRow("C_FLOAT", nameof(SqlTypeName.DOUBLE))]
         [DataRow("C_REAL", nameof(SqlTypeName.REAL))]
         [DataRow("C_CHAR", nameof(SqlTypeName.CHAR))]
@@ -254,7 +190,6 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_DATE", nameof(SqlTypeName.DATE))]
         [DataRow("C_TIME", nameof(SqlTypeName.TIME))]
         [DataRow("C_DATETIME", nameof(SqlTypeName.TIMESTAMP))]
-        [DataRow("C_SMALLDATETIME", nameof(SqlTypeName.TIMESTAMP))]
         [DataRow("C_DATETIME2", nameof(SqlTypeName.TIMESTAMP))]
         [DataRow("C_DATETIMEOFFSET", nameof(SqlTypeName.TIMESTAMP_TZ))]
         [DataRow("C_BINARY", nameof(SqlTypeName.VARBINARY))]
@@ -263,13 +198,28 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_XML", nameof(SqlTypeName.VARCHAR))]
         public void AColumnGetsItsCalciteType(string columnName, string expected)
         {
-            Assert.AreEqual(expected, TypeOf("TYPES", columnName));
+            Assert.AreEqual(expected, Fields("TYPES")[columnName].getSqlTypeName().name());
         }
 
         /// <summary>
-        /// Reading the wide table is a separate claim from typing it: the reader picks its accessor from the
-        /// Calcite type, and a mapping that types a column plausibly can still refuse to read one.
+        /// A <c>DBTYPE</c> says <c>DBTYPE_STR</c> for both <c>char</c> and <c>varchar</c>; only
+        /// <c>DBCOLUMNFLAGS_ISFIXEDLENGTH</c> tells them apart, and Calcite pads a <c>CHAR</c>.
         /// </summary>
+        [TestMethod]
+        public void AFixedLengthColumnIsDistinguishedFromAVaryingOne()
+        {
+            Assert.AreEqual(nameof(SqlTypeName.CHAR), Fields("TYPES")["C_CHAR"].getSqlTypeName().name());
+            Assert.AreEqual(nameof(SqlTypeName.VARCHAR), Fields("TYPES")["C_VARCHAR"].getSqlTypeName().name());
+            Assert.AreEqual(nameof(SqlTypeName.CHAR), Fields("TYPES")["C_NCHAR"].getSqlTypeName().name());
+            Assert.AreEqual(nameof(SqlTypeName.VARCHAR), Fields("TYPES")["C_NVARCHAR"].getSqlTypeName().name());
+        }
+
+        [TestMethod]
+        public void EveryColumnTypeIsMapped()
+        {
+            Assert.AreEqual(26, Fields("TYPES").Count);
+        }
+
         [TestMethod]
         public void EveryColumnTypeCanBeRead()
         {
@@ -277,48 +227,19 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         [TestMethod]
-        public void ANullOfEveryTypeComesBackNull()
-        {
-            var row = Scalar("SELECT * FROM ADO.TYPES WHERE ID = 2");
-            var values = row.Split('|');
-
-            Assert.AreEqual("2", values[0]);
-            for (int i = 1; i < values.Length; i++)
-                Assert.AreEqual("NULL", values[i], $"column {i} of the all-null row");
-        }
-
-        [TestMethod]
-        public void ADecimalKeepsItsScale()
-        {
-            Assert.AreEqual("123456789.125", Scalar("SELECT C_DECIMAL FROM ADO.TYPES WHERE ID = 1"));
-        }
-
-        [TestMethod]
-        public void AVarcharMaxIsReadable()
-        {
-            Assert.AreEqual("unbounded", Scalar("SELECT C_VARCHARMAX FROM ADO.TYPES WHERE ID = 1"));
-        }
-
-        /// <summary>
-        /// A <c>uniqueidentifier</c> is a <see cref="Guid"/> to the provider and a <c>CHAR(36)</c> to
-        /// Calcite, so what the reader hands over has to be the text.
-        /// </summary>
-        [TestMethod]
-        public void AUniqueIdentifierComesBackAsItsText()
-        {
-            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", Scalar("SELECT C_GUID FROM ADO.TYPES WHERE ID = 1"));
-        }
-
-        [TestMethod]
         [DataRow("C_BIT", "true")]
         [DataRow("C_TINYINT", "200")]
         [DataRow("C_SMALLINT", "-300")]
         [DataRow("C_BIGINT", "9000000000")]
+        [DataRow("C_DECIMAL", "123456789.125")]
         [DataRow("C_FLOAT", "1.5")]
         [DataRow("C_REAL", "2.5")]
         [DataRow("C_CHAR", "abcd")]
+        [DataRow("C_VARCHAR", "varchar")]
+        [DataRow("C_VARCHARMAX", "unbounded")]
         [DataRow("C_NCHAR", "wxyz")]
         [DataRow("C_NVARCHAR", "nvarchar")]
+        [DataRow("C_GUID", "3f2504e0-4f89-11d3-9a0c-0305e82c3301")]
         public void AScalarValueComesBackAsWritten(string columnName, string expected)
         {
             Assert.AreEqual(expected, Scalar($"SELECT {columnName} FROM ADO.TYPES WHERE ID = 1"));
@@ -327,6 +248,14 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         #endregion
 
         #region Query
+
+        [TestMethod]
+        public void ScanningATableReturnsItsRows()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Widget|Acme|3", "Gadget|Globex|10", "Doohickey|Initech|1" },
+                Rows("SELECT * FROM ADO.SUPPLIERS"));
+        }
 
         [TestMethod]
         public void AFilterIsApplied()
@@ -351,11 +280,9 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         [TestMethod]
-        public void AnOrderByIsHonoured()
+        public void AnOffsetIsHonoured()
         {
-            CollectionAssert.AreEqual(
-                new[] { "Doohickey", "Widget", "Gadget" },
-                Rows("SELECT PRODUCT FROM ADO.SUPPLIERS ORDER BY LEAD_DAYS"));
+            Assert.AreEqual("Widget", Scalar("SELECT PRODUCT FROM ADO.SUPPLIERS ORDER BY LEAD_DAYS OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY"));
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerFixture.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerFixture.cs
@@ -2,7 +2,10 @@ using Microsoft.Data.SqlClient;
 
 using System;
 using System.Data.Common;
+using System.Data.Odbc;
+using System.Data.OleDb;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Apache.Calcite.Adapter.AdoNet.Tests
 {
@@ -11,9 +14,18 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
     /// A SQL Server LocalDB database, populated, and dropped with the test.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// LocalDB is the only SQL Server a test run can assume it can create for itself, and it exists on
     /// Windows alone. <see cref="IsAvailable"/> answers whether one is reachable; a suite running anywhere
     /// else skips rather than fails.
+    /// </para>
+    /// <para>
+    /// The same database is reachable through three drivers, and the fixture offers all three:
+    /// <see cref="DataSource"/> is SqlClient, <see cref="OdbcDataSource"/> is whichever SQL Server ODBC
+    /// driver is installed, and <see cref="OleDbDataSource"/> whichever OLE DB provider is registered. One
+    /// server described three ways is the only thing that shows a metadata provider reading its own
+    /// driver's collections wrongly, because the right answer is the same for all three.
+    /// </para>
     /// </remarks>
     sealed class SqlServerFixture : IDisposable
     {
@@ -34,8 +46,29 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
                 IntegratedSecurity = true,
                 TrustServerCertificate = true,
                 ConnectTimeout = 30,
-                Pooling = false,
             }.ConnectionString;
+        }
+
+        static SqlServerFixture? _shared;
+
+        /// <summary>
+        /// Gets the one database the suite shares, made on first use.
+        /// </summary>
+        /// <remarks>
+        /// Shared rather than made per test because <c>CREATE DATABASE</c> against LocalDB costs a second or
+        /// two and there are some two hundred tests behind it — per test that is ten minutes of a suite that
+        /// otherwise runs in forty seconds. Nothing that reads it writes to it. <see cref="DisposeShared"/>
+        /// is called from the assembly cleanup.
+        /// </remarks>
+        public static SqlServerFixture Shared => _shared ??= new SqlServerFixture();
+
+        /// <summary>
+        /// Drops the shared database, if one was ever made.
+        /// </summary>
+        public static void DisposeShared()
+        {
+            _shared?.Dispose();
+            _shared = null;
         }
 
         static bool? _available;
@@ -69,6 +102,105 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// The SQL Server ODBC drivers worth trying, newest first.
+        /// </summary>
+        static readonly string[] OdbcDrivers = ["ODBC Driver 18 for SQL Server", "ODBC Driver 17 for SQL Server", "SQL Server"];
+
+        /// <summary>
+        /// The SQL Server OLE DB providers worth trying, newest first.
+        /// </summary>
+        static readonly string[] OleDbProviders = ["MSOLEDBSQL19", "MSOLEDBSQL", "SQLOLEDB"];
+
+        static string? _odbcDriver;
+        static bool _odbcProbed;
+        static string? _oleDbProvider;
+        static bool _oleDbProbed;
+
+        /// <summary>
+        /// Gets the name of an installed SQL Server ODBC driver, or <see langword="null"/> if there is none.
+        /// </summary>
+        public static string? OdbcDriver
+        {
+            get
+            {
+                if (_odbcProbed == false)
+                {
+                    _odbcDriver = IsAvailable ? FirstThatConnects(OdbcDrivers, d => new OdbcConnection(OdbcConnectionStringFor(d, "master"))) : null;
+                    _odbcProbed = true;
+                }
+
+                return _odbcDriver;
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of a registered SQL Server OLE DB provider, or <see langword="null"/> if there is
+        /// none.
+        /// </summary>
+        public static string? OleDbProvider
+        {
+            get
+            {
+                if (_oleDbProbed == false)
+                {
+                    _oleDbProvider = IsAvailable ? FirstThatConnects(OleDbProviders, p => new OleDbConnection(OleDbConnectionStringFor(p, "master"))) : null;
+                    _oleDbProbed = true;
+                }
+
+                return _oleDbProvider;
+            }
+        }
+
+        /// <summary>
+        /// Returns the first of the candidates a connection can be opened with.
+        /// </summary>
+        /// <param name="candidates"></param>
+        /// <param name="connect"></param>
+        /// <returns></returns>
+        static string? FirstThatConnects(string[] candidates, Func<string, DbConnection> connect)
+        {
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    using var connection = connect(candidate);
+                    connection.Open();
+                    return candidate;
+                }
+                catch (Exception)
+                {
+                    // an absent driver, an absent provider, or one built for the other architecture
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns an ODBC connection string to the named database on the local instance.
+        /// </summary>
+        /// <param name="driver"></param>
+        /// <param name="database"></param>
+        /// <returns></returns>
+        static string OdbcConnectionStringFor(string driver, string database)
+        {
+            // TrustServerCertificate matters to driver 18, which defaults to encrypting and then refuses
+            // LocalDB's self-signed certificate
+            return $"Driver={{{driver}}};Server={Instance};Database={database};Trusted_Connection=yes;TrustServerCertificate=yes;";
+        }
+
+        /// <summary>
+        /// Returns an OLE DB connection string to the named database on the local instance.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="database"></param>
+        /// <returns></returns>
+        static string OleDbConnectionStringFor(string provider, string database)
+        {
+            return $"Provider={provider};Data Source={Instance};Initial Catalog={database};Integrated Security=SSPI;";
         }
 
         readonly string _database;
@@ -189,6 +321,24 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         public DbDataSource DataSource { get; }
 
         /// <summary>
+        /// Gets the same database reached through ODBC.
+        /// </summary>
+        public DbDataSource OdbcDataSource => _odbcDataSource ??= new Source<OdbcConnection>(
+            OdbcConnectionStringFor(OdbcDriver ?? throw new InvalidOperationException("no ODBC driver"), _database),
+            s => new OdbcConnection(s));
+
+        DbDataSource? _odbcDataSource;
+
+        /// <summary>
+        /// Gets the same database reached through OLE DB.
+        /// </summary>
+        public DbDataSource OleDbDataSource => _oleDbDataSource ??= new Source<OleDbConnection>(
+            OleDbConnectionStringFor(OleDbProvider ?? throw new InvalidOperationException("no OLE DB provider"), _database),
+            s => new OleDbConnection(s));
+
+        DbDataSource? _oleDbDataSource;
+
+        /// <summary>
         /// Runs a statement against the fixture's database.
         /// </summary>
         /// <param name="sql"></param>
@@ -219,6 +369,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         /// <inheritdoc />
         public void Dispose()
         {
+            _odbcDataSource?.Dispose();
+            _oleDbDataSource?.Dispose();
             DataSource.Dispose();
             SqlConnection.ClearAllPools();
 
@@ -245,6 +397,24 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
             /// <inheritdoc />
             protected override DbConnection CreateDbConnection() => new SqlConnection(connectionString);
+
+        }
+
+        /// <summary>
+        /// The <see cref="DbDataSource"/> neither System.Data.Odbc nor System.Data.OleDb ships.
+        /// </summary>
+        /// <typeparam name="TConnection">The connection type, which is what the metadata factory dispatches on.</typeparam>
+        /// <param name="connectionString"></param>
+        /// <param name="create"></param>
+        sealed class Source<TConnection>(string connectionString, Func<string, TConnection> create) : DbDataSource
+            where TConnection : DbConnection
+        {
+
+            /// <inheritdoc />
+            public override string ConnectionString => connectionString;
+
+            /// <inheritdoc />
+            protected override DbConnection CreateDbConnection() => create(connectionString);
 
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerFixture.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerFixture.cs
@@ -1,0 +1,253 @@
+using Microsoft.Data.SqlClient;
+
+using System;
+using System.Data.Common;
+using System.Runtime.InteropServices;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// A SQL Server LocalDB database, populated, and dropped with the test.
+    /// </summary>
+    /// <remarks>
+    /// LocalDB is the only SQL Server a test run can assume it can create for itself, and it exists on
+    /// Windows alone. <see cref="IsAvailable"/> answers whether one is reachable; a suite running anywhere
+    /// else skips rather than fails.
+    /// </remarks>
+    sealed class SqlServerFixture : IDisposable
+    {
+
+        const string Instance = @"(localdb)\MSSQLLocalDB";
+
+        /// <summary>
+        /// Returns a connection string to the named database on the local instance.
+        /// </summary>
+        /// <param name="database"></param>
+        /// <returns></returns>
+        static string ConnectionStringFor(string database)
+        {
+            return new SqlConnectionStringBuilder()
+            {
+                DataSource = Instance,
+                InitialCatalog = database,
+                IntegratedSecurity = true,
+                TrustServerCertificate = true,
+                ConnectTimeout = 30,
+                Pooling = false,
+            }.ConnectionString;
+        }
+
+        static bool? _available;
+
+        /// <summary>
+        /// Gets whether a LocalDB instance can be reached, so the tests that need one can be skipped where
+        /// there is none.
+        /// </summary>
+        /// <remarks>
+        /// Asked once: a failing connection waits out the timeout, and doing that per test would cost more
+        /// than the suite.
+        /// </remarks>
+        public static bool IsAvailable => _available ??= Probe();
+
+        /// <summary>
+        /// Opens a connection to <c>master</c> and reports whether it worked.
+        /// </summary>
+        /// <returns></returns>
+        static bool Probe()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
+                return false;
+
+            try
+            {
+                using var connection = new SqlConnection(ConnectionStringFor("master"));
+                connection.Open();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        readonly string _database;
+
+        /// <summary>
+        /// Creates a database holding the tables the tests query.
+        /// </summary>
+        public SqlServerFixture()
+        {
+            _database = $"calcite_ado_{Guid.NewGuid():N}";
+            ExecuteOnMaster($"CREATE DATABASE [{_database}]");
+
+            DataSource = new Source(ConnectionStringFor(_database));
+
+            // the table from the report this fixture exists for: a scan of it read the information schema,
+            // and the INT column's tinyint precision is what threw
+            Execute("""
+                CREATE TABLE dbo.SUPPLIERS (
+                    PRODUCT   VARCHAR(64)  NOT NULL PRIMARY KEY,
+                    SUPPLIER  VARCHAR(128) NOT NULL,
+                    LEAD_DAYS INT          NOT NULL)
+                """);
+
+            Execute("""
+                INSERT INTO dbo.SUPPLIERS (PRODUCT, SUPPLIER, LEAD_DAYS) VALUES
+                    ('Widget', 'Acme', 3),
+                    ('Gadget', 'Globex', 10),
+                    ('Doohickey', 'Initech', 1)
+                """);
+
+            Execute("""
+                CREATE TABLE dbo.EMPS (
+                    EMPNO   INT           NOT NULL PRIMARY KEY,
+                    NAME    NVARCHAR(64)  NOT NULL,
+                    DEPTNO  INT           NULL,
+                    SALARY  DECIMAL(9,2)  NULL)
+                """);
+
+            Execute("""
+                INSERT INTO dbo.EMPS (EMPNO, NAME, DEPTNO, SALARY) VALUES
+                    (1, 'Alice', 10, 100.50),
+                    (2, 'Bob',   10, 200.00),
+                    (3, 'Carol', 20, 300.25),
+                    (4, 'Dave',  20, NULL)
+                """);
+
+            Execute("CREATE TABLE dbo.DEPTS (DEPTNO INT NOT NULL PRIMARY KEY, DNAME NVARCHAR(64) NOT NULL)");
+            Execute("INSERT INTO dbo.DEPTS (DEPTNO, DNAME) VALUES (10, 'Sales'), (20, 'Engineering'), (30, 'Empty')");
+
+            // one column of every type the server's information schema names differently, so that a gap in
+            // the type mapping shows up as a failing test rather than as a table nobody can read
+            Execute("""
+                CREATE TABLE dbo.TYPES (
+                    ID          INT              NOT NULL PRIMARY KEY,
+                    C_BIT       BIT              NULL,
+                    C_TINYINT   TINYINT          NULL,
+                    C_SMALLINT  SMALLINT         NULL,
+                    C_BIGINT    BIGINT           NULL,
+                    C_DECIMAL   DECIMAL(12,3)    NULL,
+                    C_NUMERIC   NUMERIC(8,4)     NULL,
+                    C_MONEY     MONEY            NULL,
+                    C_SMALLMONEY SMALLMONEY      NULL,
+                    C_FLOAT     FLOAT            NULL,
+                    C_REAL      REAL             NULL,
+                    C_CHAR      CHAR(4)          NULL,
+                    C_VARCHAR   VARCHAR(16)      NULL,
+                    C_VARCHARMAX VARCHAR(MAX)    NULL,
+                    C_NCHAR     NCHAR(4)         NULL,
+                    C_NVARCHAR  NVARCHAR(16)     NULL,
+                    C_DATE      DATE             NULL,
+                    C_TIME      TIME(3)          NULL,
+                    C_DATETIME  DATETIME         NULL,
+                    C_SMALLDATETIME SMALLDATETIME NULL,
+                    C_DATETIME2 DATETIME2(3)     NULL,
+                    C_DATETIMEOFFSET DATETIMEOFFSET(3) NULL,
+                    C_BINARY    BINARY(4)        NULL,
+                    C_VARBINARY VARBINARY(16)    NULL,
+                    C_GUID      UNIQUEIDENTIFIER NULL,
+                    C_XML       XML              NULL)
+                """);
+
+            Execute("""
+                INSERT INTO dbo.TYPES VALUES (
+                    1,
+                    1,
+                    200,
+                    -300,
+                    9000000000,
+                    123456789.125,
+                    1234.5678,
+                    12.3400,
+                    1.2300,
+                    1.5,
+                    2.5,
+                    'abcd',
+                    'varchar',
+                    'unbounded',
+                    N'wxyz',
+                    N'nvarchar',
+                    '2020-01-15',
+                    '01:02:03.500',
+                    '2020-01-15T10:20:30',
+                    '2020-01-15T10:20:00',
+                    '2020-01-15T10:20:30.250',
+                    '2020-01-15T10:20:30.250+00:00',
+                    0x01020304,
+                    0x0A0B,
+                    '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+                    '<a b="c"/>')
+                """);
+
+            Execute("INSERT INTO dbo.TYPES (ID) VALUES (2)");
+        }
+
+        /// <summary>
+        /// Gets the data source the adapter is pointed at.
+        /// </summary>
+        public DbDataSource DataSource { get; }
+
+        /// <summary>
+        /// Runs a statement against the fixture's database.
+        /// </summary>
+        /// <param name="sql"></param>
+        public void Execute(string sql)
+        {
+            using var connection = DataSource.CreateConnection();
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            command.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Runs a statement against <c>master</c>, which is where a database is created and dropped from.
+        /// </summary>
+        /// <param name="sql"></param>
+        static void ExecuteOnMaster(string sql)
+        {
+            using var connection = new SqlConnection(ConnectionStringFor("master"));
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            command.ExecuteNonQuery();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            DataSource.Dispose();
+            SqlConnection.ClearAllPools();
+
+            try
+            {
+                // a connection of our own still open would make the drop wait for it
+                ExecuteOnMaster($"ALTER DATABASE [{_database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{_database}]");
+            }
+            catch (SqlException)
+            {
+                // a database left behind on a developer's LocalDB is not worth failing a test over
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="DbDataSource"/> Microsoft.Data.SqlClient does not ship.
+        /// </summary>
+        /// <param name="connectionString"></param>
+        sealed class Source(string connectionString) : DbDataSource
+        {
+
+            /// <inheritdoc />
+            public override string ConnectionString => connectionString;
+
+            /// <inheritdoc />
+            protected override DbConnection CreateDbConnection() => new SqlConnection(connectionString);
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
@@ -237,8 +237,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         [TestMethod]
         [DataRow("C_BIT", nameof(SqlTypeName.BOOLEAN))]
-        // the server's tinyint is unsigned 0..255 and Calcite's TINYINT is signed, so SMALLINT is what holds it
-        [DataRow("C_TINYINT", nameof(SqlTypeName.SMALLINT))]
+        // the server's tinyint is unsigned 0..255 and Calcite's TINYINT is signed, so UTINYINT is what holds it
+        [DataRow("C_TINYINT", nameof(SqlTypeName.UTINYINT))]
         [DataRow("C_SMALLINT", nameof(SqlTypeName.SMALLINT))]
         [DataRow("C_BIGINT", nameof(SqlTypeName.BIGINT))]
         [DataRow("C_DECIMAL", nameof(SqlTypeName.DECIMAL))]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
@@ -1,0 +1,366 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql.type;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers the adapter against a real SQL Server, which is the only thing that exercises the information
+    /// schema path and the SQL Server type mapping.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every query against SQL Server failed with <c>InvalidCastException: Unable to cast object of type
+    /// 'System.Byte' to type 'System.Int32'</c> and nothing here said so, because the suite had only ever
+    /// been pointed at SQLite, whose metadata comes from <c>PRAGMA table_xinfo</c> rather than from
+    /// <c>INFORMATION_SCHEMA</c>. A provider's own description of itself is not something one provider can
+    /// stand in for.
+    /// </para>
+    /// <para>
+    /// LocalDB is Windows only, and a Windows machine need not have it either, so these skip where there is
+    /// no server to talk to.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class SqlServerQueryTests
+    {
+
+        static SqlServerQueryTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
+            java.lang.Class.forName("org.apache.calcite.jdbc.Driver");
+        }
+
+        SqlServerFixture _server = null!;
+        java.sql.Connection _connection = null!;
+        AdoSchema _schema = null!;
+        JavaTypeFactoryImpl _types = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            if (SqlServerFixture.IsAvailable == false)
+                Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+
+            _server = new SqlServerFixture();
+            _types = new JavaTypeFactoryImpl();
+
+            var properties = new java.util.Properties();
+            properties.setProperty("lex", "JAVA");
+            properties.setProperty("caseSensitive", "false");
+
+            _connection = java.sql.DriverManager.getConnection("jdbc:calcite:", properties);
+
+            var calcite = (CalciteConnection)_connection;
+            var root = calcite.getRootSchema();
+            _schema = AdoSchema.Create(root, "ADO", _server.DataSource, null, "dbo");
+            root.add("ADO", _schema);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _connection?.close();
+            _server?.Dispose();
+        }
+
+        /// <summary>
+        /// Runs a query and returns its rows as strings, so a comparison does not depend on which numeric
+        /// type a provider chose.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        List<string> Rows(string sql)
+        {
+            using var statement = _connection.createStatement();
+            var results = statement.executeQuery(sql);
+
+            var rows = new List<string>();
+            var columns = results.getMetaData().getColumnCount();
+
+            while (results.next())
+            {
+                var values = new string[columns];
+                for (int i = 0; i < columns; i++)
+                    values[i] = results.getObject(i + 1)?.ToString() ?? "NULL";
+
+                rows.Add(string.Join("|", values));
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Runs a query and returns the single value it produces.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        string Scalar(string sql)
+        {
+            var rows = Rows(sql);
+            Assert.AreEqual(1, rows.Count, $"expected one row from: {sql}");
+            return rows[0];
+        }
+
+        /// <summary>
+        /// Returns a table by name.
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        org.apache.calcite.schema.Table Table(string tableName)
+        {
+            return (org.apache.calcite.schema.Table?)_schema.tables().get(tableName)
+                ?? throw new AssertFailedException($"no table {tableName}; found {string.Join(", ", TableNames())}");
+        }
+
+        /// <summary>
+        /// Returns every table name the schema exposes.
+        /// </summary>
+        /// <returns></returns>
+        List<string> TableNames()
+        {
+            var names = _schema.tables().getNames(org.apache.calcite.schema.lookup.LikePattern.any());
+
+            var result = new List<string>();
+            for (var i = names.iterator(); i.hasNext();)
+                result.Add((string)i.next());
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the fields of a table's row type, by name.
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        Dictionary<string, RelDataType> Fields(string tableName)
+        {
+            var fields = Table(tableName).getRowType(_types).getFieldList();
+
+            var result = new Dictionary<string, RelDataType>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < fields.size(); i++)
+                result[((RelDataTypeField)fields.get(i)).getName()] = ((RelDataTypeField)fields.get(i)).getType();
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the Calcite type name of a named column of a table.
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        string TypeOf(string tableName, string columnName)
+        {
+            if (Fields(tableName).TryGetValue(columnName, out var type) == false)
+                throw new AssertFailedException($"no column {columnName} on {tableName}");
+
+            return type.getSqlTypeName().name();
+        }
+
+        #region The report
+
+        /// <summary>
+        /// The query from the report, verbatim in shape: three columns, one of them the <c>INT</c> whose
+        /// <c>tinyint</c> precision in the information schema was read as an <c>int</c> and threw.
+        /// </summary>
+        [TestMethod]
+        public void ScanningATableWithAnIntegerColumnReturnsItsRows()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Widget|Acme|3", "Gadget|Globex|10", "Doohickey|Initech|1" },
+                Rows("SELECT * FROM ADO.SUPPLIERS"));
+        }
+
+        /// <summary>
+        /// Projecting the two <c>VARCHAR</c> columns failed the same way, because the row type is derived
+        /// from every column of the table whatever the query asks for.
+        /// </summary>
+        [TestMethod]
+        public void ProjectingOnlyTheCharacterColumnsAlsoWorks()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Widget|Acme", "Gadget|Globex", "Doohickey|Initech" },
+                Rows("SELECT PRODUCT, SUPPLIER FROM ADO.SUPPLIERS"));
+        }
+
+        #endregion
+
+        #region Discovery
+
+        [TestMethod]
+        public void ASqlServerConnectionSelectsTheSqlServerMetadata()
+        {
+            var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_server.DataSource);
+            Assert.AreEqual("SqlServerDatabaseMetadata", metadata.GetType().Name);
+        }
+
+        [TestMethod]
+        public void TheSchemaFindsTheTables()
+        {
+            var names = TableNames();
+
+            CollectionAssert.Contains(names, "SUPPLIERS");
+            CollectionAssert.Contains(names, "EMPS");
+            CollectionAssert.Contains(names, "DEPTS");
+        }
+
+        [TestMethod]
+        public void NullabilityIsCarriedOntoTheType()
+        {
+            var fields = Fields("EMPS");
+
+            Assert.IsFalse(fields["EMPNO"].isNullable(), "EMPNO is declared NOT NULL");
+            Assert.IsTrue(fields["DEPTNO"].isNullable(), "DEPTNO is declared NULL");
+        }
+
+        #endregion
+
+        #region Types
+
+        /// <summary>
+        /// Every column of the fixture's wide table has to reach a Calcite type: a name the mapping does not
+        /// know throws, and takes the whole table with it.
+        /// </summary>
+        [TestMethod]
+        public void EveryColumnTypeIsMapped()
+        {
+            Assert.AreEqual(26, Fields("TYPES").Count);
+        }
+
+        [TestMethod]
+        [DataRow("C_BIT", nameof(SqlTypeName.BOOLEAN))]
+        // the server's tinyint is unsigned 0..255 and Calcite's TINYINT is signed, so SMALLINT is what holds it
+        [DataRow("C_TINYINT", nameof(SqlTypeName.SMALLINT))]
+        [DataRow("C_SMALLINT", nameof(SqlTypeName.SMALLINT))]
+        [DataRow("C_BIGINT", nameof(SqlTypeName.BIGINT))]
+        [DataRow("C_DECIMAL", nameof(SqlTypeName.DECIMAL))]
+        [DataRow("C_NUMERIC", nameof(SqlTypeName.DECIMAL))]
+        [DataRow("C_MONEY", nameof(SqlTypeName.DECIMAL))]
+        [DataRow("C_SMALLMONEY", nameof(SqlTypeName.DECIMAL))]
+        [DataRow("C_FLOAT", nameof(SqlTypeName.DOUBLE))]
+        [DataRow("C_REAL", nameof(SqlTypeName.REAL))]
+        [DataRow("C_CHAR", nameof(SqlTypeName.CHAR))]
+        [DataRow("C_VARCHAR", nameof(SqlTypeName.VARCHAR))]
+        [DataRow("C_NCHAR", nameof(SqlTypeName.CHAR))]
+        [DataRow("C_NVARCHAR", nameof(SqlTypeName.VARCHAR))]
+        [DataRow("C_DATE", nameof(SqlTypeName.DATE))]
+        [DataRow("C_TIME", nameof(SqlTypeName.TIME))]
+        [DataRow("C_DATETIME", nameof(SqlTypeName.TIMESTAMP))]
+        [DataRow("C_SMALLDATETIME", nameof(SqlTypeName.TIMESTAMP))]
+        [DataRow("C_DATETIME2", nameof(SqlTypeName.TIMESTAMP))]
+        [DataRow("C_DATETIMEOFFSET", nameof(SqlTypeName.TIMESTAMP_TZ))]
+        [DataRow("C_BINARY", nameof(SqlTypeName.VARBINARY))]
+        [DataRow("C_VARBINARY", nameof(SqlTypeName.VARBINARY))]
+        [DataRow("C_GUID", nameof(SqlTypeName.CHAR))]
+        [DataRow("C_XML", nameof(SqlTypeName.VARCHAR))]
+        public void AColumnGetsItsCalciteType(string columnName, string expected)
+        {
+            Assert.AreEqual(expected, TypeOf("TYPES", columnName));
+        }
+
+        /// <summary>
+        /// Reading the wide table is a separate claim from typing it: the reader picks its accessor from the
+        /// Calcite type, and a mapping that types a column plausibly can still refuse to read one.
+        /// </summary>
+        [TestMethod]
+        public void EveryColumnTypeCanBeRead()
+        {
+            Assert.AreEqual(2, Rows("SELECT * FROM ADO.TYPES").Count);
+        }
+
+        [TestMethod]
+        public void ANullOfEveryTypeComesBackNull()
+        {
+            var row = Scalar("SELECT * FROM ADO.TYPES WHERE ID = 2");
+            var values = row.Split('|');
+
+            Assert.AreEqual("2", values[0]);
+            for (int i = 1; i < values.Length; i++)
+                Assert.AreEqual("NULL", values[i], $"column {i} of the all-null row");
+        }
+
+        [TestMethod]
+        public void ADecimalKeepsItsScale()
+        {
+            Assert.AreEqual("123456789.125", Scalar("SELECT C_DECIMAL FROM ADO.TYPES WHERE ID = 1"));
+        }
+
+        [TestMethod]
+        public void AVarcharMaxIsReadable()
+        {
+            Assert.AreEqual("unbounded", Scalar("SELECT C_VARCHARMAX FROM ADO.TYPES WHERE ID = 1"));
+        }
+
+        /// <summary>
+        /// A <c>uniqueidentifier</c> is a <see cref="Guid"/> to the provider and a <c>CHAR(36)</c> to
+        /// Calcite, so what the reader hands over has to be the text.
+        /// </summary>
+        [TestMethod]
+        public void AUniqueIdentifierComesBackAsItsText()
+        {
+            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", Scalar("SELECT C_GUID FROM ADO.TYPES WHERE ID = 1"));
+        }
+
+        [TestMethod]
+        [DataRow("C_BIT", "true")]
+        [DataRow("C_TINYINT", "200")]
+        [DataRow("C_SMALLINT", "-300")]
+        [DataRow("C_BIGINT", "9000000000")]
+        [DataRow("C_FLOAT", "1.5")]
+        [DataRow("C_REAL", "2.5")]
+        [DataRow("C_CHAR", "abcd")]
+        [DataRow("C_NCHAR", "wxyz")]
+        [DataRow("C_NVARCHAR", "nvarchar")]
+        public void AScalarValueComesBackAsWritten(string columnName, string expected)
+        {
+            Assert.AreEqual(expected, Scalar($"SELECT {columnName} FROM ADO.TYPES WHERE ID = 1"));
+        }
+
+        #endregion
+
+        #region Query
+
+        [TestMethod]
+        public void AFilterIsApplied()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Gadget" },
+                Rows("SELECT PRODUCT FROM ADO.SUPPLIERS WHERE LEAD_DAYS > 5"));
+        }
+
+        [TestMethod]
+        public void AnAggregateIsComputed()
+        {
+            Assert.AreEqual("14", Scalar("SELECT SUM(LEAD_DAYS) FROM ADO.SUPPLIERS"));
+        }
+
+        [TestMethod]
+        public void AJoinAcrossTwoTablesReturnsTheMatchedRows()
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice|Sales", "Bob|Sales", "Carol|Engineering", "Dave|Engineering" },
+                Rows("SELECT E.NAME, D.DNAME FROM ADO.EMPS E JOIN ADO.DEPTS D ON E.DEPTNO = D.DEPTNO"));
+        }
+
+        [TestMethod]
+        public void AnOrderByIsHonoured()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "Doohickey", "Widget", "Gadget" },
+                Rows("SELECT PRODUCT FROM ADO.SUPPLIERS ORDER BY LEAD_DAYS"));
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
@@ -328,6 +328,19 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         #region Query
 
+        /// <summary>
+        /// A filter on the unsigned column, which the planner pushes down as a comparison against a literal
+        /// typed <c>UTINYINT</c>: the value 200 has to survive planning without wrapping to -56, and the
+        /// dialect has to unparse the literal as something the server parses.
+        /// </summary>
+        [TestMethod]
+        public void AFilterOnATinyIntComparesUnsigned()
+        {
+            Assert.AreEqual("1", Scalar("SELECT ID FROM ADO.TYPES WHERE C_TINYINT = 200"));
+            Assert.AreEqual("1", Scalar("SELECT ID FROM ADO.TYPES WHERE C_TINYINT > 100"));
+            Assert.AreEqual(0, Rows("SELECT ID FROM ADO.TYPES WHERE C_TINYINT < 0").Count);
+        }
+
         [TestMethod]
         public void AFilterIsApplied()
         {

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerReaderUtilTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerReaderUtilTests.cs
@@ -1,0 +1,212 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.sql.type;
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers the mapping from a SQL Server value to the representation Calcite's runtime expects.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AdoReaderUtilTests"/> reads from SQLite, which decodes nearly everything to
+    /// <see cref="long"/>, <see cref="double"/> or <see cref="string"/> and so never presents the reader with
+    /// a value of the type the column was declared in. SQL Server does: a <c>uniqueidentifier</c> arrives as
+    /// a <see cref="Guid"/>, a <c>datetimeoffset</c> as a <see cref="DateTimeOffset"/>, a <c>tinyint</c> as a
+    /// <see cref="byte"/>. Those are the cases a typed accessor casts and fails on.
+    /// </remarks>
+    [TestClass]
+    public class SqlServerReaderUtilTests
+    {
+
+        SqlConnection _connection = null!;
+        readonly List<DbCommand> _commands = [];
+
+        [TestInitialize]
+        public void Setup()
+        {
+            if (SqlServerFixture.IsAvailable == false)
+                Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+
+            _connection = new SqlConnection(new SqlConnectionStringBuilder()
+            {
+                DataSource = @"(localdb)\MSSQLLocalDB",
+                InitialCatalog = "master",
+                IntegratedSecurity = true,
+                TrustServerCertificate = true,
+            }.ConnectionString);
+
+            _connection.Open();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            foreach (var command in _commands)
+                command.Dispose();
+
+            _commands.Clear();
+            _connection?.Dispose();
+        }
+
+        /// <summary>
+        /// Returns a reader positioned on a single row holding the given expression.
+        /// </summary>
+        /// <param name="selectExpression"></param>
+        /// <returns></returns>
+        DbDataReader Row(string selectExpression)
+        {
+            var command = _connection.CreateCommand();
+            command.CommandText = $"SELECT {selectExpression}";
+            _commands.Add(command);
+
+            var reader = command.ExecuteReader();
+            Assert.IsTrue(reader.Read(), "expected one row");
+            return reader;
+        }
+
+        /// <summary>
+        /// The whole of the server's tiny integer range reaches a <c>SMALLINT</c>, which is why that is what
+        /// it is mapped to: the top half of it does not fit a signed <c>TINYINT</c>.
+        /// </summary>
+        [TestMethod]
+        public void ATinyIntWidensToAShort()
+        {
+            using var reader = Row("CAST(200 AS TINYINT)");
+            var value = AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.SMALLINT);
+
+            Assert.IsInstanceOfType<java.lang.Short>(value);
+            Assert.AreEqual((short)200, ((java.lang.Short)value!).shortValue());
+        }
+
+        [TestMethod]
+        public void ABitIsReadAsAJavaBoolean()
+        {
+            using var reader = Row("CAST(1 AS BIT)");
+            Assert.IsTrue(((java.lang.Boolean)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.BOOLEAN)!).booleanValue());
+        }
+
+        [TestMethod]
+        public void ARealIsReadAsAJavaFloat()
+        {
+            using var reader = Row("CAST(2.5 AS REAL)");
+            Assert.AreEqual(2.5f, ((java.lang.Float)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.REAL)!).floatValue());
+        }
+
+        [TestMethod]
+        public void AFloatIsReadAsAJavaDouble()
+        {
+            using var reader = Row("CAST(1.5 AS FLOAT)");
+            Assert.AreEqual(1.5d, ((java.lang.Double)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.DOUBLE)!).doubleValue());
+        }
+
+        [TestMethod]
+        public void AMoneyKeepsItsScale()
+        {
+            using var reader = Row("CAST(12.34 AS MONEY)");
+            var value = AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.DECIMAL);
+
+            Assert.IsInstanceOfType<java.math.BigDecimal>(value);
+            Assert.AreEqual("12.3400", value!.ToString());
+        }
+
+        /// <summary>
+        /// A <c>uniqueidentifier</c> is a <see cref="Guid"/> to the provider, and Calcite is holding the
+        /// column as a <c>CHAR(36)</c>: <see cref="DbDataReader.GetString"/> casts and refuses it.
+        /// </summary>
+        [TestMethod]
+        public void AUniqueIdentifierIsReadAsItsText()
+        {
+            using var reader = Row("CAST('3f2504e0-4f89-11d3-9a0c-0305e82c3301' AS UNIQUEIDENTIFIER)");
+            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.CHAR));
+        }
+
+        [TestMethod]
+        public void AVarbinaryIsReadAsAByteString()
+        {
+            using var reader = Row("CAST(0x01FF80 AS VARBINARY(8))");
+            var value = AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.VARBINARY);
+
+            Assert.IsInstanceOfType<org.apache.calcite.avatica.util.ByteString>(value);
+            CollectionAssert.AreEqual(new byte[] { 0x01, 0xFF, 0x80 }, ((org.apache.calcite.avatica.util.ByteString)value!).getBytes());
+        }
+
+        #region Temporal
+
+        /// <summary>
+        /// 2020-01-15, as a count of whole days from the epoch.
+        /// </summary>
+        const int ExpectedDay = 18276;
+
+        /// <summary>
+        /// 2020-01-15T10:20:30, as the count of milliseconds from the epoch to that wall clock read as UTC.
+        /// </summary>
+        const long ExpectedMillis = 1579083630000L;
+
+        [TestMethod]
+        public void ADateIsReadAsDaysSinceTheEpoch()
+        {
+            using var reader = Row("CAST('2020-01-15' AS DATE)");
+            Assert.AreEqual(ExpectedDay, ((java.lang.Integer)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.DATE)!).intValue());
+        }
+
+        [TestMethod]
+        public void ATimeIsReadAsMillisecondsSinceMidnight()
+        {
+            using var reader = Row("CAST('01:02:03.500' AS TIME(3))");
+            Assert.AreEqual(3723500, ((java.lang.Integer)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.TIME)!).intValue());
+        }
+
+        /// <summary>
+        /// A timestamp carries no zone, so the count is to the wall clock read as UTC. Reading it as local
+        /// time instead put every timestamp out by the machine's offset, and only a machine at UTC would
+        /// have noticed.
+        /// </summary>
+        [TestMethod]
+        public void ATimestampDoesNotDependOnTheMachineTimeZone()
+        {
+            using var reader = Row("CAST('2020-01-15T10:20:30' AS DATETIME)");
+            Assert.AreEqual(ExpectedMillis, ((java.lang.Long)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.TIMESTAMP)!).longValue());
+        }
+
+        [TestMethod]
+        public void ADateTime2IsTheSameTimestamp()
+        {
+            using var reader = Row("CAST('2020-01-15T10:20:30' AS DATETIME2(3))");
+            Assert.AreEqual(ExpectedMillis, ((java.lang.Long)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.TIMESTAMP)!).longValue());
+        }
+
+        /// <summary>
+        /// A zoned timestamp is an instant, and the provider hands one over as a
+        /// <see cref="DateTimeOffset"/> — <see cref="DbDataReader.GetDateTime"/> refuses it outright.
+        /// </summary>
+        [TestMethod]
+        public void AZonedTimestampIsReadAsAnInstant()
+        {
+            using var reader = Row("CAST('2020-01-15T10:20:30+00:00' AS DATETIMEOFFSET(3))");
+            Assert.AreEqual(ExpectedMillis, ((java.lang.Long)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.TIMESTAMP_TZ)!).longValue());
+        }
+
+        /// <summary>
+        /// The offset is part of the value, not decoration: the same wall clock at a different offset is a
+        /// different instant.
+        /// </summary>
+        [TestMethod]
+        public void AZonedTimestampHonoursItsOffset()
+        {
+            using var reader = Row("CAST('2020-01-15T10:20:30-05:00' AS DATETIMEOFFSET(3))");
+            Assert.AreEqual(
+                ExpectedMillis + 5 * 60 * 60 * 1000L,
+                ((java.lang.Long)AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.TIMESTAMP_TZ)!).longValue());
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/TestAssemblyHooks.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/TestAssemblyHooks.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Holds what the suite as a whole owns.
+    /// </summary>
+    [TestClass]
+    public static class TestAssemblyHooks
+    {
+
+        /// <summary>
+        /// Drops the LocalDB database the SQL Server, ODBC and OLE DB suites share.
+        /// </summary>
+        /// <remarks>
+        /// Here rather than in a test cleanup because it is made once for all of them: dropping it per test
+        /// means creating it per test, and that is ten minutes of LocalDB.
+        /// </remarks>
+        [AssemblyCleanup]
+        public static void Cleanup()
+        {
+            SqlServerFixture.DisposeShared();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
@@ -134,16 +134,19 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// </summary>
         /// <param name="dataSource">The source whose syntax names a parameter for this provider.</param>
         /// <param name="indexes">The variable index behind each parameter, in parameter order.</param>
+        /// <param name="typeNames">The <see cref="org.apache.calcite.sql.type.SqlTypeName"/> name behind each parameter, in the same order, or a null where none was recorded.</param>
         /// <param name="context">The context the values are read from, one per correlation variable.</param>
         /// <returns></returns>
         /// <remarks>
         /// Reached from the code the converter generates, once per execution of the inner side of a
         /// correlated join. The context is an <see cref="AdoCorrelationDataContext"/> closed over the outer
-        /// row, so reading <c>?N</c> yields that row's value.
+        /// row, so reading <c>?N</c> yields that row's value. The type names travel beside the indexes
+        /// because a value alone cannot be bound: a <c>DATE</c> leaves the plan as a day count in a
+        /// <see cref="java.lang.Integer"/>, and only the type says it is not simply an <c>INTEGER</c>.
         /// </remarks>
-        public static DbCommandEnricher CreateEnricher(AdoDataSource dataSource, java.util.List indexes, DataContext context)
+        public static DbCommandEnricher CreateEnricher(AdoDataSource dataSource, java.util.List indexes, java.util.List typeNames, DataContext context)
         {
-            return new ParameterEnricher(dataSource.Metadata.Syntax, indexes, context);
+            return new ParameterEnricher(dataSource.Metadata.Syntax, indexes, typeNames, context);
         }
 
         /// <summary>
@@ -151,15 +154,18 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// </summary>
         /// <param name="syntax"></param>
         /// <param name="indexes"></param>
+        /// <param name="typeNames"></param>
         /// <param name="context"></param>
-        sealed class ParameterEnricher(IAdoSqlSyntax syntax, java.util.List indexes, DataContext context) : DbCommandEnricher
+        sealed class ParameterEnricher(IAdoSqlSyntax syntax, java.util.List indexes, java.util.List typeNames, DataContext context) : DbCommandEnricher
         {
 
             /// <inheritdoc />
             public void Enrich(DbCommand command)
             {
                 for (int i = 0; i < indexes.size(); i++)
-                    SetParameter(syntax, command, i, context.get("?" + ((java.lang.Number)indexes.get(i)).intValue()));
+                    SetParameter(syntax, command, i,
+                        context.get("?" + ((java.lang.Number)indexes.get(i)).intValue()),
+                        i < typeNames.size() ? (string?)typeNames.get(i) : null);
             }
 
         }
@@ -171,12 +177,64 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="command"></param>
         /// <param name="i"></param>
         /// <param name="value"></param>
-        static void SetParameter(IAdoSqlSyntax syntax, DbCommand command, int i, object? value)
+        /// <param name="typeName"></param>
+        static void SetParameter(IAdoSqlSyntax syntax, DbCommand command, int i, object? value, string? typeName)
         {
             var parameter = command.CreateParameter();
             parameter.ParameterName = syntax.GetParameterName(i);
-            parameter.Value = ToProviderValue(value) ?? DBNull.Value;
+            parameter.Value = ToProviderValue(value, typeName) ?? DBNull.Value;
+
+            // ODBC and OLE DB bind a temporal parameter at scale zero unless told otherwise, and then refuse
+            // the fractional seconds the value itself carries: "Datetime field overflow. Fractional second
+            // precision exceeds the scale specified in the parameter binding." Three digits is the honest
+            // scale — the representation these values decode from is a millisecond count. Measured: scale 3
+            // makes both drivers accept the value, and SqlClient ignores it for an inferred datetime.
+            if (parameter.Value is DateTime or TimeSpan or DateTimeOffset)
+                parameter.Scale = 3;
+
             command.Parameters.Insert(i, parameter);
+        }
+
+        /// <summary>
+        /// The instant the temporal representations count from.
+        /// </summary>
+        static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        /// <summary>
+        /// Converts a value read from a <see cref="DataContext"/> into one a provider can bind, undoing the
+        /// temporal encodings first.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="typeName"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A temporal value leaves the plan as a count — a <c>DATE</c> as whole days since the epoch, a
+        /// <c>TIME</c> as milliseconds since midnight, a <c>TIMESTAMP</c> as milliseconds since the epoch —
+        /// which is Calcite's internal representation and nothing a typed column accepts: SQL Server answers
+        /// "Operand type clash: date is incompatible with int". Only SQLite tolerated it, and only because
+        /// SQLite compares whatever it is handed. The count is decoded to the temporal value it stands for,
+        /// exactly inverting what <see cref="AdoReaderUtil"/> encoded on the way in; the kind is Unspecified
+        /// because the count is of the wall clock as written, no zone having entered into it.
+        /// </remarks>
+        static object? ToProviderValue(object? value, string? typeName)
+        {
+            if (value is null)
+                return null;
+
+            switch (typeName)
+            {
+                case nameof(org.apache.calcite.sql.type.SqlTypeName.DATE):
+                    return UnixEpoch.AddDays(((java.lang.Number)value).intValue());
+                case nameof(org.apache.calcite.sql.type.SqlTypeName.TIME):
+                    return TimeSpan.FromMilliseconds(((java.lang.Number)value).intValue());
+                case nameof(org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP):
+                    return UnixEpoch.AddMilliseconds(((java.lang.Number)value).longValue());
+                case nameof(org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP_TZ):
+                case nameof(org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE):
+                    return new DateTimeOffset(DateTime.SpecifyKind(UnixEpoch, DateTimeKind.Utc).AddMilliseconds(((java.lang.Number)value).longValue()), TimeSpan.Zero);
+                default:
+                    return ToProviderValue(value);
+            }
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
@@ -205,6 +205,14 @@ namespace Apache.Calcite.Adapter.AdoNet
                 java.lang.Character c => c.charValue(),
                 java.math.BigDecimal m => decimal.Parse(m.toString(), System.Globalization.CultureInfo.InvariantCulture),
                 org.apache.calcite.avatica.util.ByteString bs => bs.getBytes(),
+                // the unsigned types travel as joou values, and no provider knows those either. Each is
+                // unwrapped to the narrowest CLR type every provider binds: SqlClient takes a byte but none
+                // of ushort, uint or ulong, so the wider three go to the signed type that holds their range
+                // exactly — and ULong to decimal, ulong's top half being outside long
+                org.joou.UByte ub => (byte)ub.shortValue(),
+                org.joou.UShort us => us.intValue(),
+                org.joou.UInteger ui => ui.longValue(),
+                org.joou.ULong ul => decimal.Parse(ul.toString(), System.Globalization.CultureInfo.InvariantCulture),
                 _ => value,
             };
         }

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
@@ -261,7 +261,9 @@ namespace Apache.Calcite.Adapter.AdoNet
             }
             catch (DbException e)
             {
-                throw new AdoCalciteException("Exception while enumerating query.", e);
+                // with the SQL, because what a provider says about a statement it rejected is rarely enough
+                // to find it: "Incorrect syntax near '='" names neither the statement nor the position
+                throw new AdoCalciteException($"Exception while enumerating query: {_sql}", e);
             }
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoImplementor.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoImplementor.cs
@@ -12,6 +12,7 @@ using org.apache.calcite.rel.type;
 using org.apache.calcite.rex;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql.parser;
+using org.apache.calcite.sql.type;
 
 namespace Apache.Calcite.Adapter.AdoNet
 {
@@ -67,13 +68,32 @@ namespace Apache.Calcite.Adapter.AdoNet
             public override SqlNode field(int ordinal)
             {
                 var field = (RelDataTypeField)_fieldList.get(ordinal);
-                return new SqlDynamicParam(_implementor._dataContextBuilder.Add(_variable.id, ordinal, _implementor._typeFactory.getJavaClass(field.getType())), SqlParserPos.ZERO);
+                var index = _implementor._dataContextBuilder.Add(_variable.id, ordinal, _implementor._typeFactory.getJavaClass(field.getType()));
+
+                // the SQL type is recorded here because this is the last place it exists: the value will
+                // leave the plan in Calcite's internal representation — a DATE as a day count in an Integer —
+                // and the Java class alone cannot tell that from an INTEGER when the parameter is bound
+                _implementor._dynamicParamTypes[index] = field.getType().getSqlTypeName();
+
+                return new SqlDynamicParam(index, SqlParserPos.ZERO);
             }
 
         }
 
         readonly JavaTypeFactory _typeFactory;
         readonly IAdoCorrelationDataContextBuilder _dataContextBuilder;
+        readonly System.Collections.Generic.Dictionary<int, SqlTypeName> _dynamicParamTypes = [];
+
+        /// <summary>
+        /// Returns the SQL type of the correlation variable behind a dynamic parameter, or
+        /// <see langword="null"/> for an index that is not one.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public SqlTypeName? GetDynamicParamType(int index)
+        {
+            return _dynamicParamTypes.TryGetValue(index, out var type) ? type : null;
+        }
 
         /// <summary>
         /// Initializes a new instance.

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
@@ -51,6 +51,16 @@ namespace Apache.Calcite.Adapter.AdoNet
                     return GetInt(reader, index);
                 case nameof(SqlTypeName.BIGINT):
                     return GetLong(reader, index);
+                // the unsigned types travel as joou values, which is what JavaTypeFactoryImpl.getJavaClass
+                // answers for them and what CalciteResultValue decodes at the other end
+                case nameof(SqlTypeName.UTINYINT):
+                    return GetUByte(reader, index);
+                case nameof(SqlTypeName.USMALLINT):
+                    return GetUShort(reader, index);
+                case nameof(SqlTypeName.UINTEGER):
+                    return GetUInt(reader, index);
+                case nameof(SqlTypeName.UBIGINT):
+                    return GetULong(reader, index);
                 case nameof(SqlTypeName.TIMESTAMP):
                     return GetTimestamp(reader, index);
                 case nameof(SqlTypeName.DATE):
@@ -93,9 +103,9 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <para>
         /// The width a provider declares a column in is not the width Calcite chose for it, and the typed
         /// accessors on <see cref="DbDataReader"/> cast rather than convert: <see cref="DbDataReader.GetInt16"/>
-        /// on SQL Server's <c>tinyint</c>, which only <c>SMALLINT</c> holds without loss, throws rather than
-        /// widening. Every one of these is a lossless widening of an integral or approximate value the
-        /// provider already decoded, so converting is what the mapping meant.
+        /// on a column the driver decoded as a <see cref="byte"/> throws rather than widening. Every one of
+        /// these is a lossless widening of an integral or approximate value the provider already decoded, so
+        /// converting is what the mapping meant.
         /// </para>
         /// <para>
         /// The cost is one boxed value per cell, which is what every one of these accessors was going to pay
@@ -132,8 +142,9 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <remarks>
         /// Calcite's <c>TINYINT</c> is signed, so this is an <see cref="sbyte"/> and not the <see cref="byte"/>
         /// the <see cref="DbDataReader.GetByte"/> accessor answers with. A provider whose own tiny integer is
-        /// unsigned — SQL Server's is — maps to <c>SMALLINT</c> rather than through here. Java's <c>byte</c>
-        /// is IKVM's <see cref="byte"/> and is unsigned, so the sign travels in the bits.
+        /// unsigned — SQL Server's is — maps to <c>UTINYINT</c> and comes through <see cref="GetUByte"/>
+        /// instead. Java's <c>byte</c> is IKVM's <see cref="byte"/> and is unsigned, so the sign travels in
+        /// the bits.
         /// </remarks>
         public static object? GetByte(DbDataReader reader, int index)
         {
@@ -171,6 +182,61 @@ namespace Apache.Calcite.Adapter.AdoNet
         public static object? GetLong(DbDataReader reader, int index)
         {
             return GetValueAs<long>(reader, index) is long value ? java.lang.Long.valueOf(value) : null;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="org.joou.UByte"/>, which is what Calcite holds a <c>UTINYINT</c> in.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The unsigned types are not a variation on the signed ones: <c>getJavaClass</c> answers a joou
+        /// <c>UByte</c>, <c>UShort</c>, <c>UInteger</c> or <c>ULong</c> rather than a <c>java.lang</c>
+        /// wrapper, and <c>CalciteResultValue</c> is written to decode exactly those. Handing over a
+        /// <see cref="java.lang.Short"/> instead would be a value of the wrong class for the type the row
+        /// declares. The widening overload is taken in each case so that the sign is never in question.
+        /// </remarks>
+        public static object? GetUByte(DbDataReader reader, int index)
+        {
+            return GetValueAs<byte>(reader, index) is byte value ? org.joou.UByte.valueOf((int)value) : null;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="org.joou.UShort"/>, which is what Calcite holds a <c>USMALLINT</c> in.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static object? GetUShort(DbDataReader reader, int index)
+        {
+            return GetValueAs<ushort>(reader, index) is ushort value ? org.joou.UShort.valueOf((int)value) : null;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="org.joou.UInteger"/>, which is what Calcite holds a <c>UINTEGER</c> in.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static object? GetUInt(DbDataReader reader, int index)
+        {
+            return GetValueAs<uint>(reader, index) is uint value ? org.joou.UInteger.valueOf((long)value) : null;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="org.joou.ULong"/>, which is what Calcite holds a <c>UBIGINT</c> in.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Through the decimal string, because the whole of the range is the point: <c>valueOf(long)</c>
+        /// refuses anything above <see cref="long.MaxValue"/>, which is half of what the type holds.
+        /// </remarks>
+        public static object? GetULong(DbDataReader reader, int index)
+        {
+            return GetValueAs<ulong>(reader, index) is ulong value ? org.joou.ULong.valueOf(value.ToString(CultureInfo.InvariantCulture)) : null;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data.Common;
+using System.Globalization;
 
 using org.apache.calcite.rel.type;
 using org.apache.calcite.sql.type;
@@ -51,16 +52,16 @@ namespace Apache.Calcite.Adapter.AdoNet
                 case nameof(SqlTypeName.BIGINT):
                     return GetLong(reader, index);
                 case nameof(SqlTypeName.TIMESTAMP):
-                    return reader.IsDBNull(index) ? null : java.lang.Long.valueOf(((DateTimeOffset)reader.GetDateTime(index)).ToUnixTimeMilliseconds());
+                    return GetTimestamp(reader, index);
                 case nameof(SqlTypeName.DATE):
                     return GetDate(reader, index);
                 // FLOAT is eight bytes in Calcite, as it is in SQL, and shares DOUBLE's representation;
                 // REAL is the four byte one. JavaTypeFactoryImpl.getJavaClass says so, and marks it "sic".
                 case nameof(SqlTypeName.FLOAT):
                 case nameof(SqlTypeName.DOUBLE):
-                    return reader.IsDBNull(index) ? null : java.lang.Double.valueOf(reader.GetDouble(index));
+                    return GetDouble(reader, index);
                 case nameof(SqlTypeName.REAL):
-                    return reader.IsDBNull(index) ? null : java.lang.Float.valueOf(reader.GetFloat(index));
+                    return GetFloat(reader, index);
                 case nameof(SqlTypeName.DECIMAL):
                     return GetDecimal(reader, index);
                 case nameof(SqlTypeName.BINARY):
@@ -69,7 +70,7 @@ namespace Apache.Calcite.Adapter.AdoNet
                 case nameof(SqlTypeName.TIME):
                     return GetTime(reader, index);
                 case nameof(SqlTypeName.TIMESTAMP_TZ):
-                    return reader.IsDBNull(index) ? null : java.lang.Long.valueOf(new DateTimeOffset(reader.GetDateTime(index), TimeSpan.Zero).ToUnixTimeMilliseconds());
+                    return GetTimestampTz(reader, index);
                 case nameof(SqlTypeName.VARCHAR):
                     return GetString(reader, index);
                 case nameof(SqlTypeName.OTHER):
@@ -82,6 +83,36 @@ namespace Apache.Calcite.Adapter.AdoNet
         }
 
         /// <summary>
+        /// Gets the value at an index converted to a CLR type, or <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <para>
+        /// The width a provider declares a column in is not the width Calcite chose for it, and the typed
+        /// accessors on <see cref="DbDataReader"/> cast rather than convert: <see cref="DbDataReader.GetInt16"/>
+        /// on SQL Server's <c>tinyint</c>, which only <c>SMALLINT</c> holds without loss, throws rather than
+        /// widening. Every one of these is a lossless widening of an integral or approximate value the
+        /// provider already decoded, so converting is what the mapping meant.
+        /// </para>
+        /// <para>
+        /// The cost is one boxed value per cell, which is what every one of these accessors was going to pay
+        /// anyway: the result is a <c>java.lang</c> wrapper, allocated per cell, whatever route it took.
+        /// </para>
+        /// </remarks>
+        static T? GetValueAs<T>(DbDataReader reader, int index)
+            where T : struct
+        {
+            if (reader.IsDBNull(index))
+                return null;
+
+            var value = reader.GetValue(index);
+            return value is T typed ? typed : (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
         /// Gets a <see cref="java.lang.Boolean"/>.
         /// </summary>
         /// <param name="reader"></param>
@@ -89,7 +120,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         public static object? GetBoolean(DbDataReader reader, int index)
         {
-            return reader.IsDBNull(index) ? null : java.lang.Boolean.valueOf(reader.GetBoolean(index));
+            return GetValueAs<bool>(reader, index) is bool value ? java.lang.Boolean.valueOf(value) : null;
         }
 
         /// <summary>
@@ -98,9 +129,15 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="reader"></param>
         /// <param name="index"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// Calcite's <c>TINYINT</c> is signed, so this is an <see cref="sbyte"/> and not the <see cref="byte"/>
+        /// the <see cref="DbDataReader.GetByte"/> accessor answers with. A provider whose own tiny integer is
+        /// unsigned — SQL Server's is — maps to <c>SMALLINT</c> rather than through here. Java's <c>byte</c>
+        /// is IKVM's <see cref="byte"/> and is unsigned, so the sign travels in the bits.
+        /// </remarks>
         public static object? GetByte(DbDataReader reader, int index)
         {
-            return reader.IsDBNull(index) ? null : java.lang.Byte.valueOf(reader.GetByte(index));
+            return GetValueAs<sbyte>(reader, index) is sbyte value ? java.lang.Byte.valueOf(unchecked((byte)value)) : null;
         }
 
         /// <summary>
@@ -111,7 +148,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         public static object? GetShort(DbDataReader reader, int index)
         {
-            return reader.IsDBNull(index) ? null : java.lang.Short.valueOf(reader.GetInt16(index));
+            return GetValueAs<short>(reader, index) is short value ? java.lang.Short.valueOf(value) : null;
         }
 
         /// <summary>
@@ -122,7 +159,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         public static object? GetInt(DbDataReader reader, int index)
         {
-            return reader.IsDBNull(index) ? null : java.lang.Integer.valueOf(reader.GetInt32(index));
+            return GetValueAs<int>(reader, index) is int value ? java.lang.Integer.valueOf(value) : null;
         }
 
         /// <summary>
@@ -133,7 +170,29 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         public static object? GetLong(DbDataReader reader, int index)
         {
-            return reader.IsDBNull(index) ? null : java.lang.Long.valueOf(reader.GetInt64(index));
+            return GetValueAs<long>(reader, index) is long value ? java.lang.Long.valueOf(value) : null;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="java.lang.Double"/>.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static object? GetDouble(DbDataReader reader, int index)
+        {
+            return GetValueAs<double>(reader, index) is double value ? java.lang.Double.valueOf(value) : null;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="java.lang.Float"/>.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static object? GetFloat(DbDataReader reader, int index)
+        {
+            return GetValueAs<float>(reader, index) is float value ? java.lang.Float.valueOf(value) : null;
         }
 
         /// <summary>
@@ -167,6 +226,70 @@ namespace Apache.Calcite.Adapter.AdoNet
                 return null;
 
             return java.lang.Integer.valueOf(DateOnly.FromDateTime(reader.GetDateTime(index)).DayNumber - UnixEpochDay.DayNumber);
+        }
+
+        /// <summary>
+        /// The instant a <see cref="SqlTypeName.TIMESTAMP"/> counts from.
+        /// </summary>
+        static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// Gets a <see cref="SqlTypeName.TIMESTAMP"/> in Calcite's internal representation.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A timestamp carries no zone: the count is of milliseconds from the epoch to the wall clock read
+        /// as though it were UTC, which is what <c>ParameterBinder.ConvertTimestamp</c> writes and what
+        /// <c>CalciteResultValue</c> decodes with <c>UnixEpoch.AddMilliseconds</c>. Casting the provider's
+        /// <see cref="DateTime"/> to a <see cref="DateTimeOffset"/> instead reads an unspecified
+        /// <see cref="DateTime.Kind"/> as local time and shifts the value by the machine's offset — the same
+        /// hazard <see cref="GetDate"/> avoids, and for the same reason.
+        /// </remarks>
+        public static object? GetTimestamp(DbDataReader reader, int index)
+        {
+            if (reader.IsDBNull(index))
+                return null;
+
+            return java.lang.Long.valueOf(ToUnixTimeMilliseconds(DateTime.SpecifyKind(reader.GetDateTime(index), DateTimeKind.Utc)));
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SqlTypeName.TIMESTAMP_TZ"/> in Calcite's internal representation.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A zoned timestamp is an instant, so the count is of milliseconds from the epoch to it. A provider
+        /// that has a type for one hands back a <see cref="DateTimeOffset"/> and refuses
+        /// <see cref="DbDataReader.GetDateTime"/> outright — SQL Server's <c>datetimeoffset</c> does; one
+        /// that does not is read as UTC, the offset being the thing it had no way to tell us.
+        /// </remarks>
+        public static object? GetTimestampTz(DbDataReader reader, int index)
+        {
+            if (reader.IsDBNull(index))
+                return null;
+
+            return java.lang.Long.valueOf(reader.GetValue(index) switch
+            {
+                DateTimeOffset o => o.ToUnixTimeMilliseconds(),
+                DateTime d => ToUnixTimeMilliseconds(d.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(d, DateTimeKind.Utc) : d.ToUniversalTime()),
+                string s => DateTimeOffset.Parse(s, CultureInfo.InvariantCulture).ToUnixTimeMilliseconds(),
+                _ => ToUnixTimeMilliseconds(DateTime.SpecifyKind(reader.GetDateTime(index), DateTimeKind.Utc)),
+            });
+        }
+
+        /// <summary>
+        /// Counts the milliseconds from the epoch to a <see cref="DateTime"/> already in the terms it is to
+        /// be counted in.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        static long ToUnixTimeMilliseconds(DateTime value)
+        {
+            return (long)(value - UnixEpoch).TotalMilliseconds;
         }
 
         /// <summary>
@@ -236,9 +359,20 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="reader"></param>
         /// <param name="index"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// A column Calcite holds as <see cref="SqlTypeName.CHAR"/> or <see cref="SqlTypeName.VARCHAR"/> need
+        /// not be a string to the provider: SQL Server hands back a <see cref="Guid"/> for a
+        /// <c>uniqueidentifier</c>, which <c>AdoTable</c> types as <c>CHAR(36)</c>, and
+        /// <see cref="DbDataReader.GetString"/> casts rather than converts and refuses it. Formatting the
+        /// value is what the type says it is.
+        /// </remarks>
         public static object? GetString(DbDataReader reader, int index)
         {
-            return reader.IsDBNull(index) ? null : reader.GetString(index);
+            if (reader.IsDBNull(index))
+                return null;
+
+            var value = reader.GetValue(index);
+            return value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -162,10 +162,11 @@ namespace Apache.Calcite.Adapter.AdoNet
                 case DbType.Binary:
                     return typeFactory.createSqlType(SqlTypeName.VARBINARY, size);
                 // DbType.Byte is the unsigned 0..255 one and TINYINT is signed, so the top half of its range
-                // comes back negative: SQL Server's tinyint 200 read as a TINYINT is -56. SMALLINT is the
-                // narrowest Calcite type that holds it
+                // comes back negative: SQL Server's tinyint 200 read as a TINYINT is -56. UTINYINT is the
+                // type that holds it, as USMALLINT holds a UInt16 below — and as ParameterBinder already
+                // says on the way in, binding a DbType.Byte as a joou UByte
                 case DbType.Byte:
-                    return typeFactory.createSqlType(SqlTypeName.SMALLINT);
+                    return typeFactory.createSqlType(SqlTypeName.UTINYINT);
                 case DbType.Boolean:
                     return typeFactory.createSqlType(SqlTypeName.BOOLEAN);
                 // the scale money carries in every provider that has a distinct type for it

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -161,8 +161,11 @@ namespace Apache.Calcite.Adapter.AdoNet
                     return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
                 case DbType.Binary:
                     return typeFactory.createSqlType(SqlTypeName.VARBINARY, size);
+                // DbType.Byte is the unsigned 0..255 one and TINYINT is signed, so the top half of its range
+                // comes back negative: SQL Server's tinyint 200 read as a TINYINT is -56. SMALLINT is the
+                // narrowest Calcite type that holds it
                 case DbType.Byte:
-                    return typeFactory.createSqlType(SqlTypeName.TINYINT);
+                    return typeFactory.createSqlType(SqlTypeName.SMALLINT);
                 case DbType.Boolean:
                     return typeFactory.createSqlType(SqlTypeName.BOOLEAN);
                 // the scale money carries in every provider that has a distinct type for it

--- a/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
@@ -10,6 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Apache.Calcite.Adapter.AdoNet.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\" />
         <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
     </ItemGroup>

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoInformationSchemaDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoInformationSchemaDatabaseMetadata.cs
@@ -1,17 +1,23 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Globalization;
 
 namespace Apache.Calcite.Adapter.AdoNet.Metadata
 {
 
     /// <summary>
-    /// Implements the <see cref="AdoDatabaseMetadata"/> for a basic database that supports the GetSchema collections.
+    /// Implements the <see cref="AdoDatabaseMetadata"/> for a driver whose <c>Tables</c> and <c>Columns</c>
+    /// schema collections are the SQL <c>INFORMATION_SCHEMA</c> views.
     /// </summary>
-    abstract class AdoInformationSchemaDatabaseMetadata<TConnection> : AdoDatabaseMetadata
-        where TConnection : DbConnection
+    /// <remarks>
+    /// The shape is the driver's choice and not every driver's is this one, so a driver whose collections
+    /// are shaped otherwise derives from <see cref="AdoDatabaseMetadata"/> instead:
+    /// <see cref="OdbcDatabaseMetadata"/> reads the ODBC catalog, whose columns are <c>TABLE_CAT</c>,
+    /// <c>TABLE_SCHEM</c> and a numeric <c>DATA_TYPE</c>, and <see cref="OleDbDatabaseMetadata"/> reads the
+    /// OLE DB schema rowsets, which share these names and not their types.
+    /// </remarks>
+    abstract class AdoInformationSchemaDatabaseMetadata : AdoDatabaseMetadata
     {
 
         readonly DbDataSource _dbDataSource;
@@ -31,9 +37,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// <inheritdoc />
         public override string? GetDefaultDatabase()
         {
-            using var cnn = (TConnection?)_dbDataSource.OpenConnection();
-            if (cnn is null)
-                throw new NullReferenceException();
+            using var cnn = _dbDataSource.OpenConnection();
 
             // return database we connected to
             return cnn.Database;
@@ -42,9 +46,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// <inheritdoc />
         public override IReadOnlySet<AdoSchemaMetadata> GetSchemas(string? databaseName)
         {
-            using var cnn = (TConnection?)_dbDataSource.OpenConnection();
-            if (cnn is null)
-                throw new NullReferenceException();
+            using var cnn = _dbDataSource.OpenConnection();
 
             // establish target database
             if (databaseName is not null)
@@ -64,9 +66,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// <inheritdoc />
         public override IReadOnlySet<AdoTableMetadata> GetTables(string? databaseName, string? schemaName)
         {
-            using var cnn = (TConnection?)_dbDataSource.OpenConnection();
-            if (cnn is null)
-                throw new NullReferenceException();
+            using var cnn = _dbDataSource.OpenConnection();
 
             // establish target database
             if (databaseName is not null)
@@ -92,9 +92,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         {
             ArgumentNullException.ThrowIfNull(tableName);
 
-            using var cnn = (TConnection?)_dbDataSource.OpenConnection();
-            if (cnn is null)
-                throw new NullReferenceException();
+            using var cnn = _dbDataSource.OpenConnection();
 
             // establish target database
             if (databaseName is not null)
@@ -112,41 +110,15 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             foreach (DataRow row in result.Rows)
                 if ((string)row["TABLE_CATALOG"] == databaseName && (string)row["TABLE_SCHEMA"] == schemaName && (string)row["TABLE_NAME"] == tableName)
                     list.Add(new AdoFieldMetadata(
-                        row.Field<string>("COLUMN_NAME") ?? throw new InvalidOperationException(),
-                        ParseDbType(row.Field<string>("DATA_TYPE") ?? throw new InvalidOperationException()),
-                        GetInt32(row, "CHARACTER_MAXIMUM_LENGTH"),
-                        GetInt32(row, "NUMERIC_PRECISION"),
-                        GetInt32(row, "NUMERIC_SCALE"),
-                        row.Field<string>("IS_NULLABLE") == "YES"
+                        SchemaRow.String(row, "COLUMN_NAME") ?? throw new InvalidOperationException(),
+                        ParseDbType(SchemaRow.String(row, "DATA_TYPE") ?? throw new InvalidOperationException()),
+                        SchemaRow.Int32(row, "CHARACTER_MAXIMUM_LENGTH"),
+                        SchemaRow.Int32(row, "NUMERIC_PRECISION"),
+                        SchemaRow.Int32(row, "NUMERIC_SCALE"),
+                        SchemaRow.Boolean(row, "IS_NULLABLE") ?? true
                     ));
 
             return list;
-        }
-
-        /// <summary>
-        /// Reads a count out of the information schema without insisting on the width the server declared it
-        /// in.
-        /// </summary>
-        /// <param name="row"></param>
-        /// <param name="columnName"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// The information schema does not type these columns uniformly, and a driver carries the declared
-        /// type onto the <see cref="DataTable"/> it builds: SQL Server's <c>NUMERIC_PRECISION</c> is a
-        /// <c>tinyint</c> and arrives as a <see cref="byte"/>, its <c>DATETIME_PRECISION</c> and
-        /// <c>NUMERIC_PRECISION_RADIX</c> as <see cref="short"/>, while <c>NUMERIC_SCALE</c> and
-        /// <c>CHARACTER_MAXIMUM_LENGTH</c> are <see cref="int"/>. <see cref="DataRowExtensions.Field{T}(DataRow, string)"/>
-        /// unboxes rather than converts, so it throws on any of them that is not exactly the width asked
-        /// for — which is every table with a numeric column, and so every query. Each of these is a small
-        /// count whatever it was declared as, so widening it is exact.
-        /// </remarks>
-        static int? GetInt32(DataRow row, string columnName)
-        {
-            var value = row[columnName];
-            if (value is null || value == DBNull.Value)
-                return null;
-
-            return Convert.ToInt32(value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoInformationSchemaDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoInformationSchemaDatabaseMetadata.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 
 namespace Apache.Calcite.Adapter.AdoNet.Metadata
 {
@@ -113,13 +114,39 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
                     list.Add(new AdoFieldMetadata(
                         row.Field<string>("COLUMN_NAME") ?? throw new InvalidOperationException(),
                         ParseDbType(row.Field<string>("DATA_TYPE") ?? throw new InvalidOperationException()),
-                        row.Field<int?>("CHARACTER_MAXIMUM_LENGTH"),
-                        row.Field<int?>("NUMERIC_PRECISION"),
-                        row.Field<int?>("NUMERIC_SCALE"),
+                        GetInt32(row, "CHARACTER_MAXIMUM_LENGTH"),
+                        GetInt32(row, "NUMERIC_PRECISION"),
+                        GetInt32(row, "NUMERIC_SCALE"),
                         row.Field<string>("IS_NULLABLE") == "YES"
                     ));
 
             return list;
+        }
+
+        /// <summary>
+        /// Reads a count out of the information schema without insisting on the width the server declared it
+        /// in.
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The information schema does not type these columns uniformly, and a driver carries the declared
+        /// type onto the <see cref="DataTable"/> it builds: SQL Server's <c>NUMERIC_PRECISION</c> is a
+        /// <c>tinyint</c> and arrives as a <see cref="byte"/>, its <c>DATETIME_PRECISION</c> and
+        /// <c>NUMERIC_PRECISION_RADIX</c> as <see cref="short"/>, while <c>NUMERIC_SCALE</c> and
+        /// <c>CHARACTER_MAXIMUM_LENGTH</c> are <see cref="int"/>. <see cref="DataRowExtensions.Field{T}(DataRow, string)"/>
+        /// unboxes rather than converts, so it throws on any of them that is not exactly the width asked
+        /// for — which is every table with a numeric column, and so every query. Each of these is a small
+        /// count whatever it was declared as, so widening it is exact.
+        /// </remarks>
+        static int? GetInt32(DataRow row, string columnName)
+        {
+            var value = row[columnName];
+            if (value is null || value == DBNull.Value)
+                return null;
+
+            return Convert.ToInt32(value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Data;
+using System.Data.Common;
+
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.dialect;
+
+namespace Apache.Calcite.Adapter.AdoNet.Metadata
+{
+
+    /// <summary>
+    /// Works out which <see cref="SqlDialect"/> a provider is speaking to.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A driver that fronts one database knows what it is; ODBC and OLE DB do not, and the only thing they
+    /// can be asked is the <c>DataSourceInformation</c> collection, whose <c>DataSourceProductName</c> is
+    /// the same string JDBC's <c>getDatabaseProductName</c> returns. So the name is matched with the tests
+    /// <c>SqlDialectFactoryImpl.create</c> applies to it, and the answer is that product's own dialect.
+    /// </para>
+    /// <para>
+    /// Calcite calls what a product name alone can give you "a dummy dialect ... at best an approximation",
+    /// and it is: <see cref="SqlDialect.DatabaseProduct.getDialect"/> carries no version, and a dialect can
+    /// turn on one. <see cref="MssqlSqlDialect"/> does — under version 11 it writes <c>TOP(n)</c> and
+    /// <em>discards the offset</em>, so a paged query returns the first page for every page. That one is
+    /// therefore built from the version, which both providers do report. A provider that needs more than
+    /// this derives from <see cref="AdoDatabaseMetadata"/> and answers <c>Dialect</c> itself, which is what
+    /// <see cref="SqlServerDatabaseMetadata"/> does.
+    /// </para>
+    /// </remarks>
+    static class AdoSqlDialects
+    {
+
+        /// <summary>
+        /// Asks a connection what it is talking to and returns the dialect for it.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns></returns>
+        public static SqlDialect ForConnection(DbConnection connection)
+        {
+            string? productName = null;
+            string? productVersion = null;
+
+            try
+            {
+                using var information = connection.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
+                if (information.Rows.Count > 0)
+                {
+                    productName = SchemaRow.String(information.Rows[0], DbMetaDataColumnNames.DataSourceProductName);
+                    productVersion = SchemaRow.String(information.Rows[0], DbMetaDataColumnNames.DataSourceProductVersion);
+                }
+            }
+            catch (Exception)
+            {
+                // a driver need not offer the collection at all, and an unknown product is a supported answer
+            }
+
+            // the connection's own version is the better one where the collection did not carry it: ODBC and
+            // OLE DB both fill ServerVersion from the same place
+            if (string.IsNullOrWhiteSpace(productVersion))
+                productVersion = TryGetServerVersion(connection);
+
+            return For(productName, productVersion);
+        }
+
+        /// <summary>
+        /// Reads <see cref="DbConnection.ServerVersion"/>, which a driver is entitled to refuse.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns></returns>
+        static string? TryGetServerVersion(DbConnection connection)
+        {
+            try
+            {
+                return connection.ServerVersion;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the dialect for a product name, as Calcite matches one.
+        /// </summary>
+        /// <param name="productName"></param>
+        /// <param name="productVersion"></param>
+        /// <returns></returns>
+        public static SqlDialect For(string? productName, string? productVersion)
+        {
+            var product = ProductFor(productName);
+
+            // the one product whose dialect answers differently for different versions, and answers wrongly
+            // rather than conservatively when it guesses low
+            if (product == SqlDialect.DatabaseProduct.MSSQL)
+                return CreateMssql(productName, productVersion);
+
+            // UNKNOWN's own dialect is a bare SqlDialect over the enum's quote character; the generic
+            // dialect Calcite's create ends at is the ANSI one, and that is the answer being reproduced
+            if (product == SqlDialect.DatabaseProduct.UNKNOWN)
+                return AnsiSqlDialect.DEFAULT;
+
+            return product.getDialect();
+        }
+
+        /// <summary>
+        /// Builds the SQL Server dialect against the version the server reported.
+        /// </summary>
+        /// <param name="productName"></param>
+        /// <param name="productVersion"></param>
+        /// <returns></returns>
+        public static SqlDialect CreateMssql(string? productName, string? productVersion)
+        {
+            var context = MssqlSqlDialect.DEFAULT_CONTEXT
+                .withDatabaseProductName(productName ?? "Microsoft SQL Server")
+                .withDatabaseMajorVersion(MajorVersion(productVersion))
+                .withDatabaseMinorVersion(MinorVersion(productVersion));
+
+            if (productVersion is not null)
+                context = context.withDatabaseVersion(productVersion);
+
+            return new MssqlSqlDialect(context);
+        }
+
+        /// <summary>
+        /// Matches a product name to a product, with the exact names and then the fuzzy tests
+        /// <c>SqlDialectFactoryImpl.create</c> applies in that order.
+        /// </summary>
+        /// <param name="productName"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Ported rather than called: <c>create</c> takes a JDBC <c>DatabaseMetaData</c>, and there is none
+        /// here. Where Calcite dispatches to a dialect this dispatches to the product whose
+        /// <c>getDialect</c> is that dialect; the products Calcite has a name test for but no product
+        /// constant — Firebolt, Paraccel, Doris — fall where their names put them or to
+        /// <see cref="SqlDialect.DatabaseProduct.UNKNOWN"/>, whose dialect is the generic one
+        /// <c>create</c> ends at.
+        /// </remarks>
+        public static SqlDialect.DatabaseProduct ProductFor(string? productName)
+        {
+            var name = (productName ?? "").ToUpperInvariant().Trim();
+
+            switch (name)
+            {
+                case "ACCESS":
+                    return SqlDialect.DatabaseProduct.ACCESS;
+                case "APACHE DERBY":
+                case "DBMS:CLOUDSCAPE":
+                    return SqlDialect.DatabaseProduct.DERBY;
+                case "CLICKHOUSE":
+                    return SqlDialect.DatabaseProduct.CLICKHOUSE;
+                case "EXASOL":
+                    return SqlDialect.DatabaseProduct.EXASOL;
+                case "FIREBOLT":
+                    return SqlDialect.DatabaseProduct.FIREBOLT;
+                case "HIVE":
+                    return SqlDialect.DatabaseProduct.HIVE;
+                case "INGRES":
+                    return SqlDialect.DatabaseProduct.INGRES;
+                case "INTERBASE":
+                    return SqlDialect.DatabaseProduct.INTERBASE;
+                case "JETHRODATA":
+                    return SqlDialect.DatabaseProduct.JETHRO;
+                case "LUCIDDB":
+                    return SqlDialect.DatabaseProduct.LUCIDDB;
+                case "ORACLE":
+                    return SqlDialect.DatabaseProduct.ORACLE;
+                case "PHOENIX":
+                    return SqlDialect.DatabaseProduct.PHOENIX;
+                case "PRESTO":
+                case "AWS.ATHENA":
+                    return SqlDialect.DatabaseProduct.PRESTO;
+                case "MYSQL (INFOBRIGHT)":
+                    return SqlDialect.DatabaseProduct.INFOBRIGHT;
+                case "MYSQL":
+                    return SqlDialect.DatabaseProduct.MYSQL;
+                case "REDSHIFT":
+                    return SqlDialect.DatabaseProduct.REDSHIFT;
+                case "SNOWFLAKE":
+                    return SqlDialect.DatabaseProduct.SNOWFLAKE;
+                case "SPARK":
+                    return SqlDialect.DatabaseProduct.SPARK;
+                default:
+                    break;
+            }
+
+            // now the fuzzy matches, in Calcite's order: an earlier test wins where two would both hit
+            if (name.StartsWith("DB2", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.DB2;
+            if (name.Contains("FIREBIRD", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.FIREBIRD;
+            if (name.Contains("FIREBOLT", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.FIREBOLT;
+            if (name.Contains("GOOGLE BIGQUERY", StringComparison.Ordinal) || name.Contains("GOOGLE BIG QUERY", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.BIG_QUERY;
+            if (name.StartsWith("INFORMIX", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.INFORMIX;
+            if (name.Contains("NETEZZA", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.NETEZZA;
+            if (name.Contains("PARACCEL", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.PARACCEL;
+            if (name.StartsWith("HP NEOVIEW", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.NEOVIEW;
+            if (name.Contains("POSTGRE", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.POSTGRESQL;
+            if (name.Contains("SQL SERVER", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.MSSQL;
+            if (name.Contains("SYBASE", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.SYBASE;
+            if (name.Contains("TERADATA", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.TERADATA;
+            if (name.Contains("HSQL", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.HSQLDB;
+            if (name.Contains("H2", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.H2;
+            if (name.Contains("VERTICA", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.VERTICA;
+            if (name.Contains("SNOWFLAKE", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.SNOWFLAKE;
+            if (name.Contains("SPARK", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.SPARK;
+
+            // an addition rather than a port: Calcite's create has no SQLite branch, its JDBC driver being
+            // one nobody had put through this, and a bridged driver over SQLite says exactly this
+            if (name.Contains("SQLITE", StringComparison.Ordinal))
+                return SqlDialect.DatabaseProduct.SQLITE;
+
+            return SqlDialect.DatabaseProduct.UNKNOWN;
+        }
+
+        /// <summary>
+        /// Returns the leading component of a dotted version string, or zero.
+        /// </summary>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        public static int MajorVersion(string? version)
+        {
+            return Component(version, 0);
+        }
+
+        /// <summary>
+        /// Returns the second component of a dotted version string, or zero.
+        /// </summary>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        public static int MinorVersion(string? version)
+        {
+            return Component(version, 1);
+        }
+
+        /// <summary>
+        /// Returns one component of a dotted version string.
+        /// </summary>
+        /// <param name="version"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        static int Component(string? version, int index)
+        {
+            if (version is null)
+                return 0;
+
+            var parts = version.Split('.');
+            return parts.Length > index && int.TryParse(parts[index], out var value) ? value : 0;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
@@ -119,7 +119,38 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             if (productVersion is not null)
                 context = context.withDatabaseVersion(productVersion);
 
-            return new MssqlSqlDialect(context);
+            return new Mssql(context);
+        }
+
+        /// <summary>
+        /// <see cref="MssqlSqlDialect"/>, and the one thing it does not say about SQL Server.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <remarks>
+        /// <para>
+        /// SQL Server cannot group by a constant, and <see cref="MssqlSqlDialect"/> does not declare it:
+        /// <c>SqlDialect.supportsGroupByLiteral</c> defaults to true and Postgres, Redshift and Informix
+        /// each override it while SQL Server does not. Measured — <c>GROUP BY (1 = 1)</c> is "Incorrect
+        /// syntax near '='" and <c>GROUP BY 1</c> is "Each GROUP BY expression must contain at least one
+        /// column that is not an outer reference".
+        /// </para>
+        /// <para>
+        /// It costs every correlated sub-query. <c>EXISTS</c> becomes an aggregate over a constant true, and
+        /// <c>SqlImplementor.visitRoot</c> only runs <c>AggregateProjectConstantToDummyJoinRule</c> — which
+        /// exists for exactly this — when the dialect has said it is needed. Saying so is a correction to
+        /// Calcite rather than a reproduction of it, which the adapter is entitled to make: it generates SQL
+        /// for a server to run, and the server is the authority on what it accepts.
+        /// </para>
+        /// </remarks>
+        sealed class Mssql(SqlDialect.Context context) : MssqlSqlDialect(context)
+        {
+
+            /// <inheritdoc />
+            public override bool supportsGroupByLiteral()
+            {
+                return false;
+            }
+
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/OdbcDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/OdbcDatabaseMetadata.cs
@@ -248,7 +248,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             {
                 SqlBit => DbType.Boolean,
                 // ODBC does not say whether the driver's tiny integer is signed, and SQL Server's is not:
-                // DbType.Byte is the unsigned one, which AdoTable widens to SMALLINT and so holds both
+                // DbType.Byte is the unsigned one, which AdoTable holds as a UTINYINT; a driver whose tiny
+                // integer really is signed loses the negative half, and ODBC gives no way to tell
                 SqlTinyint => DbType.Byte,
                 SqlSmallint => DbType.Int16,
                 SqlInteger => DbType.Int32,

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/OdbcDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/OdbcDatabaseMetadata.cs
@@ -1,4 +1,6 @@
-﻿using System.Data;
+using System;
+using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Data.Odbc;
 
@@ -10,31 +12,265 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
     /// <summary>
     /// Implements the <see cref="AdoDatabaseMetadata"/> for any <see cref="OdbcConnection"/>.
     /// </summary>
-    class OdbcDatabaseMetadata : AdoInformationSchemaDatabaseMetadata<OdbcConnection>
+    /// <remarks>
+    /// <para>
+    /// ODBC's catalog is not the SQL <c>INFORMATION_SCHEMA</c> and does not have its shape: the schema
+    /// collections come from <c>SQLTables</c> and <c>SQLColumns</c>, which name the catalog and schema
+    /// <c>TABLE_CAT</c> and <c>TABLE_SCHEM</c>, state the type as the numeric <c>DATA_TYPE</c> code rather
+    /// than a name, and carry no <c>NUMERIC_PRECISION</c> at all — <c>COLUMN_SIZE</c> is the length of a
+    /// character column and the precision of a numeric one.
+    /// </para>
+    /// <para>
+    /// What sits behind the driver is unknown, so there is no default schema to speak of: a null database or
+    /// schema means every one rather than a particular one, and a caller who wants a single schema names it.
+    /// </para>
+    /// </remarks>
+    class OdbcDatabaseMetadata : AdoDatabaseMetadata
     {
+
+        readonly DbDataSource _dbDataSource;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="dbDataSource"></param>
-        public OdbcDatabaseMetadata(DbDataSource dbDataSource) :
-            base(dbDataSource)
+        public OdbcDatabaseMetadata(DbDataSource dbDataSource)
         {
+            _dbDataSource = dbDataSource ?? throw new ArgumentNullException(nameof(dbDataSource));
+        }
+
+        /// <summary>
+        /// Gets the data source this metadata describes.
+        /// </summary>
+        public DbDataSource DbDataSource => _dbDataSource;
+
+        /// <inheritdoc />
+        public override string? GetDefaultDatabase()
+        {
+            using var cnn = _dbDataSource.OpenConnection();
+
+            // a driver that has no notion of a catalog reports an empty one
+            return string.IsNullOrEmpty(cnn.Database) ? null : cnn.Database;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// ODBC has no portable way to ask which schema an identifier resolves in, so there is no answer
+        /// but "all of them".
+        /// </remarks>
+        public override string? GetDefaultSchema()
+        {
+            return null;
+        }
+
+        /// <inheritdoc />
+        public override SqlDialect Dialect => _dialect ??= CreateDialect();
+
+        SqlDialect? _dialect;
+
+        /// <summary>
+        /// Asks the driver what is behind it, once: the convention reads the dialect for every rule that
+        /// matches while planning.
+        /// </summary>
+        /// <returns></returns>
+        SqlDialect CreateDialect()
+        {
+            using var cnn = _dbDataSource.OpenConnection();
+
+            return AdoSqlDialects.ForConnection(cnn);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The parameter marker is <c>?</c> and positional: <see cref="OdbcCommand"/> binds by ordinal and
+        /// ignores the name.
+        /// </remarks>
+        public override IAdoSqlSyntax Syntax { get; } = new OdbcSqlSyntax();
+
+        /// <summary>
+        /// ODBC names no parameter; it counts them.
+        /// </summary>
+        sealed class OdbcSqlSyntax : IAdoSqlSyntax
+        {
+
+            /// <inheritdoc />
+            public string GetParameterName(int index) => "?";
 
         }
 
-        public override string GetDefaultSchema()
+        /// <inheritdoc />
+        public override IReadOnlySet<AdoSchemaMetadata> GetSchemas(string? databaseName)
         {
-            throw new System.NotImplementedException();
+            var set = new HashSet<AdoSchemaMetadata>();
+
+            foreach (var row in Rows("Tables", databaseName, null, null))
+                if (SchemaRow.String(row, "TABLE_SCHEM") is string schemaName)
+                    set.Add(new AdoSchemaMetadata(schemaName));
+
+            return set;
         }
 
-        public override SqlDialect Dialect => throw new System.NotImplementedException();
-
-        protected override DbType ParseDbType(string typeName)
+        /// <inheritdoc />
+        public override IReadOnlySet<AdoTableMetadata> GetTables(string? databaseName, string? schemaName)
         {
-            throw new System.NotImplementedException();
+            var set = new HashSet<AdoTableMetadata>();
+
+            foreach (var row in Rows("Tables", databaseName, schemaName, null))
+                if (SchemaRow.String(row, "TABLE_NAME") is string tableName)
+                    set.Add(new AdoTableMetadata(SchemaRow.String(row, "TABLE_CAT"), SchemaRow.String(row, "TABLE_SCHEM"), tableName));
+
+            return set;
         }
 
+        /// <inheritdoc />
+        public override IReadOnlySet<AdoFieldMetadata> GetFields(string? databaseName, string? schemaName, string tableName)
+        {
+            ArgumentNullException.ThrowIfNull(tableName);
+
+            var set = new HashSet<AdoFieldMetadata>();
+
+            foreach (var row in Rows("Columns", databaseName, schemaName, tableName))
+            {
+                var name = SchemaRow.String(row, "COLUMN_NAME");
+                if (name is null)
+                    continue;
+
+                // COLUMN_SIZE is the character count of a character column and the precision of a numeric
+                // one, and a driver reports zero for a column with no bound — SQL Server's varchar(max) and
+                // xml both arrive as zero rather than as the -1 the information schema gives
+                var size = SchemaRow.Int32(row, "COLUMN_SIZE") is int columnSize && columnSize > 0 ? columnSize : (int?)null;
+
+                set.Add(new AdoFieldMetadata(
+                    name,
+                    ParseDbType(SchemaRow.Int32(row, "DATA_TYPE") ?? SqlUnknownType),
+                    size,
+                    size,
+                    SchemaRow.Int32(row, "DECIMAL_DIGITS"),
+                    // SQL_NO_NULLS is zero and SQL_NULLABLE_UNKNOWN is two: only a stated no is a no
+                    SchemaRow.Int32(row, "NULLABLE") != 0));
+            }
+
+            return set;
+        }
+
+        /// <summary>
+        /// Returns the rows of a schema collection that describe one catalog, schema and table, taking a
+        /// null for any of them as every one.
+        /// </summary>
+        /// <param name="collectionName"></param>
+        /// <param name="databaseName"></param>
+        /// <param name="schemaName"></param>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        IEnumerable<DataRow> Rows(string collectionName, string? databaseName, string? schemaName, string? tableName)
+        {
+            using var cnn = _dbDataSource.OpenConnection();
+
+            if (databaseName is not null)
+                cnn.ChangeDatabase(databaseName);
+
+            using var result = cnn.GetSchema(collectionName);
+
+            var rows = new List<DataRow>();
+            foreach (DataRow row in result.Rows)
+            {
+                if (databaseName is not null && SchemaRow.String(row, "TABLE_CAT") != databaseName)
+                    continue;
+                if (schemaName is not null && SchemaRow.String(row, "TABLE_SCHEM") != schemaName)
+                    continue;
+                if (tableName is not null && SchemaRow.String(row, "TABLE_NAME") != tableName)
+                    continue;
+
+                rows.Add(row);
+            }
+
+            return rows;
+        }
+
+        #region Type codes
+
+        // the concise type codes SQLColumns reports, from ODBC's sql.h and sqlext.h
+        const int SqlUnknownType = 0;
+        const int SqlChar = 1;
+        const int SqlNumeric = 2;
+        const int SqlDecimal = 3;
+        const int SqlInteger = 4;
+        const int SqlSmallint = 5;
+        const int SqlFloat = 6;
+        const int SqlReal = 7;
+        const int SqlDouble = 8;
+        const int SqlVarchar = 12;
+        const int SqlLongVarchar = -1;
+        const int SqlBinary = -2;
+        const int SqlVarbinary = -3;
+        const int SqlLongVarbinary = -4;
+        const int SqlBigint = -5;
+        const int SqlTinyint = -6;
+        const int SqlBit = -7;
+        const int SqlWchar = -8;
+        const int SqlWvarchar = -9;
+        const int SqlWlongVarchar = -10;
+        const int SqlGuid = -11;
+
+        // ODBC 2 spelled the datetime types 9, 10 and 11; ODBC 3 spells them 91, 92 and 93, and a driver
+        // answers in whichever version the application asked for
+        const int SqlDateV2 = 9;
+        const int SqlTimeV2 = 10;
+        const int SqlTimestampV2 = 11;
+        const int SqlTypeDate = 91;
+        const int SqlTypeTime = 92;
+        const int SqlTypeTimestamp = 93;
+
+        // SQL Server's driver-specific codes. System.Data.Odbc has no mapping for SQL_SS_TIME2 or
+        // SQL_SS_TIMESTAMPOFFSET and throws ArgumentException on reading either, whatever they are typed as
+        // here; they are named so that the column at least appears with the type it has
+        const int SqlSsVariant = -150;
+        const int SqlSsUdt = -151;
+        const int SqlSsXml = -152;
+        const int SqlSsTime2 = -154;
+        const int SqlSsTimestampOffset = -155;
+
+        #endregion
+
+        /// <summary>
+        /// Returns the <see cref="DbType"/> for an ODBC type code.
+        /// </summary>
+        /// <param name="dataType"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A code with no mapping goes to <see cref="DbType.Object"/>, which <c>AdoTable</c> maps to
+        /// <c>OTHER</c> and the reader passes through: an unrecognised column costs that column rather than
+        /// the table. The interval types are among them, Calcite's own interval being a different thing.
+        /// </remarks>
+        static DbType ParseDbType(int dataType)
+        {
+            return dataType switch
+            {
+                SqlBit => DbType.Boolean,
+                // ODBC does not say whether the driver's tiny integer is signed, and SQL Server's is not:
+                // DbType.Byte is the unsigned one, which AdoTable widens to SMALLINT and so holds both
+                SqlTinyint => DbType.Byte,
+                SqlSmallint => DbType.Int16,
+                SqlInteger => DbType.Int32,
+                SqlBigint => DbType.Int64,
+                SqlDecimal or SqlNumeric => DbType.Decimal,
+                SqlFloat or SqlDouble => DbType.Double,
+                SqlReal => DbType.Single,
+                SqlChar => DbType.AnsiStringFixedLength,
+                SqlWchar => DbType.StringFixedLength,
+                SqlVarchar or SqlLongVarchar => DbType.AnsiString,
+                SqlWvarchar or SqlWlongVarchar => DbType.String,
+                SqlSsXml => DbType.Xml,
+                SqlBinary or SqlVarbinary or SqlLongVarbinary => DbType.Binary,
+                SqlGuid => DbType.Guid,
+                SqlTypeDate or SqlDateV2 => DbType.Date,
+                SqlTypeTime or SqlTimeV2 or SqlSsTime2 => DbType.Time,
+                SqlTypeTimestamp or SqlTimestampV2 => DbType.DateTime,
+                SqlSsTimestampOffset => DbType.DateTimeOffset,
+                SqlSsVariant or SqlSsUdt => DbType.Object,
+                _ => DbType.Object,
+            };
+        }
 
     }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/OleDbDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/OleDbDatabaseMetadata.cs
@@ -254,7 +254,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             {
                 DbTypeBool => DbType.Boolean,
                 // DBTYPE_I1 is the signed one and DBTYPE_UI1 the unsigned; AdoTable holds the unsigned in a
-                // SMALLINT, TINYINT being signed
+                // UTINYINT, TINYINT being signed
                 DbTypeI1 => DbType.SByte,
                 DbTypeUi1 => DbType.Byte,
                 DbTypeI2 => DbType.Int16,

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/OleDbDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/OleDbDatabaseMetadata.cs
@@ -1,4 +1,6 @@
-﻿using System.Data;
+using System;
+using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Data.OleDb;
 
@@ -10,29 +12,275 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
     /// <summary>
     /// Implements the <see cref="AdoDatabaseMetadata"/> for any <see cref="OleDbConnection"/>.
     /// </summary>
-    class OleDbDatabaseMetadata : AdoInformationSchemaDatabaseMetadata<OleDbConnection>
+    /// <remarks>
+    /// <para>
+    /// OLE DB's schema rowsets borrow the information schema's column names and not its types: the type is
+    /// the numeric <c>DBTYPE</c> in <c>DATA_TYPE</c> rather than a name, <c>IS_NULLABLE</c> is a
+    /// <see cref="bool"/>, <c>CHARACTER_MAXIMUM_LENGTH</c> is a <see cref="decimal"/> and
+    /// <c>NUMERIC_SCALE</c> a <see cref="short"/>. A <c>DBTYPE</c> says nothing about whether a character or
+    /// binary column is fixed or varying, so that comes from <c>COLUMN_FLAGS</c>.
+    /// </para>
+    /// <para>
+    /// What sits behind the provider is unknown, so a null database or schema means every one rather than a
+    /// particular one, and a caller who wants a single schema names it.
+    /// </para>
+    /// </remarks>
+    class OleDbDatabaseMetadata : AdoDatabaseMetadata
     {
+
+        readonly DbDataSource _dbDataSource;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="dbDataSource"></param>
-        public OleDbDatabaseMetadata(DbDataSource dbDataSource) :
-            base(dbDataSource)
+        public OleDbDatabaseMetadata(DbDataSource dbDataSource)
         {
+            _dbDataSource = dbDataSource ?? throw new ArgumentNullException(nameof(dbDataSource));
+        }
+
+        /// <summary>
+        /// Gets the data source this metadata describes.
+        /// </summary>
+        public DbDataSource DbDataSource => _dbDataSource;
+
+        /// <inheritdoc />
+        public override string? GetDefaultDatabase()
+        {
+            using var cnn = _dbDataSource.OpenConnection();
+
+            // a provider over something with no catalogs reports an empty one
+            return string.IsNullOrEmpty(cnn.Database) ? null : cnn.Database;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// OLE DB has no portable way to ask which schema an identifier resolves in, so there is no answer
+        /// but "all of them".
+        /// </remarks>
+        public override string? GetDefaultSchema()
+        {
+            return null;
+        }
+
+        /// <inheritdoc />
+        public override SqlDialect Dialect => _dialect ??= CreateDialect();
+
+        SqlDialect? _dialect;
+
+        /// <summary>
+        /// Asks the provider what is behind it, once: the convention reads the dialect for every rule that
+        /// matches while planning.
+        /// </summary>
+        /// <returns></returns>
+        SqlDialect CreateDialect()
+        {
+            using var cnn = _dbDataSource.OpenConnection();
+
+            return AdoSqlDialects.ForConnection(cnn);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The parameter marker is <c>?</c> and positional: <see cref="OleDbCommand"/> binds by ordinal and
+        /// ignores the name.
+        /// </remarks>
+        public override IAdoSqlSyntax Syntax { get; } = new OleDbSqlSyntax();
+
+        /// <summary>
+        /// OLE DB names no parameter; it counts them.
+        /// </summary>
+        sealed class OleDbSqlSyntax : IAdoSqlSyntax
+        {
+
+            /// <inheritdoc />
+            public string GetParameterName(int index) => "?";
 
         }
 
-        public override string GetDefaultSchema()
+        /// <inheritdoc />
+        public override IReadOnlySet<AdoSchemaMetadata> GetSchemas(string? databaseName)
         {
-            throw new System.NotImplementedException();
+            var set = new HashSet<AdoSchemaMetadata>();
+
+            foreach (var row in Rows("Tables", databaseName, null, null))
+                if (SchemaRow.String(row, "TABLE_SCHEMA") is string schemaName)
+                    set.Add(new AdoSchemaMetadata(schemaName));
+
+            return set;
         }
 
-        public override SqlDialect Dialect => throw new System.NotImplementedException();
-
-        protected override DbType ParseDbType(string typeName)
+        /// <inheritdoc />
+        public override IReadOnlySet<AdoTableMetadata> GetTables(string? databaseName, string? schemaName)
         {
-            throw new System.NotImplementedException();
+            var set = new HashSet<AdoTableMetadata>();
+
+            foreach (var row in Rows("Tables", databaseName, schemaName, null))
+                if (SchemaRow.String(row, "TABLE_NAME") is string tableName)
+                    set.Add(new AdoTableMetadata(SchemaRow.String(row, "TABLE_CATALOG"), SchemaRow.String(row, "TABLE_SCHEMA"), tableName));
+
+            return set;
+        }
+
+        /// <inheritdoc />
+        public override IReadOnlySet<AdoFieldMetadata> GetFields(string? databaseName, string? schemaName, string tableName)
+        {
+            ArgumentNullException.ThrowIfNull(tableName);
+
+            var set = new HashSet<AdoFieldMetadata>();
+
+            foreach (var row in Rows("Columns", databaseName, schemaName, tableName))
+            {
+                var name = SchemaRow.String(row, "COLUMN_NAME");
+                if (name is null)
+                    continue;
+
+                // a provider reports zero for a column with no bound: SQL Server's varchar(max) and xml both
+                // arrive as zero rather than as the -1 the information schema gives
+                var size = SchemaRow.Int32(row, "CHARACTER_MAXIMUM_LENGTH") is int length && length > 0 ? length : (int?)null;
+                var flags = SchemaRow.Int64(row, "COLUMN_FLAGS") ?? 0;
+
+                set.Add(new AdoFieldMetadata(
+                    name,
+                    ParseDbType(SchemaRow.Int32(row, "DATA_TYPE") ?? DbTypeEmpty, (flags & DbColumnFlagsIsFixedLength) != 0),
+                    size,
+                    SchemaRow.Int32(row, "NUMERIC_PRECISION"),
+                    SchemaRow.Int32(row, "NUMERIC_SCALE"),
+                    SchemaRow.Boolean(row, "IS_NULLABLE") ?? true));
+            }
+
+            return set;
+        }
+
+        /// <summary>
+        /// Returns the rows of a schema collection that describe one catalog, schema and table, taking a
+        /// null for any of them as every one.
+        /// </summary>
+        /// <param name="collectionName"></param>
+        /// <param name="databaseName"></param>
+        /// <param name="schemaName"></param>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        IEnumerable<DataRow> Rows(string collectionName, string? databaseName, string? schemaName, string? tableName)
+        {
+            using var cnn = _dbDataSource.OpenConnection();
+
+            if (databaseName is not null)
+                cnn.ChangeDatabase(databaseName);
+
+            using var result = cnn.GetSchema(collectionName);
+
+            var rows = new List<DataRow>();
+            foreach (DataRow row in result.Rows)
+            {
+                if (databaseName is not null && SchemaRow.String(row, "TABLE_CATALOG") != databaseName)
+                    continue;
+                if (schemaName is not null && SchemaRow.String(row, "TABLE_SCHEMA") != schemaName)
+                    continue;
+                if (tableName is not null && SchemaRow.String(row, "TABLE_NAME") != tableName)
+                    continue;
+
+                rows.Add(row);
+            }
+
+            return rows;
+        }
+
+        #region Type codes
+
+        // the DBTYPE enumeration from OLE DB's oledb.h, and the three SQL Server adds to it
+        const int DbTypeEmpty = 0;
+        const int DbTypeNull = 1;
+        const int DbTypeI2 = 2;
+        const int DbTypeI4 = 3;
+        const int DbTypeR4 = 4;
+        const int DbTypeR8 = 5;
+        const int DbTypeCy = 6;
+        const int DbTypeDate = 7;
+        const int DbTypeBstr = 8;
+        const int DbTypeBool = 11;
+        const int DbTypeVariant = 12;
+        const int DbTypeDecimal = 14;
+        const int DbTypeI1 = 16;
+        const int DbTypeUi1 = 17;
+        const int DbTypeUi2 = 18;
+        const int DbTypeUi4 = 19;
+        const int DbTypeI8 = 20;
+        const int DbTypeUi8 = 21;
+        const int DbTypeFileTime = 64;
+        const int DbTypeGuid = 72;
+        const int DbTypeBytes = 128;
+        const int DbTypeStr = 129;
+        const int DbTypeWstr = 130;
+        const int DbTypeNumeric = 131;
+        const int DbTypeUdt = 132;
+        const int DbTypeDbDate = 133;
+        const int DbTypeDbTime = 134;
+        const int DbTypeDbTimestamp = 135;
+        const int DbTypeVarNumeric = 139;
+        const int DbTypeXml = 141;
+        const int DbTypeDbTime2 = 145;
+        const int DbTypeDbTimestampOffset = 146;
+
+        /// <summary>
+        /// The modifier bits a <c>DBTYPE</c> can carry — <c>DBTYPE_VECTOR</c>, <c>DBTYPE_ARRAY</c>,
+        /// <c>DBTYPE_BYREF</c> and <c>DBTYPE_RESERVED</c> — which say how the value is handed over rather
+        /// than what it is.
+        /// </summary>
+        const int DbTypeModifierMask = 0x1000 | 0x2000 | 0x4000 | 0x8000;
+
+        /// <summary>
+        /// <c>DBCOLUMNFLAGS_ISFIXEDLENGTH</c>: set for <c>char</c> and clear for <c>varchar</c>, which the
+        /// <c>DBTYPE</c> alone does not distinguish.
+        /// </summary>
+        const long DbColumnFlagsIsFixedLength = 0x10;
+
+        #endregion
+
+        /// <summary>
+        /// Returns the <see cref="DbType"/> for a <c>DBTYPE</c> code.
+        /// </summary>
+        /// <param name="dataType"></param>
+        /// <param name="fixedLength"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A code with no mapping goes to <see cref="DbType.Object"/>, which <c>AdoTable</c> maps to
+        /// <c>OTHER</c> and the reader passes through: an unrecognised column costs that column rather than
+        /// the table.
+        /// </remarks>
+        static DbType ParseDbType(int dataType, bool fixedLength)
+        {
+            return (dataType & ~DbTypeModifierMask) switch
+            {
+                DbTypeBool => DbType.Boolean,
+                // DBTYPE_I1 is the signed one and DBTYPE_UI1 the unsigned; AdoTable holds the unsigned in a
+                // SMALLINT, TINYINT being signed
+                DbTypeI1 => DbType.SByte,
+                DbTypeUi1 => DbType.Byte,
+                DbTypeI2 => DbType.Int16,
+                DbTypeUi2 => DbType.UInt16,
+                DbTypeI4 => DbType.Int32,
+                DbTypeUi4 => DbType.UInt32,
+                DbTypeI8 => DbType.Int64,
+                DbTypeUi8 => DbType.UInt64,
+                DbTypeNumeric or DbTypeDecimal or DbTypeVarNumeric => DbType.Decimal,
+                DbTypeCy => DbType.Currency,
+                DbTypeR4 => DbType.Single,
+                DbTypeR8 => DbType.Double,
+                DbTypeStr => fixedLength ? DbType.AnsiStringFixedLength : DbType.AnsiString,
+                DbTypeWstr or DbTypeBstr => fixedLength ? DbType.StringFixedLength : DbType.String,
+                DbTypeXml => DbType.Xml,
+                DbTypeBytes => DbType.Binary,
+                DbTypeGuid => DbType.Guid,
+                DbTypeDbDate => DbType.Date,
+                DbTypeDbTime or DbTypeDbTime2 => DbType.Time,
+                // DBTYPE_DATE is an OLE automation double and DBTYPE_FILETIME a 64 bit tick count, but a
+                // provider hands either over as a DateTime and that is what the reader asks for
+                DbTypeDbTimestamp or DbTypeDate or DbTypeFileTime => DbType.DateTime,
+                DbTypeDbTimestampOffset => DbType.DateTimeOffset,
+                DbTypeNull or DbTypeEmpty or DbTypeVariant or DbTypeUdt => DbType.Object,
+                _ => DbType.Object,
+            };
         }
 
     }

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/SchemaRow.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/SchemaRow.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Data;
+using System.Globalization;
+
+namespace Apache.Calcite.Adapter.AdoNet.Metadata
+{
+
+    /// <summary>
+    /// Reads a row of a provider's <see cref="System.Data.Common.DbConnection.GetSchema(string)"/> collection
+    /// without insisting on the CLR type the driver chose to carry a value in.
+    /// </summary>
+    /// <remarks>
+    /// A driver builds its schema <see cref="DataTable"/> from whatever its catalog gave it, and the widths
+    /// are neither uniform across drivers nor across the columns of one collection: SQL Server's
+    /// <c>NUMERIC_PRECISION</c> arrives as a <see cref="byte"/> and its <c>NUMERIC_SCALE</c> as an
+    /// <see cref="int"/>; OLE DB's <c>CHARACTER_MAXIMUM_LENGTH</c> is a <see cref="decimal"/> and its
+    /// <c>NUMERIC_SCALE</c> a <see cref="short"/>; ODBC's <c>DECIMAL_DIGITS</c> is a <see cref="short"/>.
+    /// <see cref="DataRowExtensions.Field{T}(DataRow, string)"/> unboxes rather than converts and throws on
+    /// every one of those that is not the width asked for — which is how every query against SQL Server came
+    /// to fail. These are counts and codes, so widening one is exact.
+    /// </remarks>
+    static class SchemaRow
+    {
+
+        /// <summary>
+        /// Reads a count or a type code, whatever integral width the driver declared it in.
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        public static int? Int32(DataRow row, string columnName)
+        {
+            return Value(row, columnName) is object value ? Convert.ToInt32(value, CultureInfo.InvariantCulture) : null;
+        }
+
+        /// <summary>
+        /// Reads a flags word, whatever integral width the driver declared it in.
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        public static long? Int64(DataRow row, string columnName)
+        {
+            return Value(row, columnName) is object value ? Convert.ToInt64(value, CultureInfo.InvariantCulture) : null;
+        }
+
+        /// <summary>
+        /// Reads a name.
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        public static string? String(DataRow row, string columnName)
+        {
+            return Value(row, columnName) is object value ? Convert.ToString(value, CultureInfo.InvariantCulture) : null;
+        }
+
+        /// <summary>
+        /// Reads a flag, whether the driver stated it as a <see cref="bool"/> or as the <c>YES</c> / <c>NO</c>
+        /// text the information schema and ODBC both use.
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        public static bool? Boolean(DataRow row, string columnName)
+        {
+            return Value(row, columnName) switch
+            {
+                null => null,
+                bool b => b,
+                string s => s.Equals("YES", StringComparison.OrdinalIgnoreCase),
+                object value => Convert.ToBoolean(value, CultureInfo.InvariantCulture),
+            };
+        }
+
+        /// <summary>
+        /// Returns the value of a column, or <see langword="null"/> where the column is absent from the
+        /// collection or holds no value.
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="columnName"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Absent rather than throwing, because which columns a schema collection carries is the driver's
+        /// choice: ODBC's <c>Columns</c> collection has no <c>NUMERIC_PRECISION</c> at all, and one driver's
+        /// extension columns are another's absence.
+        /// </remarks>
+        static object? Value(DataRow row, string columnName)
+        {
+            if (row.Table.Columns.Contains(columnName) == false)
+                return null;
+
+            var value = row[columnName];
+            return value is null || value == DBNull.Value ? null : value;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/SqlServerDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/SqlServerDatabaseMetadata.cs
@@ -2,9 +2,6 @@
 using System.Data;
 using System.Data.Common;
 
-using org.apache.calcite.avatica.util;
-using org.apache.calcite.config;
-using org.apache.calcite.rex;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql.dialect;
 
@@ -14,7 +11,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
     /// <summary>
     /// Implements the <see cref="AdoDatabaseMetadata"/> for Microsoft SQL Server.
     /// </summary>
-    class SqlServerDatabaseMetadata : AdoInformationSchemaDatabaseMetadata<DbConnection>
+    class SqlServerDatabaseMetadata : AdoInformationSchemaDatabaseMetadata
     {
 
         /// <summary>
@@ -70,49 +67,18 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// Asks the server what it is, and describes it to Calcite.
         /// </summary>
         /// <returns></returns>
+        /// <remarks>
+        /// The version is the part that has to be asked for: under major version 11
+        /// <see cref="MssqlSqlDialect"/> writes <c>TOP(n)</c> and discards the offset, so a paged query
+        /// silently returns the first page for every page. The rest of the context is
+        /// <see cref="MssqlSqlDialect.DEFAULT_CONTEXT"/>'s, which already states the bracket quoting, the
+        /// type system and the low null collation.
+        /// </remarks>
         SqlDialect CreateDialect()
         {
             using var cnn = DbDataSource.OpenConnection();
 
-            return new MssqlSqlDialect(SqlDialect.EMPTY_CONTEXT
-                .withDatabaseProductName("Microsoft SQL Server")
-                .withDatabaseMajorVersion(ParseMajorVersion(cnn.ServerVersion))
-                .withDatabaseMinorVersion(ParseMinorVersion(cnn.ServerVersion))
-                .withDatabaseVersion(cnn.ServerVersion)
-                .withIdentifierQuoteString("\"")
-                .withUnquotedCasing(Casing.UNCHANGED)
-                .withQuotedCasing(Casing.UNCHANGED)
-                .withCaseSensitive(true)
-                .withNullCollation(NullCollation.LOW));
-        }
-
-        /// <summary>
-        /// Parses the major SQL Server version.
-        /// </summary>
-        /// <param name="v"></param>
-        /// <returns></returns>
-        int ParseMajorVersion(string v)
-        {
-            int p = v.IndexOf('.');
-            if (p > 0)
-                v = v.Substring(0, p);
-
-            return int.TryParse(v, out int r) ? r : 0;
-        }
-
-        /// <summary>
-        /// Parses the minor SQL Server version.
-        /// </summary>
-        /// <param name="v"></param>
-        /// <returns></returns>
-        int ParseMinorVersion(string v)
-        {
-            int p = v.IndexOf('.');
-            int q = v.IndexOf('.', p + 1);
-            if (p > 0 && q > 0)
-                v = v.Substring(p + 1, q);
-
-            return int.TryParse(v, out int r) ? r : 0;
+            return AdoSqlDialects.CreateMssql("Microsoft SQL Server", cnn.ServerVersion);
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/SqlServerDatabaseMetadata.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/SqlServerDatabaseMetadata.cs
@@ -116,19 +116,42 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Every type the server names in <c>INFORMATION_SCHEMA.COLUMNS.DATA_TYPE</c>, because a name that
+        /// is missing does not cost that column — it throws, and takes the whole table with it. The spatial
+        /// and hierarchy types, and <c>sql_variant</c>, go to <see cref="DbType.Object"/>, which
+        /// <c>AdoTable</c> maps to <c>OTHER</c> and the reader passes through untouched.
+        /// </remarks>
         protected override DbType ParseDbType(string typeName)
         {
-            return typeName switch
+            return typeName.ToLowerInvariant() switch
             {
+                "bit" => DbType.Boolean,
+                "tinyint" => DbType.Byte,
+                "smallint" => DbType.Int16,
                 "int" => DbType.Int32,
+                "bigint" => DbType.Int64,
+                "decimal" or "numeric" => DbType.Decimal,
+                // money is a decimal of a fixed scale of its own, which is what DbType.Currency states
+                "money" or "smallmoney" => DbType.Currency,
+                // float is the eight byte one whatever its declared mantissa: the server reports a
+                // float(1..24) as 'real', so this name is only ever the wide type
+                "float" => DbType.Double,
+                "real" => DbType.Single,
                 "char" => DbType.AnsiStringFixedLength,
-                "varchar" => DbType.AnsiString,
+                "varchar" or "text" => DbType.AnsiString,
                 "nchar" => DbType.StringFixedLength,
-                "nvarchar" => DbType.String,
+                "nvarchar" or "ntext" => DbType.String,
+                "xml" => DbType.Xml,
                 "uniqueidentifier" => DbType.Guid,
-                "datetime" => DbType.DateTime,
+                "date" => DbType.Date,
+                "time" => DbType.Time,
+                "datetime" or "smalldatetime" => DbType.DateTime,
                 "datetime2" => DbType.DateTime2,
-                _ => throw new NotImplementedException($"Unsupported field type: {typeName}"),
+                "datetimeoffset" => DbType.DateTimeOffset,
+                // rowversion is spelled 'timestamp' here and is eight opaque bytes, not a time
+                "binary" or "varbinary" or "image" or "timestamp" or "rowversion" => DbType.Binary,
+                _ => DbType.Object,
             };
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -146,6 +146,7 @@ Two limitations worth knowing before choosing one of these over a native provide
 
 - A dialect matched from a product name alone is, in Calcite's words, an approximation. The version is carried where it changes the SQL — SQL Server below 2012 gets `TOP (n)` rather than `OFFSET`/`FETCH` — but a driver that will not report its product gets generic SQL. Name a metadata provider through `adoDatabaseMetadata` where that is not good enough.
 - `System.Data.Odbc` has no mapping for SQL Server's `time` or `datetimeoffset` and throws `ArgumentException` on reading either. The columns are still discovered and typed; only reading one fails. That is the driver, not the adapter.
+- `System.Data.OleDb` cannot bind a `DateTimeOffset` parameter at all — the Variant marshal refuses it on the client — and binds a `TimeSpan` through OLE DB's `DBTIME`, which has no fractional seconds, so a bound time reaches the server truncated to the whole second. Reading both types works; only a correlated comparison on one is affected.
 
 ## Key public types
 

--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -127,14 +127,25 @@ Each side is pushed to its own database as far as it can go, and the join runs i
 
 `AdoDatabaseMetadataFactoryImpl` — the default, used when you do not name one — inspects the connection the data source produces and selects a metadata provider:
 
-| Connection type | Discovery |
-|---|---|
-| `Microsoft.Data.SqlClient.SqlConnection`, `System.Data.SqlClient.SqlConnection` | SQL Server, via `INFORMATION_SCHEMA` |
-| `Microsoft.Data.Sqlite.SqliteConnection` | SQLite |
-| `System.Data.Odbc.OdbcConnection` | Generic ODBC, via `INFORMATION_SCHEMA` |
-| `System.Data.OleDb.OleDbConnection` | Generic OLE DB, via `INFORMATION_SCHEMA` |
+| Connection type | Discovery | Dialect |
+|---|---|---|
+| `Microsoft.Data.SqlClient.SqlConnection`, `System.Data.SqlClient.SqlConnection` | `INFORMATION_SCHEMA`, via `GetSchema` | SQL Server, at the version the server reports |
+| `Microsoft.Data.Sqlite.SqliteConnection` | `PRAGMA table_xinfo` | SQLite |
+| `System.Data.Odbc.OdbcConnection` | The ODBC catalog — `SQLTables` and `SQLColumns`, via `GetSchema` | Whatever the driver names as the product behind it |
+| `System.Data.OleDb.OleDbConnection` | The OLE DB schema rowsets, via `GetSchema` | Whatever the provider names as the product behind it |
 
 Anything else throws `AdoCalciteException` naming the connection type. To support it, derive from `AdoDatabaseMetadata` — the abstract base that supplies the `SqlDialect`, table and column enumeration, and type mapping — and pass your implementation to an `AdoSchema.Create` overload, or name it in the `adoDatabaseMetadata` operand. The built-in implementations are internal; `AdoDatabaseMetadata` and `AdoDatabaseMetadataFactory` are the extension points.
+
+### ODBC and OLE DB
+
+Both front an unknown database, so both take the product name from the driver's `DataSourceInformation` collection and match it the way Calcite's own `SqlDialectFactoryImpl` does. An unrecognised name gets the generic ANSI dialect, which is Calcite's answer too. Neither has a default schema — a null schema means every schema rather than a particular one — so pass `adoSchema` (or the `schemaName` argument) where the database has more than one and the table names collide.
+
+The parameter marker for both is `?`, bound by position.
+
+Two limitations worth knowing before choosing one of these over a native provider:
+
+- A dialect matched from a product name alone is, in Calcite's words, an approximation. The version is carried where it changes the SQL — SQL Server below 2012 gets `TOP (n)` rather than `OFFSET`/`FETCH` — but a driver that will not report its product gets generic SQL. Name a metadata provider through `adoDatabaseMetadata` where that is not good enough.
+- `System.Data.Odbc` has no mapping for SQL Server's `time` or `datetimeoffset` and throws `ArgumentException` on reading either. The columns are still discovered and typed; only reading one fails. That is the driver, not the adapter.
 
 ## Key public types
 

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
@@ -48,7 +48,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         static readonly System.Reflection.MethodInfo GetDbReaderValueMethod = typeof(AdoReaderUtil).GetMethod(nameof(AdoReaderUtil.GetDbReaderValue), [typeof(DbDataReader), typeof(int), typeof(SqlTypeName)])
             ?? throw new InvalidOperationException($"'{nameof(AdoReaderUtil.GetDbReaderValue)}' is missing from {nameof(AdoReaderUtil)}.");
 
-        static readonly System.Reflection.MethodInfo CreateEnricherMethod = typeof(AdoEnumerable).GetMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(DataContext)])
+        static readonly System.Reflection.MethodInfo CreateEnricherMethod = typeof(AdoEnumerable).GetMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(java.util.List), typeof(DataContext)])
             ?? throw new InvalidOperationException($"'{nameof(AdoEnumerable.CreateEnricher)}' is missing from {nameof(AdoEnumerable)}.");
 
         /// <summary>
@@ -83,8 +83,9 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
 
             var dataContextBuilder = new AdoClrCorrelationDataContextBuilder(implementor, implementor.Root);
 
-            var writer = GenerateSql(convention, dataContextBuilder, self);
+            var writer = GenerateSql(convention, dataContextBuilder, self, out var sqlImplementor);
             var parameters = writer.Indexes;
+            var parameterTypeNames = AdoToEnumerableConverter.GetParameterTypeNames(sqlImplementor, parameters);
 
             var sql = writer.toSqlString().getSql();
             Hook.QUERY_PLAN.run(sql);
@@ -99,7 +100,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
             // handed to the provider unfilled.
             var enricher = parameters.isEmpty()
                 ? (Expression)Expression.Constant(null, typeof(DbCommandEnricher))
-                : Expression.Call(null, CreateEnricherMethod, dataSource, Expression.Constant(parameters), dataContextBuilder.Build());
+                : Expression.Call(null, CreateEnricherMethod, dataSource, Expression.Constant(parameters), Expression.Constant(parameterTypeNames), dataContextBuilder.Build());
 
             return implementor.Result(physType,
                 Expression.Call(null,
@@ -179,9 +180,9 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         /// <param name="dataContextBuilder"></param>
         /// <param name="input"></param>
         /// <returns></returns>
-        AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input)
+        AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input, out AdoImplementor implementor)
         {
-            var implementor = new AdoImplementor(convention.Dialect, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder);
+            implementor = new AdoImplementor(convention.Dialect, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder);
             var result = implementor.visitRoot(input);
 
             var writer = new AdoSqlWriter(convention.Dialect, convention.Syntax);

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToEnumerableConverter.cs
@@ -35,7 +35,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         static readonly Method GetDbReaderValueMethod = ((Class)typeof(AdoReaderUtil)).getDeclaredMethod(nameof(AdoReaderUtil.GetDbReaderValue), [typeof(DbDataReader), typeof(int), typeof(SqlTypeName)]);
         static readonly Method CreateReaderMethod = ((Class)typeof(AdoEnumerable)).getDeclaredMethod(nameof(AdoEnumerable.CreateReader), [typeof(AdoDataSource), typeof(string), typeof(Function1)]);
         static readonly Method CreateReaderWithEnricherMethod = ((Class)typeof(AdoEnumerable)).getDeclaredMethod(nameof(AdoEnumerable.CreateReader), [typeof(AdoDataSource), typeof(string), typeof(Function1), typeof(DbCommandEnricher)]);
-        static readonly Method CreateEnricherMethod = ((Class)typeof(AdoEnumerable)).getDeclaredMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(DataContext)]);
+        static readonly Method CreateEnricherMethod = ((Class)typeof(AdoEnumerable)).getDeclaredMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(java.util.List), typeof(DataContext)]);
 
         /// <summary>
         /// Initializes a new instance.
@@ -78,11 +78,12 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
 
             // generate the SQL for the query, with every parameter already written as the name this
             // provider binds by rather than the bare ? that JDBC would match by position
-            var writer = GenerateSql(convention, dataContextBuilder, self);
+            var writer = GenerateSql(convention, dataContextBuilder, self, out var sqlImplementor);
             var dataSource = Schemas.unwrap(convention.Expression, typeof(AdoDataSource));
 
             var parameters = writer.Indexes;
             var hasParameters = parameters.isEmpty() == false;
+            var parameterTypeNames = GetParameterTypeNames(sqlImplementor, parameters);
 
             var sql = writer.toSqlString().getSql();
             Hook.QUERY_PLAN.run(sql);
@@ -172,8 +173,10 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
                                 null,
                                 CreateEnricherMethod,
                                 dataSource,
-                                // the indexes are settled while planning, so they travel as a constant
+                                // the indexes and their types are settled while planning, so they travel as
+                                // constants
                                 Expressions.constant(parameters),
+                                Expressions.constant(parameterTypeNames),
                                 dataContextBuilder.Build()))))
                 : list.append("enumerable",
                     Expressions.call(
@@ -223,14 +226,29 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         /// <param name="dataContextBuilder"></param>
         /// <param name="input"></param>
         /// <returns></returns>
-        AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input)
+        AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input, out AdoImplementor implementor)
         {
-            var implementor = new AdoImplementor(convention.Dialect, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder);
+            implementor = new AdoImplementor(convention.Dialect, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder);
             var result = implementor.visitRoot(input);
 
             var writer = new AdoSqlWriter(convention.Dialect, convention.Syntax);
             result.asStatement().unparse(writer, 0, 0);
             return writer;
+        }
+
+        /// <summary>
+        /// Returns the SQL type name behind each parameter, in the writer's parameter order.
+        /// </summary>
+        /// <param name="implementor">The implementor that recorded a type per dynamic parameter index.</param>
+        /// <param name="indexes">The variable index behind each parameter, in parameter order.</param>
+        /// <returns></returns>
+        internal static java.util.ArrayList GetParameterTypeNames(AdoImplementor implementor, java.util.List indexes)
+        {
+            var names = new java.util.ArrayList(indexes.size());
+            for (int i = 0; i < indexes.size(); i++)
+                names.add(implementor.GetDynamicParamType(((java.lang.Number)indexes.get(i)).intValue())?.name());
+
+            return names;
         }
 
         #region EnumerableRel


### PR DESCRIPTION
Closes #24.

## The reported failure

Every query against SQL Server failed with `InvalidCastException: Unable to cast object of type 'System.Byte' to type 'System.Int32'`.

Not `AdoReaderUtil.GetInt`, as the report guessed — the reader was never reached. `INFORMATION_SCHEMA.COLUMNS` types `NUMERIC_PRECISION` as a `tinyint`, SqlClient carries that onto the `DataTable` it builds, and `DataRow.Field<int?>` unboxes rather than converts. Any table with a numeric column threw, whatever the query projected, because the row type is derived from every column of the table — which is why `SELECT "PRODUCT", "SUPPLIER"` over two `VARCHAR`s failed too.

Reading those counts through `Convert.ToInt32` is the fix, in `AdoInformationSchemaDatabaseMetadata.GetFields`.

## Four more before a SQL Server table was actually readable

Each found by a test that could not have been written against SQLite:

- `SqlServerDatabaseMetadata.ParseDbType` knew eight type names out of the server's thirty and threw `NotImplementedException` on the rest, so a `bit`, a `decimal` or a `date` anywhere in a table made the whole table unreadable.
- `DbType.Byte` is unsigned 0–255 and Calcite's `TINYINT` is signed, so a `tinyint` of 200 came back as **-56**. `UTINYINT` is the type that holds it — see below.
- The typed `DbDataReader` accessors cast rather than convert, so a provider column narrower than the Calcite type throws — a `Guid` under a `CHAR(36)`, a `byte` under anything wider.
- `TIMESTAMP` was cast through `DateTimeOffset`, which reads an unspecified `DateTime.Kind` as local time: **every timestamp was out by the machine's UTC offset**, the inverse of what `ParameterBinder.ConvertTimestamp` writes and `CalciteResultValue` decodes. `GetDate` already avoided that hazard and said so in a comment. `TIMESTAMP_TZ` went through `GetDateTime`, which SqlClient refuses outright for a `datetimeoffset`.

## The unsigned types

`SqlTypeName` has `UTINYINT`, `USMALLINT`, `UINTEGER` and `UBIGINT`, and `AdoTable` already mapped `DbType.UInt16`/`UInt32`/`UInt64` onto the last three. `DbType.Byte` therefore maps to `UTINYINT` — which is also what the other half of this codebase already said: `ParameterBinder` binds a `DbType.Byte` parameter as an `org.joou.UByte`, and `CalciteResultColumns` reads a `UTINYINT` back as a `byte`. The read side now agrees with the write side.

This matters beyond tidiness. `JavaTypeFactoryImpl.getJavaClass` answers a joou `UByte` for a `UTINYINT`, so anything else carries the value as the wrong class as well as the wrong type, and `CalciteResultValue` never finds it.

`AdoReaderUtil` had no case for any of the four, so `USMALLINT`, `UINTEGER` and `UBIGINT` threw `Unsupported SQL type mapping` on the first row and had done since they were mapped — nothing reached them from SQLite or SqlClient. Each has a case now. `ULong` goes through the decimal string, because `valueOf(long)` refuses everything above `Long.MAX_VALUE`, which is half the range of the type.

Two consumers of the change were caught by re-review rather than by the commit that made it: `AdoEnumerable.ToProviderValue` had no joou cases, so correlating on a tinyint column failed on all three drivers ("No mapping exists from object type org.joou.UByte") — each joou value is now unwrapped to the narrowest CLR type every provider binds. And the pushed-down literal path is pinned: `WHERE C_TINYINT = 200` has to survive planning without wrapping to -56, and does.

## Temporal correlation values

A systematic pass over the same question — what else leaves the plan in a representation no provider understands — found the temporal types. A `DATE` leaves as a day count in an `Integer`, a `TIMESTAMP` as a millisecond count in a `Long`, and the enricher bound the count raw: "Operand type clash: date is incompatible with int" through all three drivers. Only SQLite had tolerated it, because SQLite compares whatever it is handed — which is why the existing date-correlation test proved nothing.

The value alone cannot be decoded — a day count is indistinguishable from an `INTEGER` — so the SQL type is recorded where it last exists (`AdoImplementor`'s correlation context), carried through both converters beside the parameter indexes, and the enricher inverts exactly what `AdoReaderUtil` encoded. Parameters bind at scale 3, the honest scale for a millisecond count; ODBC and OLE DB otherwise bind temporal parameters at scale zero and refuse the value's own fractional seconds.

Two further `System.Data.OleDb` limitations are pinned by tests rather than worked around: it cannot marshal a `DateTimeOffset` to a Variant at all, and it binds a `TimeSpan` through OLE DB's `DBTIME`, which has no fractional seconds — measured, `01:02:03.500` compares equal to `01:02:03` and unequal to itself, so an equality on a fractional `time` silently matches nothing. A wrong answer rather than an error, which is the worse kind.

## ODBC and OLE DB were stubs

Both were listed in the README as supported providers and both threw `NotImplementedException` from `GetDefaultSchema`, `Dialect` and `ParseDbType`. They derived from the information-schema base, and neither driver's collections have that shape — measured against LocalDB through both:

- ODBC's come from `SQLTables`/`SQLColumns`: `TABLE_CAT`, `TABLE_SCHEM`, a numeric `DATA_TYPE`, and no `NUMERIC_PRECISION` at all — `COLUMN_SIZE` is the length of a character column and the precision of a numeric one.
- OLE DB's are the `DBSCHEMA` rowsets, which borrow the information schema's names without its types: `DATA_TYPE` a `DBTYPE` code, `IS_NULLABLE` a `bool`, `CHARACTER_MAXIMUM_LENGTH` a `decimal`. A `DBTYPE` is `DBTYPE_STR` for `char` and `varchar` alike; only `DBCOLUMNFLAGS_ISFIXEDLENGTH` separates them, and Calcite pads a `CHAR`.

Each reads its own catalog now, with type tables from ODBC's `sql.h` and OLE DB's `oledb.h`. An unmapped code falls to `DbType.Object`, which `AdoTable` maps to `OTHER`, so an unrecognised column costs that column rather than the table.

A generic driver fronts an unknown database, so the dialect comes from the product name in `DataSourceInformation`, matched with the tests `SqlDialectFactoryImpl.create` applies — ported, because `create` takes a JDBC `DatabaseMetaData` and there is none here. The version is carried too: `MssqlSqlDialect` under major version 11 writes `TOP(n)` and **discards the offset**, so a paged query returns the first page for every page.

## One upstream gap, corrected here

Correlated sub-queries against SQL Server failed through **all three** drivers, on a statement with no parameters in it:

```
SELECT 1 AS [i] GROUP BY (1 = 1)
Incorrect syntax near '='.
```

`EXISTS` becomes an aggregate over a constant `true`, which Calcite writes as `(1 = 1)` since T-SQL has no boolean literal. SQL Server takes neither that nor `GROUP BY 1` — measured both ways. `SqlImplementor.visitRoot` already has the rewrite (`AggregateProjectConstantToDummyJoinRule`) and runs it only when the dialect sets `supportsGroupByLiteral` false. Postgres, Redshift and Informix each do; `MssqlSqlDialect` does not.

That is an upstream gap rather than something to reproduce — the adapter generates SQL for a server to run, and the server is the authority on what it accepts. `AdoSqlDialects.Mssql` says it, and `TODO.md` records that the fix belongs in Calcite. This was broken before either generic provider existed; keeping SqlClient in the correlation table as a control is what showed so.

## Tests

`SqlServerFixture` serves one LocalDB database through all three drivers, which is the point: the right answer is identical for all three, so a provider misreading its own collections says something different. One database for the whole assembly, dropped at assembly cleanup — per test it was ten minutes of `CREATE DATABASE` against a suite that runs in two.

**344 tests, none failing, on net8.0 and net10.0.** `AdoSqlDialectsTests` and the unsigned-type reader tests need no SQL Server and run on every leg of the matrix. The provider suites skip unless a LocalDB, an ODBC driver and an OLE DB provider are present respectively — every skip path verified by forcing its probe to fail, and the run passes with 191 skipped.

Also closed while the harness was there: `AdoEnumerable.ToProviderValue`'s `Boolean`, `Double`, `BigDecimal` and `ByteString`, all previously unexercised for want of a fixture with such columns.

## Known limitations, recorded in `TODO.md`

- `System.Data.Odbc` has no mapping for SQL Server's `time` or `datetimeoffset` and throws `ArgumentException` from `TypeMap.FromSqlType` on reading either. The columns are still discovered and typed; only the read fails. That is the driver, not the adapter — pinned by a test and stated in the README.
- Both generic providers are covered against SQL Server and nothing else, the backend that proves least: an ODBC driver over Oracle or DB2 reports its catalog differently in ways only that driver will show. No backend in reach reports an unsigned column, so `USMALLINT`, `UINTEGER` and `UBIGINT` are covered at the reader and not end to end.
- The Linux and macOS legs of the matrix still see SQLite alone.


