### PR TITLE
Plan queries in the convention the connection asks for, asynchronous by default

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
@@ -13,10 +13,12 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
     /// </summary>
     /// <remarks>
     /// Every other test in this project opens <c>jdbc:calcite:</c> through <c>DriverManager</c>, which is
-    /// Calcite's connection and Calcite's prepare. None of them says anything about this path. The adapter
-    /// produces its rows through <c>AdoToEnumerableConverter</c>, a node of Calcite's convention, so a plan
-    /// over an ADO.NET schema is necessarily a mixed one: the adapter's own subtree in
-    /// <c>EnumerableConvention</c>, and a converter carrying its rows into this one.
+    /// Calcite's connection and Calcite's prepare. None of them says anything about this path. A plan over
+    /// an ADO.NET schema is necessarily a mixed one — the adapter's own subtree stays in its convention —
+    /// and the crossing depends on the connection's mode: by default the rows go through
+    /// <c>AdoToEnumerableConverter</c>, Calcite's convention, under the converter into the asynchronous one;
+    /// in synchronous mode the adapter converts straight into <c>ClrEnumerableConvention</c> through
+    /// <c>AdoToClrEnumerableConverter</c>, with no linq4j layer between.
     /// </remarks>
     [TestClass]
     public class AdoClrEnumerableTests
@@ -29,17 +31,27 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         public void Setup()
         {
             _sqlite = new SqliteFixture();
+            _connection = OpenConnection();
+        }
 
-            _connection = new CalciteConnection(new CalciteConnectionStringBuilder
+        /// <summary>
+        /// Opens a connection over the fixture's SQLite schema, in the mode asked for.
+        /// </summary>
+        CalciteConnection OpenConnection(bool synchronous = false)
+        {
+            var c = new CalciteConnection(new CalciteConnectionStringBuilder
             {
                 Lex = "JAVA",
                 CaseSensitive = false,
+                Synchronous = synchronous ? true : null,
             }.ToString());
 
-            _connection.Open();
+            c.Open();
 
-            var root = _connection.RootSchema;
+            var root = c.RootSchema;
             root.add("ADO", AdoSchema.Create(root, "ADO", _sqlite.DataSource, null, null));
+
+            return c;
         }
 
         [TestCleanup]
@@ -74,21 +86,57 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             return rows;
         }
 
-        [TestMethod]
-        public void ShouldConvertStraightIntoThisConvention()
+        /// <summary>
+        /// Returns the rendered plan for <paramref name="sql"/> on <paramref name="connection"/>.
+        /// </summary>
+        static string Explain(CalciteConnection connection, string sql)
         {
-            using var cmd = _connection.CreateCommand();
-            cmd.CommandText = "EXPLAIN PLAN FOR SELECT empno, name FROM ADO.emps WHERE deptno = 10";
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "EXPLAIN PLAN FOR " + sql;
 
             var plan = new System.Text.StringBuilder();
             using (var r = cmd.ExecuteReader())
                 while (r.Read())
                     plan.AppendLine(r.GetValue(0)?.ToString());
 
-            // one converter, and it is this convention's. Reaching AdoToEnumerableConverter instead would
-            // still answer correctly, by way of a second converter, and no other assertion here would notice.
-            StringAssert.Contains(plan.ToString(), "AdoToClrEnumerableConverter");
-            Assert.IsFalse(plan.ToString().Contains("AdoToEnumerableConverter"), plan.ToString());
+            return plan.ToString();
+        }
+
+        /// <summary>
+        /// In synchronous mode the adapter converts straight into the synchronous convention.
+        /// </summary>
+        /// <remarks>
+        /// One converter, and it is that convention's own. Reaching <c>AdoToEnumerableConverter</c> instead
+        /// would still answer correctly, by way of a second converter, and no other assertion here would
+        /// notice. The mode is pinned because the default plans asynchronously, where the routes tie on the
+        /// planner's row-count-only cost and the adapter's rows go through Calcite's converter —
+        /// <see cref="ShouldCarryTheAdapterIntoTheAsyncConvention"/> holds that plan.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldConvertStraightIntoThisConvention()
+        {
+            using var c = OpenConnection(synchronous: true);
+
+            var plan = Explain(c, "SELECT empno, name FROM ADO.emps WHERE deptno = 10");
+
+            StringAssert.Contains(plan, "AdoToClrEnumerableConverter");
+            Assert.IsFalse(plan.Contains("AdoToEnumerableConverter"), plan);
+        }
+
+        /// <summary>
+        /// By default the adapter's subtree is carried into the asynchronous convention, pushed down intact.
+        /// </summary>
+        /// <remarks>
+        /// The subtree under the converter is the adapter's own — an <c>AdoProject</c> rather than a scan
+        /// with the work done above it — so the crossing costs a wrapper and loses no pushdown.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCarryTheAdapterIntoTheAsyncConvention()
+        {
+            var plan = Explain(_connection, "SELECT empno, name FROM ADO.emps WHERE deptno = 10");
+
+            StringAssert.Contains(plan, "EnumerableToClrAsyncEnumerableConverter");
+            StringAssert.Contains(plan, "AdoProject");
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Data.Tests/CalciteDdlTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDdlTests.cs
@@ -92,6 +92,79 @@ namespace Apache.Calcite.Data.Tests
             Assert.Equal(1, affected);
         }
 
