### PR TITLE
Acquire at the enumerator, as linq4j does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,18 @@ them sooner" is not: that was `Window`'s laziness, filed under record-do-not-fix
 builds an `ArrayList` and returns `Linq4j.asEnumerable(list)`. Whether ours is better is not the question
 the port gets to answer.
 
+**Obtaining an enumerator runs the plan; `yield` defers it.** linq4j's operators acquire their source's
+enumerator inside `enumerator()` — `where` on the spot, `orderBy` draining its whole input there, the JDBC
+leaf executing its statement there — and deferral is the marked exception (the CALCITE-2909 memoized join
+lookups). A C# iterator method defers everything to its first `MoveNext`, acquisition included, so
+re-expressing an operator as one silently moved that seam, across the whole of both conventions, and no
+row-comparing test could see it. `ClrEnumerable` and `Acquiring` in `Runtime` put a factory where
+`enumerator()` is; the one sanctioned exception is a drain that must await, which acquires eagerly and
+drains in the first `MoveNextAsync`, stated at the site. Timing is held by `AcquisitionTimingTests`, which
+reads a counting leaf's acquisitions and its rows as two numbers — and note the operators whose eagerness
+is *call*-time are linq4j's own call-time drains (`union`, `distinct`, `asofJoin`, `groupBy`, the window,
+`nestedLoopJoinAsList`): do not "fix" them toward the factory.
+
 **A claim about how something fails is a claim to run.** Reasoning from a comparator's semantics gave "a
 CLR-boxed row element and a Java-boxed one compare unequal, their hashes agree, so a set operator quietly
 keeps both copies" — a description of a state no query reaches. One query over a table holding CLR-boxed

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -348,8 +348,11 @@ type, the value and the SQL type. `BigDecimalConverter` carries `java.math.BigDe
 6. **Bind.** Parameters are converted and assembled with the cancel flag, the timeout and the
    signature's internal parameters into a `StatementDataContext`.
 7. **Execute.** The plan's enumerator is taken — `BindAsync(...).GetAsyncEnumerator(token)` or
-   `Bind(...).GetEnumerator()` by mode — and wrapped in the matching `CalciteResult`. Nothing has
-   been enumerated yet.
+   `Bind(...).GetEnumerator()` by mode — and wrapped in the matching `CalciteResult`. Obtaining the
+   enumerator **runs** the plan, as it does in linq4j: every operator acquires its source's
+   enumerator there, a sort drains its input there, and a linq4j leaf executes its statement there —
+   so failures and side effects of starting the plan land at Execute. No row has been read; an
+   asynchronous drain that must await waits for the first `ReadAsync`.
 8. **Read.** `CalciteDataReader` pulls rows through `CalciteResult.ReadAsync`, and each accessor
    goes `CalciteResultRow` → `CalciteResultValue` → CLR value.
 9. **Dispose.** Disposing the reader disposes the result and its enumerator. Disposing the

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -249,6 +249,8 @@ Every plan is compiled into a `System.Linq.Expressions` tree and run as .NET cod
 
 There is nothing to configure and nothing to switch off. This provider owns the prepare pipeline rather than subclassing Calcite's: it never calls `CalcitePrepare.prepareSql`, and a statement never produces a Calcite `Bindable`. The rows a reader returns come from the compiled delegate's own enumerator, with nothing in between.
 
+Execute runs the plan; reading pulls rows. `ExecuteReader` obtains the plan's enumerator, and — as in Calcite's own linq4j — obtaining an enumerator is where each operator acquires its input, a sort drains, and an underlying source opens or executes its statement. A failing plan therefore throws at `ExecuteReader`, not at the first `Read`.
+
 A single plan may still use both engines. Anything the .NET convention has no rule for is planned by Calcite as usual, and rows cross between the two untouched.
 
 ## Diagnostics

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -26,18 +26,21 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
     /// takes are the same synchronous <see cref="Func{T, TResult}"/>, because they are the per-row work
     /// Calcite's generators write and there is nothing in one to await.
     ///
-    /// <para><b>Cancellation is carried by the language rather than by the plan.</b> Every operator is an
-    /// <c>async IAsyncEnumerable</c> iterator declaring
-    /// <c>[EnumeratorCancellation] CancellationToken</c> and consuming its input through
-    /// <c>WithCancellation</c>, so a token entering at the root's
-    /// <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator"/> reaches the leaf without appearing anywhere in
-    /// the expression tree. The tree passes nothing.</para>
+    /// <para><b>Cancellation is carried by the language rather than by the plan.</b> A token entering at
+    /// the root's <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator"/> reaches the leaf without appearing
+    /// anywhere in the expression tree: an operator of the eager-acquisition shape hands the token its
+    /// factory receives to its source's <c>GetAsyncEnumerator</c>, and one still written as an
+    /// <c>async</c> iterator declares <c>[EnumeratorCancellation] CancellationToken</c> and consumes its
+    /// inputs through <c>WithCancellation</c>. The tree passes nothing. Every public operator keeps its
+    /// trailing <see cref="CancellationToken"/> parameter whether or not its body reads it, because the
+    /// generated trees bind these methods by <see cref="System.Reflection.MethodInfo"/>.</para>
     ///
-    /// <para><b>Several of these are iterators where their counterparts delegate to
-    /// <see cref="System.Linq.Enumerable"/>.</b> <c>System.Linq.AsyncEnumerable</c> arrived in .NET 10 and
-    /// this targets net8.0 — measured, absent — so <see cref="Where"/>, <see cref="Select"/>,
-    /// <see cref="Skip"/> and <see cref="Take"/> are written out. They are the only operators here that are
-    /// not a transcription of a body in the synchronous file.</para>
+    /// <para><b>Acquisition happens at <c>GetAsyncEnumerator</c>, as linq4j acquires at
+    /// <c>enumerator()</c>.</b> The shapes are the synchronous file's, through the same
+    /// <c>Acquiring</c> seam, less the one thing an <see cref="IAsyncEnumerable{T}"/> cannot say:
+    /// <c>GetAsyncEnumerator</c> cannot await, so work that must — a sort's drain, a hash join's build
+    /// side, a merge join's <c>start()</c> positioning — waits for the first <c>MoveNextAsync</c>, and
+    /// says so at the site. Acquisition itself is eager everywhere linq4j's is.</para>
     /// </remarks>
     static class ClrAsyncEnumerableDefaults
     {
@@ -52,14 +55,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <see cref="ClrEnumerableDefaults.Slice0"/>. A one column result is the value, not a one element
         /// row.
         /// </remarks>
-        public static async IAsyncEnumerable<TRow> Slice0<TRow>(IAsyncEnumerable<object[]> source, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TRow> Slice0<TRow>(IAsyncEnumerable<object[]> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
+            // Enumerables.slice0 is select(elements -> elements[0]), and select acquires its source's
+            // enumerator inside enumerator() -- so obtaining this enumerator acquires the scan's
+            return source.Acquiring((e, token) => Slice0Rows<TRow>(e));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Slice0"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TRow> Slice0Rows<TRow>(IAsyncEnumerator<object[]> source)
+        {
             // the row came from a table and its fields are still Java's, so the field taken out of it is
             // converted rather than cast
-            await foreach (var row in source.WithCancellation(cancellationToken))
-                yield return JavaValues.As<TRow>(row[0]);
+            while (await source.MoveNextAsync())
+                yield return JavaValues.As<TRow>(source.Current[0]);
         }
 
         /// <summary>
@@ -76,14 +89,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <see cref="ClrEnumerableDefaults.Calc"/>, which is what Calcite generates an anonymous
         /// <c>Enumerator</c> for. Both halves are still one pass over the input.
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> Calc<TSource, TResult>(IAsyncEnumerable<TSource> source, Func<TSource, bool>? predicate, Func<TSource, TResult> selector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TResult> Calc<TSource, TResult>(IAsyncEnumerable<TSource> source, Func<TSource, bool>? predicate, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(selector);
 
-            await foreach (var row in source.WithCancellation(cancellationToken))
-                if (predicate == null || predicate(row))
-                    yield return selector(row);
+            // the generated enumerator acquires its input in a field initializer, which runs at
+            // enumerator() -- so obtaining this enumerator acquires the input's
+            return source.Acquiring((e, token) => CalcRows(e, predicate, selector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Calc"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> CalcRows<TSource, TResult>(IAsyncEnumerator<TSource> source, Func<TSource, bool>? predicate, Func<TSource, TResult> selector)
+        {
+            while (await source.MoveNextAsync())
+                if (predicate == null || predicate(source.Current))
+                    yield return selector(source.Current);
         }
 
         /// <summary>
@@ -97,14 +120,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <remarks>
         /// Written out rather than delegated, for the reason the class remarks give.
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> Where<TSource>(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> Where<TSource>(IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            await foreach (var row in source.WithCancellation(cancellationToken))
-                if (predicate(row))
-                    yield return row;
+            // EnumerableDefaults.where acquires source.enumerator() inside enumerator() -- acquisition at
+            // enumerator(), rows at moveNext
+            return source.Acquiring((e, token) => WhereRows(e, predicate));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Where"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> WhereRows<TSource>(IAsyncEnumerator<TSource> source, Func<TSource, bool> predicate)
+        {
+            while (await source.MoveNextAsync())
+                if (predicate(source.Current))
+                    yield return source.Current;
         }
 
         /// <summary>
@@ -119,13 +152,23 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <remarks>
         /// Written out rather than delegated, for the reason the class remarks give.
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> Select<TSource, TResult>(IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TResult> Select<TSource, TResult>(IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(selector);
 
-            await foreach (var row in source.WithCancellation(cancellationToken))
-                yield return selector(row);
+            // EnumerableDefaults.select acquires source.enumerator() in a field initializer, which runs at
+            // enumerator() -- acquisition at enumerator(), rows at moveNext
+            return source.Acquiring((e, token) => SelectRows(e, selector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Select"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> SelectRows<TSource, TResult>(IAsyncEnumerator<TSource> source, Func<TSource, TResult> selector)
+        {
+            while (await source.MoveNextAsync())
+                yield return selector(source.Current);
         }
 
         /// <summary>
@@ -147,12 +190,29 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <para>The comparator is Java's, because that is what <c>PhysType.generateCollationKey</c>
         /// yields.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> OrderBy<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> OrderBy<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            foreach (var row in ClrEnumerableDefaults.OrderBy(await Buffer(source, cancellationToken).ConfigureAwait(false), keySelector, comparator))
+            // EnumerableDefaults.orderBy drains its whole input inside enumerator(). GetAsyncEnumerator
+            // cannot await, so only the acquisition half can move there: the source's enumerator is
+            // acquired eagerly, and the awaited drain -- and the sort behind it -- waits for the first
+            // MoveNextAsync. The CLR imposes that; acquisition itself is eager.
+            return source.Acquiring((e, token) => OrderByRows(e, keySelector, comparator));
+        }
+
+        /// <summary>
+        /// The drain and sort of <see cref="OrderBy"/>, over an enumerator the factory acquired. The sort
+        /// itself stays the synchronous operator's.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> OrderByRows<TSource, TKey>(IAsyncEnumerator<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator)
+        {
+            var buffer = new List<TSource>();
+            while (await source.MoveNextAsync())
+                buffer.Add(source.Current);
+
+            foreach (var row in ClrEnumerableDefaults.OrderBy(buffer, keySelector, comparator))
                 yield return row;
         }
 
@@ -167,15 +227,32 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <remarks>
         /// Written out rather than delegated, for the reason the class remarks give.
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> Skip<TSource>(IAsyncEnumerable<TSource> source, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> Skip<TSource>(IAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            var skipped = 0;
+            // EnumerableDefaults.skip is skipWhile over n < count, and SkipWhileEnumerator takes
+            // source.enumerator() eagerly -- acquisition at enumerator(), rows at moveNext
+            return source.Acquiring((e, token) => SkipRows(e, count));
+        }
 
-            await foreach (var row in source.WithCancellation(cancellationToken))
-                if (skipped++ >= count)
-                    yield return row;
+        /// <summary>
+        /// The row loop of <see cref="Skip"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> SkipRows<TSource>(IAsyncEnumerator<TSource> source, int count)
+        {
+            var n = 0;
+
+            while (await source.MoveNextAsync())
+            {
+                if (n < count)
+                {
+                    n++;
+                    continue;
+                }
+
+                yield return source.Current;
+            }
         }
 
         /// <summary>
@@ -198,16 +275,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// what runs a lazy collection spool's write-back and a repeat union's clean-up. Returning an empty
         /// sequence without touching the input skips both.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> Take<TSource>(IAsyncEnumerable<TSource> source, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> Take<TSource>(IAsyncEnumerable<TSource> source, int count, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            await using var enumerator = source.GetAsyncEnumerator(cancellationToken);
+            // TakeWhileLongEnumerator takes source.enumerator() eagerly -- acquisition at enumerator(),
+            // the drawn-but-untested row at moveNext
+            return source.Acquiring((e, token) => TakeRows(e, count));
+        }
 
+        /// <summary>
+        /// The row loop of <see cref="Take"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> TakeRows<TSource>(IAsyncEnumerator<TSource> source, int count)
+        {
             var n = -1;
 
-            while (await enumerator.MoveNextAsync().ConfigureAwait(false) && ++n < count)
-                yield return enumerator.Current;
+            while (await source.MoveNextAsync() && ++n < count)
+                yield return source.Current;
         }
 
         /// <summary>
@@ -226,13 +311,118 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <see cref="ClrEnumerableDefaults.OrderByWithFetchAndOffset"/>: a sort carrying a limit rather than
         /// a sort followed by one.
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> OrderByWithFetchAndOffset<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, int offset, int fetch, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> OrderByWithFetchAndOffset<TSource, TKey>(IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, int offset, int fetch, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            foreach (var row in ClrEnumerableDefaults.OrderByWithFetchAndOffset(await Buffer(source, cancellationToken).ConfigureAwait(false), keySelector, comparator, offset, fetch))
-                yield return row;
+            if (fetch == 0)
+                return Empty<TSource>();
+
+            // linq4j reads the input into the tree map inside enumerator(). GetAsyncEnumerator cannot
+            // await, so only the acquisition half can move there: the source's enumerator is acquired
+            // eagerly, and the awaited drain -- the bounded sort and the offset trim -- waits for the
+            // first MoveNextAsync. The CLR imposes that; acquisition itself is eager.
+            return source.Acquiring((e, token) => OrderedRows(e, keySelector, comparator, offset, fetch));
+        }
+
+        /// <summary>
+        /// The drain and trim of <see cref="OrderByWithFetchAndOffset"/>, over an enumerator the factory
+        /// acquired: linq4j's bounded <c>java.util.TreeMap</c>, transcribed as the synchronous file's
+        /// <c>OrderedRows</c> transcribes it, holding at most <c>offset + fetch</c> rows.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> OrderedRows<TSource, TKey>(IAsyncEnumerator<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, int offset, int fetch)
+        {
+            var map = comparator == null ? new java.util.TreeMap() : new java.util.TreeMap(comparator);
+            var size = 0L;
+            var needed = fetch + (long)offset;
+
+            // read the input into a tree map
+            while (await source.MoveNextAsync())
+            {
+                var row = source.Current;
+                var key = (object?)keySelector(row);
+
+                if (needed >= 0 && size >= needed)
+                {
+                    // the current row will never appear in the output, so just skip it
+                    var lastKey = map.lastKey();
+                    if (Compare(comparator, key, lastKey) >= 0)
+                        continue;
+
+                    // remove last entry from tree map, so that we keep at most 'needed' rows
+                    var last = (List<TSource>)map.get(lastKey);
+                    if (last.Count == 1)
+                        map.remove(lastKey);
+                    else
+                        last.RemoveAt(last.Count - 1);
+
+                    size--;
+                }
+
+                // add the current element to the map
+                if (map.get(key) is List<TSource> held)
+                    held.Add(row);
+                else
+                    map.put(key, new List<TSource> { row });
+
+                size++;
+            }
+
+            // skip the first 'offset' rows by deleting them from the map
+            if (offset > 0)
+            {
+                // search the key up to (but excluding) which we have to remove entries from the map
+                var skipped = 0;
+                var found = false;
+                object? until = null;
+
+                for (var i = map.entrySet().iterator(); i.hasNext();)
+                {
+                    var entry = (java.util.Map.Entry)i.next();
+                    var rows = (List<TSource>)entry.getValue();
+                    skipped += rows.Count;
+
+                    if (skipped > offset)
+                    {
+                        // we might need to remove entries from the list
+                        var keep = skipped - offset;
+                        if (keep < rows.Count)
+                            rows.RemoveRange(0, rows.Count - keep);
+
+                        until = entry.getKey();
+                        found = true;
+                        break;
+                    }
+                }
+
+                // the offset is bigger than the number of rows in the map
+                if (found == false)
+                    yield break;
+
+                map.headMap(until, false).clear();
+            }
+
+            for (var i = map.values().iterator(); i.hasNext();)
+                foreach (var row in (List<TSource>)i.next())
+                    yield return row;
+        }
+
+        /// <summary>
+        /// Compares two keys the way the map holding them does.
+        /// </summary>
+        /// <remarks>
+        /// The comparator where there is one, which is every case Calcite reaches; the fallback matches
+        /// what a <c>TreeMap</c> built without one does -- order by the keys themselves. It goes through
+        /// <see cref="IComparable"/> rather than <c>java.lang.Comparable</c>, which is a ghost interface a
+        /// cast cannot reach from C#.
+        /// </remarks>
+        static int Compare(java.util.Comparator? comparator, object? x, object? y)
+        {
+            if (comparator != null)
+                return comparator.compare(x, y);
+
+            return Comparer<object>.Default.Compare(x, y);
         }
 
         /// <summary>
@@ -490,7 +680,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// Calcite collection. None of this map order escapes — a mark join emits in the outer input order —
         /// but the hashing has to be Java hashing, because the keys are Calcite values.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> LeftMarkHashJoin<TSource, TInner, TKey, TNsKey, TResult>(
+        public static IAsyncEnumerable<TResult> LeftMarkHashJoin<TSource, TInner, TKey, TNsKey, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeyNullAwareSelector,
@@ -503,34 +693,65 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             EqualityComparer? nullSafeComparer,
             Func<TSource, TInner, java.lang.Boolean?>? nonEquiPredicate,
             Func<TSource, TInner, java.lang.Boolean?> equiPredicate,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+            CancellationToken cancellationToken = default)
+        {
             ArgumentNullException.ThrowIfNull(outer);
             ArgumentNullException.ThrowIfNull(inner);
 
+            // leftMarkHashJoin builds its hash table inside enumerator() and acquires the probe side's
+            // enumerator there too. GetAsyncEnumerator cannot await, so only the acquisition half can move
+            // there: the probe enumerator is acquired eagerly, and the build drain -- which must await its
+            // input -- waits for the first MoveNextAsync. The CLR imposes that; acquisition itself is
+            // eager.
+            return outer.Acquiring((e, token) => LeftMarkHashJoinRows(
+                e, inner, outerKeyNullAwareSelector, innerKeyNullAwareSelector, outerNullSafeKeySelector,
+                innerNullSafeKeySelector, atMostOneNotNullSafeKey, resultSelector, comparer,
+                nullSafeComparer, nonEquiPredicate, equiPredicate, token));
+        }
+
+        /// <summary>
+        /// The build drain and probe loop of <see cref="LeftMarkHashJoin"/>, over an enumerator the
+        /// factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> LeftMarkHashJoinRows<TSource, TInner, TKey, TNsKey, TResult>(
+            IAsyncEnumerator<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeyNullAwareSelector,
+            Func<TInner, TKey> innerKeyNullAwareSelector,
+            Func<TSource, TNsKey>? outerNullSafeKeySelector,
+            Func<TInner, TNsKey>? innerNullSafeKeySelector,
+            bool atMostOneNotNullSafeKey,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
+            EqualityComparer? comparer,
+            EqualityComparer? nullSafeComparer,
+            Func<TSource, TInner, java.lang.Boolean?>? nonEquiPredicate,
+            Func<TSource, TInner, java.lang.Boolean?> equiPredicate,
+            CancellationToken cancellationToken)
+        {
             // the build side: one bucket per key, plus the set of null-safe keys seen. A null key goes into
             // the map under null rather than being dropped, because the rows behind it are what say UNKNOWN
             var lookup = new java.util.HashMap();
             var nullSafeKeys = new java.util.HashSet();
 
-            await foreach (var row in (inner).WithCancellation(cancellationToken))
+            await foreach (var innerRow in inner.WithCancellation(cancellationToken))
             {
-                var key = innerKeyNullAwareSelector(row);
-                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                var innerKey = innerKeyNullAwareSelector(innerRow);
+                var wrapped = innerKey == null ? null : JavaWrapped.Of(comparer, JavaValues.From(innerKey));
 
                 if (lookup.get(wrapped) is not List<TInner> bucket)
                     lookup.put(wrapped, bucket = []);
 
-                bucket.Add(row);
+                bucket.Add(innerRow);
 
                 if (innerNullSafeKeySelector != null)
-                    nullSafeKeys.add(JavaWrapped.Of(nullSafeComparer, JavaValues.From(innerNullSafeKeySelector(row))));
+                    nullSafeKeys.add(JavaWrapped.Of(nullSafeComparer, JavaValues.From(innerNullSafeKeySelector(innerRow))));
             }
 
             var buildSideIsEmpty = lookup.isEmpty();
 
-            await foreach (var row in (outer).WithCancellation(cancellationToken))
+            while (await outer.MoveNextAsync())
             {
+                var row = outer.Current;
                 java.lang.Boolean? marker = java.lang.Boolean.FALSE;
 
                 if (outerNullSafeKeySelector != null
@@ -666,7 +887,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// extra test — what "matched nothing" means is a key in one and a row in the other — so they are
         /// two methods rather than one with a null check inside the loop.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> HashJoin<TSource, TInner, TKey, TResult>(
+        public static IAsyncEnumerable<TResult> HashJoin<TSource, TInner, TKey, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
@@ -676,14 +897,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
             Func<TSource, TInner, bool>? predicate,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
-            var rows = predicate == null
-                ? HashEquiJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, generateNullsOnLeft, generateNullsOnRight, cancellationToken)
-                : HashJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, generateNullsOnLeft, generateNullsOnRight, predicate, cancellationToken);
-
-            await foreach (var row in rows.WithCancellation(cancellationToken))
-                yield return row;
+            CancellationToken cancellationToken = default)
+        {
+            return predicate == null
+                ? HashEquiJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, generateNullsOnLeft, generateNullsOnRight)
+                : HashJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer, generateNullsOnLeft, generateNullsOnRight, predicate);
         }
 
 
@@ -694,7 +912,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// The counterpart of <c>EnumerableDefaults.hashEquiJoin_</c>. What is left over at the end is a
         /// <em>key</em> no outer row carried, and every build row under it comes out together.
         /// </remarks>
-        static async IAsyncEnumerable<TResult> HashEquiJoin<TSource, TInner, TKey, TResult>(
+        static IAsyncEnumerable<TResult> HashEquiJoin<TSource, TInner, TKey, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
@@ -702,24 +920,48 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             Func<TSource?, TInner?, TResult> resultSelector,
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
+            bool generateNullsOnRight)
+        {
+            // hashEquiJoin_'s enumerator() drains the build side into the lookup and acquires the probe
+            // side's enumerator, both before the first moveNext. GetAsyncEnumerator cannot await, so only
+            // the acquisition half can move there: the probe enumerator is acquired eagerly, and the build
+            // drain -- which must await its input -- waits for the first MoveNextAsync. The CLR imposes
+            // that; acquisition itself is eager.
+            return outer.Acquiring((e, token) => HashEquiJoinRows(
+                e, inner, outerKeySelector, innerKeySelector, resultSelector, comparer,
+                generateNullsOnLeft, generateNullsOnRight, token));
+        }
+
+        /// <summary>
+        /// The build drain and probe loop of <see cref="HashEquiJoin"/>, over an enumerator the factory
+        /// acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> HashEquiJoinRows<TSource, TInner, TKey, TResult>(
+            IAsyncEnumerator<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
+            EqualityComparer? comparer,
+            bool generateNullsOnLeft,
             bool generateNullsOnRight,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             // the lookup is a java.util.HashMap, as linq4j's toLookup builds one: a right or a full join ends
             // with the rows of the right input that matched nothing, and the order those come out in is this
             // map's. See JavaHashingTests for why that order is the same in every process.
             var lookup = new java.util.HashMap();
 
-            await foreach (var row in inner.WithCancellation(cancellationToken))
+            await foreach (var innerRow in inner.WithCancellation(cancellationToken))
             {
-                var key = innerKeySelector(row);
+                var innerKey = innerKeySelector(innerRow);
 
                 // a null key is kept under a null key, as toLookup keeps one, and nothing probes it
-                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                var wrapped = innerKey == null ? null : JavaWrapped.Of(comparer, JavaValues.From(innerKey));
                 if (lookup.get(wrapped) is not List<TInner> bucket)
                     lookup.put(wrapped, bucket = []);
 
-                bucket.Add(row);
+                bucket.Add(innerRow);
             }
 
             // every key the build side has, less the ones an outer row carries. Calcite keeps it this way
@@ -727,8 +969,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // right or a full join owes against a null left.
             var unmatched = generateNullsOnLeft ? new java.util.HashSet(lookup.keySet()) : null;
 
-            await foreach (var row in outer.WithCancellation(cancellationToken))
+            while (await outer.MoveNextAsync())
             {
+                var row = outer.Current;
                 var key = outerKeySelector(row);
                 var any = false;
 
@@ -781,7 +1024,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// whose predicate did not has matched nothing, and a right join owes it a row against a null left.
         /// Tracking the key instead lost it, because some other row under that key had passed.</para>
         /// </remarks>
-        static async IAsyncEnumerable<TResult> HashJoinWithPredicate<TSource, TInner, TKey, TResult>(
+        static IAsyncEnumerable<TResult> HashJoinWithPredicate<TSource, TInner, TKey, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
@@ -790,29 +1033,55 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             EqualityComparer? comparer,
             bool generateNullsOnLeft,
             bool generateNullsOnRight,
+            Func<TSource, TInner, bool> predicate)
+        {
+            // hashJoinWithPredicate_'s enumerator() reads the build side, builds the lookup and the
+            // leftover list, and acquires the probe side's enumerator, all before the first moveNext.
+            // GetAsyncEnumerator cannot await, so only the acquisition half can move there: the probe
+            // enumerator is acquired eagerly, and the build read waits for the first MoveNextAsync. The
+            // CLR imposes that; acquisition itself is eager.
+            return outer.Acquiring((e, token) => HashJoinWithPredicateRows(
+                e, inner, outerKeySelector, innerKeySelector, resultSelector, comparer,
+                generateNullsOnLeft, generateNullsOnRight, predicate, token));
+        }
+
+        /// <summary>
+        /// The build read and probe loop of <see cref="HashJoinWithPredicate"/>, over an enumerator the
+        /// factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> HashJoinWithPredicateRows<TSource, TInner, TKey, TResult>(
+            IAsyncEnumerator<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
+            EqualityComparer? comparer,
+            bool generateNullsOnLeft,
+            bool generateNullsOnRight,
             Func<TSource, TInner, bool> predicate,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             // read once, because a right or a full join walks it twice
-            IReadOnlyList<TInner> innerToLookUp = await Buffer(inner, cancellationToken).ConfigureAwait(false);
+            IReadOnlyList<TInner> innerToLookUp = await Buffer(inner, cancellationToken);
 
             var lookup = new java.util.HashMap();
 
-            foreach (var row in innerToLookUp)
+            foreach (var innerRow in innerToLookUp)
             {
-                var key = innerKeySelector(row);
+                var innerKey = innerKeySelector(innerRow);
 
-                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                var wrapped = innerKey == null ? null : JavaWrapped.Of(comparer, JavaValues.From(innerKey));
                 if (lookup.get(wrapped) is not List<TInner> bucket)
                     lookup.put(wrapped, bucket = []);
 
-                bucket.Add(row);
+                bucket.Add(innerRow);
             }
 
             var unmatched = generateNullsOnLeft ? new List<TInner>(innerToLookUp) : null;
 
-            await foreach (var row in outer.WithCancellation(cancellationToken))
+            while (await outer.MoveNextAsync())
             {
+                var row = outer.Current;
                 var key = outerKeySelector(row);
                 var any = false;
 
@@ -874,8 +1143,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             CancellationToken cancellationToken = default)
         {
             return predicate == null
-                ? SemiEquiJoin(outer, inner, outerKeySelector, innerKeySelector, comparer, anti, cancellationToken)
-                : SemiJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, comparer, anti, predicate, cancellationToken);
+                ? SemiEquiJoin(outer, inner, outerKeySelector, innerKeySelector, comparer, anti)
+                : SemiJoinWithPredicate(outer, inner, outerKeySelector, innerKeySelector, comparer, anti, predicate);
         }
 
         /// <summary>
@@ -886,19 +1155,36 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <c>EnumerableDefaults.semiEquiJoin_</c>, the distinct keys rather than the rows, the two sets that
         /// keep the comparer off the membership test, and CALCITE-2909's memoization.
         /// </remarks>
-        static async IAsyncEnumerable<TSource> SemiEquiJoin<TSource, TInner, TKey>(
+        static IAsyncEnumerable<TSource> SemiEquiJoin<TSource, TInner, TKey>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
             EqualityComparer? comparer,
+            bool anti)
+        {
+            // semiEquiJoin_'s enumerator() acquires the outer enumerator eagerly; only the lookup is
+            // deferred, memoized to the first outer row per CALCITE-2909
+            return outer.Acquiring((e, token) => SemiEquiJoinRows(e, inner, outerKeySelector, innerKeySelector, comparer, anti, token));
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="SemiEquiJoin"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> SemiEquiJoinRows<TSource, TInner, TKey>(
+            IAsyncEnumerator<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
             bool anti,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             java.util.HashSet? keys = null;
 
-            await foreach (var row in outer.WithCancellation(cancellationToken))
+            while (await outer.MoveNextAsync())
             {
+                var row = outer.Current;
                 if (keys == null)
                 {
                     var distinct = new java.util.HashSet();
@@ -930,20 +1216,38 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <c>EnumerableDefaults.semiJoinWithPredicate_</c>, which holds the rows and does let the comparer
         /// reach the lookup.
         /// </remarks>
-        static async IAsyncEnumerable<TSource> SemiJoinWithPredicate<TSource, TInner, TKey>(
+        static IAsyncEnumerable<TSource> SemiJoinWithPredicate<TSource, TInner, TKey>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
             Func<TInner, TKey> innerKeySelector,
             EqualityComparer? comparer,
             bool anti,
+            Func<TSource, TInner, bool> predicate)
+        {
+            // semiJoinWithPredicate_'s enumerator() acquires the outer enumerator eagerly; only the
+            // lookup is deferred, memoized to the first outer row
+            return outer.Acquiring((e, token) => SemiJoinWithPredicateRows(e, inner, outerKeySelector, innerKeySelector, comparer, anti, predicate, token));
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="SemiJoinWithPredicate"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> SemiJoinWithPredicateRows<TSource, TInner, TKey>(
+            IAsyncEnumerator<TSource> outer,
+            IAsyncEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti,
             Func<TSource, TInner, bool> predicate,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             java.util.HashMap? lookup = null;
 
-            await foreach (var row in outer.WithCancellation(cancellationToken))
+            while (await outer.MoveNextAsync())
             {
+                var row = outer.Current;
                 if (lookup == null)
                 {
                     lookup = new java.util.HashMap();
@@ -1110,21 +1414,38 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// which is the whole point of it against <see cref="GroupBy"/>, and the groups come out in the
         /// order the input was sorted in rather than a map's.
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> SortedGroupBy<TSource, TKey, TResult>(
+        public static IAsyncEnumerable<TResult> SortedGroupBy<TSource, TKey, TResult>(
             IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Function0 accumulatorInitializer,
             Function2 accumulatorAdder,
             Function2 resultSelector,
             java.util.Comparator comparator,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+            CancellationToken cancellationToken = default)
+        {
+            // SortedAggregateEnumerator's constructor acquires enumerable.enumerator() -- acquisition at
+            // enumerator(), the walk at moveNext
+            return source.Acquiring((e, token) => SortedGroupByRows<TSource, TKey, TResult>(e, keySelector, accumulatorInitializer, accumulatorAdder, resultSelector, comparator));
+        }
+
+        /// <summary>
+        /// The group loop of <see cref="SortedGroupBy"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> SortedGroupByRows<TSource, TKey, TResult>(
+            IAsyncEnumerator<TSource> source,
+            Func<TSource, TKey> keySelector,
+            Function0 accumulatorInitializer,
+            Function2 accumulatorAdder,
+            Function2 resultSelector,
+            java.util.Comparator comparator)
+        {
             object? accumulator = null;
             object? previousKey = null;
             var any = false;
 
-            await foreach (var row in (source).WithCancellation(cancellationToken))
+            while (await source.MoveNextAsync())
             {
+                var row = source.Current;
                 var key = JavaValues.From(keySelector(row));
 
                 if (any && comparator.compare(previousKey, key) != 0)
@@ -1163,18 +1484,38 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// current key: the inputs are sorted, so a row that repeats one already emitted arrives before the
         /// key changes. That is Calcite's reasoning and its set is cleared the same way.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> MergeUnion<TSource, TKey>(
+        public static IAsyncEnumerable<TSource> MergeUnion<TSource, TKey>(
             java.util.List sources,
             Func<TSource, TKey> sortKeySelector,
             java.util.Comparator sortComparator,
             bool all,
             EqualityComparer? comparer,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
-            var inputs = new IAsyncEnumerator<TSource>[sources.size()];
-            for (int i = 0; i < inputs.Length; i++)
-                inputs[i] = ((IAsyncEnumerable<TSource>)sources.get(i)).GetAsyncEnumerator(cancellationToken);
+            CancellationToken cancellationToken = default)
+        {
+            // MergeUnionEnumerator's constructor acquires every input's enumerator -- acquisition at
+            // enumerator(), the initial positioning at the first moveNext
+            return new ClrAsyncEnumerable<TSource>(token =>
+            {
+                var inputs = new IAsyncEnumerator<TSource>[sources.size()];
+                for (int i = 0; i < inputs.Length; i++)
+                    inputs[i] = ((IAsyncEnumerable<TSource>)sources.get(i)).GetAsyncEnumerator(token);
 
+                // the owner disposes every input, moved or not; the loop no longer needs its own finally
+                return new AcquiredAsyncEnumerator<TSource>(
+                    MergeUnionRows(inputs, sortKeySelector, sortComparator, all, comparer), inputs);
+            });
+        }
+
+        /// <summary>
+        /// The merge loop of <see cref="MergeUnion"/>, over enumerators the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> MergeUnionRows<TSource, TKey>(
+            IAsyncEnumerator<TSource>[] inputs,
+            Func<TSource, TKey> sortKeySelector,
+            java.util.Comparator sortComparator,
+            bool all,
+            EqualityComparer? comparer)
+        {
             var current = new TSource[inputs.Length];
             var finished = new bool[inputs.Length];
             var active = inputs.Length;
@@ -1230,47 +1571,39 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 return sortComparator.compare(JavaValues.From(sortKeySelector(a)), JavaValues.From(sortKeySelector(b)));
             }
 
-            try
-            {
-                for (int i = 0; i < inputs.Length; i++)
-                    await Move(i);
+            for (int i = 0; i < inputs.Length; i++)
+                await Move(i);
 
-                while (active > 0)
+            while (active > 0)
+            {
+                var candidate = -1;
+                for (int i = 0; i < current.Length; i++)
                 {
-                    var candidate = -1;
-                    for (int i = 0; i < current.Length; i++)
+                    if (finished[i] == false)
                     {
-                        if (finished[i] == false)
-                        {
-                            candidate = i;
-                            break;
-                        }
+                        candidate = i;
+                        break;
                     }
-
-                    if (active > 1)
-                    {
-                        for (int i = candidate + 1; i < current.Length; i++)
-                        {
-                            if (finished[i])
-                                continue;
-
-                            if (Compare(current[candidate], current[i]) > 0)
-                                candidate = i;
-                        }
-                    }
-
-                    var value = current[candidate];
-                    var emit = NotDuplicated(value);
-                    await Move(candidate);
-
-                    if (emit)
-                        yield return value;
                 }
-            }
-            finally
-            {
-                foreach (var input in inputs)
-                    await input.DisposeAsync().ConfigureAwait(false);
+
+                if (active > 1)
+                {
+                    for (int i = candidate + 1; i < current.Length; i++)
+                    {
+                        if (finished[i])
+                            continue;
+
+                        if (Compare(current[candidate], current[i]) > 0)
+                            candidate = i;
+                    }
+                }
+
+                var value = current[candidate];
+                var emit = NotDuplicated(value);
+                await Move(candidate);
+
+                if (emit)
+                    yield return value;
             }
         }
 
@@ -1307,16 +1640,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="comparer">Decides whether two keys of one input are the same; null means they do.</param>
         /// <returns></returns>
         /// <remarks>
-        /// The counterpart of <c>EnumerableDefaults.mergeJoin</c>, statement for statement, as an iterator
-        /// rather than the enumerator with a state machine that Java needs. Both inputs are walked once and
-        /// only the rows of one key are held.
+        /// The counterpart of <c>EnumerableDefaults.mergeJoin</c>, statement for statement, holding its state
+        /// in <see cref="MergeJoinAsyncCursor{TSource, TInner, TKey, TResult}"/> the way linq4j's
+        /// <c>MergeJoinEnumerator</c> holds it. Both inputs are walked once and only the rows of one key are
+        /// held.
         ///
         /// <para>Two nulls must not compare equal, or a join of two null keys would return rows SQL says it
         /// does not. Calcite signals that out of its comparator by throwing, and catches it to advance the
         /// right side; the generated comparator this is called with is that comparator, so the same throw is
         /// caught here — by name, since the exception class is package private.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> MergeJoin<TSource, TInner, TKey, TResult>(
+        public static IAsyncEnumerable<TResult> MergeJoin<TSource, TInner, TKey, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TKey> outerKeySelector,
@@ -1326,31 +1660,88 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             org.apache.calcite.linq4j.JoinType joinType,
             java.util.Comparator? comparator,
             EqualityComparer? comparer,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+            CancellationToken cancellationToken = default)
+        {
             if (IsMergeJoinSupported(joinType) == false)
                 throw new java.lang.UnsupportedOperationException($"MergeJoin unsupported for join type {joinType}");
 
-            var name = joinType.name();
-            var isLeft = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
-            var isAnti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
-            var isSemi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
-            var isLeftOrAnti = isLeft || isAnti;
-            var equality = JavaEqualityComparer<TKey>.Of(comparer);
+            // MergeJoinEnumerator's constructor acquires both enumerators and calls start() -- the factory
+            // builds the cursor, whose constructor acquires both; the start() positioning is the one part
+            // the CLR will not let it keep, per the note on the cursor's row loop
+            return new ClrAsyncEnumerable<TResult>(token =>
+            {
+                var cursor = new MergeJoinAsyncCursor<TSource, TInner, TKey, TResult>(
+                    outer, inner, outerKeySelector, innerKeySelector, predicate, resultSelector, joinType, comparator, comparer, token);
 
-            var lefts = new List<TSource>();
-            var rights = new List<TInner>();
-            var done = false;
-            var remainingLeft = false;
-            IEnumerable<TResult>? results = null;
+                return new AcquiredAsyncEnumerator<TResult>(cursor.Rows(), cursor.LeftEnumerator, cursor.RightEnumerator);
+            });
+        }
 
-            await using var leftEnumerator = outer.GetAsyncEnumerator(cancellationToken);
-            await using var rightEnumerator = inner.GetAsyncEnumerator(cancellationToken);
+        /// <summary>
+        /// The state of one merge join: linq4j's <c>MergeJoinEnumerator</c>, with the fields its anonymous
+        /// class holds and the methods it dispatches. The constructor acquires both enumerators as linq4j's
+        /// does; the <c>start()</c> it also runs there cannot run here, per the note on <see cref="Rows"/>.
+        /// </summary>
+        sealed class MergeJoinAsyncCursor<TSource, TInner, TKey, TResult>
+        {
+
+            internal readonly IAsyncEnumerator<TSource> LeftEnumerator;
+            internal readonly IAsyncEnumerator<TInner> RightEnumerator;
+
+            readonly Func<TSource, TKey> outerKeySelector;
+            readonly Func<TInner, TKey> innerKeySelector;
+            readonly Func<TSource, TInner, bool>? predicate;
+            readonly Func<TSource?, TInner?, TResult> resultSelector;
+            readonly org.apache.calcite.linq4j.JoinType joinType;
+            readonly java.util.Comparator? comparator;
+            readonly IEqualityComparer<TKey> equality;
+
+            readonly bool isLeft;
+            readonly bool isAnti;
+            readonly bool isSemi;
+            readonly bool isLeftOrAnti;
+
+            readonly List<TSource> lefts = [];
+            readonly List<TInner> rights = [];
+            bool done;
+            bool remainingLeft;
+            IEnumerable<TResult>? results;
+
+            internal MergeJoinAsyncCursor(
+                IAsyncEnumerable<TSource> outer,
+                IAsyncEnumerable<TInner> inner,
+                Func<TSource, TKey> outerKeySelector,
+                Func<TInner, TKey> innerKeySelector,
+                Func<TSource, TInner, bool>? predicate,
+                Func<TSource?, TInner?, TResult> resultSelector,
+                org.apache.calcite.linq4j.JoinType joinType,
+                java.util.Comparator? comparator,
+                EqualityComparer? comparer,
+                CancellationToken cancellationToken)
+            {
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.predicate = predicate;
+                this.resultSelector = resultSelector;
+                this.joinType = joinType;
+                this.comparator = comparator;
+                this.equality = JavaEqualityComparer<TKey>.Of(comparer);
+
+                var name = joinType.name();
+                isLeft = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
+                isAnti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
+                isSemi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
+                isLeftOrAnti = isLeft || isAnti;
+
+                LeftEnumerator = outer.GetAsyncEnumerator(cancellationToken);
+                RightEnumerator = inner.GetAsyncEnumerator(cancellationToken);
+            }
 
             // the left enumerator advanced, and onto a row whose key is not null — a LEFT join reads its
             // left input to the end whatever the keys are, because every row of it is a result
-            async ValueTask<bool> LeftMoveNext() => await leftEnumerator.MoveNextAsync().ConfigureAwait(false) && (isLeft || outerKeySelector(leftEnumerator.Current) != null);
-            async ValueTask<bool> RightMoveNext() => await rightEnumerator.MoveNextAsync().ConfigureAwait(false) && innerKeySelector(rightEnumerator.Current) != null;
+            async ValueTask<bool> LeftMoveNext() => await LeftEnumerator.MoveNextAsync() && (isLeft || outerKeySelector(LeftEnumerator.Current) != null);
+
+            async ValueTask<bool> RightMoveNext() => await RightEnumerator.MoveNextAsync() && innerKeySelector(RightEnumerator.Current) != null;
 
             int Compare(TKey a, TKey b)
             {
@@ -1374,9 +1765,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 lefts.Clear();
                 lefts.Add(left);
 
-                while (await leftEnumerator.MoveNextAsync().ConfigureAwait(false))
+                while (await LeftEnumerator.MoveNextAsync())
                 {
-                    left = leftEnumerator.Current;
+                    left = LeftEnumerator.Current;
                     var leftKey2 = outerKeySelector(left);
                     if (leftKey2 == null && isLeft == false)
                         break;
@@ -1394,9 +1785,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 rights.Clear();
                 rights.Add(right);
 
-                while (await rightEnumerator.MoveNextAsync().ConfigureAwait(false))
+                while (await RightEnumerator.MoveNextAsync())
                 {
-                    right = rightEnumerator.Current;
+                    right = RightEnumerator.Current;
                     var rightKey2 = innerKeySelector(right);
                     if (rightKey2 == null)
                         break;
@@ -1414,9 +1805,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             {
                 while (true)
                 {
-                    var left = leftEnumerator.Current;
+                    var left = LeftEnumerator.Current;
                     var leftKey = outerKeySelector(left);
-                    var right = rightEnumerator.Current;
+                    var right = RightEnumerator.Current;
                     var rightKey = innerKeySelector(right);
 
                     while (true)
@@ -1464,18 +1855,18 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                                 return true;
                             }
 
-                            if (await leftEnumerator.MoveNextAsync().ConfigureAwait(false) == false)
+                            if (await LeftEnumerator.MoveNextAsync() == false)
                             {
                                 done = true;
                                 return false;
                             }
 
-                            left = leftEnumerator.Current;
+                            left = LeftEnumerator.Current;
                             leftKey = outerKeySelector(left);
                         }
                         else
                         {
-                            if (await rightEnumerator.MoveNextAsync().ConfigureAwait(false) == false)
+                            if (await RightEnumerator.MoveNextAsync() == false)
                             {
                                 if (isLeftOrAnti)
                                 {
@@ -1487,7 +1878,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                                 return false;
                             }
 
-                            right = rightEnumerator.Current;
+                            right = RightEnumerator.Current;
                             rightKey = innerKeySelector(right);
                         }
                     }
@@ -1532,49 +1923,59 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 }
             }
 
-            if (isLeftOrAnti)
+            /// <summary>
+            /// The row loop, positioning first and then continuing from the state that left.
+            /// </summary>
+            internal async IAsyncEnumerator<TResult> Rows()
             {
-                if (await LeftMoveNext() == false)
-                    done = true;
-                else if (await RightMoveNext() == false)
-                    remainingLeft = true;
-                else if (await Advance() == false)
-                    done = true;
-            }
-            else if (await LeftMoveNext() == false || await RightMoveNext() == false || await Advance() == false)
-            {
-                done = true;
-            }
-
-            while (true)
-            {
-                if (results != null)
+                // GetAsyncEnumerator cannot await, so the start() positioning linq4j runs at enumerator()
+                // waits for the first MoveNextAsync — a stated divergence the CLR imposes; acquisition
+                // itself is eager.
+                if (isLeftOrAnti)
                 {
-                    foreach (var row in results)
-                        yield return row;
-
-                    results = null;
+                    if (await LeftMoveNext() == false)
+                        done = true;
+                    else if (await RightMoveNext() == false)
+                        remainingLeft = true;
+                    else if (await Advance() == false)
+                        done = true;
+                }
+                else if (await LeftMoveNext() == false || await RightMoveNext() == false || await Advance() == false)
+                {
+                    done = true;
                 }
 
-                if (remainingLeft)
+                while (true)
                 {
-                    yield return resultSelector(leftEnumerator.Current, default);
-
-                    if (await LeftMoveNext() == false)
+                    if (results != null)
                     {
-                        remainingLeft = false;
-                        done = true;
+                        foreach (var row in results)
+                            yield return row;
+
+                        results = null;
                     }
 
-                    continue;
+                    if (remainingLeft)
+                    {
+                        yield return resultSelector(LeftEnumerator.Current, default);
+
+                        if (await LeftMoveNext() == false)
+                        {
+                            remainingLeft = false;
+                            done = true;
+                        }
+
+                        continue;
+                    }
+
+                    if (done)
+                        yield break;
+
+                    if (await Advance() == false)
+                        yield break;
                 }
-
-                if (done)
-                    yield break;
-
-                if (await Advance() == false)
-                    yield break;
             }
+
         }
 
 
@@ -1666,15 +2067,32 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// first, because the rest of the batch reads what it cached. Calcite does exactly that, for exactly
         /// that reason.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> CorrelateBatchJoin<TSource, TInner, TResult>(
+        public static IAsyncEnumerable<TResult> CorrelateBatchJoin<TSource, TInner, TResult>(
             org.apache.calcite.linq4j.JoinType joinType,
             IAsyncEnumerable<TSource> outer,
             Func<java.util.List, IAsyncEnumerable<TInner>> inner,
             Func<TSource?, TInner?, TResult> resultSelector,
             Func<TSource, TInner, bool> predicate,
             int batchSize,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+            CancellationToken cancellationToken = default)
+        {
+            // correlateBatchJoin acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each batch's right side is built and acquired at that batch's turn
+            return outer.Acquiring((e, token) => CorrelateBatchJoinRows(joinType, e, inner, resultSelector, predicate, batchSize, token));
+        }
+
+        /// <summary>
+        /// The batch loop of <see cref="CorrelateBatchJoin"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> CorrelateBatchJoinRows<TSource, TInner, TResult>(
+            org.apache.calcite.linq4j.JoinType joinType,
+            IAsyncEnumerator<TSource> enumerator,
+            Func<java.util.List, IAsyncEnumerable<TInner>> inner,
+            Func<TSource?, TInner?, TResult> resultSelector,
+            Func<TSource, TInner, bool> predicate,
+            int batchSize,
+            CancellationToken cancellationToken)
+        {
             var name = joinType.name();
             var isSemi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
             var isAnti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
@@ -1682,8 +2100,6 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             var batch = new List<TSource>(batchSize);
             var rows = new List<TInner>();
-
-            await using var enumerator = outer.GetAsyncEnumerator(cancellationToken);
 
             // the right rows of the batch being read, held across the batch's first left row because that is
             // the only one that pulls from it
@@ -1792,17 +2208,16 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// seen when there is no match is kept — which is what makes <c>IN</c> over a nullable column answer
         /// UNKNOWN rather than FALSE.
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> LeftMarkNestedLoopJoin<TSource, TInner, TResult>(
+        public static IAsyncEnumerable<TResult> LeftMarkNestedLoopJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             IAsyncEnumerable<TInner> inner,
             Func<TSource, TInner, java.lang.Boolean?> predicate,
             Func<TSource, java.lang.Boolean?, TResult> resultSelector,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+            CancellationToken cancellationToken = default)
+        {
             ArgumentNullException.ThrowIfNull(inner);
 
-            await foreach (var row in LeftMarkJoin(outer, _ => inner, predicate, resultSelector, cancellationToken).WithCancellation(cancellationToken))
-                yield return row;
+            return LeftMarkJoin(outer, _ => inner, predicate, resultSelector);
         }
 
 
@@ -1822,15 +2237,14 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// join, and the same walk as <see cref="LeftMarkNestedLoopJoin"/>. Calcite writes both against one
         /// <c>leftMarkJoinInternal</c>, and so does this.
         /// </remarks>
-        public static async IAsyncEnumerable<TResult> CorrelateLeftMarkJoin<TSource, TInner, TResult>(
+        public static IAsyncEnumerable<TResult> CorrelateLeftMarkJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             Func<TSource, IAsyncEnumerable<TInner>?> inner,
             Func<TSource, TInner, java.lang.Boolean?> predicate,
             Func<TSource, java.lang.Boolean?, TResult> resultSelector,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
-            await foreach (var row in LeftMarkJoin(outer, inner, predicate, resultSelector, cancellationToken).WithCancellation(cancellationToken))
-                yield return row;
+            CancellationToken cancellationToken = default)
+        {
+            return LeftMarkJoin(outer, inner, predicate, resultSelector);
         }
 
 
@@ -1848,20 +2262,35 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <remarks>
         /// The counterpart of <c>EnumerableDefaults.leftMarkJoinInternal</c>.
         /// </remarks>
-        static async IAsyncEnumerable<TResult> LeftMarkJoin<TSource, TInner, TResult>(
+        static IAsyncEnumerable<TResult> LeftMarkJoin<TSource, TInner, TResult>(
             IAsyncEnumerable<TSource> outer,
             Func<TSource, IAsyncEnumerable<TInner>?> inner,
             Func<TSource, TInner, java.lang.Boolean?> predicate,
-            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector)
         {
             ArgumentNullException.ThrowIfNull(outer);
             ArgumentNullException.ThrowIfNull(inner);
             ArgumentNullException.ThrowIfNull(predicate);
             ArgumentNullException.ThrowIfNull(resultSelector);
 
-            await foreach (var left in outer.WithCancellation(cancellationToken))
+            // leftMarkJoinInternal acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each right side is built and read at its left row's turn
+            return outer.Acquiring((e, token) => LeftMarkJoinRows(e, inner, predicate, resultSelector, token));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="LeftMarkJoin"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> LeftMarkJoinRows<TSource, TInner, TResult>(
+            IAsyncEnumerator<TSource> outer,
+            Func<TSource, IAsyncEnumerable<TInner>?> inner,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
+            CancellationToken cancellationToken)
+        {
+            while (await outer.MoveNextAsync())
             {
+                var left = outer.Current;
                 java.lang.Boolean? marker = java.lang.Boolean.FALSE;
                 var rows = inner(left);
 
@@ -2040,11 +2469,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
                 throw new ArgumentException($"JoinType {name} is unsupported");
 
-            return Walk(cancellationToken);
+            // nestedLoopJoinOptimized acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each inner enumerator is acquired at its outer row's turn, inside moveNext
+            return outer.Acquiring((e, token) => Walk(e, token));
 
-            async IAsyncEnumerable<TResult> Walk([EnumeratorCancellation] CancellationToken cancellationToken = default)
+            async IAsyncEnumerator<TResult> Walk(IAsyncEnumerator<TSource> outerEnumerator, CancellationToken cancellationToken)
             {
-                var outerEnumerator = outer.GetAsyncEnumerator(cancellationToken);
                 IAsyncEnumerator<TInner>? innerEnumerator = null;
                 var outerMatch = false;
                 var outerValue = default(TSource)!;
@@ -2058,12 +2488,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                         switch (state)
                         {
                             case 0:
-                                if (await outerEnumerator.MoveNextAsync().ConfigureAwait(false) == false)
+                                if (await outerEnumerator.MoveNextAsync() == false)
                                     yield break;
 
                                 outerValue = outerEnumerator.Current;
                                 if (innerEnumerator != null)
-                                    await innerEnumerator.DisposeAsync().ConfigureAwait(false);
+                                    await innerEnumerator.DisposeAsync();
                                 innerEnumerator = inner.GetAsyncEnumerator(cancellationToken);
                                 outerMatch = false;
                                 state = 1;
@@ -2118,9 +2548,9 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 }
                 finally
                 {
-                    await outerEnumerator.DisposeAsync().ConfigureAwait(false);
+                    // the factory's owner disposes the outer; the inner in flight is this loop's own
                     if (innerEnumerator != null)
-                        await innerEnumerator.DisposeAsync().ConfigureAwait(false);
+                        await innerEnumerator.DisposeAsync();
                 }
             }
         }
@@ -2161,16 +2591,19 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
                 throw new ArgumentException($"JoinType {name} is not valid for correlation");
 
-            return Walk(cancellationToken);
+            // correlateJoin acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each inner sequence is built and acquired at its outer row's turn
+            return outer.Acquiring((e, token) => Walk(e, token));
 
-            async IAsyncEnumerable<TResult> Walk([EnumeratorCancellation] CancellationToken cancellationToken = default)
+            async IAsyncEnumerator<TResult> Walk(IAsyncEnumerator<TSource> outerEnumerator, CancellationToken cancellationToken)
             {
                 var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
                 var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
                 var nullsOnRight = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
 
-                await foreach (var row in outer.WithCancellation(cancellationToken))
+                while (await outerEnumerator.MoveNextAsync())
                 {
+                    var row = outerEnumerator.Current;
                     var any = false;
 
                     await foreach (var other in (inner(row) ?? Empty<TInner>(cancellationToken)).WithCancellation(cancellationToken))
@@ -2581,18 +3014,28 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="source"></param>
         /// <param name="selector">Yields a linq4j sequence for one row, which is what Calcite builds here.</param>
         /// <returns></returns>
-        public static async IAsyncEnumerable<TResult> SelectMany<TSource, TResult>(IAsyncEnumerable<TSource> source, Function1 selector,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+        public static IAsyncEnumerable<TResult> SelectMany<TSource, TResult>(IAsyncEnumerable<TSource> source, Function1 selector,
+            CancellationToken cancellationToken = default)
+        {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(selector);
 
+            // selectMany acquires the source enumerator in a field initializer, which runs at
+            // enumerator(); each row's sequence is built and read at its turn, inside moveNext
+            return source.Acquiring((e, token) => SelectManyRows<TSource, TResult>(e, selector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="SelectMany"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TResult> SelectManyRows<TSource, TResult>(IAsyncEnumerator<TSource> source, Function1 selector)
+        {
             // the inner sequence is linq4j's, produced for one row by a generator of Calcite's, and it is
             // iterated synchronously on purpose: it is a value already in hand rather than a source, so
             // nothing about reading it can block. Awaiting it would mean an adapter over a Java sequence,
             // which is the async-over-sync this convention exists to refuse.
-            await foreach (var row in source.WithCancellation(cancellationToken))
-                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(row)))
+            while (await source.MoveNextAsync())
+                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(source.Current)))
                     yield return item;
         }
 
@@ -2611,16 +3054,27 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// yielded and the collection is replaced once the input is exhausted, so it holds one round rather
         /// than everything seen so far. That is what makes the next round of a recursive query read a delta.
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> LazyCollectionSpool<TSource>(java.util.Collection collection, IAsyncEnumerable<TSource> input,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
+        public static IAsyncEnumerable<TSource> LazyCollectionSpool<TSource>(java.util.Collection collection, IAsyncEnumerable<TSource> input,
+            CancellationToken cancellationToken = default)
+        {
             ArgumentNullException.ThrowIfNull(collection);
             ArgumentNullException.ThrowIfNull(input);
 
+            // lazyCollectionSpool acquires the input enumerator in a field initializer, which runs at
+            // enumerator(); the write-back still happens where the input exhausts
+            return input.Acquiring((e, token) => LazyCollectionSpoolRows(collection, e));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="LazyCollectionSpool"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> LazyCollectionSpoolRows<TSource>(java.util.Collection collection, IAsyncEnumerator<TSource> input)
+        {
             var buffer = new List<TSource>();
 
-            await foreach (var row in (input).WithCancellation(cancellationToken))
+            while (await input.MoveNextAsync())
             {
+                var row = input.Current;
                 buffer.Add(row);
                 yield return row;
             }
@@ -2628,7 +3082,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the collection belongs to the table, and what reads it back is Java — the interpreter, for a
             // transient table neither convention's scan will touch. So this is a boundary and it converts
             collection.clear();
-            foreach (var row in (buffer))
+            foreach (var row in buffer)
                 collection.add(JavaValues.From(row));
         }
 
@@ -2657,28 +3111,98 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// compares by reference; a row can never be that object, so a <see cref="bool"/> decides exactly what
         /// the reference comparison decides, without a cast that would be a lie about the row type.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> RepeatUnion<TSource>(IAsyncEnumerable<TSource> seed, IAsyncEnumerable<TSource> iteration, int iterationLimit, bool all, EqualityComparer? comparer, Action? cleanUp,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> RepeatUnion<TSource>(IAsyncEnumerable<TSource> seed, IAsyncEnumerable<TSource> iteration, int iterationLimit, bool all, EqualityComparer? comparer, Action? cleanUp,
+            CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(seed);
             ArgumentNullException.ThrowIfNull(iteration);
 
+            // repeatUnion acquires the seed enumerator in a field initializer, which runs at enumerator();
+            // the iterative part is acquired afresh each round. The state box is what close() reaches:
+            // linq4j runs the clean-up and closes both enumerators from close() whether or not a row was
+            // ever read, so the disposal lives with the state rather than in the loop's finally, which an
+            // unstarted iterator would never run.
+            return new ClrAsyncEnumerable<TSource>(token =>
+            {
+                var state = new RepeatUnionState<TSource>(seed.GetAsyncEnumerator(token), cleanUp);
+                return new AcquiredAsyncEnumerator<TSource>(RepeatUnionRows(state, iteration, iterationLimit, all, comparer, token), state);
+            });
+        }
+
+        /// <summary>
+        /// What linq4j's repeat union enumerator holds and what its <c>close()</c> releases: the clean-up
+        /// first, then the two enumerators, once.
+        /// </summary>
+        sealed class RepeatUnionState<TSource> : IAsyncDisposable
+        {
+
+            internal readonly IAsyncEnumerator<TSource> SeedEnumerator;
+            internal IAsyncEnumerator<TSource>? IterativeEnumerator;
+
+            readonly Action? _cleanUp;
+            bool _disposed;
+
+            internal RepeatUnionState(IAsyncEnumerator<TSource> seedEnumerator, Action? cleanUp)
+            {
+                SeedEnumerator = seedEnumerator;
+                _cleanUp = cleanUp;
+            }
+
+            /// <inheritdoc />
+            public async ValueTask DisposeAsync()
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+
+                // Calcite's `close()` in its order: the clean-up first, then the two enumerators
+                _cleanUp?.Invoke();
+                await SeedEnumerator.DisposeAsync().ConfigureAwait(false);
+                if (IterativeEnumerator != null)
+                    await IterativeEnumerator.DisposeAsync().ConfigureAwait(false);
+            }
+
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="RepeatUnion"/>, over the state the factory built.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> RepeatUnionRows<TSource>(RepeatUnionState<TSource> state, IAsyncEnumerable<TSource> iteration, int iterationLimit, bool all, EqualityComparer? comparer, CancellationToken cancellationToken)
+        {
             var processed = all ? null : new HashSet<TSource>(JavaEqualityComparer<TSource>.Of(comparer));
 
             // Calcite's `current == DUMMY`. Set false wherever `checkValue` passed and Calcite assigned
             // `current`, and back to true wherever Calcite put the sentinel back.
             var currentIsDummy = true;
 
-            // the seed enumerator is held for the whole life of the sequence, as Calcite holds it -- it is
-            // closed in `close()` and not when the seed runs out
-            var seedEnumerator = seed.GetAsyncEnumerator(cancellationToken);
-            IAsyncEnumerator<TSource>? iterativeEnumerator = null;
-
-            try
+            while (await state.SeedEnumerator.MoveNextAsync())
             {
-                while (await seedEnumerator.MoveNextAsync().ConfigureAwait(false))
+                var value = state.SeedEnumerator.Current;
+
+                if (processed == null || processed.Add(value))
                 {
-                    var value = seedEnumerator.Current;
+                    currentIsDummy = false;
+                    yield return value;
+                }
+            }
+
+            // The sentinel is NOT put back here, and that is Calcite's, not an oversight of the
+            // transcription. A seed that emitted a row leaves `current` holding that row, so the first
+            // iterative round to produce nothing does not stop the sequence -- it goes round once more,
+            // and only the second empty round stops it. A recursive query whose step reads the working
+            // table row by row cannot tell, because an empty table gives an empty round either way; one
+            // whose step aggregates -- COUNT(*) yields a row over no rows -- can, and does.
+            for (var currentIteration = 0; ; currentIteration++)
+            {
+                if (iterationLimit >= 0 && currentIteration == iterationLimit)
+                    yield break;
+
+                state.IterativeEnumerator = iteration.GetAsyncEnumerator(cancellationToken);
+
+                while (await state.IterativeEnumerator.MoveNextAsync())
+                {
+                    var value = state.IterativeEnumerator.Current;
 
                     if (processed == null || processed.Add(value))
                     {
@@ -2687,46 +3211,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     }
                 }
 
-                // The sentinel is NOT put back here, and that is Calcite's, not an oversight of the
-                // transcription. A seed that emitted a row leaves `current` holding that row, so the first
-                // iterative round to produce nothing does not stop the sequence -- it goes round once more,
-                // and only the second empty round stops it. A recursive query whose step reads the working
-                // table row by row cannot tell, because an empty table gives an empty round either way; one
-                // whose step aggregates -- COUNT(*) yields a row over no rows -- can, and does.
-                for (var currentIteration = 0; ; currentIteration++)
-                {
-                    if (iterationLimit >= 0 && currentIteration == iterationLimit)
-                        yield break;
+                if (currentIsDummy)
+                    yield break;
 
-                    iterativeEnumerator = iteration.GetAsyncEnumerator(cancellationToken);
-
-                    while (await iterativeEnumerator.MoveNextAsync().ConfigureAwait(false))
-                    {
-                        var value = iterativeEnumerator.Current;
-
-                        if (processed == null || processed.Add(value))
-                        {
-                            currentIsDummy = false;
-                            yield return value;
-                        }
-                    }
-
-                    if (currentIsDummy)
-                        yield break;
-
-                    currentIsDummy = true;
-                    await iterativeEnumerator.DisposeAsync().ConfigureAwait(false);
-                    iterativeEnumerator = null;
-                }
-            }
-            finally
-            {
-                // Calcite's `close()` in its order: the clean-up first, then the two enumerators. An await
-                // foreach would have disposed them first, which is the other way round.
-                cleanUp?.Invoke();
-                await seedEnumerator.DisposeAsync().ConfigureAwait(false);
-                if (iterativeEnumerator != null)
-                    await iterativeEnumerator.DisposeAsync().ConfigureAwait(false);
+                currentIsDummy = true;
+                await state.IterativeEnumerator.DisposeAsync();
+                state.IterativeEnumerator = null;
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -37,12 +37,22 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         {
             ArgumentNullException.ThrowIfNull(source);
 
+            // Enumerables.slice0 is select(elements -> elements[0]), and select acquires its source's
+            // enumerator inside enumerator() -- so obtaining this enumerator acquires the scan's
+            return source.Acquiring(e => Slice0Rows<TRow>(e));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Slice0"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TRow> Slice0Rows<TRow>(IEnumerator<object[]> source)
+        {
             // the row came from a table and its fields are still Java's, so the field taken out of it is
             // converted rather than cast. Calcite's slice0 is Enumerable<E[]> to Enumerable<E> and needs
             // neither: a linq4j Enumerable erases its element type, so nothing downstream can tell what came
             // out, and a CLR sequence says so in its own type.
-            foreach (var row in source)
-                yield return JavaValues.As<TRow>(row[0]);
+            while (source.MoveNext())
+                yield return JavaValues.As<TRow>(source.Current[0]);
         }
 
         /// <summary>
@@ -65,9 +75,19 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(selector);
 
-            foreach (var row in source)
-                if (predicate == null || predicate(row))
-                    yield return selector(row);
+            // the generated enumerator acquires its input in a field initializer, which runs at
+            // enumerator() -- so obtaining this enumerator acquires the input's
+            return source.Acquiring(e => CalcRows(e, predicate, selector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Calc"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TResult> CalcRows<TSource, TResult>(IEnumerator<TSource> source, Func<TSource, bool>? predicate, Func<TSource, TResult> selector)
+        {
+            while (source.MoveNext())
+                if (predicate == null || predicate(source.Current))
+                    yield return selector(source.Current);
         }
 
         /// <summary>
@@ -79,7 +99,22 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <returns></returns>
         public static IEnumerable<TSource> Where<TSource>(IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            return source.Where(predicate);
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            // EnumerableDefaults.where acquires source.enumerator() inside enumerator() -- not
+            // System.Linq's Where, whose iterator defers the acquisition to the first MoveNext
+            return source.Acquiring(e => WhereRows(e, predicate));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Where"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> WhereRows<TSource>(IEnumerator<TSource> source, Func<TSource, bool> predicate)
+        {
+            while (source.MoveNext())
+                if (predicate(source.Current))
+                    yield return source.Current;
         }
 
         /// <summary>
@@ -92,7 +127,21 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <returns></returns>
         public static IEnumerable<TResult> Select<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            return source.Select(selector);
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(selector);
+
+            // EnumerableDefaults.select acquires source.enumerator() in a field initializer, which runs at
+            // enumerator() -- not System.Linq's Select, whose iterator defers it to the first MoveNext
+            return source.Acquiring(e => SelectRows(e, selector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Select"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TResult> SelectRows<TSource, TResult>(IEnumerator<TSource> source, Func<TSource, TResult> selector)
+        {
+            while (source.MoveNext())
+                yield return selector(source.Current);
         }
 
         /// <summary>
@@ -111,9 +160,20 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </remarks>
         public static IEnumerable<TSource> OrderBy<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator)
         {
-            return comparator == null
-                ? source.OrderBy(keySelector)
-                : source.OrderBy(keySelector, Comparer<TKey>.Create((x, y) => comparator.compare(x, y)));
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(keySelector);
+
+            // EnumerableDefaults.orderBy drains its whole input into the TreeMap inside enumerator() --
+            // obtaining this enumerator runs the sort. The sort itself stays System.Linq's, which is stable
+            // exactly as the TreeMap-of-lists is; only when it runs moves.
+            return new ClrEnumerable<TSource>(() =>
+            {
+                var sorted = comparator == null
+                    ? source.OrderBy(keySelector).ToList()
+                    : source.OrderBy(keySelector, Comparer<TKey>.Create((x, y) => comparator.compare(x, y))).ToList();
+
+                return sorted.GetEnumerator();
+            });
         }
 
         /// <summary>
@@ -125,7 +185,30 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <returns></returns>
         public static IEnumerable<TSource> Skip<TSource>(IEnumerable<TSource> source, int count)
         {
-            return source.Skip(count);
+            ArgumentNullException.ThrowIfNull(source);
+
+            // EnumerableDefaults.skip is skipWhile over n < count, and SkipWhileEnumerator takes
+            // source.enumerator() eagerly -- acquisition at enumerator(), rows at moveNext
+            return source.Acquiring(e => SkipRows(e, count));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Skip"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> SkipRows<TSource>(IEnumerator<TSource> source, int count)
+        {
+            var n = 0;
+
+            while (source.MoveNext())
+            {
+                if (n < count)
+                {
+                    n++;
+                    continue;
+                }
+
+                yield return source.Current;
+            }
         }
 
         /// <summary>
@@ -151,12 +234,20 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            using var enumerator = source.GetEnumerator();
+            // TakeWhileLongEnumerator takes source.enumerator() eagerly -- acquisition at enumerator(),
+            // the drawn-but-untested row at moveNext
+            return source.Acquiring(e => TakeRows(e, count));
+        }
 
+        /// <summary>
+        /// The row loop of <see cref="Take"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> TakeRows<TSource>(IEnumerator<TSource> source, int count)
+        {
             var n = -1;
 
-            while (enumerator.MoveNext() && ++n < count)
-                yield return enumerator.Current;
+            while (source.MoveNext() && ++n < count)
+                yield return source.Current;
         }
 
         /// <summary>
@@ -166,6 +257,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="source"></param>
         /// <param name="other"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// System.Linq's, deliberately, because the timing matches: <c>Linq4j.CompositeEnumerable</c>'s
+        /// <c>enumerator()</c> acquires nothing of its sources — each is acquired at its turn inside
+        /// <c>moveNext</c> — and LINQ's <c>Concat</c> does the same. The one operator here whose deferral is
+        /// linq4j's own.
+        /// </remarks>
         public static IEnumerable<TSource> Concat<TSource>(IEnumerable<TSource> source, IEnumerable<TSource> other)
         {
             return source.Concat(other);
@@ -179,6 +276,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="other"></param>
         /// <param name="comparer"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// Drains both inputs <b>at the call</b>, not at <c>GetEnumerator</c>, and that is linq4j's own
+        /// timing: <c>EnumerableDefaults.union</c> runs <c>source0.into(set)</c> in the method body and
+        /// returns <c>Linq4j.asEnumerable(set)</c>. <c>intersect</c>, <c>except</c> and <c>distinct</c> are
+        /// the same shape, so all four here are. Re-enumerating one of these replays the snapshot, in
+        /// linq4j exactly as here — do not move the drain into an enumerator factory in the name of the
+        /// acquisition rule; that would be a divergence, not a fix.
+        /// </remarks>
         public static IEnumerable<TSource> Union<TSource>(IEnumerable<TSource> source, IEnumerable<TSource> other, EqualityComparer? comparer)
         {
             // a java.util.HashSet, and not because the CLR has nothing to hold rows in: what a set operator
@@ -329,29 +434,60 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(outer);
             ArgumentNullException.ThrowIfNull(inner);
 
-            // the build side: one bucket per key, plus the set of null-safe keys seen. A null key goes into
-            // the map under null rather than being dropped, because the rows behind it are what say UNKNOWN
-            var lookup = new java.util.HashMap();
-            var nullSafeKeys = new java.util.HashSet();
-
-            foreach (var row in inner)
+            // leftMarkHashJoin builds its hash table inside enumerator() -- HashTableWithNullSafeKeySet.build
+            // drains the build side there -- and the probe side's enumerator is acquired there too
+            return new ClrEnumerable<TResult>(() =>
             {
-                var key = innerKeyNullAwareSelector(row);
-                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                // the build side: one bucket per key, plus the set of null-safe keys seen. A null key goes
+                // into the map under null rather than being dropped, because the rows behind it are what say
+                // UNKNOWN
+                var lookup = new java.util.HashMap();
+                var nullSafeKeys = new java.util.HashSet();
 
-                if (lookup.get(wrapped) is not List<TInner> bucket)
-                    lookup.put(wrapped, bucket = []);
+                foreach (var row in inner)
+                {
+                    var key = innerKeyNullAwareSelector(row);
+                    var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
 
-                bucket.Add(row);
+                    if (lookup.get(wrapped) is not List<TInner> bucket)
+                        lookup.put(wrapped, bucket = []);
 
-                if (innerNullSafeKeySelector != null)
-                    nullSafeKeys.add(JavaWrapped.Of(nullSafeComparer, JavaValues.From(innerNullSafeKeySelector(row))));
-            }
+                    bucket.Add(row);
 
+                    if (innerNullSafeKeySelector != null)
+                        nullSafeKeys.add(JavaWrapped.Of(nullSafeComparer, JavaValues.From(innerNullSafeKeySelector(row))));
+                }
+
+                var e = outer.GetEnumerator();
+                return new AcquiredEnumerator<TResult>(
+                    LeftMarkHashJoinRows(
+                        e, outerKeyNullAwareSelector, outerNullSafeKeySelector, atMostOneNotNullSafeKey,
+                        resultSelector, comparer, nullSafeComparer, nonEquiPredicate, equiPredicate,
+                        lookup, nullSafeKeys), e);
+            });
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="LeftMarkHashJoin"/>, over the lookup the factory built.
+        /// </summary>
+        static IEnumerator<TResult> LeftMarkHashJoinRows<TSource, TInner, TKey, TNsKey, TResult>(
+            IEnumerator<TSource> outer,
+            Func<TSource, TKey> outerKeyNullAwareSelector,
+            Func<TSource, TNsKey>? outerNullSafeKeySelector,
+            bool atMostOneNotNullSafeKey,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector,
+            EqualityComparer? comparer,
+            EqualityComparer? nullSafeComparer,
+            Func<TSource, TInner, java.lang.Boolean?>? nonEquiPredicate,
+            Func<TSource, TInner, java.lang.Boolean?> equiPredicate,
+            java.util.HashMap lookup,
+            java.util.HashSet nullSafeKeys)
+        {
             var buildSideIsEmpty = lookup.isEmpty();
 
-            foreach (var row in outer)
+            while (outer.MoveNext())
             {
+                var row = outer.Current;
                 java.lang.Boolean? marker = java.lang.Boolean.FALSE;
 
                 if (outerNullSafeKeySelector != null
@@ -519,30 +655,53 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             bool generateNullsOnLeft,
             bool generateNullsOnRight)
         {
-            // the lookup is a java.util.HashMap, as linq4j's toLookup builds one: a right or a full join ends
-            // with the rows of the right input that matched nothing, and the order those come out in is this
-            // map's. See JavaHashingTests for why that order is the same in every process.
-            var lookup = new java.util.HashMap();
-
-            foreach (var row in inner)
+            // hashEquiJoin_'s enumerator() drains the build side into the lookup and acquires the probe
+            // side's enumerator, both before the first moveNext -- so does this factory
+            return new ClrEnumerable<TResult>(() =>
             {
-                var key = innerKeySelector(row);
+                // the lookup is a java.util.HashMap, as linq4j's toLookup builds one: a right or a full join
+                // ends with the rows of the right input that matched nothing, and the order those come out in
+                // is this map's. See JavaHashingTests for why that order is the same in every process.
+                var lookup = new java.util.HashMap();
 
-                // a null key is kept under a null key, as toLookup keeps one, and nothing probes it
-                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
-                if (lookup.get(wrapped) is not List<TInner> bucket)
-                    lookup.put(wrapped, bucket = []);
+                foreach (var row in inner)
+                {
+                    var key = innerKeySelector(row);
 
-                bucket.Add(row);
-            }
+                    // a null key is kept under a null key, as toLookup keeps one, and nothing probes it
+                    var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                    if (lookup.get(wrapped) is not List<TInner> bucket)
+                        lookup.put(wrapped, bucket = []);
 
-            // every key the build side has, less the ones an outer row carries. Calcite keeps it this way
-            // round, and it matters where the lookup holds a key nothing probes: that key's rows are what a
-            // right or a full join owes against a null left.
-            var unmatched = generateNullsOnLeft ? new java.util.HashSet(lookup.keySet()) : null;
+                    bucket.Add(row);
+                }
 
-            foreach (var row in outer)
+                // every key the build side has, less the ones an outer row carries. Calcite keeps it this way
+                // round, and it matters where the lookup holds a key nothing probes: that key's rows are what
+                // a right or a full join owes against a null left.
+                var unmatched = generateNullsOnLeft ? new java.util.HashSet(lookup.keySet()) : null;
+
+                var e = outer.GetEnumerator();
+                return new AcquiredEnumerator<TResult>(
+                    HashEquiJoinRows(e, outerKeySelector, resultSelector, comparer, generateNullsOnRight, lookup, unmatched), e);
+            });
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="HashEquiJoin"/>, over the lookup and enumerator the factory built.
+        /// </summary>
+        static IEnumerator<TResult> HashEquiJoinRows<TSource, TInner, TKey, TResult>(
+            IEnumerator<TSource> outer,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
+            EqualityComparer? comparer,
+            bool generateNullsOnRight,
+            java.util.HashMap lookup,
+            java.util.HashSet? unmatched)
+        {
+            while (outer.MoveNext())
             {
+                var row = outer.Current;
                 var key = outerKeySelector(row);
                 var any = false;
 
@@ -606,26 +765,52 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             bool generateNullsOnRight,
             Func<TSource, TInner, bool> predicate)
         {
-            // read once, because a right or a full join walks it twice
-            IEnumerable<TInner> innerToLookUp = generateNullsOnLeft ? new List<TInner>(inner) : inner;
-
-            var lookup = new java.util.HashMap();
-
-            foreach (var row in innerToLookUp)
+            // hashJoinWithPredicate_'s enumerator() reads the build side, builds the lookup and the
+            // leftover list, and acquires the probe side's enumerator, all before the first moveNext --
+            // so does this factory
+            return new ClrEnumerable<TResult>(() =>
             {
-                var key = innerKeySelector(row);
+                // read once, because a right or a full join walks it twice
+                IEnumerable<TInner> innerToLookUp = generateNullsOnLeft ? new List<TInner>(inner) : inner;
 
-                var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
-                if (lookup.get(wrapped) is not List<TInner> bucket)
-                    lookup.put(wrapped, bucket = []);
+                var lookup = new java.util.HashMap();
 
-                bucket.Add(row);
-            }
+                foreach (var row in innerToLookUp)
+                {
+                    var key = innerKeySelector(row);
 
-            var unmatched = generateNullsOnLeft ? new List<TInner>(innerToLookUp) : null;
+                    var wrapped = key == null ? null : JavaWrapped.Of(comparer, JavaValues.From(key));
+                    if (lookup.get(wrapped) is not List<TInner> bucket)
+                        lookup.put(wrapped, bucket = []);
 
-            foreach (var row in outer)
+                    bucket.Add(row);
+                }
+
+                var unmatched = generateNullsOnLeft ? new List<TInner>(innerToLookUp) : null;
+
+                var e = outer.GetEnumerator();
+                return new AcquiredEnumerator<TResult>(
+                    HashJoinWithPredicateRows(e, outerKeySelector, resultSelector, comparer, generateNullsOnRight, predicate, lookup, unmatched), e);
+            });
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="HashJoinWithPredicate"/>, over the lookup and enumerator the
+        /// factory built.
+        /// </summary>
+        static IEnumerator<TResult> HashJoinWithPredicateRows<TSource, TInner, TKey, TResult>(
+            IEnumerator<TSource> outer,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TSource?, TInner?, TResult> resultSelector,
+            EqualityComparer? comparer,
+            bool generateNullsOnRight,
+            Func<TSource, TInner, bool> predicate,
+            java.util.HashMap lookup,
+            List<TInner>? unmatched)
+        {
+            while (outer.MoveNext())
             {
+                var row = outer.Current;
                 var key = outerKeySelector(row);
                 var any = false;
 
@@ -716,10 +901,27 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             EqualityComparer? comparer,
             bool anti)
         {
+            // semiEquiJoin_'s enumerator() acquires the outer enumerator eagerly; only the lookup is
+            // deferred, per the CALCITE-2909 note below
+            return outer.Acquiring(e => SemiEquiJoinRows(e, inner, outerKeySelector, innerKeySelector, comparer, anti));
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="SemiEquiJoin"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> SemiEquiJoinRows<TSource, TInner, TKey>(
+            IEnumerator<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti)
+        {
             java.util.HashSet? keys = null;
 
-            foreach (var row in outer)
+            while (outer.MoveNext())
             {
+                var row = outer.Current;
                 if (keys == null)
                 {
                     var distinct = new java.util.HashSet();
@@ -760,10 +962,28 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             bool anti,
             Func<TSource, TInner, bool> predicate)
         {
+            // semiJoinWithPredicate_'s enumerator() acquires the outer enumerator eagerly; only the
+            // lookup is deferred, memoized to the first outer row
+            return outer.Acquiring(e => SemiJoinWithPredicateRows(e, inner, outerKeySelector, innerKeySelector, comparer, anti, predicate));
+        }
+
+        /// <summary>
+        /// The probe loop of <see cref="SemiJoinWithPredicate"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> SemiJoinWithPredicateRows<TSource, TInner, TKey>(
+            IEnumerator<TSource> outer,
+            IEnumerable<TInner> inner,
+            Func<TSource, TKey> outerKeySelector,
+            Func<TInner, TKey> innerKeySelector,
+            EqualityComparer? comparer,
+            bool anti,
+            Func<TSource, TInner, bool> predicate)
+        {
             java.util.HashMap? lookup = null;
 
-            foreach (var row in outer)
+            while (outer.MoveNext())
             {
+                var row = outer.Current;
                 if (lookup == null)
                 {
                     lookup = new java.util.HashMap();
@@ -938,12 +1158,29 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             Function2 resultSelector,
             java.util.Comparator comparator)
         {
+            // SortedAggregateEnumerator's constructor acquires enumerable.enumerator() -- acquisition at
+            // enumerator(), the walk at moveNext
+            return source.Acquiring(e => SortedGroupByRows<TSource, TKey, TResult>(e, keySelector, accumulatorInitializer, accumulatorAdder, resultSelector, comparator));
+        }
+
+        /// <summary>
+        /// The group loop of <see cref="SortedGroupBy"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TResult> SortedGroupByRows<TSource, TKey, TResult>(
+            IEnumerator<TSource> source,
+            Func<TSource, TKey> keySelector,
+            Function0 accumulatorInitializer,
+            Function2 accumulatorAdder,
+            Function2 resultSelector,
+            java.util.Comparator comparator)
+        {
             object? accumulator = null;
             object? previousKey = null;
             var any = false;
 
-            foreach (var row in source)
+            while (source.MoveNext())
             {
+                var row = source.Current;
                 var key = JavaValues.From(keySelector(row));
 
                 if (any && comparator.compare(previousKey, key) != 0)
@@ -988,10 +1225,30 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             bool all,
             EqualityComparer? comparer)
         {
-            var inputs = new IEnumerator<TSource>[sources.size()];
-            for (int i = 0; i < inputs.Length; i++)
-                inputs[i] = ((IEnumerable<TSource>)sources.get(i)).GetEnumerator();
+            // MergeUnionEnumerator's constructor acquires every input's enumerator -- acquisition at
+            // enumerator(), the initial positioning at the first moveNext
+            return new ClrEnumerable<TSource>(() =>
+            {
+                var inputs = new IEnumerator<TSource>[sources.size()];
+                for (int i = 0; i < inputs.Length; i++)
+                    inputs[i] = ((IEnumerable<TSource>)sources.get(i)).GetEnumerator();
 
+                // the owner disposes every input, moved or not; the loop no longer needs its own finally
+                return new AcquiredEnumerator<TSource>(
+                    MergeUnionRows(inputs, sortKeySelector, sortComparator, all, comparer), inputs);
+            });
+        }
+
+        /// <summary>
+        /// The merge loop of <see cref="MergeUnion"/>, over enumerators the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> MergeUnionRows<TSource, TKey>(
+            IEnumerator<TSource>[] inputs,
+            Func<TSource, TKey> sortKeySelector,
+            java.util.Comparator sortComparator,
+            bool all,
+            EqualityComparer? comparer)
+        {
             var current = new TSource[inputs.Length];
             var finished = new bool[inputs.Length];
             var active = inputs.Length;
@@ -1047,47 +1304,39 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 return sortComparator.compare(JavaValues.From(sortKeySelector(a)), JavaValues.From(sortKeySelector(b)));
             }
 
-            try
-            {
-                for (int i = 0; i < inputs.Length; i++)
-                    Move(i);
+            for (int i = 0; i < inputs.Length; i++)
+                Move(i);
 
-                while (active > 0)
+            while (active > 0)
+            {
+                var candidate = -1;
+                for (int i = 0; i < current.Length; i++)
                 {
-                    var candidate = -1;
-                    for (int i = 0; i < current.Length; i++)
+                    if (finished[i] == false)
                     {
-                        if (finished[i] == false)
-                        {
-                            candidate = i;
-                            break;
-                        }
+                        candidate = i;
+                        break;
                     }
-
-                    if (active > 1)
-                    {
-                        for (int i = candidate + 1; i < current.Length; i++)
-                        {
-                            if (finished[i])
-                                continue;
-
-                            if (Compare(current[candidate], current[i]) > 0)
-                                candidate = i;
-                        }
-                    }
-
-                    var value = current[candidate];
-                    var emit = NotDuplicated(value);
-                    Move(candidate);
-
-                    if (emit)
-                        yield return value;
                 }
-            }
-            finally
-            {
-                foreach (var input in inputs)
-                    input.Dispose();
+
+                if (active > 1)
+                {
+                    for (int i = candidate + 1; i < current.Length; i++)
+                    {
+                        if (finished[i])
+                            continue;
+
+                        if (Compare(current[candidate], current[i]) > 0)
+                            candidate = i;
+                    }
+                }
+
+                var value = current[candidate];
+                var emit = NotDuplicated(value);
+                Move(candidate);
+
+                if (emit)
+                    yield return value;
             }
         }
 
@@ -1122,9 +1371,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="comparer">Decides whether two keys of one input are the same; null means they do.</param>
         /// <returns></returns>
         /// <remarks>
-        /// The counterpart of <c>EnumerableDefaults.mergeJoin</c>, statement for statement, as an iterator
-        /// rather than the enumerator with a state machine that Java needs. Both inputs are walked once and
-        /// only the rows of one key are held.
+        /// The counterpart of <c>EnumerableDefaults.mergeJoin</c>, statement for statement, holding its state
+        /// in <see cref="MergeJoinCursor{TSource, TInner, TKey, TResult}"/> the way linq4j's
+        /// <c>MergeJoinEnumerator</c> holds it. Both inputs are walked once and only the rows of one key are
+        /// held.
         ///
         /// <para>Two nulls must not compare equal, or a join of two null keys would return rows SQL says it
         /// does not. Calcite signals that out of its comparator by throwing, and catches it to advance the
@@ -1145,26 +1395,96 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             if (IsMergeJoinSupported(joinType) == false)
                 throw new java.lang.UnsupportedOperationException($"MergeJoin unsupported for join type {joinType}");
 
-            var name = joinType.name();
-            var isLeft = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
-            var isAnti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
-            var isSemi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
-            var isLeftOrAnti = isLeft || isAnti;
-            var equality = JavaEqualityComparer<TKey>.Of(comparer);
+            // MergeJoinEnumerator's constructor acquires both enumerators and calls start(), which
+            // positions both cursors -- so the factory builds the cursor, and obtaining this enumerator
+            // reads each input as far as its first key run, exactly as linq4j's does
+            return new ClrEnumerable<TResult>(() =>
+            {
+                var cursor = new MergeJoinCursor<TSource, TInner, TKey, TResult>(
+                    outer, inner, outerKeySelector, innerKeySelector, predicate, resultSelector, joinType, comparator, comparer);
 
-            var lefts = new List<TSource>();
-            var rights = new List<TInner>();
-            var done = false;
-            var remainingLeft = false;
-            IEnumerable<TResult>? results = null;
+                return new AcquiredEnumerator<TResult>(cursor.Rows(), cursor.LeftEnumerator, cursor.RightEnumerator);
+            });
+        }
 
-            using var leftEnumerator = outer.GetEnumerator();
-            using var rightEnumerator = inner.GetEnumerator();
+        /// <summary>
+        /// The state of one merge join: linq4j's <c>MergeJoinEnumerator</c>, with the fields its anonymous
+        /// class holds and the methods it dispatches, and the same constructor-time <c>start()</c>.
+        /// </summary>
+        sealed class MergeJoinCursor<TSource, TInner, TKey, TResult>
+        {
+
+            internal readonly IEnumerator<TSource> LeftEnumerator;
+            internal readonly IEnumerator<TInner> RightEnumerator;
+
+            readonly Func<TSource, TKey> outerKeySelector;
+            readonly Func<TInner, TKey> innerKeySelector;
+            readonly Func<TSource, TInner, bool>? predicate;
+            readonly Func<TSource?, TInner?, TResult> resultSelector;
+            readonly org.apache.calcite.linq4j.JoinType joinType;
+            readonly java.util.Comparator? comparator;
+            readonly IEqualityComparer<TKey> equality;
+
+            readonly bool isLeft;
+            readonly bool isAnti;
+            readonly bool isSemi;
+            readonly bool isLeftOrAnti;
+
+            readonly List<TSource> lefts = [];
+            readonly List<TInner> rights = [];
+            bool done;
+            bool remainingLeft;
+            IEnumerable<TResult>? results;
+
+            internal MergeJoinCursor(
+                IEnumerable<TSource> outer,
+                IEnumerable<TInner> inner,
+                Func<TSource, TKey> outerKeySelector,
+                Func<TInner, TKey> innerKeySelector,
+                Func<TSource, TInner, bool>? predicate,
+                Func<TSource?, TInner?, TResult> resultSelector,
+                org.apache.calcite.linq4j.JoinType joinType,
+                java.util.Comparator? comparator,
+                EqualityComparer? comparer)
+            {
+                this.outerKeySelector = outerKeySelector;
+                this.innerKeySelector = innerKeySelector;
+                this.predicate = predicate;
+                this.resultSelector = resultSelector;
+                this.joinType = joinType;
+                this.comparator = comparator;
+                this.equality = JavaEqualityComparer<TKey>.Of(comparer);
+
+                var name = joinType.name();
+                isLeft = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
+                isAnti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
+                isSemi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
+                isLeftOrAnti = isLeft || isAnti;
+
+                LeftEnumerator = outer.GetEnumerator();
+                RightEnumerator = inner.GetEnumerator();
+
+                // start(): position both cursors and settle the initial state
+                if (isLeftOrAnti)
+                {
+                    if (LeftMoveNext() == false)
+                        done = true;
+                    else if (RightMoveNext() == false)
+                        remainingLeft = true;
+                    else if (Advance() == false)
+                        done = true;
+                }
+                else if (LeftMoveNext() == false || RightMoveNext() == false || Advance() == false)
+                {
+                    done = true;
+                }
+            }
 
             // the left enumerator advanced, and onto a row whose key is not null — a LEFT join reads its
             // left input to the end whatever the keys are, because every row of it is a result
-            bool LeftMoveNext() => leftEnumerator.MoveNext() && (isLeft || outerKeySelector(leftEnumerator.Current) != null);
-            bool RightMoveNext() => rightEnumerator.MoveNext() && innerKeySelector(rightEnumerator.Current) != null;
+            bool LeftMoveNext() => LeftEnumerator.MoveNext() && (isLeft || outerKeySelector(LeftEnumerator.Current) != null);
+
+            bool RightMoveNext() => RightEnumerator.MoveNext() && innerKeySelector(RightEnumerator.Current) != null;
 
             int Compare(TKey a, TKey b)
             {
@@ -1188,9 +1508,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 lefts.Clear();
                 lefts.Add(left);
 
-                while (leftEnumerator.MoveNext())
+                while (LeftEnumerator.MoveNext())
                 {
-                    left = leftEnumerator.Current;
+                    left = LeftEnumerator.Current;
                     var leftKey2 = outerKeySelector(left);
                     if (leftKey2 == null && isLeft == false)
                         break;
@@ -1208,9 +1528,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 rights.Clear();
                 rights.Add(right);
 
-                while (rightEnumerator.MoveNext())
+                while (RightEnumerator.MoveNext())
                 {
-                    right = rightEnumerator.Current;
+                    right = RightEnumerator.Current;
                     var rightKey2 = innerKeySelector(right);
                     if (rightKey2 == null)
                         break;
@@ -1228,9 +1548,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             {
                 while (true)
                 {
-                    var left = leftEnumerator.Current;
+                    var left = LeftEnumerator.Current;
                     var leftKey = outerKeySelector(left);
-                    var right = rightEnumerator.Current;
+                    var right = RightEnumerator.Current;
                     var rightKey = innerKeySelector(right);
 
                     while (true)
@@ -1278,18 +1598,18 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                                 return true;
                             }
 
-                            if (leftEnumerator.MoveNext() == false)
+                            if (LeftEnumerator.MoveNext() == false)
                             {
                                 done = true;
                                 return false;
                             }
 
-                            left = leftEnumerator.Current;
+                            left = LeftEnumerator.Current;
                             leftKey = outerKeySelector(left);
                         }
                         else
                         {
-                            if (rightEnumerator.MoveNext() == false)
+                            if (RightEnumerator.MoveNext() == false)
                             {
                                 if (isLeftOrAnti)
                                 {
@@ -1301,7 +1621,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                                 return false;
                             }
 
-                            right = rightEnumerator.Current;
+                            right = RightEnumerator.Current;
                             rightKey = innerKeySelector(right);
                         }
                     }
@@ -1346,49 +1666,42 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
             }
 
-            if (isLeftOrAnti)
+            /// <summary>
+            /// The row loop, continuing from the state <c>start()</c> left.
+            /// </summary>
+            internal IEnumerator<TResult> Rows()
             {
-                if (LeftMoveNext() == false)
-                    done = true;
-                else if (RightMoveNext() == false)
-                    remainingLeft = true;
-                else if (Advance() == false)
-                    done = true;
-            }
-            else if (LeftMoveNext() == false || RightMoveNext() == false || Advance() == false)
-            {
-                done = true;
-            }
-
-            while (true)
-            {
-                if (results != null)
+                while (true)
                 {
-                    foreach (var row in results)
-                        yield return row;
-
-                    results = null;
-                }
-
-                if (remainingLeft)
-                {
-                    yield return resultSelector(leftEnumerator.Current, default);
-
-                    if (LeftMoveNext() == false)
+                    if (results != null)
                     {
-                        remainingLeft = false;
-                        done = true;
+                        foreach (var row in results)
+                            yield return row;
+
+                        results = null;
                     }
 
-                    continue;
+                    if (remainingLeft)
+                    {
+                        yield return resultSelector(LeftEnumerator.Current, default);
+
+                        if (LeftMoveNext() == false)
+                        {
+                            remainingLeft = false;
+                            done = true;
+                        }
+
+                        continue;
+                    }
+
+                    if (done)
+                        yield break;
+
+                    if (Advance() == false)
+                        yield break;
                 }
-
-                if (done)
-                    yield break;
-
-                if (Advance() == false)
-                    yield break;
             }
+
         }
 
         /// <summary>
@@ -1487,6 +1800,22 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             Func<TSource, TInner, bool> predicate,
             int batchSize)
         {
+            // correlateBatchJoin acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each batch's right side is built and acquired at that batch's turn
+            return outer.Acquiring(e => CorrelateBatchJoinRows(joinType, e, inner, resultSelector, predicate, batchSize));
+        }
+
+        /// <summary>
+        /// The batch loop of <see cref="CorrelateBatchJoin"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TResult> CorrelateBatchJoinRows<TSource, TInner, TResult>(
+            org.apache.calcite.linq4j.JoinType joinType,
+            IEnumerator<TSource> enumerator,
+            Func<java.util.List, IEnumerable<TInner>> inner,
+            Func<TSource?, TInner?, TResult> resultSelector,
+            Func<TSource, TInner, bool> predicate,
+            int batchSize)
+        {
             var name = joinType.name();
             var isSemi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
             var isAnti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
@@ -1494,8 +1823,6 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var batch = new List<TSource>(batchSize);
             var rows = new List<TInner>();
-
-            using var enumerator = outer.GetEnumerator();
 
             // the right rows of the batch being read, held across the batch's first left row because that is
             // the only one that pulls from it
@@ -1662,8 +1989,23 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(predicate);
             ArgumentNullException.ThrowIfNull(resultSelector);
 
-            foreach (var left in outer)
+            // leftMarkJoinInternal acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each right side is built and read at its left row's turn
+            return outer.Acquiring(e => LeftMarkJoinRows(e, inner, predicate, resultSelector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="LeftMarkJoin"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TResult> LeftMarkJoinRows<TSource, TInner, TResult>(
+            IEnumerator<TSource> outer,
+            Func<TSource, IEnumerable<TInner>?> inner,
+            Func<TSource, TInner, java.lang.Boolean?> predicate,
+            Func<TSource, java.lang.Boolean?, TResult> resultSelector)
+        {
+            while (outer.MoveNext())
             {
+                var left = outer.Current;
                 java.lang.Boolean? marker = java.lang.Boolean.FALSE;
                 var rows = inner(left);
 
@@ -1854,11 +2196,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
                 throw new ArgumentException($"JoinType {name} is unsupported");
 
-            return Walk();
+            // nestedLoopJoinOptimized acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each inner enumerator is acquired at its outer row's turn, inside moveNext
+            return outer.Acquiring(e => Walk(e));
 
-            IEnumerable<TResult> Walk()
+            IEnumerator<TResult> Walk(IEnumerator<TSource> outerEnumerator)
             {
-                var outerEnumerator = outer.GetEnumerator();
                 IEnumerator<TInner>? innerEnumerator = null;
                 var outerMatch = false; // whether the outerValue has matched an innerValue
                 var outerValue = default(TSource)!;
@@ -1936,7 +2279,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 }
                 finally
                 {
-                    outerEnumerator.Dispose();
+                    // the factory's owner disposes the outer; the inner in flight is this loop's own
                     innerEnumerator?.Dispose();
                 }
             }
@@ -1977,16 +2320,19 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             if (name is nameof(org.apache.calcite.linq4j.JoinType.RIGHT) or nameof(org.apache.calcite.linq4j.JoinType.FULL))
                 throw new ArgumentException($"JoinType {name} is not valid for correlation");
 
-            return Walk();
+            // correlateJoin acquires the outer enumerator in a field initializer, which runs at
+            // enumerator(); each inner sequence is built and acquired at its outer row's turn
+            return outer.Acquiring(e => Walk(e));
 
-            IEnumerable<TResult> Walk()
+            IEnumerator<TResult> Walk(IEnumerator<TSource> outerEnumerator)
             {
                 var semi = name == nameof(org.apache.calcite.linq4j.JoinType.SEMI);
                 var anti = name == nameof(org.apache.calcite.linq4j.JoinType.ANTI);
                 var nullsOnRight = name == nameof(org.apache.calcite.linq4j.JoinType.LEFT);
 
-                foreach (var row in outer)
+                while (outerEnumerator.MoveNext())
                 {
+                    var row = outerEnumerator.Current;
                     var any = false;
 
                     foreach (var other in inner(row) ?? [])
@@ -2422,8 +2768,18 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(selector);
 
-            foreach (var row in source)
-                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(row)))
+            // selectMany acquires the source enumerator in a field initializer, which runs at
+            // enumerator(); each row's sequence is built and acquired at its turn, inside moveNext
+            return source.Acquiring(e => SelectManyRows<TSource, TResult>(e, selector));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="SelectMany"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TResult> SelectManyRows<TSource, TResult>(IEnumerator<TSource> source, Function1 selector)
+        {
+            while (source.MoveNext())
+                foreach (var item in JavaSequences.FromJava<TResult>((org.apache.calcite.linq4j.Enumerable)selector.apply(source.Current)))
                     yield return item;
         }
 
@@ -2489,6 +2845,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </remarks>
         static IEnumerable<TSource> Ordered<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, int offset, int fetch)
         {
+            // linq4j reads the input into the tree map inside enumerator() -- obtaining this enumerator
+            // runs the bounded sort, and the offset trim with it
+            return new ClrEnumerable<TSource>(() => OrderedRows(source, keySelector, comparator, offset, fetch));
+        }
+
+        /// <summary>
+        /// The drain and trim of <see cref="Ordered"/>, run by the factory, returning an enumerator over
+        /// the finished map.
+        /// </summary>
+        static IEnumerator<TSource> OrderedRows<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, java.util.Comparator? comparator, int offset, int fetch)
+        {
             var map = comparator == null ? new java.util.TreeMap() : new java.util.TreeMap(comparator);
             var size = 0L;
             var needed = fetch + (long)offset;
@@ -2553,11 +2920,19 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
                 // the offset is bigger than the number of rows in the map
                 if (found == false)
-                    yield break;
+                    return System.Linq.Enumerable.Empty<TSource>().GetEnumerator();
 
                 map.headMap(until, false).clear();
             }
 
+            return WalkOrdered<TSource>(map);
+        }
+
+        /// <summary>
+        /// Walks the finished map's values in order.
+        /// </summary>
+        static IEnumerator<TSource> WalkOrdered<TSource>(java.util.TreeMap map)
+        {
             for (var i = map.values().iterator(); i.hasNext();)
                 foreach (var row in (List<TSource>)i.next())
                     yield return row;
@@ -2655,10 +3030,21 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(collection);
             ArgumentNullException.ThrowIfNull(input);
 
+            // lazyCollectionSpool acquires the input enumerator in a field initializer, which runs at
+            // enumerator(); the write-back still happens where the input exhausts
+            return input.Acquiring(e => LazyCollectionSpoolRows(collection, e));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="LazyCollectionSpool"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> LazyCollectionSpoolRows<TSource>(java.util.Collection collection, IEnumerator<TSource> input)
+        {
             var buffer = new List<TSource>();
 
-            foreach (var row in input)
+            while (input.MoveNext())
             {
+                var row = input.Current;
                 buffer.Add(row);
                 yield return row;
             }
@@ -2699,22 +3085,91 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ArgumentNullException.ThrowIfNull(seed);
             ArgumentNullException.ThrowIfNull(iteration);
 
+            // repeatUnion acquires the seed enumerator in a field initializer, which runs at enumerator();
+            // the iterative part is acquired afresh each round. The state box is what close() reaches:
+            // linq4j runs the clean-up and closes both enumerators from close() whether or not a row was
+            // ever read, so the disposal lives with the state rather than in the loop's finally, which an
+            // unstarted iterator would never run.
+            return new ClrEnumerable<TSource>(() =>
+            {
+                var state = new RepeatUnionState<TSource>(seed.GetEnumerator(), cleanUp);
+                return new AcquiredEnumerator<TSource>(RepeatUnionRows(state, iteration, iterationLimit, all, comparer), state);
+            });
+        }
+
+        /// <summary>
+        /// What linq4j's repeat union enumerator holds and what its <c>close()</c> releases: the clean-up
+        /// first, then the two enumerators, once.
+        /// </summary>
+        sealed class RepeatUnionState<TSource> : IDisposable
+        {
+
+            internal readonly IEnumerator<TSource> SeedEnumerator;
+            internal IEnumerator<TSource>? IterativeEnumerator;
+
+            readonly Action? _cleanUp;
+            bool _disposed;
+
+            internal RepeatUnionState(IEnumerator<TSource> seedEnumerator, Action? cleanUp)
+            {
+                SeedEnumerator = seedEnumerator;
+                _cleanUp = cleanUp;
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+
+                // Calcite's `close()` in its order: the clean-up first, then the two enumerators
+                _cleanUp?.Invoke();
+                SeedEnumerator.Dispose();
+                IterativeEnumerator?.Dispose();
+            }
+
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="RepeatUnion"/>, over the state the factory built.
+        /// </summary>
+        static IEnumerator<TSource> RepeatUnionRows<TSource>(RepeatUnionState<TSource> state, IEnumerable<TSource> iteration, int iterationLimit, bool all, EqualityComparer? comparer)
+        {
             var processed = all ? null : new HashSet<TSource>(JavaEqualityComparer<TSource>.Of(comparer));
 
             // Calcite's `current == DUMMY`. Set false wherever `checkValue` passed and Calcite assigned
             // `current`, and back to true wherever Calcite put the sentinel back.
             var currentIsDummy = true;
 
-            // the seed enumerator is held for the whole life of the sequence, as Calcite holds it -- it is
-            // closed in `close()` and not when the seed runs out
-            var seedEnumerator = seed.GetEnumerator();
-            IEnumerator<TSource>? iterativeEnumerator = null;
-
-            try
+            while (state.SeedEnumerator.MoveNext())
             {
-                while (seedEnumerator.MoveNext())
+                var value = state.SeedEnumerator.Current;
+
+                if (processed == null || processed.Add(value))
                 {
-                    var value = seedEnumerator.Current;
+                    currentIsDummy = false;
+                    yield return value;
+                }
+            }
+
+            // The sentinel is NOT put back here, and that is Calcite's, not an oversight of the
+            // transcription. A seed that emitted a row leaves `current` holding that row, so the first
+            // iterative round to produce nothing does not stop the sequence -- it goes round once more,
+            // and only the second empty round stops it. A recursive query whose step reads the working
+            // table row by row cannot tell, because an empty table gives an empty round either way; one
+            // whose step aggregates -- COUNT(*) yields a row over no rows -- can, and does.
+            for (var currentIteration = 0; ; currentIteration++)
+            {
+                if (iterationLimit >= 0 && currentIteration == iterationLimit)
+                    yield break;
+
+                state.IterativeEnumerator = iteration.GetEnumerator();
+
+                while (state.IterativeEnumerator.MoveNext())
+                {
+                    var value = state.IterativeEnumerator.Current;
 
                     if (processed == null || processed.Add(value))
                     {
@@ -2723,45 +3178,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     }
                 }
 
-                // The sentinel is NOT put back here, and that is Calcite's, not an oversight of the
-                // transcription. A seed that emitted a row leaves `current` holding that row, so the first
-                // iterative round to produce nothing does not stop the sequence -- it goes round once more,
-                // and only the second empty round stops it. A recursive query whose step reads the working
-                // table row by row cannot tell, because an empty table gives an empty round either way; one
-                // whose step aggregates -- COUNT(*) yields a row over no rows -- can, and does.
-                for (var currentIteration = 0; ; currentIteration++)
-                {
-                    if (iterationLimit >= 0 && currentIteration == iterationLimit)
-                        yield break;
+                if (currentIsDummy)
+                    yield break;
 
-                    iterativeEnumerator = iteration.GetEnumerator();
-
-                    while (iterativeEnumerator.MoveNext())
-                    {
-                        var value = iterativeEnumerator.Current;
-
-                        if (processed == null || processed.Add(value))
-                        {
-                            currentIsDummy = false;
-                            yield return value;
-                        }
-                    }
-
-                    if (currentIsDummy)
-                        yield break;
-
-                    currentIsDummy = true;
-                    iterativeEnumerator.Dispose();
-                    iterativeEnumerator = null;
-                }
-            }
-            finally
-            {
-                // Calcite's `close()` in its order: the clean-up first, then the two enumerators. A foreach
-                // would have disposed them first, which is the other way round.
-                cleanUp?.Invoke();
-                seedEnumerator.Dispose();
-                iterativeEnumerator?.Dispose();
+                currentIsDummy = true;
+                state.IterativeEnumerator.Dispose();
+                state.IterativeEnumerator = null;
             }
         }
 

--- a/src/Apache.Calcite.Extensions/Interop/JavaSequences.cs
+++ b/src/Apache.Calcite.Extensions/Interop/JavaSequences.cs
@@ -38,17 +38,35 @@ namespace Apache.Calcite.Extensions.Interop
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            var enumerator = source.enumerator();
+            // a linq4j sub-plan executes at enumerator() -- ResultSetEnumerable runs its JDBC statement
+            // there, AdoReaderEnumerable its DbCommand -- so the crossing calls it where the rest of the
+            // plan's acquisition happens: at GetEnumerator, closed by the owner whether or not a row was
+            // ever read
+            return new Runtime.ClrEnumerable<TSource>(() =>
+            {
+                var enumerator = source.enumerator();
+                return new Runtime.AcquiredEnumerator<TSource>(FromJavaRows<TSource>(enumerator), new JavaCloseable(enumerator));
+            });
+        }
 
-            try
-            {
-                while (enumerator.moveNext())
-                    yield return JavaValues.As<TSource>(enumerator.current());
-            }
-            finally
-            {
-                enumerator.close();
-            }
+        /// <summary>
+        /// The row loop of <see cref="FromJava"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> FromJavaRows<TSource>(org.apache.calcite.linq4j.Enumerator enumerator)
+        {
+            while (enumerator.moveNext())
+                yield return JavaValues.As<TSource>(enumerator.current());
+        }
+
+        /// <summary>
+        /// Closes a linq4j enumerator from a disposal.
+        /// </summary>
+        sealed class JavaCloseable(org.apache.calcite.linq4j.Enumerator enumerator) : IDisposable
+        {
+
+            /// <inheritdoc />
+            public void Dispose() => enumerator.close();
+
         }
 
         /// <summary>
@@ -68,27 +86,50 @@ namespace Apache.Calcite.Extensions.Interop
         /// convention refuses, which is a caller blocked waiting. A plan reading a Calcite sub-plan this way
         /// is simply not asynchronous over that part of itself, and cannot be.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> FromJavaAsync<TSource>(org.apache.calcite.linq4j.Enumerable source, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> FromJavaAsync<TSource>(org.apache.calcite.linq4j.Enumerable source, System.Threading.CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            var enumerator = source.enumerator();
-
-            try
+            // enumerator() runs at GetAsyncEnumerator for the reason FromJava gives; the token that
+            // matters is GetAsyncEnumerator's, which is the one the parameter used to combine with and
+            // every generated call site passes default for
+            return new Runtime.ClrAsyncEnumerable<TSource>(token =>
             {
-                while (enumerator.moveNext())
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
+                var enumerator = source.enumerator();
+                return new Runtime.AcquiredAsyncEnumerator<TSource>(FromJavaAsyncRows<TSource>(enumerator, token), new AsyncJavaCloseable(enumerator));
+            });
+        }
 
-                    yield return JavaValues.As<TSource>(enumerator.current());
-                }
-            }
-            finally
+        /// <summary>
+        /// The row loop of <see cref="FromJavaAsync"/>, over an enumerator the factory acquired. Nothing
+        /// here suspends, and that is the honest shape of it: the source is pulled, and an asynchronous
+        /// sequence that always completes synchronously costs a state machine and no thread.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> FromJavaAsyncRows<TSource>(org.apache.calcite.linq4j.Enumerator enumerator, System.Threading.CancellationToken cancellationToken)
+        {
+            while (enumerator.moveNext())
             {
-                enumerator.close();
+                cancellationToken.ThrowIfCancellationRequested();
+
+                yield return JavaValues.As<TSource>(enumerator.current());
             }
 
             await System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Closes a linq4j enumerator from an asynchronous disposal, which completes synchronously.
+        /// </summary>
+        sealed class AsyncJavaCloseable(org.apache.calcite.linq4j.Enumerator enumerator) : IAsyncDisposable
+        {
+
+            /// <inheritdoc />
+            public System.Threading.Tasks.ValueTask DisposeAsync()
+            {
+                enumerator.close();
+                return default;
+            }
+
         }
 
 

--- a/src/Apache.Calcite.Extensions/Runtime/ClrEnumerables.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/ClrEnumerables.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Apache.Calcite.Extensions.Runtime
+{
+
+    /// <summary>
+    /// The shorthand for the operators' dominant shape: acquire the source's enumerator at
+    /// <c>GetEnumerator</c>, hand it to a row loop, own its disposal.
+    /// </summary>
+    static class ClrEnumerables
+    {
+
+        /// <summary>
+        /// Returns a sequence whose <c>GetEnumerator</c> acquires <paramref name="source"/>'s enumerator,
+        /// as linq4j's operators acquire theirs inside <c>enumerator()</c>, and hands it to
+        /// <paramref name="rows"/>. The acquired enumerator is disposed whether or not the loop ever ran.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="rows">Builds the row loop over the acquired enumerator.</param>
+        /// <returns></returns>
+        internal static IEnumerable<TResult> Acquiring<TSource, TResult>(this IEnumerable<TSource> source, Func<IEnumerator<TSource>, IEnumerator<TResult>> rows)
+        {
+            return new ClrEnumerable<TResult>(() =>
+            {
+                var e = source.GetEnumerator();
+                return new AcquiredEnumerator<TResult>(rows(e), e);
+            });
+        }
+
+        /// <summary>
+        /// <see cref="Acquiring{TSource, TResult}(IEnumerable{TSource}, Func{IEnumerator{TSource}, IEnumerator{TResult}})"/>
+        /// for the asynchronous convention: the token enters at <c>GetAsyncEnumerator</c>, where .NET puts
+        /// it, and is handed on to the loop.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="rows">Builds the row loop over the acquired enumerator and the caller's token.</param>
+        /// <returns></returns>
+        internal static IAsyncEnumerable<TResult> Acquiring<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<IAsyncEnumerator<TSource>, CancellationToken, IAsyncEnumerator<TResult>> rows)
+        {
+            return new ClrAsyncEnumerable<TResult>(cancellationToken =>
+            {
+                var e = source.GetAsyncEnumerator(cancellationToken);
+                return new AcquiredAsyncEnumerator<TResult>(rows(e, cancellationToken), e);
+            });
+        }
+
+    }
+
+    /// <summary>
+    /// A sequence whose <see cref="IEnumerable{T}.GetEnumerator"/> runs a factory.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of linq4j's <c>AbstractEnumerable</c>, and the seam the whole convention's
+    /// execution model hangs on: linq4j runs a plan by obtaining its enumerator — <c>where</c> acquires
+    /// its source's enumerator inside <c>enumerator()</c>, <c>orderBy</c> drains its whole input there,
+    /// and the JDBC leaf executes its statement there — and <c>moveNext</c> only reads rows. A C#
+    /// iterator method cannot say that: it defers everything, acquisition included, to the first
+    /// <c>MoveNext</c>. So an operator builds one of these, and puts in the factory exactly what linq4j
+    /// puts in <c>enumerator()</c>.
+    ///
+    /// <para>Where linq4j defers deliberately — the CALCITE-2909 memoized join lookups — the factory
+    /// defers the same way, and says so at the site. Deferral is the marked exception, not the
+    /// default.</para>
+    /// </remarks>
+    sealed class ClrEnumerable<T> : IEnumerable<T>
+    {
+
+        readonly Func<IEnumerator<T>> _factory;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="factory">Runs once per <see cref="GetEnumerator"/>, exactly as linq4j's
+        /// <c>enumerator()</c> runs once per call.</param>
+        public ClrEnumerable(Func<IEnumerator<T>> factory)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+
+            _factory = factory;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<T> GetEnumerator() => _factory();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    }
+
+    /// <summary>
+    /// An enumerator over a row loop, owning the enumerators the factory acquired for it.
+    /// </summary>
+    /// <remarks>
+    /// The row loop is a C# iterator, and disposing one that never moved runs none of its
+    /// <c>finally</c> blocks — so an enumerator the factory acquired eagerly would leak if the loop
+    /// were trusted to dispose it. This owns them instead: <see cref="Dispose"/> disposes the loop and
+    /// then each acquired enumerator, unconditionally, which is linq4j's <c>close()</c> contract — a
+    /// wrapping <c>Enumerator</c> closes its source whether or not a row was ever read.
+    /// </remarks>
+    sealed class AcquiredEnumerator<T> : IEnumerator<T>
+    {
+
+        readonly IEnumerator<T> _rows;
+        readonly IDisposable?[] _acquired;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="rows">The row loop, reading from the acquired enumerators.</param>
+        /// <param name="acquired">What the factory acquired, disposed after the loop, in order.</param>
+        public AcquiredEnumerator(IEnumerator<T> rows, params IDisposable?[] acquired)
+        {
+            ArgumentNullException.ThrowIfNull(rows);
+            ArgumentNullException.ThrowIfNull(acquired);
+
+            _rows = rows;
+            _acquired = acquired;
+        }
+
+        /// <inheritdoc />
+        public T Current => _rows.Current;
+
+        /// <inheritdoc />
+        object? IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public bool MoveNext() => _rows.MoveNext();
+
+        /// <inheritdoc />
+        public void Reset() => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            try
+            {
+                _rows.Dispose();
+            }
+            finally
+            {
+                foreach (var acquired in _acquired)
+                    acquired?.Dispose();
+            }
+        }
+
+    }
+
+    /// <summary>
+    /// An asynchronous sequence whose <see cref="IAsyncEnumerable{T}.GetAsyncEnumerator"/> runs a
+    /// factory.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ClrEnumerable{T}"/> for the asynchronous convention, with the one difference the CLR
+    /// imposes: <c>GetAsyncEnumerator</c> cannot await, so a factory acquires its source enumerators —
+    /// acquisition is synchronous all the way down — but work that must await, a sort's drain above
+    /// all, stays in the first <c>MoveNextAsync</c> and is stated at the site. linq4j has no
+    /// asynchronous counterpart to transcribe; the contract mirrored is the synchronous one's, less
+    /// what an <c>IAsyncEnumerable</c> cannot say.
+    /// </remarks>
+    sealed class ClrAsyncEnumerable<T> : IAsyncEnumerable<T>
+    {
+
+        readonly Func<CancellationToken, IAsyncEnumerator<T>> _factory;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="factory">Runs once per <see cref="GetAsyncEnumerator"/>.</param>
+        public ClrAsyncEnumerable(Func<CancellationToken, IAsyncEnumerator<T>> factory)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+
+            _factory = factory;
+        }
+
+        /// <inheritdoc />
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) => _factory(cancellationToken);
+
+    }
+
+    /// <summary>
+    /// An asynchronous enumerator over a row loop, owning the enumerators the factory acquired for it.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AcquiredEnumerator{T}"/> for the asynchronous convention: disposing an async
+    /// iterator that never moved runs none of its <c>finally</c> blocks, so what the factory acquired
+    /// is disposed here, unconditionally.
+    /// </remarks>
+    sealed class AcquiredAsyncEnumerator<T> : IAsyncEnumerator<T>
+    {
+
+        readonly IAsyncEnumerator<T> _rows;
+        readonly IAsyncDisposable?[] _acquired;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="rows">The row loop, reading from the acquired enumerators.</param>
+        /// <param name="acquired">What the factory acquired, disposed after the loop, in order.</param>
+        public AcquiredAsyncEnumerator(IAsyncEnumerator<T> rows, params IAsyncDisposable?[] acquired)
+        {
+            ArgumentNullException.ThrowIfNull(rows);
+            ArgumentNullException.ThrowIfNull(acquired);
+
+            _rows = rows;
+            _acquired = acquired;
+        }
+
+        /// <inheritdoc />
+        public T Current => _rows.Current;
+
+        /// <inheritdoc />
+        public ValueTask<bool> MoveNextAsync() => _rows.MoveNextAsync();
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await _rows.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                foreach (var acquired in _acquired)
+                    if (acquired is not null)
+                        await acquired.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Runtime/ClrSequences.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/ClrSequences.cs
@@ -59,17 +59,35 @@ namespace Apache.Calcite.Extensions.Runtime
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            var enumerator = source.GetAsyncEnumerator(CancellationToken.None);
+            // acquisition is synchronous even on an asynchronous sequence -- GetAsyncEnumerator cannot
+            // await -- so the crossing acquires where the synchronous side's acquisition arrives, at
+            // GetEnumerator, and the owner block-disposes whether or not a row was ever read
+            return new ClrEnumerable<TSource>(() =>
+            {
+                var enumerator = source.GetAsyncEnumerator(CancellationToken.None);
+                return new AcquiredEnumerator<TSource>(ToEnumerableRows(enumerator), new BlockingDisposal<TSource>(enumerator));
+            });
+        }
 
-            try
-            {
-                while (BlockMoveNext(enumerator))
-                    yield return enumerator.Current;
-            }
-            finally
-            {
-                BlockDispose(enumerator);
-            }
+        /// <summary>
+        /// The row loop of <see cref="ToEnumerable{TSource}"/>, over an enumerator the factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> ToEnumerableRows<TSource>(IAsyncEnumerator<TSource> enumerator)
+        {
+            while (BlockMoveNext(enumerator))
+                yield return enumerator.Current;
+        }
+
+        /// <summary>
+        /// Disposes the acquired asynchronous enumerator by blocking for its disposal, with the context
+        /// suppressed before the call, as every wait here is.
+        /// </summary>
+        sealed class BlockingDisposal<TSource>(IAsyncEnumerator<TSource> enumerator) : IDisposable
+        {
+
+            /// <inheritdoc />
+            public void Dispose() => BlockDispose(enumerator);
+
         }
 
         /// <summary>
@@ -180,18 +198,51 @@ namespace Apache.Calcite.Extensions.Runtime
         /// <para>The trailing <c>await</c> is what makes the compiler accept an async iterator that has
         /// nothing to await, as <c>FromJavaAsync</c> does for the same reason.</para>
         /// </remarks>
-        public static async IAsyncEnumerable<TSource> ToAsyncEnumerable<TSource>(IEnumerable<TSource> source, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public static IAsyncEnumerable<TSource> ToAsyncEnumerable<TSource>(IEnumerable<TSource> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            foreach (var row in source)
+            // the synchronous sub-plan's whole acquisition cascade runs at its GetEnumerator -- a scan
+            // opens, a sort drains -- so the crossing acquires it at GetAsyncEnumerator, where the
+            // asynchronous side's acquisition arrives. The token that matters is GetAsyncEnumerator's;
+            // every generated call site passes default for the parameter.
+            return new ClrAsyncEnumerable<TSource>(token =>
+            {
+                var e = source.GetEnumerator();
+                return new AcquiredAsyncEnumerator<TSource>(ToAsyncEnumerableRows(e, token), new SynchronousDisposal(e));
+            });
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="ToAsyncEnumerable{TSource}"/>, over an enumerator the factory
+        /// acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> ToAsyncEnumerableRows<TSource>(IEnumerator<TSource> source, CancellationToken cancellationToken)
+        {
+            while (source.MoveNext())
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                yield return row;
+                yield return source.Current;
             }
 
             await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Disposes the acquired synchronous enumerator from an asynchronous disposal, which completes
+        /// synchronously.
+        /// </summary>
+        sealed class SynchronousDisposal(IDisposable disposable) : IAsyncDisposable
+        {
+
+            /// <inheritdoc />
+            public ValueTask DisposeAsync()
+            {
+                disposable.Dispose();
+                return default;
+            }
+
         }
 
     }

--- a/src/Apache.Calcite.Tests/AcquisitionTimingTests.cs
+++ b/src/Apache.Calcite.Tests/AcquisitionTimingTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Apache.Calcite.Data;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.rel.type;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Obtaining an enumerator runs the plan; reading pulls rows.
+    /// </summary>
+    /// <remarks>
+    /// linq4j's contract, transcribed into both conventions: an operator's <c>enumerator()</c> acquires its
+    /// source's enumerator — a sort drains its input there, a linq4j leaf executes its statement there —
+    /// and <c>moveNext</c> only reads. The provider obtains the enumerator at Execute, so Execute is where
+    /// the plan runs. These tests read a counting table's two numbers apart:
+    /// <c>EnumeratorCalls</c> says whether the leaf was <em>acquired</em>, and <c>Produced</c> says how many
+    /// rows were <em>read</em> — and it is the gap between the two that the whole rewrite is about. A suite
+    /// that only compared answers could never see it.
+    /// </remarks>
+    [TestClass]
+    public class AcquisitionTimingTests
+    {
+
+        const string Model =
+            "Model=inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]};Schema=adhoc";
+
+        const string SynchronousModel = Model + ";Synchronous=true";
+
+        /// <summary>
+        /// A <c>ScannableTable</c> of three rows that counts how often its enumerator is acquired and how
+        /// many rows it has produced.
+        /// </summary>
+        sealed class CountingTable : org.apache.calcite.schema.impl.AbstractTable, org.apache.calcite.schema.ScannableTable
+        {
+
+            /// <summary>
+            /// How many times <c>scan</c>'s enumerable was asked for an enumerator.
+            /// </summary>
+            public int EnumeratorCalls;
+
+            /// <summary>
+            /// How many rows have been read out of it, across every enumerator.
+            /// </summary>
+            public int Produced;
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder().add("ID", org.apache.calcite.sql.type.SqlTypeName.INTEGER).build();
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(org.apache.calcite.DataContext root)
+            {
+                return new CountingEnumerable(this);
+            }
+
+        }
+
+        sealed class CountingEnumerable(CountingTable table) : org.apache.calcite.linq4j.AbstractEnumerable
+        {
+
+            /// <inheritdoc />
+            public override org.apache.calcite.linq4j.Enumerator enumerator()
+            {
+                table.EnumeratorCalls++;
+                return new CountingEnumerator(table);
+            }
+
+        }
+
+        sealed class CountingEnumerator(CountingTable table) : org.apache.calcite.linq4j.Enumerator
+        {
+
+            static readonly object[][] Rows =
+            [
+                [java.lang.Integer.valueOf(1)],
+                [java.lang.Integer.valueOf(2)],
+                [java.lang.Integer.valueOf(3)],
+            ];
+
+            int _index = -1;
+
+            /// <inheritdoc />
+            public object? current() => Rows[_index];
+
+            /// <inheritdoc />
+            public bool moveNext()
+            {
+                if (_index + 1 >= Rows.Length)
+                    return false;
+
+                _index++;
+                table.Produced++;
+                return true;
+            }
+
+            /// <inheritdoc />
+            public void reset() => _index = -1;
+
+            /// <inheritdoc />
+            public void close()
+            {
+
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+
+            }
+
+        }
+
+        static (CalciteConnection Connection, CountingTable Table) Open(string model)
+        {
+            var c = new CalciteConnection(model);
+            c.Open();
+
+            var table = new CountingTable();
+            c.RootSchema.add("T", table);
+
+            return (c, table);
+        }
+
+        /// <summary>
+        /// A synchronous plan's Execute acquires the leaf without reading a row.
+        /// </summary>
+        [TestMethod]
+        public void ExecuteShouldAcquireTheLeafWithoutReading()
+        {
+            var (c, table) = Open(SynchronousModel);
+            using (c)
+            {
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "SELECT ID FROM T WHERE ID > 1";
+
+                using var reader = cmd.ExecuteReader();
+
+                table.EnumeratorCalls.Should().Be(1, "Execute obtains the enumerator, and the chain acquires down to the leaf");
+                table.Produced.Should().Be(0, "no row has been asked for");
+
+                var rows = new List<int>();
+                while (reader.Read())
+                    rows.Add(reader.GetInt32(0));
+
+                rows.Should().Equal([2, 3]);
+                table.Produced.Should().Be(3, "the filter read the whole input to answer");
+            }
+        }
+
+        /// <summary>
+        /// A synchronous plan's sort drains its input at Execute, as linq4j's <c>orderBy</c> drains inside
+        /// <c>enumerator()</c>.
+        /// </summary>
+        [TestMethod]
+        public void ExecuteShouldRunASynchronousSort()
+        {
+            var (c, table) = Open(SynchronousModel);
+            using (c)
+            {
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "SELECT ID FROM T ORDER BY ID DESC";
+
+                using var reader = cmd.ExecuteReader();
+
+                table.EnumeratorCalls.Should().Be(1);
+                table.Produced.Should().Be(3, "the sort drains its whole input inside GetEnumerator, which Execute called");
+
+                var rows = new List<int>();
+                while (reader.Read())
+                    rows.Add(reader.GetInt32(0));
+
+                rows.Should().Equal([3, 2, 1]);
+            }
+        }
+
+        /// <summary>
+        /// The default mode's Execute acquires a Calcite leaf under the asynchronous root without reading
+        /// a row.
+        /// </summary>
+        /// <remarks>
+        /// The leaf is a linq4j sequence and its <c>enumerator()</c> is where a sub-plan executes — the
+        /// AdoNet adapter runs its <c>DbCommand</c> there — so the crossing calls it at
+        /// <c>GetAsyncEnumerator</c>, which Execute reaches. This is the asynchronous half of the rewrite's
+        /// point: failures and side effects of starting a plan land at Execute, from either entry point.
+        /// </remarks>
+        [TestMethod]
+        public async Task ExecuteAsyncShouldAcquireTheLeafWithoutReading()
+        {
+            var (c, table) = Open(Model);
+            using (c)
+            {
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "SELECT ID FROM T WHERE ID > 1";
+
+                await using var reader = await cmd.ExecuteReaderAsync();
+
+                table.EnumeratorCalls.Should().Be(1, "GetAsyncEnumerator acquires down to the leaf, and Execute called it");
+                table.Produced.Should().Be(0, "no row has been asked for");
+
+                var rows = new List<int>();
+                while (await reader.ReadAsync())
+                    rows.Add(reader.GetInt32(0));
+
+                rows.Should().Equal([2, 3]);
+            }
+        }
+
+        /// <summary>
+        /// An asynchronous sort acquires its input at Execute and drains at the first read — the one
+        /// deviation the CLR imposes, stated where the operator states it.
+        /// </summary>
+        /// <remarks>
+        /// <c>GetAsyncEnumerator</c> cannot await, so a drain that must await waits for the first
+        /// <c>MoveNextAsync</c>. Acquisition is still eager: the leaf's <c>enumerator()</c> has run before
+        /// the first read is asked for.
+        /// </remarks>
+        [TestMethod]
+        public async Task AnAsynchronousSortShouldAcquireAtExecuteAndDrainAtTheFirstRead()
+        {
+            var (c, table) = Open(Model);
+            using (c)
+            {
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "SELECT ID FROM T ORDER BY ID DESC";
+
+                await using var reader = await cmd.ExecuteReaderAsync();
+
+                table.EnumeratorCalls.Should().Be(1, "acquisition is eager even where the drain cannot be");
+                table.Produced.Should().Be(0, "an awaited drain waits for the first MoveNextAsync");
+
+                (await reader.ReadAsync()).Should().BeTrue();
+                table.Produced.Should().Be(3, "the first read ran the drain");
+                reader.GetInt32(0).Should().Be(3);
+            }
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
@@ -449,18 +449,16 @@ namespace Apache.Calcite.Tests
         /// Nothing is read until the first <c>ReadAsync</c>.
         /// </summary>
         /// <remarks>
-        /// Which is why <c>ExecuteReaderAsync</c> has nothing to await and returns a completed task. It
-        /// parses, plans and compiles — all CPU, on the calling thread — and then composes the operator
-        /// chain, but every operator is an <c>async IAsyncEnumerable</c> iterator, so calling one builds a
-        /// state machine and runs none of it. <c>GetAsyncEnumerator</c> is the same. The table is not
-        /// touched.
-        ///
-        /// <para>So the answer to "could it yield" is that there is nothing there to yield on, rather than
-        /// that the work is hidden. The first suspension is inside the first <c>ReadAsync</c>.</para>
+        /// "Read" is the word doing the work. Execute acquires: <c>GetAsyncEnumerator</c> now chains down
+        /// the whole plan — <c>AcquisitionTimingTests</c> holds that a Calcite leaf's <c>enumerator()</c>
+        /// runs there — but this leaf is an <c>IClrAsyncScannableTable</c> whose <c>ScanAsync</c> is a C#
+        /// iterator, and an iterator's body, its counting included, runs nothing until the first
+        /// <c>MoveNextAsync</c>. So the table produces no row at Execute, which is this test's claim.
         ///
         /// <para>A table that did eager work in <c>ScanAsync</c> — opening a connection before returning the
         /// sequence — would be doing it synchronously, because <c>ScanAsync</c> returns an
-        /// <see cref="IAsyncEnumerable{T}"/> rather than a task. The place to do that work is the first
+        /// <see cref="IAsyncEnumerable{T}"/> rather than a task. The place for acquisition-time work is
+        /// <c>GetAsyncEnumerator</c>, which Execute now reaches; the place for awaited work is the first
         /// <c>MoveNextAsync</c>, which an iterator gives for free.</para>
         /// </remarks>
         [TestMethod]


### PR DESCRIPTION
Builds on #29, now merged.

linq4j runs a plan by obtaining its enumerator: `where` acquires its source inside `enumerator()` (EnumerableDefaults.java:4349), `orderBy` drains its whole input there (:3223), the JDBC leaf executes its statement there, and deferral is the marked exception (the CALCITE-2909 memoized join lookups). Both Clr conventions had re-expressed those operators as C# iterators, which defer everything to the first `MoveNext`, acquisition included -- a structural divergence no row-comparing test could see. The provider already obtains the enumerator at Execute, so restoring linq4j's timing makes Execute run the plan and read nothing: failures land there, a sort has drained there, a leaf statement has executed there.

What changed:

- **Runtime gains the seam.** `ClrEnumerable`/`ClrAsyncEnumerable` run a factory at `GetEnumerator`, which is where `enumerator()` runs. `AcquiredEnumerator` and its async twin own what a factory acquires -- a row iterator disposed before it ever moved runs none of its `finally` blocks and would leak the acquired enumerators. The `Acquiring` extensions collapse the dominant shape to one line.
- **Each operator transcribed against its linq4j counterpart, not blanket rewritten.** Eager-acquire family via `Acquiring`; drains (`orderBy`, the bounded limit sort, hash-join lookups) in the factory; `MergeJoin` restructured into a cursor class whose constructor acquires both inputs and runs `start()`, as `MergeJoinEnumerator` does; `RepeatUnion` holds its state in a box whose disposal runs `close()` in Calcite's order -- clean-up first -- whether or not a row was ever read. The call-time drains stay call-time because linq4j drains them in the method body (`union`, `intersect`, `except`, `distinct`, `asofJoin`, `groupBy`, the window, `nestedLoopJoinAsList`), and `Concat` keeps its deferral, which is linq4j's own.
- **The asynchronous convention mirrors all of it** with the one exception the CLR imposes, stated at each site: `GetAsyncEnumerator` cannot await, so a drain that must await acquires eagerly and drains in the first `MoveNextAsync`. The async limit sort also now transcribes the bounded TreeMap rather than buffering the whole input, which it had been doing.
- **The crossings acquire.** `JavaSequences.FromJava`/`FromJavaAsync` call the linq4j `enumerator()` at `GetEnumerator` -- where a JDBC or ADO.NET sub-plan executes -- and `ClrSequences` carries a synchronous sub-plan's whole acquisition cascade across at `GetAsyncEnumerator`.
- **`AcquisitionTimingTests`** holds the timing by reading a counting leaf's acquisitions and produced rows as two separate numbers: Execute acquires without reading, a synchronous sort drains at Execute, the default mode acquires a Calcite leaf under the asynchronous root at Execute, and an asynchronous sort acquires at Execute and drains at the first read.
- CLAUDE.md gains the rule, with the warning not to "fix" the call-time drains toward the factory.

Test runs: `Apache.Calcite.Tests` 672/672 (including the four new timing tests), `Apache.Calcite.Adapter.AdoNet.Tests` 345/345, `Apache.Calcite.Data.Tests` 324/324.