+        static readonly string SynchronousServerDdlConnectionString = new CalciteConnectionStringBuilder
+        {
+            Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
+            ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            Schema = "adhoc",
+            Synchronous = true,
+        };
+
+        /// <summary>
+        /// The synchronous mode's DML drain, so both drains stay covered.
+        /// </summary>
+        [Fact]
+        public void ExecuteNonQuery_insert_should_return_row_count_in_synchronous_mode()
+        {
+            using var c = new CalciteConnection(SynchronousServerDdlConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+
+            cmd.CommandText = "CREATE TABLE IF NOT EXISTS \"dmlsync\" (\"id\" INTEGER NOT NULL)";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = "INSERT INTO \"dmlsync\" VALUES (3)";
+            Assert.Equal(1, cmd.ExecuteNonQuery());
+        }
+
+        /// <summary>
+        /// A write plans under the asynchronous program: the modify stays Calcite's and the converter
+        /// carries its count row, exactly as any node the convention lacks is carried.
+        /// </summary>
+        [Fact]
+        public void Explain_insert_should_render_the_async_rooted_plan()
+        {
+            using var c = new CalciteConnection(ServerDdlConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+
+            cmd.CommandText = "CREATE TABLE IF NOT EXISTS \"dmlexplain\" (\"id\" INTEGER NOT NULL)";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = "EXPLAIN PLAN FOR INSERT INTO \"dmlexplain\" VALUES (7)";
+            using var r = cmd.ExecuteReader();
+            Assert.True(r.Read());
+
+            var plan = r.GetValue(0)?.ToString() ?? "";
+            Assert.Contains("EnumerableToClrAsyncEnumerableConverter", plan);
+            Assert.Contains("TableModify", plan);
+        }
+
+        /// <summary>
+        /// The same INSERT through the reader path executes and reports its count row, so a write is one
+        /// plan on the connection whichever entry point asked.
+        /// </summary>
+        [Fact]
+        public void ExecuteReader_insert_should_run_and_report_the_count()
+        {
+            using var c = new CalciteConnection(ServerDdlConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+
+            cmd.CommandText = "CREATE TABLE IF NOT EXISTS \"dmlreader\" (\"id\" INTEGER NOT NULL)";
+            cmd.ExecuteNonQuery();
+
+            cmd.CommandText = "INSERT INTO \"dmlreader\" VALUES (9)";
+            using (var r = cmd.ExecuteReader())
+            {
+                Assert.True(r.Read());
+                Assert.Equal("1", r.GetValue(0)?.ToString());
+            }
+
+            cmd.CommandText = "SELECT COUNT(*) FROM \"dmlreader\" WHERE \"id\" = 9";
+            Assert.Equal("1", cmd.ExecuteScalar()?.ToString());
+        }
+
         static readonly string SchemaPropertyOnlyConnectionString = new CalciteConnectionStringBuilder
         {
             // Model has NO defaultSchema — the connection-string Schema property is the sole source.

--- a/src/Apache.Calcite.Data.Tests/ClrEnumerablePlanShapeTests.cs
+++ b/src/Apache.Calcite.Data.Tests/ClrEnumerablePlanShapeTests.cs
@@ -13,11 +13,13 @@ namespace Apache.Calcite.Data.Tests
     /// A plan of Calcite's own convention still runs on a connection of this provider — a converter carries
     /// its rows, and nothing about the result says which convention produced it. So a silent fallback to
     /// <c>EnumerableConvention</c> would pass every other test in this project while defeating the point of
-    /// the default. These read the plan back with <c>EXPLAIN PLAN FOR</c> and require that it is ours.
+    /// the connection's mode. These read the plan back with <c>EXPLAIN PLAN FOR</c> and require that it is
+    /// ours: the asynchronous convention by default, the synchronous one where the connection string says
+    /// <c>Synchronous</c>.
     ///
-    /// <para>Nothing here needs a cost multiplier to hold. A plan built wholly in this convention crosses no
+    /// <para>Nothing here needs a cost multiplier to hold. A plan built wholly in one convention crosses no
     /// converter, and a converter adds its own row count to the cumulative cost, so it is already the cheaper
-    /// plan wherever every node has an implementation here.</para>
+    /// plan wherever every node has an implementation there.</para>
     /// </remarks>
     public class ClrEnumerablePlanShapeTests
     {
@@ -28,14 +30,22 @@ namespace Apache.Calcite.Data.Tests
             Schema = "adhoc",
         };
 
+        static readonly string SynchronousConnectionString = new CalciteConnectionStringBuilder
+        {
+            Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
+            Schema = "adhoc",
+            Synchronous = true,
+        };
+
         /// <summary>
         /// Returns the plan a connection of this provider builds for a query.
         /// </summary>
+        /// <param name="connectionString"></param>
         /// <param name="sql"></param>
         /// <returns></returns>
-        static string Plan(string sql)
+        static string Plan(string connectionString, string sql)
         {
-            using var c = new CalciteConnection(ConnectionString);
+            using var c = new CalciteConnection(connectionString);
             c.Open();
             using var cmd = c.CreateCommand();
             cmd.CommandText = "EXPLAIN PLAN FOR " + sql;
@@ -48,16 +58,13 @@ namespace Apache.Calcite.Data.Tests
             return sb.ToString();
         }
 
-        [Theory]
-        [InlineData("SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(x, y) WHERE x > 1")]
-        [InlineData("SELECT y, COUNT(*) FROM (VALUES (1, 'a'), (2, 'a'), (3, 'b')) AS t(x, y) GROUP BY y")]
-        [InlineData("SELECT a.x FROM (VALUES (1), (2)) AS a(x) JOIN (VALUES (1), (3)) AS b(x) ON a.x = b.x")]
-        [InlineData("SELECT x FROM (VALUES (3), (1), (2)) AS t(x) ORDER BY x LIMIT 2")]
-        [InlineData("SELECT x FROM (VALUES (1), (2)) AS a(x) UNION SELECT x FROM (VALUES (2), (3)) AS b(x)")]
-        public void Plan_should_be_built_in_the_clr_convention(string sql)
+        /// <summary>
+        /// Asserts every node of <paramref name="plan"/> begins with <paramref name="prefix"/>.
+        /// </summary>
+        /// <param name="plan"></param>
+        /// <param name="prefix"></param>
+        static void AssertEveryNode(string plan, string prefix)
         {
-            var plan = Plan(sql);
-
             Assert.NotEmpty(plan);
 
             foreach (var line in plan.Split('\n'))
@@ -66,8 +73,32 @@ namespace Apache.Calcite.Data.Tests
                 if (node.Length == 0)
                     continue;
 
-                Assert.StartsWith("ClrEnumerable", node);
+                Assert.StartsWith(prefix, node);
             }
+        }
+
+        [Theory]
+        [InlineData("SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(x, y) WHERE x > 1")]
+        [InlineData("SELECT y, COUNT(*) FROM (VALUES (1, 'a'), (2, 'a'), (3, 'b')) AS t(x, y) GROUP BY y")]
+        [InlineData("SELECT a.x FROM (VALUES (1), (2)) AS a(x) JOIN (VALUES (1), (3)) AS b(x) ON a.x = b.x")]
+        [InlineData("SELECT x FROM (VALUES (3), (1), (2)) AS t(x) ORDER BY x LIMIT 2")]
+        [InlineData("SELECT x FROM (VALUES (1), (2)) AS a(x) UNION SELECT x FROM (VALUES (2), (3)) AS b(x)")]
+        public void Plan_should_be_built_in_the_async_convention_by_default(string sql)
+        {
+            AssertEveryNode(Plan(ConnectionString, sql), "ClrAsyncEnumerable");
+        }
+
+        [Theory]
+        [InlineData("SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(x, y) WHERE x > 1")]
+        [InlineData("SELECT y, COUNT(*) FROM (VALUES (1, 'a'), (2, 'a'), (3, 'b')) AS t(x, y) GROUP BY y")]
+        [InlineData("SELECT a.x FROM (VALUES (1), (2)) AS a(x) JOIN (VALUES (1), (3)) AS b(x) ON a.x = b.x")]
+        [InlineData("SELECT x FROM (VALUES (3), (1), (2)) AS t(x) ORDER BY x LIMIT 2")]
+        [InlineData("SELECT x FROM (VALUES (1), (2)) AS a(x) UNION SELECT x FROM (VALUES (2), (3)) AS b(x)")]
+        public void Plan_should_be_built_in_the_sync_convention_when_asked(string sql)
+        {
+            // "ClrEnumerable" is not a prefix of "ClrAsyncEnumerable", so this also proves the mode
+            // was not ignored
+            AssertEveryNode(Plan(SynchronousConnectionString, sql), "ClrEnumerable");
         }
 
     }

--- a/src/Apache.Calcite.Data/CalciteBatch.cs
+++ b/src/Apache.Calcite.Data/CalciteBatch.cs
@@ -240,20 +240,14 @@ namespace Apache.Calcite.Data
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <remarks>
-        /// The synchronous plan, though this method is awaited. A batch is a sequence of statements over
-        /// whatever tables the caller has, and there is no reason to think they can produce rows
-        /// asynchronously — <c>ExecuteReaderAsync</c> would throw for any that cannot, which would make a
-        /// batch fail on the strength of how it happened to be executed rather than on what it says.
-        ///
-        /// <para>An asynchronous batch would want the asynchronous plan and would then need every table it
-        /// touches to be an <c>IClrAsyncScannableTable</c>. That is a decision about the batch API and not
-        /// one to make here by accident.</para>
+        /// The connection's plan, exactly as a command prepares it — the convention is the connection's
+        /// mode, so a batch does not fail or block on the strength of how it happened to be executed. The
+        /// token goes to the session, where an asynchronous plan's enumerator is the place a token can
+        /// enter.
         /// </remarks>
         Task<CalciteResult> ExecuteReaderCoreAsync(CalciteSession session, CalciteBatchCommand command, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            return Task.FromResult<CalciteResult>(session.ExecuteReader(CalciteExecuteRequest.From(command.CommandText, command.Parameters, _timeout)));
+            return session.ExecuteReaderAsync(CalciteExecuteRequest.From(command.CommandText, command.Parameters, _timeout), cancellationToken);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Data/CalciteCommand.cs
+++ b/src/Apache.Calcite.Data/CalciteCommand.cs
@@ -262,9 +262,9 @@ namespace Apache.Calcite.Data
 
         /// <inheritdoc />
         /// <remarks>
-        /// Reads the synchronous plan, rather than blocking on <see cref="ExecuteScalarAsync"/>. Doing the
-        /// latter would make an ordinary <c>ExecuteScalar</c> demand a table that can produce rows
-        /// asynchronously, which is not what a synchronous caller asked for.
+        /// The reader path with one row and one column taken off it, through <see cref="CalciteResult.Read"/>.
+        /// The plan is the connection's — mode, not entry point — so in the default mode this blocks per row
+        /// exactly as <c>Read</c> on the reader would, and in synchronous mode nothing here ever waits.
         /// </remarks>
         public override object? ExecuteScalar()
         {
@@ -293,10 +293,11 @@ namespace Apache.Calcite.Data
 
         /// <inheritdoc />
         /// <remarks>
-        /// Asks for a synchronous plan, because the reader it returns will be read with
-        /// <c>DbDataReader.Read</c>. A reader over an asynchronous plan answers that too, by blocking --
-        /// <c>CalciteResult</c> says why it has to -- and asking for the synchronous plan here is what keeps
-        /// a caller who never touched an <c>Async</c> method off that path.
+        /// The same plan <see cref="ExecuteDbDataReaderAsync"/> prepares — the convention is the
+        /// connection's mode, not the entry point's choice. In the default mode the reader answers
+        /// <c>Read</c> by blocking wherever the plan genuinely suspends, which is what <c>Read</c> over an
+        /// asynchronous source means; a connection whose consumers are synchronous can say
+        /// <see cref="CalciteConnectionStringBuilder.Synchronous"/> and get the plan that never waits.
         /// </remarks>
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
@@ -306,17 +307,13 @@ namespace Apache.Calcite.Data
 
         /// <inheritdoc />
         /// <remarks>
-        /// Prepares into the asynchronous convention, and <b>throws where the query cannot be planned into
-        /// it</b>. The prepare pipeline puts one convention's rules on the planner and not the other's, so
-        /// although converters exist between the two Clr conventions, no plan prepared here mixes them and a
-        /// query the asynchronous rules cannot cover has nowhere to go. Preparing the synchronous plan
-        /// instead would hand back a reader that looks asynchronous and blocks a thread per row, which a
-        /// caller cannot tell from the outside. <see cref="ExecuteReader()"/> is how a caller asks for that
-        /// plan deliberately.
-        ///
-        /// <para>A table Calcite can scan is not that case: it is planned in <c>EnumerableConvention</c> and
-        /// <c>EnumerableToClrAsyncEnumerableConverter</c> carries its rows, which costs a state machine and
-        /// no thread.</para>
+        /// Prepares the connection's plan. By default that is the asynchronous convention, and everything
+        /// plans: an <c>IClrAsyncScannableTable</c> is scanned asynchronously, a table Calcite can scan is
+        /// read the way Calcite reads it and completes synchronously — a state machine and no thread — and
+        /// anything else is implemented in <c>EnumerableConvention</c> with a converter carrying its rows.
+        /// In synchronous mode this is the synchronous plan in a completed task, and a query touching a
+        /// table that can <em>only</em> produce rows asynchronously fails to plan — visibly, rather than
+        /// blocking behind a surface that looks asynchronous.
         /// </remarks>
         protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -34,6 +34,11 @@ namespace Apache.Calcite.Data
         public const string SchemaKey = "Schema";
 
         /// <summary>
+        /// Connection string key for whether the provider plans queries into the synchronous convention.
+        /// </summary>
+        public const string SynchronousKey = "Synchronous";
+
+        /// <summary>
         /// Connection string key for whether identifiers are matched case-sensitively.
         /// </summary>
         public const string CaseSensitiveKey = "CaseSensitive";
@@ -177,6 +182,31 @@ namespace Apache.Calcite.Data
         {
             get => TryGetString(SchemaKey);
             set => SetOrRemove(SchemaKey, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether queries are planned into the synchronous convention. Default is
+        /// <see langword="false"/>.
+        /// </summary>
+        /// <remarks>
+        /// A provider option rather than an engine one, the way Calcite's own connection can ask for the
+        /// bindable convention. By default every query is planned into the asynchronous convention, whichever
+        /// entry point asked — a table that cannot produce rows asynchronously is still planned, carried
+        /// across a converter, and that part of the plan completes synchronously. Setting this plans into the
+        /// synchronous convention instead, for both entry points: <c>ReadAsync</c> answers with completed
+        /// tasks, and a query touching a table that can <em>only</em> produce rows asynchronously fails to
+        /// plan.
+        /// </remarks>
+        public bool? Synchronous
+        {
+            get => TryGetBool(SynchronousKey);
+            set
+            {
+                if (value is null)
+                    Remove(SynchronousKey);
+                else
+                    this[SynchronousKey] = value.Value;
+            }
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Data/CalciteDataReader.cs
+++ b/src/Apache.Calcite.Data/CalciteDataReader.cs
@@ -111,9 +111,9 @@ namespace Apache.Calcite.Data
         /// Blocks where the rows come from a plan of the asynchronous convention, and does not refuse:
         /// <c>DbDataReader.Read</c> is a contract a generic consumer calls, and a provider whose reader
         /// throws there is not a provider. <c>CalciteResult</c> has the argument, and
-        /// <c>CalciteAsyncEnumerableResult.Read</c> is where the block happens. The usual caution applies — a
-        /// synchronization context can deadlock on it — and a reader over an asynchronous plan has
-        /// <see cref="ReadAsync"/>.
+        /// <c>CalciteAsyncEnumerableResult.Read</c> is where the block happens — with the synchronization
+        /// context suppressed before the plan runs, so a thread carrying one does not wait on a continuation
+        /// promised to itself.
         /// </remarks>
         public override bool Read()
         {
@@ -178,13 +178,9 @@ namespace Apache.Calcite.Data
         /// <remarks>
         /// <b>Overridden, and it has to be.</b> <c>DbDataReader.CloseAsync</c> and <c>DisposeAsync</c> both
         /// fall back to the synchronous <see cref="Close"/> if a provider leaves them alone, which for a
-        /// plan of the asynchronous convention means <c>CalciteAsyncEnumerableResult.Release</c> — and that
-        /// can only finish a disposal the plan already completed synchronously. A table whose
-        /// <c>DisposeAsync</c> really suspends, because it is closing a connection or a channel, would have
-        /// had its disposal dropped.
-        ///
-        /// <para>So <c>await using</c> over a reader means what it says, and <c>using</c> still works: the
-        /// synchronous path is unchanged and is what a synchronous plan needs.</para>
+        /// plan of the asynchronous convention means <c>CalciteAsyncEnumerableResult.Release</c> — a block
+        /// per result rather than an await. The disposal completes either way; <c>await using</c> is the
+        /// one that suspends instead of parking a thread to do it.
         /// </remarks>
         public override async Task CloseAsync()
         {

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -154,8 +154,11 @@ synchronous work — and `ExecuteReader` is the core with `CancellationToken.Non
 - DDL (`CREATE`, `ALTER`, `DROP`, `OTHER_DDL`, dispatched on `name()`) has already taken effect
   during prepare, so there is nothing to enumerate and the count is `0`.
 - `SELECT` reports `-1`, by ADO.NET convention.
-- DML drains the enumerator. Here — and only here, where the enumeration is synchronous and
-  Calcite's check-points can see it — the cancellation token is registered against the cancel flag,
+- DML drains the enumerator — of the connection's plan, exactly as the reader path prepares it. The
+  modify itself is Calcite's `EnumerableTableModify` in both modes, so under the asynchronous root
+  the count row crosses the converter and completes synchronously; the drain blocks with the
+  synchronization context suppressed all the same. Here — and only here, where the drain can see
+  Calcite's check-points — the cancellation token is registered against the cancel flag,
   scoped to the drain. Because the plan was prepared for `Object[]` rows, the single row's element
   `[0]` is the `ROWCOUNT BIGINT` column of `RelOptUtil.createDmlRowType`, read through a `ToInt64`
   that accepts a Java boxed number or a CLR primitive.

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -82,7 +82,7 @@ Public, consumer-facing classes implementing the `System.Data.Common` contracts.
 | `CalciteTransaction` | `DbTransaction` | Exists to satisfy frameworks that require a non-null transaction. `Commit` and `Rollback` throw `NotSupportedException`, and `BeginDbTransaction` throws before one is ever handed out. |
 | `CalciteDataSource` | `DbDataSource` | The `DbDataSource` entry point. |
 | `CalciteProviderFactory` | `DbProviderFactory` | Standard ADO.NET factory registration. |
-| `CalciteConnectionStringBuilder` | `DbConnectionStringBuilder` | Typed connection-string keys (`Model`, `Schema`, `CaseSensitive`, `Conformance`, …). Unknown keys are preserved and forwarded. |
+| `CalciteConnectionStringBuilder` | `DbConnectionStringBuilder` | Typed connection-string keys (`Model`, `Schema`, `Synchronous`, `CaseSensitive`, `Conformance`, …). Unknown keys are preserved and forwarded. |
 | `CalciteException` | `DbException` | Provider failures, including planning and execution errors. |
 
 `CalciteConnection` also exposes Calcite-native objects directly, so there is no `Unwrap`-style
@@ -116,15 +116,18 @@ Construction, from the `CalciteConnectionStringBuilder`:
   Calcite expects via a static map from connection-string key to `CalciteConnectionProperty`, and
   wraps it in a `CalciteConnectionConfigImpl`.
 - Creates a `JavaTypeFactoryImpl`, and resolves the default schema path to zero or one name.
+- Reads the `Synchronous` key — a provider option, excluded from the engine properties like `Model` —
+  which decides the convention every query on this connection is planned into.
 
 Anything thrown here that is not already a `CalciteException` is wrapped in one.
 
-The session exposes three private steps and two public entry points.
+The session exposes three private steps and the execute entry points.
 
 **`Plan`** constructs a `PrepareContext`, pushes it onto `CalcitePrepare.Dummy`, and calls
-`ClrPrepareImpl.Prepare(ctx, sql, Object[], -1)`, returning a `ClrSignature`. The element type is
-what makes the pipeline ask for array-shaped rows; `-1` means no row limit. Nothing is executed and
-no per-statement state is created.
+`ClrPrepareImpl.Prepare(ctx, sql, Object[], -1, async)`, returning a `ClrSignature`. The element
+type is what makes the pipeline ask for array-shaped rows; `-1` means no row limit; `async` is the
+connection's mode, `true` unless `Synchronous` was set. Nothing is executed and no per-statement
+state is created.
 
 **`Bind`** builds the execution-time `DataContext`: a fresh `AtomicBoolean` cancel flag, the
 positional parameters converted by `ParameterBinder`, the command timeout in milliseconds, and
@@ -134,11 +137,17 @@ positional parameters converted by `ParameterBinder`, the command timeout in mil
 **`ActivateHooks` / `DeactivateHooks`** bind each `CalciteHookEntry` to the current thread with
 `Hook.addThread` for the duration of one request and close the handles in a `finally`.
 
-**`ExecuteReaderAsync`** plans, binds, and — unless the statement is DDL — takes
-`signature.Bind(dataContext).GetEnumerator()`. It returns a `CalciteResult` holding the signature,
-that enumerator, and a records-affected count of `0`. The cancel flag is discarded on this path:
-`cancellationToken` is only checked before planning, and cancelling it afterwards does not interrupt
-enumeration.
+**`ExecuteReader` / `ExecuteReaderAsync`** share one core: plan into the connection's convention,
+bind, and — unless the statement is DDL — take the plan's enumerator. **Which convention is the
+connection's choice, not the entry point's**, the way Calcite's own connection can ask for the
+bindable convention. By default the plan is `ClrAsyncEnumerableConvention` and the core takes
+`signature.BindAsync(dataContext).GetAsyncEnumerator(cancellationToken)` into a
+`CalciteAsyncEnumerableResult` — the token enters here, at the enumerator, which is the only place a
+token can enter an `IAsyncEnumerable`, and cancelling it stops the leaf between rows. With
+`Synchronous` set the plan is `ClrEnumerableConvention` and the core takes
+`signature.Bind(dataContext).GetEnumerator()` into a `CalciteEnumerableResult`; the token is then
+only checked before planning. `ExecuteReaderAsync` is the core in a completed task — planning is
+synchronous work — and `ExecuteReader` is the core with `CancellationToken.None`.
 
 **`ExecuteNonQueryAsync`** plans and binds, then branches on `signature.StatementType`:
 
@@ -172,11 +181,12 @@ reused as they stand. The driver had to be replaced because its one exit is a `B
 | `ClrSignature` | `CalcitePrepare.CalciteSignature` | The planned statement, member for member, with `Bindable` swapped for `IClrBindable` and `enumerable` for `Bind`. |
 
 `ClrPrepareImpl.Prepare` is the entry point this provider uses. It creates a `VolcanoPlanner` with
-`RelOptUtil.registerDefaultRules` **plus** `ClrEnumerableRules.Rules()` — Calcite's own rules stay
-on the planner, so a statement this convention has no node for is still planned and run in
-`EnumerableConvention`, with a converter carrying its rows. That is how a table modification works
-here. `PrepareRel`, the second entry point, plans a `RelNode` that was built rather than parsed; it
-is exercised by tests and not reached from this project.
+`RelOptUtil.registerDefaultRules` **plus** one convention's rules — `ClrAsyncEnumerableRules.Rules()`
+when the `async` parameter says so, `ClrEnumerableRules.Rules()` otherwise, and never both — so
+Calcite's own rules stay on the planner and a statement the chosen convention has no node for is
+still planned and run in `EnumerableConvention`, with a converter carrying its rows. That is how a
+table modification works here. `PrepareRel`, the second entry point, plans a `RelNode` that was
+built rather than parsed; it is exercised by tests and not reached from this project.
 
 A DDL statement is executed inside `Prepare2` rather than planned, exactly as Calcite does. The
 `ClrSignature` it returns has no row type, no columns, a null bindable, `CursorFactory.OBJECT` and
@@ -231,11 +241,17 @@ returning rows, plus the `ElementType` the cursor factory is deduced from. It me
 ### 5. Result stream (`Internal/CalciteResult` and friends)
 
 `CalciteResult` is what an execute call hands back: the `ClrSignature`, a
-`CalciteResultColumns` built from it, an `IEnumerator<object>?`, and a records-affected count. The
-enumerator is the plan's own — a compiled delegate returns it — so nothing stands between a row and
-the reader. `ReadAsync` advances it and wraps the current row in a `CalciteResultRow`; a null
-enumerator (DDL, or a non-query) reads as an empty result. `Dispose` disposes the enumerator, and
-holds nothing else.
+`CalciteResultColumns` built from it, the plan's enumerator, and a records-affected count. Two
+subclasses, one per convention — `CalciteEnumerableResult` over an `IEnumerator<object>`,
+`CalciteAsyncEnumerableResult` over an `IAsyncEnumerator<object>` — and both answer both `Read` and
+`ReadAsync`, because `DbDataReader` is a contract: a synchronous plan answers `ReadAsync` with a
+completed task, and an asynchronous plan blocks in `Read`, with the synchronization context
+suppressed before the plan runs so a thread carrying one does not wait on a continuation promised
+to itself. The enumerator is the plan's own — a compiled delegate returns it — so nothing stands
+between a row and the reader. A read wraps the current row in a `CalciteResultRow`; a null
+enumerator (DDL, or a non-query) reads as an empty result. `Dispose` completes the enumerator's
+disposal — blocking for it on the asynchronous result, under the same suppression — and holds
+nothing else.
 
 `CalciteResultColumns` reads the signature's Avatica `ColumnMetaData` list — name, nullability,
 provider type name — and maps each to a CLR type. The SQL type name takes precedence over the
@@ -304,7 +320,9 @@ type, the value and the SQL type. `BigDecimalConverter` carries `java.math.BigDe
   planning or execution failure in one, so a caller sees a single error type.
 - `ObjectDisposedException` is thrown when a disposed session or result is used.
 - Cancellation is honoured before planning on both paths, and during the drain of a DML statement.
-  It is not wired to a reader's enumeration.
+  In the default mode the token given to `ExecuteReaderAsync` also reaches the plan's enumerator, so
+  cancelling it stops the leaf between rows; in synchronous mode it is not wired to a reader's
+  enumeration.
 
 ---
 
@@ -318,15 +336,17 @@ type, the value and the SQL type. `BigDecimalConverter` carries `java.math.BigDe
    factory, default schema path.
 3. **Build command.** The caller sets `CommandText` and adds parameters to a `CalciteCommand`.
 4. **Request.** `ExecuteReader` builds a `CalciteExecuteRequest` from the text, the parameters, the
-   timeout and the resolved hooks, and calls `CalciteSession.ExecuteReaderAsync`.
+   timeout and the resolved hooks, and hands it to the session's reader core.
 5. **Plan.** The session pushes a `PrepareContext` onto `CalcitePrepare.Dummy` and calls
    `ClrPrepareImpl.Prepare`, which parses, validates, converts to relational algebra, optimises into
-   `ClrEnumerableConvention`, and compiles the chosen plan to a delegate. The result is a
-   `ClrSignature`.
+   the connection's convention — `ClrAsyncEnumerableConvention` by default,
+   `ClrEnumerableConvention` when the connection string says `Synchronous` — and compiles the chosen
+   plan to a delegate. The result is a `ClrSignature`.
 6. **Bind.** Parameters are converted and assembled with the cancel flag, the timeout and the
    signature's internal parameters into a `StatementDataContext`.
-7. **Execute.** `signature.Bind(dataContext).GetEnumerator()` is taken and wrapped in a
-   `CalciteResult`. Nothing has been enumerated yet.
+7. **Execute.** The plan's enumerator is taken — `BindAsync(...).GetAsyncEnumerator(token)` or
+   `Bind(...).GetEnumerator()` by mode — and wrapped in the matching `CalciteResult`. Nothing has
+   been enumerated yet.
 8. **Read.** `CalciteDataReader` pulls rows through `CalciteResult.ReadAsync`, and each accessor
    goes `CalciteResultRow` → `CalciteResultValue` → CLR value.
 9. **Dispose.** Disposing the reader disposes the result and its enumerator. Disposing the

--- a/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
@@ -33,19 +33,36 @@ namespace Apache.Calcite.Data.Internal
         /// <remarks>
         /// Blocks on <see cref="ReadAsync"/>, because <c>DbDataReader.Read</c> has to be answerable: a
         /// consumer that knows nothing but the ADO.NET interface calls it, and a provider whose reader
-        /// throws there is not one.
+        /// throws there is not one. In the default mode this is the synchronous surface over every query the
+        /// connection plans, so it blocks only where the plan genuinely suspends — a synchronous source
+        /// beneath the converters answers with a completed task and the wait never happens.
         ///
-        /// <para>This is not the sync-over-async the surface refuses, and the line is about who chose. A
-        /// plan can block inside itself too -- <c>ClrAsyncEnumerableToClrEnumerableConverter</c> does, once
-        /// per row -- and what makes that refusable is that the planner would be choosing it for a caller
-        /// who could not see it, which is why the prepare pipeline never registers the rules that would put
-        /// one on a plan. A caller reaching for <c>Read</c> on a reader they asked to be asynchronous is
-        /// choosing it in the open. The usual caution applies -- a synchronization context can deadlock on
-        /// it -- and <see cref="ReadAsync"/> is how to avoid that.</para>
+        /// <para><b>The synchronization context is suppressed around the whole call, not around the
+        /// wait.</b> The operators of the asynchronous convention await without <c>ConfigureAwait(false)</c>,
+        /// and a continuation captures the context at the moment of suspension — which is inside
+        /// <c>MoveNextAsync</c>'s synchronous phase, on this thread, <em>before</em> any wait begins.
+        /// Measured: suppressing only around the wait deadlocks under a context that cannot pump, because
+        /// the capture has already happened; suppressing before the call completes, because there is nothing
+        /// to capture and the continuation goes to the thread pool. Where there is no context, which is
+        /// every thread a query is normally read on, this costs one read of
+        /// <see cref="SynchronizationContext.Current"/>.</para>
         /// </remarks>
         public override bool Read()
         {
-            return ReadAsync(CancellationToken.None).GetAwaiter().GetResult();
+            var context = SynchronizationContext.Current;
+            if (context is null)
+                return ReadAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                return ReadAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
+            }
         }
 
         /// <summary>
@@ -78,19 +95,43 @@ namespace Apache.Calcite.Data.Internal
 
         /// <inheritdoc />
         /// <remarks>
-        /// A synchronous disposal of an asynchronous plan has nowhere to await, and blocking here is the
-        /// deadlock this convention exists to avoid. So it completes the disposal only where the plan
-        /// finished it synchronously, and a caller reading asynchronously has
-        /// <see cref="CalciteResult.DisposeAsync"/>.
+        /// Blocks until the plan's disposal completes, the way <see cref="Read"/> blocks for a row. In the
+        /// default mode a synchronous consumer's <c>using</c> lands here over every query, and abandoning a
+        /// disposal that did not finish synchronously would leak whatever the leaf holds open. The context
+        /// is suppressed before <c>DisposeAsync</c> is called, for the reason <see cref="Read"/> gives: an
+        /// iterator's <c>finally</c> can suspend too, and its continuation captures the context at
+        /// suspension, inside the call.
         /// </remarks>
         protected override void Release()
         {
             if (_enumerator is null)
                 return;
 
-            var pending = _enumerator.DisposeAsync();
-            if (pending.IsCompleted)
-                pending.GetAwaiter().GetResult();
+            var context = SynchronizationContext.Current;
+            if (context is null)
+            {
+                Wait(_enumerator.DisposeAsync());
+                return;
+            }
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                Wait(_enumerator.DisposeAsync());
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
+            }
+
+            static void Wait(ValueTask pending)
+            {
+                if (pending.IsCompleted)
+                    pending.GetAwaiter().GetResult();
+                else
+                    pending.AsTask().GetAwaiter().GetResult();
+            }
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Data/Internal/CalciteResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResult.cs
@@ -24,15 +24,17 @@ namespace Apache.Calcite.Data.Internal
     /// <c>DbDataReader</c> is a contract: a consumer that knows nothing but <c>DbDataReader</c> -- a
     /// micro-ORM, <c>DataTable.Load</c>, anything generic -- calls <c>Read</c>, and a provider whose reader
     /// throws there is not a provider. So a synchronous plan answers <c>ReadAsync</c> with a completed
-    /// task, and an asynchronous plan blocks in <c>Read</c>.</para>
+    /// task, and an asynchronous plan blocks in <c>Read</c>. Which plan a query gets is the connection's
+    /// mode, not the entry point's choice, so either crossing is the normal case rather than an edge.</para>
     ///
     /// <para>Neither is the sync-over-async this surface refuses, and the line is about who chose. A
     /// <em>plan's</em> internals can block too — <c>ClrAsyncEnumerableToClrEnumerableConverter</c> is exactly
     /// that, one blocked thread per row — and what makes it refusable there is that the planner would be
     /// choosing it, invisibly, on behalf of a caller who asked for nothing of the sort. That is why the
     /// prepare pipeline registers one convention's rules and not both, and so never produces a plan holding
-    /// one. Here the caller is choosing, in the open, at the boundary -- which is where every ADO.NET
-    /// provider blocks and what <c>Read</c> on an asynchronous source means.</para>
+    /// one. Here the block is at the boundary, where every ADO.NET provider blocks: it is what <c>Read</c>
+    /// on an asynchronous source means, and the asynchronous surface never blocks at all — a synchronous
+    /// part of a plan completes synchronously, which parks nothing.</para>
     /// </remarks>
     internal abstract class CalciteResult : IDisposable, IAsyncDisposable
     {

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -86,6 +86,7 @@ namespace Apache.Calcite.Data.Internal
         readonly JavaTypeFactory _typeFactory;
         readonly CalciteConnectionConfig _config;
         readonly IReadOnlyList<string> _defaultSchemaPath;
+        readonly bool _synchronous;
         bool _disposed;
 
         /// <summary>
@@ -95,10 +96,13 @@ namespace Apache.Calcite.Data.Internal
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="CalciteException"></exception>
         /// <remarks>
-        /// Every statement is planned into <c>ClrEnumerableConvention</c> and run as a compiled expression
-        /// tree. Calcite's own rules stay on the planner, so a statement that convention has no node for is
-        /// still planned and run — implemented in <c>EnumerableConvention</c>, with a converter carrying its
-        /// rows.
+        /// Every query is planned into one of the two Clr conventions and run as a compiled expression tree —
+        /// which one is the connection's choice, the way Calcite's own connection can ask for the bindable
+        /// convention. The default is <c>ClrAsyncEnumerableConvention</c>;
+        /// <see cref="CalciteConnectionStringBuilder.Synchronous"/> asks for <c>ClrEnumerableConvention</c>
+        /// instead. Either way Calcite's own rules stay on the planner, so a statement the chosen convention
+        /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
+        /// converter carrying its rows.
         /// </remarks>
         public CalciteSession(CalciteConnectionStringBuilder options)
         {
@@ -110,6 +114,7 @@ namespace Apache.Calcite.Data.Internal
                 _rootSchemaPlus = _rootSchema.plus();
                 _config = new CalciteConnectionConfigImpl(BuildEngineProperties(options));
                 _typeFactory = new JavaTypeFactoryImpl();
+                _synchronous = options.Synchronous ?? false;
                 var defaultSchema = modelDefaultSchema ?? options.Schema;
                 _defaultSchemaPath = string.IsNullOrEmpty(defaultSchema) ? [] : [defaultSchema];
             }
@@ -185,6 +190,10 @@ namespace Apache.Calcite.Data.Internal
             foreach (var key in options.EnumerateKeys())
             {
                 if (string.Equals(key, CalciteConnectionStringBuilder.ModelKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // a provider option, not an engine one: it chooses the convention the session plans into
+                if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 if (options.TryGetValue(key, out var v) && v is not null)
@@ -285,90 +294,90 @@ namespace Apache.Calcite.Data.Internal
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
         /// <exception cref="CalciteException">Thrown when planning or execution fails.</exception>
         /// <remarks>
-        /// Prepares into <c>ClrEnumerableConvention</c>, which reads a <c>ScannableTable</c>, a
-        /// <c>QueryableTable</c> and the rest of Calcite's table SPI, and falls through to
-        /// <c>EnumerableConvention</c> across a converter for anything it has no node for.
+        /// <see cref="ExecuteReaderAsync"/> without a token: the plan is the connection's, not the entry
+        /// point's, so both entry points prepare the same one. In the default mode the reader this hands a
+        /// synchronous caller blocks per row wherever the plan genuinely suspends —
+        /// <c>CalciteAsyncEnumerableResult.Read</c> says how that is made safe — and completes synchronously
+        /// everywhere else.
         /// </remarks>
-        public CalciteEnumerableResult ExecuteReader(CalciteExecuteRequest request)
+        public CalciteResult ExecuteReader(CalciteExecuteRequest request)
         {
-            ArgumentNullException.ThrowIfNull(request);
-
-            ThrowIfDisposed();
-
-            var closeables = ActivateHooks(request.Hooks);
-
-            try
-            {
-                var signature = Plan(request);
-                Bind(request, signature, out var dataContext, out _);
-
-                IEnumerator<object>? enumerator = null;
-                if (!IsDdl(signature.StatementType))
-                    enumerator = signature.Bind(dataContext).GetEnumerator();
-
-                return new CalciteEnumerableResult(signature, enumerator, 0);
-            }
-            catch (CalciteException)
-            {
-                throw;
-            }
-            catch (Exception e)
-            {
-                throw new CalciteException("Failed to execute Calcite statement.", e);
-            }
-            finally
-            {
-                DeactivateHooks(closeables);
-            }
+            return ExecuteReaderCore(request, CancellationToken.None);
         }
 
         /// <summary>
-        /// Prepares and executes a query into the asynchronous convention, returning a
-        /// <see cref="CalciteResult"/> whose enumerator streams the result rows.
+        /// Prepares and executes a query, returning a <see cref="CalciteResult"/> whose enumerator streams
+        /// the result rows.
         /// </summary>
         /// <param name="request">The execute request containing SQL text, parameters, timeout, and hooks.</param>
         /// <param name="cancellationToken">Token used to cancel execution. It is given to the plan's
         /// enumerator, which is the only place a token can enter an
-        /// <see cref="IAsyncEnumerable{T}"/>.</param>
-        /// <returns>A <see cref="CalciteResult"/> holding the signature and an asynchronous row enumerator.</returns>
+        /// <see cref="IAsyncEnumerable{T}"/>. In synchronous mode it is observed only before planning.</param>
+        /// <returns>A <see cref="CalciteResult"/> holding the signature and a row enumerator.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
-        /// <exception cref="CalciteException">Thrown when planning or execution fails, <b>including where the
-        /// query cannot be planned asynchronously at all</b>.</exception>
+        /// <exception cref="CalciteException">Thrown when planning or execution fails.</exception>
         /// <remarks>
-        /// <b>There is no fallback.</b> The planner this goes to carries the asynchronous convention's rules
-        /// and not the synchronous one's, so a query touching a table that is not an
-        /// <c>IClrAsyncScannableTable</c> cannot be planned and this throws. Preparing the synchronous plan
-        /// instead would hand back a reader that looks asynchronous and blocks a thread per row, which is the
-        /// one thing this convention exists to refuse -- and a caller cannot tell the difference from the
-        /// outside, so the failure has to be visible.
-        ///
-        /// <para><c>ClrEnumerableToClrAsyncEnumerableConverter</c> is what a fallback would be built from,
-        /// and it exists; what does not exist is a decision to register both rule sets here. Doing so would
-        /// make the mixed plan one the planner chose and costed rather than a second plan substituted behind
-        /// the caller's back — but it would also let a plan block a thread per row without saying so, which
-        /// is why it is not the default.</para>
-        ///
-        /// <para>A caller that wants the synchronous plan asks for it: <see cref="ExecuteReader"/>.</para>
+        /// <see cref="ExecuteReaderCore"/> in a completed task — planning is synchronous work and nothing
+        /// here awaits. Nothing is read until the first <c>ReadAsync</c>.
         /// </remarks>
         public Task<CalciteResult> ExecuteReaderAsync(CalciteExecuteRequest request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(ExecuteReaderCore(request, cancellationToken));
+        }
+
+        /// <summary>
+        /// Prepares and executes a query into the connection's convention.
+        /// </summary>
+        /// <param name="request">The execute request containing SQL text, parameters, timeout, and hooks.</param>
+        /// <param name="cancellationToken">Token given to an asynchronous plan's enumerator.</param>
+        /// <returns>A <see cref="CalciteResult"/> holding the signature and a row enumerator.</returns>
+        /// <remarks>
+        /// <b>Which convention is the connection's choice, not the entry point's</b> — the way Calcite's own
+        /// connection can ask for the bindable convention. The default is <c>ClrAsyncEnumerableConvention</c>,
+        /// so that <c>ReadAsync</c> is asynchronous wherever the schema can be: an
+        /// <c>IClrAsyncScannableTable</c> is scanned asynchronously, a table of Calcite's SPI is read the way
+        /// Calcite reads it and wrapped in a sequence that completes synchronously — a state machine and no
+        /// thread — and a statement the convention has no node for is implemented in
+        /// <c>EnumerableConvention</c> with a converter carrying its rows. Nothing on the asynchronous
+        /// surface ever parks a thread waiting for a row.
+        ///
+        /// <para><see cref="CalciteConnectionStringBuilder.Synchronous"/> plans into
+        /// <c>ClrEnumerableConvention</c> instead, for both entry points: <c>ReadAsync</c> answers with
+        /// completed tasks, and a query touching a table that can <em>only</em> produce rows asynchronously
+        /// fails to plan — the prepare pipeline registers one convention's rules and not the other's, so the
+        /// failure is visible rather than a block the planner chose invisibly.</para>
+        /// </remarks>
+        CalciteResult ExecuteReaderCore(CalciteExecuteRequest request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
 
             ThrowIfDisposed();
-            cancellationToken.ThrowIfCancellationRequested();
 
             var closeables = ActivateHooks(request.Hooks);
 
             try
             {
-                var signature = Plan(request, async: true);
+                var signature = Plan(request, async: !_synchronous);
                 Bind(request, signature, out var dataContext, out _);
 
-                IAsyncEnumerator<object>? enumerator = null;
-                if (!IsDdl(signature.StatementType))
-                    enumerator = signature.BindAsync(dataContext).GetAsyncEnumerator(cancellationToken);
+                if (_synchronous)
+                {
+                    IEnumerator<object>? enumerator = null;
+                    if (!IsDdl(signature.StatementType))
+                        enumerator = signature.Bind(dataContext).GetEnumerator();
 
-                return Task.FromResult<CalciteResult>(new CalciteAsyncEnumerableResult(signature, enumerator, 0));
+                    return new CalciteEnumerableResult(signature, enumerator, 0);
+                }
+                else
+                {
+                    IAsyncEnumerator<object>? enumerator = null;
+                    if (!IsDdl(signature.StatementType))
+                        enumerator = signature.BindAsync(dataContext).GetAsyncEnumerator(cancellationToken);
+
+                    return new CalciteAsyncEnumerableResult(signature, enumerator, 0);
+                }
             }
             catch (CalciteException)
             {
@@ -399,7 +408,8 @@ namespace Apache.Calcite.Data.Internal
         /// no asynchronous DML and there cannot be one: a table modification is not a node either of these
         /// conventions implements, and only the synchronous one reaches Calcite's across a converter -- there
         /// is no converter to <c>EnumerableConvention</c> from the asynchronous one and cannot be -- so a
-        /// write is planned into <c>ClrEnumerableConvention</c> whichever entry point asked for it.
+        /// write is planned into <c>ClrEnumerableConvention</c> whichever entry point asked for it, and the
+        /// connection's mode does not reach this path.
         /// </remarks>
         public CalciteEnumerableResult ExecuteNonQuery(CalciteExecuteRequest request, CancellationToken cancellationToken)
         {

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -404,12 +404,15 @@ namespace Apache.Calcite.Data.Internal
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
         /// <exception cref="CalciteException">Thrown when planning or execution fails.</exception>
         /// <remarks>
-        /// Synchronous, and <see cref="ExecuteNonQueryAsync"/> is this method in a completed task. There is
-        /// no asynchronous DML and there cannot be one: a table modification is not a node either of these
-        /// conventions implements, and only the synchronous one reaches Calcite's across a converter -- there
-        /// is no converter to <c>EnumerableConvention</c> from the asynchronous one and cannot be -- so a
-        /// write is planned into <c>ClrEnumerableConvention</c> whichever entry point asked for it, and the
-        /// connection's mode does not reach this path.
+        /// Synchronous, and <see cref="ExecuteNonQueryAsync"/> is this method in a completed task. The plan
+        /// is the connection's here as everywhere: a table modification is not a node either Clr convention
+        /// implements, so the modify itself is Calcite's <c>EnumerableTableModify</c> in both modes, and
+        /// under the asynchronous root its count row crosses <c>EnumerableToClrAsyncEnumerableConverter</c>
+        /// and completes synchronously — the drain never truly waits, but it blocks with the synchronization
+        /// context suppressed all the same, because correctness must not depend on what the sub-plan happens
+        /// to be. There is still no asynchronous DML in the node-level sense — the modify cannot suspend —
+        /// and the asynchronous root does not pretend otherwise; what it keeps is one plan per statement per
+        /// connection, whichever entry point asked.
         /// </remarks>
         public CalciteEnumerableResult ExecuteNonQuery(CalciteExecuteRequest request, CancellationToken cancellationToken)
         {
@@ -421,7 +424,7 @@ namespace Apache.Calcite.Data.Internal
             var closeables = ActivateHooks(request.Hooks);
             try
             {
-                var signature = Plan(request);
+                var signature = Plan(request, async: !_synchronous);
                 Bind(request, signature, out var dataContext, out var cancelFlag);
 
                 var statementType = signature.StatementType;
@@ -441,23 +444,23 @@ namespace Apache.Calcite.Data.Internal
                 {
                     // DML (INSERT/UPDATE/DELETE/MERGE): drain the enumerator to trigger execution.
                     // Wire the cancellation token to the Calcite cancel flag only here, where we
-                    // are synchronously enumerating and need Calcite's check-points to be able to
-                    // interrupt the loop. The registration is scoped to this block only.
+                    // are enumerating and need Calcite's check-points to be able to interrupt the
+                    // loop. The registration is scoped to this block only.
                     // RelOptUtil.createDmlRowType gives DML one ROWCOUNT column, and
                     // Meta.CursorFactory.deduce answers OBJECT for a single column before it looks at
                     // the element type -- measured -- so the row is the boxed count itself and not an
                     // array holding it. The array branch below is for a plan that says otherwise.
                     recordsAffected = 0;
                     using var _ = cancellationToken.Register(() => cancelFlag.set(true));
-                    using var e = signature.Bind(dataContext).GetEnumerator();
-                    if (e.MoveNext())
-                    {
-                        var cur = e.Current;
-                        if (cur is object[] row && row.Length > 0)
-                            recordsAffected = ToInt64(row[0]);
-                        else if (cur != null)
-                            recordsAffected = ToInt64(cur);
-                    }
+
+                    var cur = _synchronous
+                        ? FirstRow(signature.Bind(dataContext))
+                        : FirstRow(signature.BindAsync(dataContext), cancellationToken);
+
+                    if (cur is object[] row && row.Length > 0)
+                        recordsAffected = ToInt64(row[0]);
+                    else if (cur != null)
+                        recordsAffected = ToInt64(cur);
                 }
 
                 return new CalciteEnumerableResult(signature, null, recordsAffected);
@@ -477,15 +480,78 @@ namespace Apache.Calcite.Data.Internal
         }
 
         /// <summary>
+        /// Returns the first row of <paramref name="source"/>, or <see langword="null"/> where there is
+        /// none.
+        /// </summary>
+        static object? FirstRow(IEnumerable<object> source)
+        {
+            using var e = source.GetEnumerator();
+            return e.MoveNext() ? e.Current : null;
+        }
+
+        /// <summary>
+        /// Returns the first row of <paramref name="source"/>, or <see langword="null"/> where there is
+        /// none, blocking for it with the synchronization context suppressed before the plan runs — the
+        /// operators capture the context at suspension, inside the call, so the suppression has to precede
+        /// it. <c>CalciteAsyncEnumerableResult.Read</c> has the measurement.
+        /// </summary>
+        static object? FirstRow(IAsyncEnumerable<object> source, CancellationToken cancellationToken)
+        {
+            var context = SynchronizationContext.Current;
+            if (context is null)
+                return First(source, cancellationToken);
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                return First(source, cancellationToken);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
+            }
+
+            static object? First(IAsyncEnumerable<object> source, CancellationToken cancellationToken)
+            {
+                var e = source.GetAsyncEnumerator(cancellationToken);
+                try
+                {
+                    return WaitMove(e.MoveNextAsync()) ? e.Current : null;
+                }
+                finally
+                {
+                    Wait(e.DisposeAsync());
+                }
+            }
+
+            static bool WaitMove(ValueTask<bool> task)
+            {
+                return task.IsCompletedSuccessfully ? task.Result : task.AsTask().GetAwaiter().GetResult();
+            }
+        }
+
+        /// <summary>
+        /// Waits for a disposal the caller cannot await.
+        /// </summary>
+        static void Wait(ValueTask task)
+        {
+            if (task.IsCompleted)
+                task.GetAwaiter().GetResult();
+            else
+                task.AsTask().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Prepares and executes a DML, DDL, or SELECT statement and returns the number of rows affected.
         /// </summary>
         /// <param name="request">The execute request containing SQL text, parameters, timeout, and hooks.</param>
         /// <param name="cancellationToken">Token used to cancel execution.</param>
         /// <returns>A <see cref="CalciteResult"/> with <c>RecordsAffected</c> set and no row enumerator.</returns>
         /// <remarks>
-        /// <see cref="ExecuteNonQuery"/> in a completed task, for the reason that method gives: there is no
-        /// asynchronous DML to prepare. It is here so that a caller writing asynchronously has the method it
-        /// expects, not because anything about it awaits.
+        /// <see cref="ExecuteNonQuery"/> in a completed task, for the reason that method gives: a modify
+        /// cannot suspend, so there is nothing here to await. It is here so that a caller writing
+        /// asynchronously has the method it expects.
         /// </remarks>
         public Task<CalciteResult> ExecuteNonQueryAsync(CalciteExecuteRequest request, CancellationToken cancellationToken)
         {

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -171,7 +171,9 @@ The Calcite session is created on the **first** `Open()` and reused for the life
 
 **`CommandType.Text` only.** Setting any other `CommandType` throws `NotSupportedException`. There is no stored-procedure concept in Calcite.
 
-**Cancellation is coarse.** A `CancellationToken` is observed before a statement is planned. On a DML statement it is also wired to Calcite's cancel flag while the rows are drained. It is **not** wired to a reader's enumeration — cancelling the token after `ExecuteReaderAsync` has returned does not stop `ReadAsync` from producing more rows. `DbCommand.Cancel()` is a no-op.
+**Every query is planned asynchronously unless the connection says otherwise.** The plan is the connection's, not the entry point's: by default it is built in the asynchronous convention, so `ReadAsync` is genuinely asynchronous wherever the schema can be, and a synchronous `Read` blocks per row only where the source really is asynchronous — which is what `Read` over an asynchronous source means in every ADO.NET provider. `Synchronous=true` plans in the synchronous convention instead: nothing ever waits, `ReadAsync` answers with completed tasks, and a query touching a table that can *only* produce rows asynchronously fails to plan.
+
+**Cancellation is per-statement.** A `CancellationToken` is observed before a statement is planned. On a DML statement it is wired to Calcite's cancel flag while the rows are drained. The token given to `ExecuteReaderAsync` also reaches the plan's enumerator, so cancelling it stops the leaf between rows; in `Synchronous` mode it is not wired to a reader's enumeration. `DbCommand.Cancel()` is a no-op.
 
 **`ExecuteNonQuery` return values** follow ADO.NET convention: `-1` for a `SELECT`, `0` for DDL, and the row count Calcite reports for `INSERT` / `UPDATE` / `DELETE` / `MERGE`.
 
@@ -191,6 +193,7 @@ All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Ke
 |-----|------|---------|-------------|
 | `Model` | `string` | — | Path to a Calcite model JSON file, or `inline:<json>` for an embedded model. |
 | `Schema` | `string` | — | Default schema name when identifiers are unqualified. |
+| `Synchronous` | `bool` | `false` | Plan queries in the synchronous convention instead of the asynchronous one. A provider option, not forwarded to the engine — see [Behaviour worth knowing](#behaviour-worth-knowing). |
 | `Lex` | `string` | `ORACLE` | Lexical policy: `ORACLE`, `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`. |
 | `CaseSensitive` | `bool` | from `Lex` | Whether identifier lookup is case-sensitive. |
 | `Quoting` | `string` | from `Lex` | Quote style: `DOUBLE_QUOTE`, `BACK_TICK`, `BACK_TICK_BACKSLASH`, `BRACKET`. |
@@ -261,7 +264,7 @@ cmd.RegisterHook(Hook.PROGRAM, /* ... */);
 
 Overloads accept a Java `Consumer`, a .NET `Action<object>`, or a primitive value to set as the hook's property. Connection hooks run before command hooks.
 
-`EXPLAIN PLAN FOR <query>` also works, and returns the rendered plan as a single row. It explains the plan the reader you called would have run: `ExecuteReader` renders `ClrEnumerable*` nodes and `ExecuteReaderAsync` renders `ClrAsyncEnumerable*` ones, since nothing in the SQL says which convention is wanted.
+`EXPLAIN PLAN FOR <query>` also works, and returns the rendered plan as a single row. It explains the plan the connection would run: `ClrAsyncEnumerable*` nodes by default, `ClrEnumerable*` ones when the connection string says `Synchronous` — the same plan from `ExecuteReader` and `ExecuteReaderAsync`, since the convention is the connection's choice rather than the entry point's.
 
 ## Accessing the Calcite engine directly
 

--- a/src/Apache.Calcite.Extensions/Runtime/ClrSequences.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/ClrSequences.cs
@@ -43,13 +43,17 @@ namespace Apache.Calcite.Extensions.Runtime
         /// consumer's only way out is to stop enumerating. Abandoning the sequence disposes the enumerator,
         /// which is what ends the asynchronous plan under it.</para>
         ///
-        /// <para><b>The synchronization context is suppressed for the length of each wait</b>, and that is
-        /// load bearing rather than tidy. The operators of the asynchronous convention await without
-        /// <c>ConfigureAwait(false)</c> — <c>await foreach (var row in source.WithCancellation(token))</c>
-        /// continues on the captured context — so a caller that blocked a thread carrying one would wait for
-        /// a continuation that can only run on the thread it is blocking. Nulling the context before the call
-        /// means there is nothing to capture and the continuation goes to the thread pool. Where there is no
-        /// context, which is every thread a query is normally read on, this costs one read.</para>
+        /// <para><b>The synchronization context is suppressed around each call, not around each wait</b>,
+        /// and the placement is load bearing rather than tidy. The operators of the asynchronous convention
+        /// await without <c>ConfigureAwait(false)</c> — <c>await foreach (var row in
+        /// source.WithCancellation(token))</c> continues on the captured context — and the capture happens at
+        /// the moment of suspension, which is inside <c>MoveNextAsync</c>'s synchronous phase, on this
+        /// thread, <em>before</em> the call returns and any wait begins. Measured: nulling the context after
+        /// the call had started still deadlocked under a context that cannot pump, because the continuation
+        /// had already been promised to it; nulling before the call completes, because there is nothing to
+        /// capture and the continuation goes to the thread pool. Where there is no context, which is every
+        /// thread a query is normally read on, this costs one read of
+        /// <see cref="SynchronizationContext.Current"/> per row.</para>
         /// </remarks>
         public static IEnumerable<TSource> ToEnumerable<TSource>(IAsyncEnumerable<TSource> source)
         {
@@ -59,12 +63,64 @@ namespace Apache.Calcite.Extensions.Runtime
 
             try
             {
-                while (Block(enumerator.MoveNextAsync()))
+                while (BlockMoveNext(enumerator))
                     yield return enumerator.Current;
             }
             finally
             {
-                Block(enumerator.DisposeAsync());
+                BlockDispose(enumerator);
+            }
+        }
+
+        /// <summary>
+        /// Advances <paramref name="enumerator"/>, blocking for the row, with the synchronization context
+        /// suppressed before <c>MoveNextAsync</c> runs.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="enumerator"></param>
+        /// <returns></returns>
+        static bool BlockMoveNext<TSource>(IAsyncEnumerator<TSource> enumerator)
+        {
+            var context = SynchronizationContext.Current;
+            if (context == null)
+                return Wait(enumerator.MoveNextAsync());
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                return Wait(enumerator.MoveNextAsync());
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
+            }
+        }
+
+        /// <summary>
+        /// Disposes <paramref name="enumerator"/>, blocking for completion, with the synchronization context
+        /// suppressed before <c>DisposeAsync</c> runs — an iterator's <c>finally</c> can suspend too.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="enumerator"></param>
+        static void BlockDispose<TSource>(IAsyncEnumerator<TSource> enumerator)
+        {
+            var context = SynchronizationContext.Current;
+            if (context == null)
+            {
+                Wait(enumerator.DisposeAsync());
+                return;
+            }
+
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                Wait(enumerator.DisposeAsync());
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(context);
             }
         }
 
@@ -80,25 +136,9 @@ namespace Apache.Calcite.Extensions.Runtime
         /// <see cref="ValueTask{TResult}.AsTask"/>, which allocates. The completed case is the common one and
         /// skips that.
         /// </remarks>
-        static bool Block(ValueTask<bool> task)
+        static bool Wait(ValueTask<bool> task)
         {
-            if (task.IsCompletedSuccessfully)
-                return task.Result;
-
-            var context = SynchronizationContext.Current;
-            if (context == null)
-                return task.AsTask().GetAwaiter().GetResult();
-
-            SynchronizationContext.SetSynchronizationContext(null);
-
-            try
-            {
-                return task.AsTask().GetAwaiter().GetResult();
-            }
-            finally
-            {
-                SynchronizationContext.SetSynchronizationContext(context);
-            }
+            return task.IsCompletedSuccessfully ? task.Result : task.AsTask().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -106,10 +146,10 @@ namespace Apache.Calcite.Extensions.Runtime
         /// </summary>
         /// <param name="task"></param>
         /// <remarks>
-        /// <see cref="Block(ValueTask{bool})"/> for the disposal, which has no value. The completed case is
+        /// <see cref="Wait(ValueTask{bool})"/> for the disposal, which has no value. The completed case is
         /// still awaited rather than dropped, because that is what observes a failure.
         /// </remarks>
-        static void Block(ValueTask task)
+        static void Wait(ValueTask task)
         {
             if (task.IsCompletedSuccessfully)
             {
@@ -117,23 +157,7 @@ namespace Apache.Calcite.Extensions.Runtime
                 return;
             }
 
-            var context = SynchronizationContext.Current;
-            if (context == null)
-            {
-                task.AsTask().GetAwaiter().GetResult();
-                return;
-            }
-
-            SynchronizationContext.SetSynchronizationContext(null);
-
-            try
-            {
-                task.AsTask().GetAwaiter().GetResult();
-            }
-            finally
-            {
-                SynchronizationContext.SetSynchronizationContext(context);
-            }
+            task.AsTask().GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
@@ -23,10 +23,11 @@ namespace Apache.Calcite.Tests
     /// <c>Func&lt;DataContext, IAsyncEnumerable&lt;object&gt;&gt;</c>, and <c>DbDataReader.ReadAsync</c>
     /// pulling the rows out.
     ///
-    /// <para>Every one of them asserts <c>which</c> convention ran, not only that rows came back. There is
-    /// no fallback to be caught out by any more — <c>ExecuteReaderAsync</c> throws where it cannot plan —
-    /// but a test that checked only the rows would still be satisfied by a plan that never suspended, so
-    /// each one reads the leaf's own counters.</para>
+    /// <para>Every one of them asserts <c>which</c> convention ran, not only that rows came back. The
+    /// convention is the connection's mode — asynchronous by default,
+    /// <see cref="CalciteConnectionStringBuilder.Synchronous"/> for the other one — and a test that checked
+    /// only the rows would be satisfied by a plan that never suspended, so each one reads the leaf's own
+    /// counters.</para>
     /// </remarks>
     [TestClass]
     public class ClrAsyncEnumerableAdoNetTests
@@ -34,6 +35,8 @@ namespace Apache.Calcite.Tests
 
         const string Model =
             "Model=inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]};Schema=adhoc";
+
+        const string SynchronousModel = Model + ";Synchronous=true";
 
         static (CalciteConnection Connection, AsyncRowsTable Table) Open()
         {
@@ -75,32 +78,62 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
-        /// A table that can only produce rows asynchronously cannot be read synchronously at all.
+        /// A table that can only produce rows asynchronously is still read by a synchronous caller.
         /// </summary>
         /// <remarks>
-        /// Not a limitation to work around — it is the convention's whole premise arriving at the surface.
-        /// An <c>IClrAsyncScannableTable</c> is not a <c>ScannableTable</c>, so neither the synchronous
-        /// convention nor Calcite's own has a scan for it, and the synchronous planner is given no rule that
-        /// would put the scan in the asynchronous convention for
-        /// <c>ClrAsyncEnumerableToClrEnumerableConverter</c> to carry. <c>ExecuteReader</c> therefore fails to
-        /// plan rather than blocking a thread per row, which is the trade this whole convention exists to
-        /// make — and it is a trade the prepare pipeline makes by choosing rules, not one the planner is
-        /// incapable of unmaking.
-        ///
-        /// <para>A schema may hold both kinds of table; it is the individual query that is one or the
-        /// other.</para>
+        /// The plan is the connection's — asynchronous by default — and <c>Read</c> blocks on it per row,
+        /// which is what <c>Read</c> over an asynchronous source means and where every ADO.NET provider
+        /// blocks. The refusal this test used to hold belongs to the mode now:
+        /// <see cref="ShouldRefuseAnAsyncOnlyTableInSynchronousMode"/>.
         /// </remarks>
         [TestMethod]
-        public void ShouldRefuseToReadAnAsyncOnlyTableSynchronously()
+        public void ShouldReadAnAsyncOnlyTableSynchronously()
         {
-            var (c, _) = Open();
+            var (c, table) = Open();
             using (c)
             {
                 using var cmd = c.CreateCommand();
                 cmd.CommandText = "SELECT ID FROM SALES ORDER BY ID";
 
-                cmd.Invoking(x => x.ExecuteReader()).Should().Throw<Exception>();
+                var rows = new List<int>();
+                using var reader = cmd.ExecuteReader();
+                while (reader.Read())
+                    rows.Add(reader.GetInt32(0));
+
+                rows.Should().Equal([1, 2, 3, 4, 5, 6]);
+                table.Produced.Should().Be(6, "the rows still come from the asynchronous table");
             }
+        }
+
+        /// <summary>
+        /// In synchronous mode a query over an asynchronous-only table fails to plan, from either entry
+        /// point.
+        /// </summary>
+        /// <remarks>
+        /// An <c>IClrAsyncScannableTable</c> is not a <c>ScannableTable</c>, so neither the synchronous
+        /// convention nor Calcite's own has a scan for it, and the synchronous planner is given no rule that
+        /// would put the scan in the asynchronous convention for
+        /// <c>ClrAsyncEnumerableToClrEnumerableConverter</c> to carry. That is the mode's trade: a
+        /// connection that said <see cref="CalciteConnectionStringBuilder.Synchronous"/> asked for plans
+        /// that never wait, so a query that could only wait fails visibly rather than blocking behind the
+        /// mode's back — and it fails from <c>ExecuteReaderAsync</c> too, because the mode is the
+        /// connection's rather than the entry point's.
+        ///
+        /// <para>A schema may hold both kinds of table; it is the individual query that is one or the
+        /// other.</para>
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldRefuseAnAsyncOnlyTableInSynchronousMode()
+        {
+            using var c = new CalciteConnection(SynchronousModel);
+            c.Open();
+            c.RootSchema.add("SALES", new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false));
+
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT ID FROM SALES ORDER BY ID";
+
+            cmd.Invoking(x => x.ExecuteReader()).Should().Throw<Exception>();
+            await cmd.Awaiting(x => x.ExecuteReaderAsync()).Should().ThrowAsync<Exception>();
         }
 
         /// <summary>
@@ -138,73 +171,104 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
-        /// The same EXPLAIN over the same table renders a different plan depending on which reader asked
-        /// for it.
+        /// The same EXPLAIN over the same table renders the same plan from either entry point, and the
+        /// connection's mode is what changes it.
         /// </summary>
         /// <remarks>
         /// A <see cref="SyncRowsTable"/> can be planned either way, so this is the whole of the point:
-        /// nothing in the SQL says which convention to explain, and <c>ExecuteReader</c> against
-        /// <c>ExecuteReaderAsync</c> is where that is decided — for an <c>EXPLAIN</c> exactly as for the
-        /// query it explains.
+        /// nothing in the SQL says which convention to plan, and nothing in the entry point does either.
+        /// The choice is the connection's — the way Calcite's own connection can ask for the bindable
+        /// convention — so <c>ExecuteReader</c> and <c>ExecuteReaderAsync</c> explain the same plan, for an
+        /// <c>EXPLAIN</c> exactly as for the query it explains.
         /// </remarks>
         [TestMethod]
-        public async Task ShouldExplainTheConventionThatWasAskedFor()
+        public async Task ShouldExplainTheModesConvention()
         {
-            using var c = new CalciteConnection(Model);
-            c.Open();
-            c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
-
             const string Sql = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
 
-            string synchronous;
-            using (var cmd = c.CreateCommand())
+            using (var c = new CalciteConnection(Model))
             {
-                cmd.CommandText = Sql;
-                using var reader = cmd.ExecuteReader();
-                reader.Read().Should().BeTrue();
-                synchronous = reader.GetString(0);
+                c.Open();
+                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+
+                Explain(c, Sql).Should().Contain("ClrAsyncEnumerable");
+                (await ExplainAsync(c, Sql)).Should().Contain("ClrAsyncEnumerable");
             }
 
-            string asynchronous;
-            using (var cmd = c.CreateCommand())
+            using (var c = new CalciteConnection(SynchronousModel))
             {
-                cmd.CommandText = Sql;
-                using var reader = await cmd.ExecuteReaderAsync();
-                (await reader.ReadAsync()).Should().BeTrue();
-                asynchronous = reader.GetString(0);
-            }
+                c.Open();
+                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
-            synchronous.Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
-            asynchronous.Should().Contain("ClrAsyncEnumerable");
+                Explain(c, Sql).Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
+                (await ExplainAsync(c, Sql)).Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
+            }
         }
 
         /// <summary>
-        /// An EXPLAIN read as a scalar is the plan, by either method.
+        /// Runs an EXPLAIN through the synchronous reader and returns the rendered plan.
+        /// </summary>
+        static string Explain(CalciteConnection c, string sql)
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = sql;
+            using var reader = cmd.ExecuteReader();
+            reader.Read().Should().BeTrue();
+            return reader.GetString(0);
+        }
+
+        /// <summary>
+        /// Runs an EXPLAIN through the asynchronous reader and returns the rendered plan.
+        /// </summary>
+        static async Task<string> ExplainAsync(CalciteConnection c, string sql)
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = sql;
+            using var reader = await cmd.ExecuteReaderAsync();
+            (await reader.ReadAsync()).Should().BeTrue();
+            return reader.GetString(0);
+        }
+
+        /// <summary>
+        /// An EXPLAIN read as a scalar is the plan, by either method, and the mode's plan by both.
         /// </summary>
         /// <remarks>
         /// <c>ExecuteScalar</c> and <c>ExecuteScalarAsync</c> are the reader path with one row and one column
-        /// taken off it — the same two demands for a convention, so the same two answers. A caller reaching
-        /// for the plan as a string is the likely one, and it is a column of a result set like any other:
+        /// taken off it — the same connection, so the same plan. A caller reaching for the plan as a string
+        /// is the likely one, and it is a column of a result set like any other:
         /// <c>Meta.CursorFactory.deduce</c> makes a single column <c>OBJECT</c>, so the row <i>is</i> the
         /// text.
         /// </remarks>
         [TestMethod]
         public async Task ShouldExplainThroughExecuteScalar()
         {
-            using var c = new CalciteConnection(Model);
-            c.Open();
-            c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+            using (var c = new CalciteConnection(Model))
+            {
+                c.Open();
+                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
-            using var cmd = c.CreateCommand();
-            cmd.CommandText = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
 
-            var synchronous = cmd.ExecuteScalar();
-            var asynchronous = await cmd.ExecuteScalarAsync();
+                cmd.ExecuteScalar().Should().BeOfType<string>()
+                    .Which.Should().Contain("ClrAsyncEnumerable");
+                (await cmd.ExecuteScalarAsync()).Should().BeOfType<string>()
+                    .Which.Should().Contain("ClrAsyncEnumerable");
+            }
 
-            synchronous.Should().BeOfType<string>()
-                .Which.Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
-            asynchronous.Should().BeOfType<string>()
-                .Which.Should().Contain("ClrAsyncEnumerable");
+            using (var c = new CalciteConnection(SynchronousModel))
+            {
+                c.Open();
+                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
+
+                cmd.ExecuteScalar().Should().BeOfType<string>()
+                    .Which.Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
+                (await cmd.ExecuteScalarAsync()).Should().BeOfType<string>()
+                    .Which.Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
+            }
         }
 
         /// <summary>
@@ -276,25 +340,25 @@ namespace Apache.Calcite.Tests
         /// A reader over a synchronous plan can still be read asynchronously.
         /// </summary>
         /// <remarks>
-        /// The other half of <see cref="ShouldReadAnAsyncPlanSynchronouslyWhenAskedTo"/>, and the crossing
-        /// that had no test. A synchronous plan answers <c>ReadAsync</c> by reading and handing back a
-        /// completed task — which is what every synchronous ADO.NET provider does, and is not sync over
-        /// async because there is nothing asynchronous underneath to be over.
+        /// The other half of <see cref="ShouldReadAnAsyncPlanSynchronouslyWhenAskedTo"/>. A synchronous plan
+        /// answers <c>ReadAsync</c> by reading and handing back a completed task — which is what every
+        /// synchronous ADO.NET provider does, and is not sync over async because there is nothing
+        /// asynchronous underneath to be over.
         ///
-        /// <para>It matters because code written against <c>ReadAsync</c> is the normal case, and a query
-        /// that could not be planned asynchronously still has to be readable by it.</para>
+        /// <para>It matters because code written against <c>ReadAsync</c> is the normal case, and a
+        /// connection in synchronous mode still has to be readable by it.</para>
         /// </remarks>
         [TestMethod]
         public async Task ShouldReadASyncPlanAsynchronously()
         {
-            using var c = new CalciteConnection(Model);
+            // the synchronous plan, deliberately: the connection's mode is what asks for it
+            using var c = new CalciteConnection(SynchronousModel);
             c.Open();
             c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT K, V FROM SYNCONLY ORDER BY K, V";
 
-            // the synchronous plan, deliberately: this query cannot be planned asynchronously at all
             using var reader = cmd.ExecuteReader();
 
             var rows = new List<string>();
@@ -302,6 +366,83 @@ namespace Apache.Calcite.Tests
                 rows.Add(reader.GetInt32(0) + "|" + reader.GetString(1));
 
             rows.Should().Equal(["1|A", "2|B", "2|C", "4|D"]);
+        }
+
+        /// <summary>
+        /// A synchronous read over an asynchronous plan completes on a thread carrying a synchronization
+        /// context.
+        /// </summary>
+        /// <remarks>
+        /// The WinForms/WPF case, and the reason <c>CalciteAsyncEnumerableResult.Read</c> suppresses the
+        /// context around the whole call rather than around the wait: the operators await without
+        /// <c>ConfigureAwait(false)</c>, and a continuation captures the context at the moment of
+        /// suspension — inside <c>MoveNextAsync</c>'s synchronous phase, before any wait begins. Measured
+        /// with exactly this shape of context, one that queues and cannot pump while its thread is blocked:
+        /// suppressing only around the wait deadlocks, suppressing before the call completes.
+        ///
+        /// <para>The read runs on a dedicated background thread with a join timeout, so a regression fails
+        /// rather than hanging the suite.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadSynchronouslyUnderASynchronizationContext()
+        {
+            var (c, _) = Open();
+            using (c)
+            {
+                List<int>? rows = null;
+                Exception? error = null;
+
+                var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        SynchronizationContext.SetSynchronizationContext(new NonPumpingContext());
+
+                        using var cmd = c.CreateCommand();
+                        cmd.CommandText = "SELECT ID FROM SALES ORDER BY ID";
+
+                        var read = new List<int>();
+                        using var reader = cmd.ExecuteReader();
+                        while (reader.Read())
+                            read.Add(reader.GetInt32(0));
+
+                        rows = read;
+                    }
+                    catch (Exception e)
+                    {
+                        error = e;
+                    }
+                });
+
+                thread.IsBackground = true;
+                thread.Start();
+                thread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue(
+                    "a deadlock here means a continuation was captured by the context before it was suppressed");
+
+                error.Should().BeNull();
+                rows.Should().Equal([1, 2, 3, 4, 5, 6]);
+            }
+        }
+
+        /// <summary>
+        /// A context that accepts posts and can never run them while its thread is blocked — the observable
+        /// shape of a blocked UI thread.
+        /// </summary>
+        sealed class NonPumpingContext : SynchronizationContext
+        {
+
+            /// <summary>
+            /// Queued to a loop nobody pumps: a continuation posted here never runs, exactly as one posted
+            /// to a blocked UI thread's message loop never runs.
+            /// </summary>
+            public override void Post(SendOrPostCallback d, object? state)
+            {
+
+            }
+
+            /// <inheritdoc />
+            public override SynchronizationContext CreateCopy() => this;
+
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
+++ b/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
@@ -195,6 +197,72 @@ namespace Apache.Calcite.Tests
             var rows = await RunAsync("SELECT K, V FROM SORTED WHERE K >= 2", Schema(), rules, calcRules);
 
             rows.Should().Equal(["2|B", "2|C", "4|D"]);
+        }
+
+        /// <summary>
+        /// The blocking crossing completes on a thread carrying a synchronization context.
+        /// </summary>
+        /// <remarks>
+        /// The regression test for <c>ClrSequences</c>' suppression placement. The operators await without
+        /// <c>ConfigureAwait(false)</c>, and a continuation captures the context at the moment of
+        /// suspension — inside <c>MoveNextAsync</c>'s synchronous phase, before the converter has anything
+        /// to wait on. Measured with exactly this shape of context, one that queues and cannot pump while
+        /// its thread is blocked: nulling the context only around the wait deadlocked, nulling it before
+        /// each call completes. <c>AsyncRowsTable</c> awaits on every row, so every capture here would be
+        /// real.
+        ///
+        /// <para>The read runs on a dedicated background thread with a join timeout, so a regression fails
+        /// rather than hanging the suite.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadAnAsynchronousPlanSynchronouslyUnderASynchronizationContext()
+        {
+            var (rules, calcRules) = Both();
+
+            List<string>? rows = null;
+            Exception? error = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    SynchronizationContext.SetSynchronizationContext(new NonPumpingContext());
+                    rows = RunSync("SELECT ID, LABEL FROM SALES WHERE ID > 3", Schema(), rules, calcRules);
+                }
+                catch (Exception e)
+                {
+                    error = e;
+                }
+            });
+
+            thread.IsBackground = true;
+            thread.Start();
+            thread.Join(TimeSpan.FromSeconds(30)).Should().BeTrue(
+                "a deadlock here means a continuation was captured by the context before it was suppressed");
+
+            error.Should().BeNull();
+            rows.Should().Equal(["4|D", "5|E", "6|F"]);
+        }
+
+        /// <summary>
+        /// A context that accepts posts and can never run them while its thread is blocked — the observable
+        /// shape of a blocked UI thread.
+        /// </summary>
+        sealed class NonPumpingContext : SynchronizationContext
+        {
+
+            /// <summary>
+            /// Queued to a loop nobody pumps: a continuation posted here never runs, exactly as one posted
+            /// to a blocked UI thread's message loop never runs.
+            /// </summary>
+            public override void Post(SendOrPostCallback d, object? state)
+            {
+
+            }
+
+            /// <inheritdoc />
+            public override SynchronizationContext CreateCopy() => this;
+
         }
 
         /// <summary>


### PR DESCRIPTION
The ADO.NET provider now plans every statement into `ClrAsyncEnumerableConvention` unless the connection string says `Synchronous=true`, which plans into `ClrEnumerableConvention` instead. The mode is a provider option on `CalciteConnectionStringBuilder` -- excluded from the engine properties like `Model`, the way Calcite's own connection can enable bindable mode -- and it is uniform across every entry point: `ExecuteReader`, `ExecuteReaderAsync`, and `ExecuteNonQuery` prepare the connection's plan.

What that buys:

- `ReadAsync` is genuinely asynchronous wherever the schema can be, from either entry point. A table of Calcite's SPI is read the way Calcite reads it and completes synchronously -- a state machine, no parked thread -- and anything the convention has no node for is implemented in `EnumerableConvention` with a converter carrying its rows. Nothing on the asynchronous surface ever waits for a row.
- A synchronous consumer (`DataTable.Load`, a micro-ORM's sync API) now works over an asynchronous-only table, blocking per row, which is what `Read` over an asynchronous source means in every ADO.NET provider. Previously that query failed to plan.
- In synchronous mode nothing ever waits: `ReadAsync` answers with completed tasks, and a query touching an asynchronous-only table fails to plan visibly, from both entry points. The synchronous convention and its whole pipeline stay maintained -- the mode keeps it exercised end to end through the provider.
- One SQL text yields one plan per connection -- for a write as for a read. `EXPLAIN` renders the mode's convention regardless of which entry point asked.
- The token given to `ExecuteReaderAsync` reaches the plan's enumerator, so cancelling it stops the leaf between rows.

Also in this change:

- The remarks claiming `ExecuteReaderAsync` had no fallback and threw for any table that was not an `IClrAsyncScannableTable` were false -- the asynchronous program has always planned Calcite's table SPI through the converter, and three green EXPLAIN tests said so. They are gone.
- `ExecuteNonQuery` had pinned the synchronous program on the same false premise ("only the synchronous convention reaches Calcite's across a converter" -- both have a converter in from `EnumerableConvention`), which made an INSERT prepare a different plan through `ExecuteReader` than through `ExecuteNonQuery` on one connection. It now plans by the mode: the modify stays Calcite's `EnumerableTableModify` in both modes, the count row crosses the converter under the asynchronous root and completes synchronously, and the drain blocks with the context suppressed all the same.
- `CalciteAsyncEnumerableResult.Read` suppresses the `SynchronizationContext` around the whole `ReadAsync` call, and `Release` blocks disposal to completion under the same suppression rather than abandoning a disposal that did not finish synchronously. The placement is the point: the operators await without `ConfigureAwait(false)` and capture the context at suspension, inside `MoveNextAsync`'s synchronous phase, so suppressing only around the wait deadlocks -- measured with a repro under a non-pumping context. `ClrSequences` had exactly that defect and is fixed the same way. Regression tests hold both paths on a background thread with a join timeout, so a regression fails rather than hanging the suite.
- The AdoNet adapter's direct-converter test pins synchronous mode: under the asynchronous program the two routes tie on the planner's row-count-only cost and the adapter's rows cross through `AdoToEnumerableConverter`; a new test holds that plan and that the pushdown survives it. A direct `Ado -> ClrAsyncEnumerable` converter does not exist yet, and is the piece to build if that linq4j layer ever matters.

Test runs: `Apache.Calcite.Tests` 668/668, `Apache.Calcite.Data.Tests` 324/324, `Apache.Calcite.Adapter.AdoNet.Tests` 345/345.
