### PR TITLE
Cache prepared plans per connection, behind a factory on the connection

### DIFF
--- a/src/Apache.Calcite.Data.Tests/CalciteCommandTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteCommandTests.cs
@@ -153,9 +153,19 @@ namespace Apache.Calcite.Data.Tests
         }
 
         [Fact]
-        public void Prepare_should_be_noop()
+        public void Prepare_should_require_an_open_connection()
         {
             using var cmd = new CalciteCommand();
+            Assert.Throws<InvalidOperationException>(() => cmd.Prepare());
+        }
+
+        [Fact]
+        public void Prepare_should_be_noop_without_a_plan_cache()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES (1)";
             cmd.Prepare();
         }
 

--- a/src/Apache.Calcite.Data.Tests/PlanCacheTests.cs
+++ b/src/Apache.Calcite.Data.Tests/PlanCacheTests.cs
@@ -1,0 +1,457 @@
+using System;
+using System.Diagnostics;
+
+using Apache.Calcite.Extensions.Prepare;
+
+using org.apache.calcite;
+using org.apache.calcite.linq4j;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.runtime;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.sql.type;
+
+using Xunit;
+
+namespace Apache.Calcite.Data.Tests
+{
+
+    /// <summary>
+    /// Tests for the connection's plan cache: association, hits, admission, and invalidation.
+    /// </summary>
+    public class PlanCacheTests
+    {
+
+        readonly Xunit.Abstractions.ITestOutputHelper output;
+
+        public PlanCacheTests(Xunit.Abstractions.ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        static PlanCacheTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.server.ServerDdlExecutor).Assembly);
+        }
+
+        static readonly string ServerDdlConnectionString = new CalciteConnectionStringBuilder
+        {
+            Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
+            ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            Schema = "adhoc",
+        };
+
+        /// <summary>
+        /// An <see cref="IPlanCache"/> that counts what the session asks of it, delegating storage to the
+        /// built-in cache. The counters are the observable the tests assert on; the interface is public,
+        /// so this is also the proof that a caller-supplied implementation is enough.
+        /// </summary>
+        sealed class CountingPlanCache : IPlanCache
+        {
+
+            readonly LruPlanCache inner;
+
+            public int Gets, Hits, Adds, Removes;
+            public PreparedPlan? LastAdded, LastHit;
+
+            public CountingPlanCache(int capacity = 16) => inner = new LruPlanCache(capacity);
+
+            public int Count => inner.Count;
+
+            public PreparedPlan? Get(in PlanCacheKey key)
+            {
+                Gets++;
+                var plan = inner.Get(key);
+                if (plan is not null)
+                {
+                    Hits++;
+                    LastHit = plan;
+                }
+
+                return plan;
+            }
+
+            public void Add(in PlanCacheKey key, PreparedPlan plan)
+            {
+                Adds++;
+                LastAdded = plan;
+                inner.Add(key, plan);
+            }
+
+            public void Remove(in PlanCacheKey key)
+            {
+                Removes++;
+                inner.Remove(key);
+            }
+
+            public void Clear(PlanCacheScope scope) => inner.Clear(scope);
+
+        }
+
+        /// <summary>
+        /// A one-row, one-column table whose value tells instances apart.
+        /// </summary>
+        sealed class ValueTable : AbstractTable, ScannableTable
+        {
+
+            readonly int value;
+
+            public ValueTable(int value) => this.value = value;
+
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory) =>
+                new RelDataTypeFactory.Builder(typeFactory)
+                    .add("VAL", SqlTypeName.INTEGER)
+                    .build();
+
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root) =>
+                Linq4j.singletonEnumerable(new object[] { value });
+
+        }
+
+        static CalciteConnection OpenWithCache(CountingPlanCache cache, string? connectionString = null)
+        {
+            var c = new CalciteConnection(connectionString ?? TestModels.InlineEmptyModelConnectionString);
+            c.PlanCacheFactory = CalcitePlanCacheFactory.From(cache);
+            c.Open();
+            return c;
+        }
+
+        [Fact]
+        public void Second_execution_of_the_same_text_reuses_the_plan()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM (VALUES (1), (2), (3)) AS t(x)";
+
+            using (var r = cmd.ExecuteReader())
+            {
+                var rows = 0;
+                while (r.Read())
+                    rows++;
+                Assert.Equal(3, rows);
+            }
+
+            Assert.Equal(1, cache.Adds);
+
+            using (var r = cmd.ExecuteReader())
+            {
+                var rows = 0;
+                while (r.Read())
+                    rows++;
+                Assert.Equal(3, rows);
+            }
+
+            Assert.Equal(1, cache.Adds);
+            Assert.Equal(1, cache.Hits);
+            Assert.Same(cache.LastAdded, cache.LastHit);
+        }
+
+        [Fact]
+        public void Different_parameter_values_reuse_the_plan()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT x FROM (VALUES (1), (2), (3)) AS t(x) WHERE x = ?";
+            var p = cmd.CreateParameter();
+            p.Value = 1;
+            cmd.Parameters.Add(p);
+
+            Assert.Equal(1, Convert.ToInt32(cmd.ExecuteScalar()));
+
+            p.Value = 2;
+            Assert.Equal(2, Convert.ToInt32(cmd.ExecuteScalar()));
+
+            Assert.Equal(1, cache.Adds);
+            Assert.Equal(1, cache.Hits);
+        }
+
+        [Fact]
+        public void Table_query_reuses_the_plan()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            c.RootSchema.add("CACHED_T", new ValueTable(42));
+
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM \"CACHED_T\"";
+
+            Assert.Equal(42, Convert.ToInt32(cmd.ExecuteScalar()));
+            Assert.Equal(42, Convert.ToInt32(cmd.ExecuteScalar()));
+
+            Assert.Equal(1, cache.Adds);
+            Assert.Equal(1, cache.Hits);
+        }
+
+        [Fact]
+        public void Replacing_a_table_on_the_schema_invalidates_the_plan()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            c.RootSchema.add("REPLACED_T", new ValueTable(42));
+
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM \"REPLACED_T\"";
+
+            Assert.Equal(42, Convert.ToInt32(cmd.ExecuteScalar()));
+
+            // not DDL, so no generation moves — this is exactly the mutation the dependency check exists for
+            c.RootSchema.add("REPLACED_T", new ValueTable(43));
+
+            Assert.Equal(43, Convert.ToInt32(cmd.ExecuteScalar()));
+            Assert.Equal(1, cache.Removes);
+            Assert.Equal(2, cache.Adds);
+        }
+
+        [Fact]
+        public void A_request_carrying_hooks_bypasses_the_cache()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES (6 * 7)";
+            cmd.RegisterHook(Hook.ENABLE_BINDABLE, true);
+
+            Assert.Equal(42, Convert.ToInt32(cmd.ExecuteScalar()));
+            Assert.Equal(42, Convert.ToInt32(cmd.ExecuteScalar()));
+
+            Assert.Equal(0, cache.Gets);
+            Assert.Equal(0, cache.Adds);
+        }
+
+        [Fact]
+        public void Explain_is_not_cached()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "EXPLAIN PLAN FOR SELECT * FROM (VALUES (1)) AS t(x)";
+
+            Assert.NotNull(cmd.ExecuteScalar());
+            Assert.Equal(0, cache.Adds);
+        }
+
+        [Fact]
+        public void A_shared_cache_partitions_by_connection_and_clears_on_dispose()
+        {
+            var cache = new CountingPlanCache();
+
+            var c1 = OpenWithCache(cache);
+            using var c2 = OpenWithCache(cache);
+
+            using (var cmd1 = c1.CreateCommand())
+            {
+                cmd1.CommandText = "VALUES (1)";
+                cmd1.ExecuteScalar();
+            }
+
+            using (var cmd2 = c2.CreateCommand())
+            {
+                cmd2.CommandText = "VALUES (1)";
+                cmd2.ExecuteScalar();
+            }
+
+            // one text, two sessions, two entries — plans are never shared, only capacity
+            Assert.Equal(2, cache.Adds);
+            Assert.Equal(0, cache.Hits);
+            Assert.Equal(2, cache.Count);
+
+            c1.Dispose();
+            Assert.Equal(1, cache.Count);
+
+            using (var cmd2 = c2.CreateCommand())
+            {
+                cmd2.CommandText = "VALUES (1)";
+                cmd2.ExecuteScalar();
+            }
+
+            Assert.Equal(1, cache.Hits);
+        }
+
+        [Fact]
+        public void PlanCacheSize_connection_string_key_installs_the_builtin_cache()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";PlanCacheSize=8");
+            c.Open();
+
+            var cache = Assert.IsType<LruPlanCache>(c.RequireSession().PlanCache);
+            Assert.Equal(8, cache.Capacity);
+
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES (1)";
+            cmd.ExecuteScalar();
+            cmd.ExecuteScalar();
+            Assert.Equal(1, cache.Count);
+        }
+
+        [Fact]
+        public void Without_a_cache_nothing_is_consulted()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+
+            Assert.Null(c.RequireSession().PlanCache);
+        }
+
+        [Fact]
+        public void The_factory_cannot_change_after_open()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+
+            Assert.Throws<InvalidOperationException>(() => c.PlanCacheFactory = CalcitePlanCacheFactory.From(new CountingPlanCache()));
+        }
+
+        [Fact]
+        public void Prepare_warms_the_cache()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache);
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM (VALUES (1), (2)) AS t(x)";
+
+            cmd.Prepare();
+            Assert.Equal(1, cache.Adds);
+
+            Assert.Equal(1, Convert.ToInt32(cmd.ExecuteScalar()));
+            Assert.Equal(1, cache.Adds);
+            Assert.Equal(1, cache.Hits);
+        }
+
+        [Fact]
+        public void Prepare_does_not_execute_ddl()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache, ServerDdlConnectionString);
+
+            using (var create = c.CreateCommand())
+            {
+                create.CommandText = "CREATE TABLE \"adhoc\".\"prepared_ddl\" (\"i\" INTEGER)";
+                create.Prepare();
+                Assert.Equal(0, cache.Adds);
+            }
+
+            // the table must not exist yet: preparing DDL must not have executed it
+            using (var probe = c.CreateCommand())
+            {
+                probe.CommandText = "SELECT * FROM \"adhoc\".\"prepared_ddl\"";
+                Assert.ThrowsAny<Exception>(() => probe.ExecuteScalar());
+            }
+
+            using (var create = c.CreateCommand())
+            {
+                create.CommandText = "CREATE TABLE \"adhoc\".\"prepared_ddl\" (\"i\" INTEGER)";
+                create.ExecuteNonQuery();
+            }
+
+            using (var probe = c.CreateCommand())
+            {
+                probe.CommandText = "SELECT * FROM \"adhoc\".\"prepared_ddl\"";
+                using var r = probe.ExecuteReader();
+                Assert.False(r.Read());
+            }
+        }
+
+        [Fact]
+        public void Ddl_moves_the_generation_and_strands_the_old_entry()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache, ServerDdlConnectionString);
+
+            using var select = c.CreateCommand();
+            select.CommandText = "SELECT * FROM (VALUES (1)) AS t(x)";
+            select.ExecuteScalar();
+            Assert.Equal(1, cache.Adds);
+
+            using (var ddl = c.CreateCommand())
+            {
+                ddl.CommandText = "CREATE SCHEMA IF NOT EXISTS \"strand_test\"";
+                ddl.ExecuteNonQuery();
+            }
+
+            // the old entry's key is unreachable under the new generation: a fresh plan, no hit
+            select.ExecuteScalar();
+            Assert.Equal(2, cache.Adds);
+            Assert.Equal(0, cache.Hits);
+        }
+
+        [Fact]
+        public void Synchronous_convention_caches_too()
+        {
+            var cache = new CountingPlanCache();
+            using var c = OpenWithCache(cache, TestModels.InlineEmptyModelConnectionString + ";Synchronous=true");
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT * FROM (VALUES (1), (2)) AS t(x)";
+
+            Assert.Equal(1, Convert.ToInt32(cmd.ExecuteScalar()));
+            Assert.Equal(1, Convert.ToInt32(cmd.ExecuteScalar()));
+
+            Assert.Equal(1, cache.Adds);
+            Assert.Equal(1, cache.Hits);
+        }
+
+        [Fact]
+        public void A_data_source_applies_its_factory_to_each_connection()
+        {
+            var cache = new CountingPlanCache();
+            var source = new CalciteDataSource(TestModels.InlineEmptyModelConnectionString)
+            {
+                PlanCacheFactory = CalcitePlanCacheFactory.From(cache),
+            };
+
+            using var c1 = source.OpenConnection();
+            using var c2 = source.OpenConnection();
+
+            using (var cmd = c1.CreateCommand())
+            {
+                cmd.CommandText = "VALUES (1)";
+                cmd.ExecuteScalar();
+            }
+
+            using (var cmd = c2.CreateCommand())
+            {
+                cmd.CommandText = "VALUES (1)";
+                cmd.ExecuteScalar();
+            }
+
+            Assert.Equal(2, cache.Adds);
+            Assert.Equal(2, cache.Count);
+        }
+
+        [Fact]
+        public void A_cache_hit_costs_less_than_planning()
+        {
+            var cache = new CountingPlanCache(4);
+            using var c = OpenWithCache(cache);
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT t1.x, t2.y FROM (VALUES (1, 'a'), (2, 'b')) AS t1(x, y) JOIN (VALUES (1, 'a'), (2, 'b')) AS t2(x, y) ON t1.x = t2.x ORDER BY t1.x";
+
+            // populate, then measure hits against a no-cache connection planning the same text
+            cmd.ExecuteReader().Dispose();
+
+            var hits = Stopwatch.StartNew();
+            for (var i = 0; i < 25; i++)
+                cmd.ExecuteReader().Dispose();
+            hits.Stop();
+
+            using var uncached = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            uncached.Open();
+            using var cmd2 = uncached.CreateCommand();
+            cmd2.CommandText = cmd.CommandText;
+
+            var plans = Stopwatch.StartNew();
+            for (var i = 0; i < 25; i++)
+                cmd2.ExecuteReader().Dispose();
+            plans.Stop();
+
+            output.WriteLine($"25 cache hits: {hits.Elapsed.TotalMilliseconds:F1} ms; 25 plans: {plans.Elapsed.TotalMilliseconds:F1} ms.");
+
+            Assert.Equal(25, cache.Hits);
+            Assert.True(hits.Elapsed < plans.Elapsed,
+                $"25 cache hits took {hits.Elapsed.TotalMilliseconds:F1} ms; 25 plans took {plans.Elapsed.TotalMilliseconds:F1} ms.");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/CalciteBatch.cs
+++ b/src/Apache.Calcite.Data/CalciteBatch.cs
@@ -123,15 +123,28 @@ namespace Apache.Calcite.Data
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Plans each batch command now, so executing the batch hits the connection's plan cache. Without
+        /// a plan cache this does nothing, and a DDL statement is never planned from here — planning DDL
+        /// executes it, and <c>Prepare</c> must not have effects. <see cref="CalciteCommand.Prepare"/>
+        /// says the rest.
+        /// </remarks>
         public override void Prepare()
         {
-            // Phase 1: no preparation cache.
+            var session = GetOpenSession();
+
+            foreach (var command in _batchCommands.Items)
+                session.Prepare(CalciteExecuteRequest.From(command.CommandText, command.Parameters, _timeout));
         }
 
         /// <inheritdoc />
         public override Task PrepareAsync(CancellationToken cancellationToken = default)
         {
-            return cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+
+            Prepare();
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Data/CalciteCommand.cs
+++ b/src/Apache.Calcite.Data/CalciteCommand.cs
@@ -239,9 +239,18 @@ namespace Apache.Calcite.Data
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Plans the statement now, so a later execute of the same text hits the connection's plan cache
+        /// instead of planning again. Without a plan cache —
+        /// <see cref="CalciteConnection.PlanCacheFactory"/> or
+        /// <see cref="CalciteConnectionStringBuilder.PlanCacheSize"/> — this does nothing, because there
+        /// would be nowhere to keep the plan. A DDL statement is never planned from here: in this engine,
+        /// as in Calcite's own prepare, planning DDL executes it, and <c>Prepare</c> must not have
+        /// effects.
+        /// </remarks>
         public override void Prepare()
         {
-            // Phase 1: no preparation cache.
+            GetOpenSession().Prepare(CalciteExecuteRequest.From(_commandText, _parameters, _commandTimeout, ResolveHooks()));
         }
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Data/CalciteConnection.cs
+++ b/src/Apache.Calcite.Data/CalciteConnection.cs
@@ -41,6 +41,7 @@ namespace Apache.Calcite.Data
         ConnectionState _state = ConnectionState.Closed;
         bool _disposed;
         List<CalciteHookEntry>? _hooks;
+        CalcitePlanCacheFactory? _planCacheFactory;
 
         /// <summary>
         /// Registers a Calcite hook with a Java <see cref="Consumer"/> for the duration of every statement executed on this connection.
@@ -197,6 +198,36 @@ namespace Apache.Calcite.Data
             }
         }
 
+        /// <summary>
+        /// Gets or sets the factory that supplies this connection's plan cache.
+        /// </summary>
+        /// <remarks>
+        /// Consulted once, when the session is created on the first <see cref="Open"/>; like
+        /// <see cref="ConnectionString"/>, it cannot be changed after that. <see langword="null"/> means
+        /// the connection caches plans only if the connection string says so, through
+        /// <see cref="CalciteConnectionStringBuilder.PlanCacheSize"/>; when both are given, the factory
+        /// wins. <see cref="CalcitePlanCacheFactory.From"/> turns a cache instance into a factory, which
+        /// is how one bounded cache is shared across connections — capacity is shared, plans never are.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the factory is set after the connection has already been opened.
+        /// </exception>
+        public CalcitePlanCacheFactory? PlanCacheFactory
+        {
+            get => _planCacheFactory;
+            set
+            {
+                ThrowIfDisposed();
+                if (_session is not null)
+                    throw new InvalidOperationException(
+                        "The plan cache factory cannot be changed after the connection has been opened. " +
+                        "The Calcite session is fixed for the lifetime of this instance. " +
+                        "To use a different plan cache, create a new CalciteConnection.");
+
+                _planCacheFactory = value;
+            }
+        }
+
         /// <inheritdoc />
         /// <remarks>
         /// Calcite has no notion of a current database, so this property always returns <see cref="string.Empty"/>.
@@ -246,7 +277,7 @@ namespace Apache.Calcite.Data
             try
             {
                 // Session is created once on the first Open() and reused across Close/Open cycles.
-                _session ??= new CalciteSession(_options);
+                _session ??= new CalciteSession(_options, CreatePlanCache());
                 SetState(ConnectionState.Open);
             }
             catch
@@ -254,6 +285,19 @@ namespace Apache.Calcite.Data
                 SetState(ConnectionState.Closed);
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Resolves the plan cache the session is created with: the factory's answer, the connection
+        /// string's private cache, or none.
+        /// </summary>
+        Extensions.Prepare.IPlanCache? CreatePlanCache()
+        {
+            if (_planCacheFactory is not null)
+                return _planCacheFactory.CreatePlanCache(this);
+
+            var size = _options.PlanCacheSize;
+            return size > 0 ? new Extensions.Prepare.LruPlanCache(size.Value) : null;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -39,6 +39,11 @@ namespace Apache.Calcite.Data
         public const string SynchronousKey = "Synchronous";
 
         /// <summary>
+        /// Connection string key for how many prepared plans the connection may cache.
+        /// </summary>
+        public const string PlanCacheSizeKey = "PlanCacheSize";
+
+        /// <summary>
         /// Connection string key for whether identifiers are matched case-sensitively.
         /// </summary>
         public const string CaseSensitiveKey = "CaseSensitive";
@@ -206,6 +211,29 @@ namespace Apache.Calcite.Data
                     Remove(SynchronousKey);
                 else
                     this[SynchronousKey] = value.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how many prepared plans the connection may cache. Default is none.
+        /// </summary>
+        /// <remarks>
+        /// A provider option rather than an engine one, like <see cref="Synchronous"/>. A positive value
+        /// gives the session a private least-recently-used cache of that many plans, consulted by
+        /// statement text, so re-executing a statement skips parsing, validation and planning. Zero or
+        /// absent means every execution plans from scratch, which is also Calcite's own behavior.
+        /// <see cref="CalciteConnection.PlanCacheFactory"/> overrides this, for a cache of the caller's
+        /// own — including one shared between connections.
+        /// </remarks>
+        public int? PlanCacheSize
+        {
+            get => TryGetInt(PlanCacheSizeKey);
+            set
+            {
+                if (value is null)
+                    Remove(PlanCacheSizeKey);
+                else
+                    this[PlanCacheSizeKey] = value.Value;
             }
         }
 

--- a/src/Apache.Calcite.Data/CalciteDataSource.cs
+++ b/src/Apache.Calcite.Data/CalciteDataSource.cs
@@ -72,8 +72,19 @@ namespace Apache.Calcite.Data
         /// <inheritdoc />
         public override string ConnectionString => _connectionString;
 
+        /// <summary>
+        /// Gets or sets the plan cache factory applied to each connection this data source creates.
+        /// </summary>
+        /// <remarks>
+        /// A data source is created once and shared, which makes it the natural owner of a shared plan
+        /// cache: <c>PlanCacheFactory = CalcitePlanCacheFactory.From(new LruPlanCache(256))</c> gives
+        /// every connection it creates one capacity budget to share. Read when a connection is created;
+        /// a connection already handed out keeps the factory it was created with.
+        /// </remarks>
+        public CalcitePlanCacheFactory? PlanCacheFactory { get; set; }
+
         /// <inheritdoc />
-        protected override DbConnection CreateDbConnection() => new CalciteConnection(_connectionString);
+        protected override DbConnection CreateDbConnection() => new CalciteConnection(_connectionString) { PlanCacheFactory = PlanCacheFactory };
 
         /// <summary>
         /// Creates a new closed <see cref="CalciteConnection"/> bound to this data source's connection string.

--- a/src/Apache.Calcite.Data/CalcitePlanCacheFactory.cs
+++ b/src/Apache.Calcite.Data/CalcitePlanCacheFactory.cs
@@ -1,0 +1,69 @@
+using System;
+
+using Apache.Calcite.Extensions.Prepare;
+
+namespace Apache.Calcite.Data
+{
+
+    /// <summary>
+    /// Creates the plan cache for a connection's session.
+    /// </summary>
+    /// <remarks>
+    /// Consulted once, when the session is created on the connection's first open. The factory decides
+    /// scope: return a new cache per call for a connection-private cache, or the same instance from every
+    /// call to share one capacity budget across connections. Entries are never shared between sessions
+    /// either way — a plan is meaningful only to the session that made it — so the choice is about memory,
+    /// not correctness. The connection passed in is still opening: its connection string is readable, its
+    /// session-backed members are not.
+    ///
+    /// <para>The session never disposes a cache, because it cannot know the factory did not share it; it
+    /// clears its own entries and no more. A factory that hands out per-connection caches owning anything
+    /// disposable is the one party positioned to tie their lifetimes together.</para>
+    /// </remarks>
+    public abstract class CalcitePlanCacheFactory
+    {
+
+        /// <summary>
+        /// Returns a factory that answers every connection with <paramref name="cache"/>, sharing one
+        /// capacity budget across the connections it is set on.
+        /// </summary>
+        /// <param name="cache">The cache every connection is answered with.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="cache"/> is <see langword="null"/>.</exception>
+        public static CalcitePlanCacheFactory From(IPlanCache cache)
+        {
+            ArgumentNullException.ThrowIfNull(cache);
+
+            return new InstanceFactory(cache);
+        }
+
+        /// <summary>
+        /// Creates or returns the plan cache for a session being created.
+        /// </summary>
+        /// <param name="connection">The connection whose session is being created.</param>
+        /// <returns>The cache the session will consult for every statement it plans.</returns>
+        public abstract IPlanCache CreatePlanCache(CalciteConnection connection);
+
+        /// <summary>
+        /// The factory <see cref="From"/> answers with.
+        /// </summary>
+        sealed class InstanceFactory : CalcitePlanCacheFactory
+        {
+
+            readonly IPlanCache cache;
+
+            /// <summary>
+            /// Initializes a new instance.
+            /// </summary>
+            public InstanceFactory(IPlanCache cache)
+            {
+                this.cache = cache;
+            }
+
+            /// <inheritdoc />
+            public override IPlanCache CreatePlanCache(CalciteConnection connection) => cache;
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -103,8 +103,9 @@ The connection's hooks and the command's are concatenated per request, connectio
 
 `CalciteSession` is the per-connection engine state, created on the first `CalciteConnection.Open()`
 and kept alive across `Close`/`Open` cycles — a schema registered on `RootSchema` or a table created
-by DDL survives a close. `Dispose` is what ends it, and only marks the session disposed so later
-execute calls throw `ObjectDisposedException`.
+by DDL survives a close. `Dispose` is what ends it: it marks the session disposed so later execute
+calls throw `ObjectDisposedException`, and clears the session's entries out of its plan cache, if it
+has one — a shared cache would otherwise hold a dead session's plans until eviction found them.
 
 Construction, from the `CalciteConnectionStringBuilder`:
 
@@ -124,10 +125,24 @@ Anything thrown here that is not already a `CalciteException` is wrapped in one.
 The session exposes three private steps and the execute entry points.
 
 **`Plan`** constructs a `PrepareContext`, pushes it onto `CalcitePrepare.Dummy`, and calls
-`ClrPrepareImpl.Prepare(ctx, sql, Object[], -1, async)`, returning a `ClrSignature`. The element
+`ClrPrepareImpl.Prepare(ctx, sql, Object[], -1, async)`, returning a `PreparedPlan`. The element
 type is what makes the pipeline ask for array-shaped rows; `-1` means no row limit; `async` is the
 connection's mode, `true` unless `Synchronous` was set. Nothing is executed and no per-statement
 state is created.
+
+When the session was created with an `IPlanCache` — the connection's `PlanCacheFactory`, or the
+`PlanCacheSize` key, another provider option excluded from the engine properties — `Plan` goes
+through `CachingPrepare` instead, which fronts the same call with a lookup keyed on the SQL text
+under the session's `PlanCacheScope` and its generation. A request carrying hooks never meets the
+cache: a planning-phase hook can rewrite what prepare produces and expects to observe the phases as
+they run, and a cached plan would do neither. `CachingPrepare` owns the rest of the correctness
+story — DDL bumps the generation and is never stored, `EXPLAIN` is never stored, and a hit is
+validated by resolving each table the plan recorded against the live schema and requiring the same
+instance, which is what catches a table added, dropped or replaced directly on `RootSchema`.
+
+**`Prepare`** is `DbCommand.Prepare()`'s half: with a cache and no hooks it plans the statement so
+the next execute hits, and it classifies the statement first — one extra parse — because planning
+DDL executes it, and `Prepare` must not have effects. Without a cache it does nothing.
 
 **`Bind`** builds the execution-time `DataContext`: a fresh `AtomicBoolean` cancel flag, the
 positional parameters converted by `ParameterBinder`, the command timeout in milliseconds, and
@@ -181,7 +196,7 @@ reused as they stand. The driver had to be replaced because its one exit is a `B
 | `ClrPrepareResult` | `Prepare.PreparedResult` | What preparing produces, less `getBindable`. |
 | `ClrEnumerablePrepareResult` | `PreparedResultImpl` (anonymous, in `implement`) | Carries an `IClrBindable`. |
 | `ClrExplainResult` / `ClrExplainBindable` | `Prepare.PreparedExplain` / `CalcitePreparedExplain.getBindable` | An `EXPLAIN`: the text is rendered at prepare time and yielded as one row. |
-| `ClrSignature` | `CalcitePrepare.CalciteSignature` | The planned statement, member for member, with `Bindable` swapped for `IClrBindable` and `enumerable` for `Bind`. |
+| `PreparedPlan` | `CalcitePrepare.CalciteSignature` | The planned statement, member for member, with `Bindable` swapped for `IClrBindable` and `enumerable` for `Bind`. |
 
 `ClrPrepareImpl.Prepare` is the entry point this provider uses. It creates a `VolcanoPlanner` with
 `RelOptUtil.registerDefaultRules` **plus** one convention's rules — `ClrAsyncEnumerableRules.Rules()`
@@ -192,15 +207,15 @@ table modification works here. `PrepareRel`, the second entry point, plans a `Re
 built rather than parsed; it is exercised by tests and not reached from this project.
 
 A DDL statement is executed inside `Prepare2` rather than planned, exactly as Calcite does. The
-`ClrSignature` it returns has no row type, no columns, a null bindable, `CursorFactory.OBJECT` and
+`PreparedPlan` it returns has no row type, no columns, a null bindable, `CursorFactory.OBJECT` and
 `StatementType.OTHER_DDL`.
 
 `Describe` builds one `AvaticaParameter` per dynamic parameter and one `ColumnMetaData` per result
 column, deduces the `CursorFactory` from the columns and the compiled plan's element type, and
-assembles the `ClrSignature`. All of that metadata is ported rather than reused: every piece of it
+assembles the `PreparedPlan`. All of that metadata is ported rather than reused: every piece of it
 is a private static of `CalcitePrepareImpl`.
 
-`ClrSignature.Bind(DataContext)` runs the plan and returns `IEnumerable<object>`, applying the row
+`PreparedPlan.Bind(DataContext)` runs the plan and returns `IEnumerable<object>`, applying the row
 limit when `MaxRowCount` is not negative — the limit lives on the signature, not on the bindable, so
 a caller reaching past it would silently lose it. This provider always passes `-1`.
 
@@ -243,7 +258,7 @@ returning rows, plus the `ElementType` the cursor factory is deduced from. It me
 
 ### 5. Result stream (`Internal/CalciteResult` and friends)
 
-`CalciteResult` is what an execute call hands back: the `ClrSignature`, a
+`CalciteResult` is what an execute call hands back: the `PreparedPlan`, a
 `CalciteResultColumns` built from it, the plan's enumerator, and a records-affected count. Two
 subclasses, one per convention — `CalciteEnumerableResult` over an `IEnumerator<object>`,
 `CalciteAsyncEnumerableResult` over an `IAsyncEnumerator<object>` — and both answer both `Read` and
@@ -344,7 +359,7 @@ type, the value and the SQL type. `BigDecimalConverter` carries `java.math.BigDe
    `ClrPrepareImpl.Prepare`, which parses, validates, converts to relational algebra, optimises into
    the connection's convention — `ClrAsyncEnumerableConvention` by default,
    `ClrEnumerableConvention` when the connection string says `Synchronous` — and compiles the chosen
-   plan to a delegate. The result is a `ClrSignature`.
+   plan to a delegate. The result is a `PreparedPlan`.
 6. **Bind.** Parameters are converted and assembled with the cancel flag, the timeout and the
    signature's internal parameters into a `StatementDataContext`.
 7. **Execute.** The plan's enumerator is taken — `BindAsync(...).GetAsyncEnumerator(token)` or
@@ -415,7 +430,7 @@ src/
       CalciteParameterValue.cs            (DbType, value) pair
       ParameterBinder.cs                  CLR value → Calcite runtime representation
       BigDecimalConverter.cs              decimal ↔ java.math.BigDecimal
-      CalciteResult.cs                    Row stream over a ClrSignature
+      CalciteResult.cs                    Row stream over a PreparedPlan
       CalciteResultColumns.cs             Avatica ColumnMetaData → ADO.NET column metadata
       CalciteResultRow.cs                 Column addressing within one row, by cursor style
       CalciteResultValue.cs               Final value conversion and typed getters
@@ -430,7 +445,7 @@ src/
       ClrPrepare.cs                       The algorithm, less any wiring
       ClrPreparingStmt.cs                 Cluster, validator, view expansion
       ClrPrepareResult.cs                 What preparing produces
-      ClrSignature.cs                     The planned statement
+      PreparedPlan.cs                     The planned statement
       ClrExplainResult.cs                 EXPLAIN, rendered at prepare time
       ClrExplainBindable.cs               …and yielded as one row
       PrepareContext.cs                   CalcitePrepare.Context
@@ -455,7 +470,7 @@ src/
   `ColumnMetaData`, `AvaticaParameter` and `Meta.*` are used as the metadata value types Calcite's
   prepare produces, and nothing more.
 - **No `Bindable` and no `PreparedResult` on the row path.** A plan is a compiled delegate behind
-  `IClrBindable`; `ClrSignature` and `ClrPrepareResult` exist because Calcite's equivalents are
+  `IClrBindable`; `PreparedPlan` and `ClrPrepareResult` exist because Calcite's equivalents are
   declared in terms of the linq4j types this convention does not produce.
 - **The ADO.NET surface owns no engine logic.** Everything that touches Calcite's planner is in
   `CalciteSession` and below it. The `Internal` types are reachable from the public surface; the

--- a/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteAsyncEnumerableResult.cs
@@ -23,7 +23,7 @@ namespace Apache.Calcite.Data.Internal
         /// <param name="enumerator">The plan's enumerator, already given the caller's cancellation token,
         /// or <see langword="null"/> where there is nothing to read.</param>
         /// <param name="recordsAffected"></param>
-        public CalciteAsyncEnumerableResult(ClrSignature signature, IAsyncEnumerator<object>? enumerator, long recordsAffected = -1) :
+        public CalciteAsyncEnumerableResult(PreparedPlan signature, IAsyncEnumerator<object>? enumerator, long recordsAffected = -1) :
             base(signature, recordsAffected)
         {
             _enumerator = enumerator;

--- a/src/Apache.Calcite.Data/Internal/CalciteEnumerableResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteEnumerableResult.cs
@@ -26,7 +26,7 @@ namespace Apache.Calcite.Data.Internal
         /// <param name="enumerator">The plan's enumerator, or <see langword="null"/> where there is nothing
         /// to read — a DDL statement has already taken effect, and a DML one reports a count.</param>
         /// <param name="recordsAffected"></param>
-        public CalciteEnumerableResult(ClrSignature signature, IEnumerator<object>? enumerator, long recordsAffected = -1) :
+        public CalciteEnumerableResult(PreparedPlan signature, IEnumerator<object>? enumerator, long recordsAffected = -1) :
             base(signature, recordsAffected)
         {
             _enumerator = enumerator;

--- a/src/Apache.Calcite.Data/Internal/CalciteResult.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResult.cs
@@ -8,7 +8,7 @@ namespace Apache.Calcite.Data.Internal
 {
 
     /// <summary>
-    /// Reads the rows of a prepared <see cref="ClrSignature"/>.
+    /// Reads the rows of a prepared <see cref="PreparedPlan"/>.
     /// </summary>
     /// <remarks>
     /// What a reader holds, and what both execute paths return. Everything about a <em>row</em> is here —
@@ -39,7 +39,7 @@ namespace Apache.Calcite.Data.Internal
     internal abstract class CalciteResult : IDisposable, IAsyncDisposable
     {
 
-        readonly ClrSignature _signature;
+        readonly PreparedPlan _signature;
         readonly CalciteResultColumns _columns;
         readonly long _recordsAffected;
 
@@ -51,7 +51,7 @@ namespace Apache.Calcite.Data.Internal
         /// </summary>
         /// <param name="signature"></param>
         /// <param name="recordsAffected"></param>
-        protected CalciteResult(ClrSignature signature, long recordsAffected)
+        protected CalciteResult(PreparedPlan signature, long recordsAffected)
         {
             ArgumentNullException.ThrowIfNull(signature);
 

--- a/src/Apache.Calcite.Data/Internal/CalciteResultColumns.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResultColumns.cs
@@ -10,7 +10,7 @@ namespace Apache.Calcite.Data.Internal
 {
 
     /// <summary>
-    /// Reads a prepared <see cref="ClrSignature"/>'s columns as an ADO.NET caller expects them.
+    /// Reads a prepared <see cref="PreparedPlan"/>'s columns as an ADO.NET caller expects them.
     /// </summary>
     /// <remarks>
     /// The columns are Avatica's <see cref="ColumnMetaData"/>, which is what the metadata port produces;
@@ -84,13 +84,13 @@ namespace Apache.Calcite.Data.Internal
             return typeof(object);
         }
 
-        readonly ClrSignature _signature;
+        readonly PreparedPlan _signature;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="signature"></param>
-        public CalciteResultColumns(ClrSignature signature)
+        public CalciteResultColumns(PreparedPlan signature)
         {
             _signature = signature ?? throw new ArgumentNullException(nameof(signature));
         }

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -87,12 +87,16 @@ namespace Apache.Calcite.Data.Internal
         readonly CalciteConnectionConfig _config;
         readonly IReadOnlyList<string> _defaultSchemaPath;
         readonly bool _synchronous;
+        readonly IPlanCache? _planCache;
+        readonly CachingPrepare? _cachingPrepare;
         bool _disposed;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="options">The connection string options.</param>
+        /// <param name="planCache">Where prepared plans are kept between executions, or
+        /// <see langword="null"/> to plan every statement from scratch.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="CalciteException"></exception>
         /// <remarks>
@@ -104,7 +108,7 @@ namespace Apache.Calcite.Data.Internal
         /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
         /// converter carrying its rows.
         /// </remarks>
-        public CalciteSession(CalciteConnectionStringBuilder options)
+        public CalciteSession(CalciteConnectionStringBuilder options, IPlanCache? planCache = null)
         {
             ArgumentNullException.ThrowIfNull(options);
 
@@ -117,6 +121,12 @@ namespace Apache.Calcite.Data.Internal
                 _synchronous = options.Synchronous ?? false;
                 var defaultSchema = modelDefaultSchema ?? options.Schema;
                 _defaultSchemaPath = string.IsNullOrEmpty(defaultSchema) ? [] : [defaultSchema];
+
+                if (planCache is not null)
+                {
+                    _planCache = planCache;
+                    _cachingPrepare = new CachingPrepare(planCache, new PlanCacheScope());
+                }
             }
             catch (Exception e) when (e is not CalciteException)
             {
@@ -196,6 +206,10 @@ namespace Apache.Calcite.Data.Internal
                 if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 
+                // a provider option, not an engine one: it sizes the session's plan cache
+                if (string.Equals(key, CalciteConnectionStringBuilder.PlanCacheSizeKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 if (options.TryGetValue(key, out var v) && v is not null)
                     props.setProperty(KeyToProperty.TryGetValue(key, out var prop) ? prop.camelName() : key, v.ToString());
             }
@@ -219,21 +233,70 @@ namespace Apache.Calcite.Data.Internal
         public CalciteConnectionConfig Config => _config;
 
         /// <summary>
-        /// Parses and plans <paramref name="request"/>, returning the compiled <see cref="ClrSignature"/>.
+        /// Gets the plan cache the session was created with, or <see langword="null"/>.
+        /// </summary>
+        public IPlanCache? PlanCache => _planCache;
+
+        /// <summary>
+        /// Parses and plans <paramref name="request"/>, returning the compiled <see cref="PreparedPlan"/>.
         /// No execution state is created here.
         /// </summary>
         /// <remarks>
         /// The context is still pushed onto <c>CalcitePrepare.Dummy</c>'s thread-local stack, because
         /// Calcite's own parse-to-rel reads it from there.
+        ///
+        /// <para>A request carrying hooks does not meet the plan cache: a planning-phase hook can rewrite
+        /// what prepare produces — <c>SQL2REL_CONVERTER_CONFIG_BUILDER</c> does exactly that — and expects
+        /// to observe the phases as they run, and a cached plan would neither reflect the hooks nor fire
+        /// them.</para>
         /// </remarks>
-        ClrSignature Plan(CalciteExecuteRequest request, bool async = false)
+        PreparedPlan Plan(CalciteExecuteRequest request, bool async = false)
         {
             var ctx = new PrepareContext(_typeFactory, _rootSchema, _config, _defaultSchemaPath);
 
             CalcitePrepare.Dummy.push(ctx);
             try
             {
+                if (_cachingPrepare is not null && request.Hooks is null)
+                    return _cachingPrepare.Prepare(ctx, request.Sql, (java.lang.Class)typeof(java.lang.Object[]), -1, async);
+
                 return new ClrPrepareImpl().Prepare(ctx, request.Sql, (java.lang.Class)typeof(java.lang.Object[]), -1, async);
+            }
+            finally
+            {
+                CalcitePrepare.Dummy.pop(ctx);
+            }
+        }
+
+        /// <summary>
+        /// Plans a statement ahead of execution, so a later execute of the same text hits the plan cache.
+        /// </summary>
+        /// <remarks>
+        /// Nothing without a plan cache: there would be nowhere to keep the plan, and the next execute
+        /// would do the work again regardless. A request carrying hooks bypasses the cache, so there is
+        /// nothing to warm for it either. A DDL statement is refused <em>before</em> planning rather than
+        /// after, because in this engine — as in Calcite's own prepare — planning DDL executes it, and
+        /// <c>Prepare</c> must not have effects; the classification costs one extra parse, paid only by
+        /// callers who ask to prepare.
+        /// </remarks>
+        public void Prepare(CalciteExecuteRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            ThrowIfDisposed();
+
+            if (_cachingPrepare is null || request.Hooks is not null)
+                return;
+
+            var ctx = new PrepareContext(_typeFactory, _rootSchema, _config, _defaultSchemaPath);
+
+            CalcitePrepare.Dummy.push(ctx);
+            try
+            {
+                if (new ClrPrepareImpl().IsDdl(ctx, request.Sql))
+                    return;
+
+                _cachingPrepare.Prepare(ctx, request.Sql, (java.lang.Class)typeof(java.lang.Object[]), -1, !_synchronous);
             }
             finally
             {
@@ -248,7 +311,7 @@ namespace Apache.Calcite.Data.Internal
         /// from <c>signature.internalParameters</c>, cancel flag, and timeout are assembled into a
         /// single <see cref="StatementDataContext"/>.
         /// </summary>
-        void Bind(CalciteExecuteRequest request, ClrSignature signature, out DataContext dataContext, out AtomicBoolean cancelFlag)
+        void Bind(CalciteExecuteRequest request, PreparedPlan signature, out DataContext dataContext, out AtomicBoolean cancelFlag)
         {
             cancelFlag = new AtomicBoolean(false);
             var boundParameters = ParameterBinder.Bind(request.Parameters);
@@ -583,6 +646,10 @@ namespace Apache.Calcite.Data.Internal
         public void Dispose()
         {
             _disposed = true;
+
+            // a shared cache would otherwise hold this session's plans until eviction found them
+            if (_planCache is not null && _cachingPrepare is not null)
+                _planCache.Clear(_cachingPrepare.Scope);
         }
 
         void ThrowIfDisposed()

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -185,6 +185,40 @@ The Calcite session is created on the **first** `Open()` and reused for the life
 
 **A one-column result is the value, not a row of one.** `GetValue(0)` returns it directly.
 
+## Plan caching
+
+By default every execution parses, validates and plans from scratch — Calcite's own behavior. A plan
+cache makes re-executing a statement skip all of that: the compiled plan takes parameters, timestamps
+and schema lookups through its `DataContext` at execution time, so one plan serves every execution of
+the same text.
+
+Two ways to turn it on:
+
+```csharp
+// per-connection, from the connection string
+using var c = new CalciteConnection("Model=...;PlanCacheSize=64");
+
+// or a cache of your own — shared here, so many connections split one capacity budget
+var shared = new LruPlanCache(256);
+var factory = CalcitePlanCacheFactory.From(shared);
+connection.PlanCacheFactory = factory;   // before the first Open()
+```
+
+`PlanCacheFactory` wins when both are set, and is consulted once, when the session is created on the
+first `Open()`. A shared cache shares capacity only — plans are never served across connections. A
+caller-supplied `IPlanCache` implements retention and eviction and nothing else; what may be cached,
+what the key is, and whether a hit is still valid are the provider's decisions, so an implementation
+cannot cause a stale or wrong result, only a poor hit rate.
+
+What invalidates a cached plan: DDL executed on the connection moves every existing entry out of reach,
+and a table added, dropped or replaced directly on `RootSchema` is caught when the next hit is validated
+against the live schema. What is never cached: DDL (planning it executes it), `EXPLAIN`, and any request
+on a connection or command with hooks registered — hooks can rewrite planning, so a hooked request
+always plans fresh. `DbCommand.Prepare()` plans eagerly into the cache; on a DDL statement it does
+nothing rather than execute it early. One caveat owned and documented: a *view* replaced directly on the
+schema — not through DDL — is not detected, because a plan depends on the tables the view expanded to,
+which did not change.
+
 ## Connection string reference
 
 All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Keys are matched case-insensitively, and unknown keys are preserved and forwarded to the engine.
@@ -194,6 +228,7 @@ All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Ke
 | `Model` | `string` | — | Path to a Calcite model JSON file, or `inline:<json>` for an embedded model. |
 | `Schema` | `string` | — | Default schema name when identifiers are unqualified. |
 | `Synchronous` | `bool` | `false` | Plan queries in the synchronous convention instead of the asynchronous one. A provider option, not forwarded to the engine — see [Behaviour worth knowing](#behaviour-worth-knowing). |
+| `PlanCacheSize` | `int` | `0` | Cache up to this many prepared plans per connection, keyed by statement text, so re-executing a statement skips parsing, validation and planning. A provider option, not forwarded to the engine — see [Plan caching](#plan-caching). |
 | `Lex` | `string` | `ORACLE` | Lexical policy: `ORACLE`, `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`. |
 | `CaseSensitive` | `bool` | from `Lex` | Whether identifier lookup is case-sensitive. |
 | `Quoting` | `string` | from `Lex` | Quote style: `DOUBLE_QUOTE`, `BACK_TICK`, `BACK_TICK_BACKSLASH`, `BRACKET`. |

--- a/src/Apache.Calcite.Extensions/Prepare/CachingPrepare.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/CachingPrepare.cs
@@ -1,0 +1,148 @@
+using System;
+
+using org.apache.calcite.avatica;
+using org.apache.calcite.jdbc;
+
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// The prepare pipeline behind a plan cache.
+    /// </summary>
+    /// <remarks>
+    /// Retention and eviction belong to the <see cref="IPlanCache"/>; everything correctness-shaped is
+    /// here, so an implementation of the interface cannot get it wrong. The key carries the scope's
+    /// generation, and DDL moves it — DDL executes inside prepare, so the bump is made where its effect is
+    /// first visible, read off the returned statement type rather than wired into the pipeline. A DDL text
+    /// is never stored, so it can never hit; it is the <em>store</em> that admission guards, because a
+    /// statement's kind is not known until it has been parsed, and by then an uncacheable statement has
+    /// simply been prepared the ordinary way.
+    ///
+    /// <para>What the generation cannot see is the schema mutated directly — <c>SchemaPlus.add</c> from
+    /// outside the pipeline — and that is what the dependency check covers: a hit is validated by
+    /// resolving each recorded table against the live schema and requiring the same instance. The same
+    /// check runs before a plan is stored, so a plan whose tables do not resolve stably is never cached at
+    /// all rather than cached and evicted on every later lookup.</para>
+    ///
+    /// <para>Two things are deliberately a caller's problem. Planning-phase hooks are thread-bound and
+    /// invisible here, so a caller that has activated any must not come through this path — a cached plan
+    /// would neither reflect the hooks nor fire them. And the <c>Prepare.THREAD_EXPAND</c> /
+    /// <c>THREAD_INSUBQUERY_THRESHOLD</c> thread-locals are read by the pipeline per prepare; a caller
+    /// that varies them between statements of one session would need them in the key, and no caller of
+    /// this provider does.</para>
+    /// </remarks>
+    sealed class CachingPrepare
+    {
+
+        readonly IPlanCache cache;
+        readonly PlanCacheScope scope;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="cache">Where plans are kept.</param>
+        /// <param name="scope">The session partition the plans belong to.</param>
+        public CachingPrepare(IPlanCache cache, PlanCacheScope scope)
+        {
+            this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            this.scope = scope ?? throw new ArgumentNullException(nameof(scope));
+        }
+
+        /// <summary>
+        /// Gets the session partition the plans belong to.
+        /// </summary>
+        public PlanCacheScope Scope => scope;
+
+        /// <summary>
+        /// Returns a cached plan for the statement, or plans it and offers the result to the cache.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ClrPrepareImpl.Prepare(CalcitePrepare.Context, string, java.lang.reflect.Type, long, bool)"/>
+        /// with the cache in front of it, taking the same arguments because they are the key.
+        /// </remarks>
+        public PreparedPlan Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount, bool async)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(sql);
+
+            var key = new PlanCacheKey(scope, scope.Generation, sql, async, elementType, maxRowCount);
+
+            if (cache.Get(key) is { } hit)
+            {
+                if (Validate(hit, context))
+                    return hit;
+
+                cache.Remove(key);
+            }
+
+            var plan = new ClrPrepareImpl().Prepare(context, sql, elementType, maxRowCount, async);
+
+            if (IsDdl(plan.StatementType))
+            {
+                // the DDL has already taken effect; every key built under the old generation is now
+                // unreachable, and this plan-less signature must never be served from the cache — a hit
+                // would silently skip the DDL
+                scope.BumpGeneration();
+                return plan;
+            }
+
+            // an EXPLAIN's text renders the plan of one moment, and a plan-less signature has nothing
+            // worth a slot; neither earns a store
+            if (plan.Bindable is null or ClrExplainBindable)
+                return plan;
+
+            if (Validate(plan, context))
+                cache.Add(key, plan);
+
+            return plan;
+        }
+
+        /// <summary>
+        /// Returns whether every table the plan depends on still resolves to the instance it was planned
+        /// against.
+        /// </summary>
+        /// <remarks>
+        /// Resolution is by the recorded names, case-sensitively — they are the canonical names resolution
+        /// itself answered, not what the statement spelled.
+        /// </remarks>
+        static bool Validate(PreparedPlan plan, CalcitePrepare.Context context)
+        {
+            var dependencies = plan.Dependencies;
+            if (dependencies is null)
+                return false;
+
+            var root = context.getRootSchema();
+
+            foreach (var dependency in dependencies)
+            {
+                var schema = root;
+                for (int i = 0; i < dependency.Path.Length - 1; i++)
+                {
+                    schema = schema.getSubSchema(dependency.Path[i], true);
+                    if (schema is null)
+                        return false;
+                }
+
+                var entry = schema.getTable(dependency.Path[dependency.Path.Length - 1], true);
+                if (entry is null || ReferenceEquals(entry.getTable(), dependency.Table) == false)
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="t"/> represents a DDL statement type.
+        /// </summary>
+        static bool IsDdl(Meta.StatementType t) => t.name() switch
+        {
+            nameof(Meta.StatementType.CREATE) => true,
+            nameof(Meta.StatementType.ALTER) => true,
+            nameof(Meta.StatementType.DROP) => true,
+            nameof(Meta.StatementType.OTHER_DDL) => true,
+            _ => false,
+        };
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepare.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepare.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using org.apache.calcite.jdbc;
 using org.apache.calcite.plan;
@@ -103,6 +104,57 @@ namespace Apache.Calcite.Extensions.Prepare
         {
             get => fieldOrigins ?? throw new InvalidOperationException("The statement has not been validated.");
             set => fieldOrigins = value;
+        }
+
+        /// <summary>
+        /// Gets the tables the optimized plan reads or writes, or <see langword="null"/> where one of them
+        /// could not be resolved to a schema table — and <see langword="null"/> for an <c>EXPLAIN</c>,
+        /// which never reaches the optimized plan this is read from.
+        /// </summary>
+        public IReadOnlyList<PlanDependency>? Dependencies { get; private set; }
+
+        /// <summary>
+        /// Records the tables <paramref name="rel"/> reads or writes, for a plan cache to validate a hit
+        /// against the live schema.
+        /// </summary>
+        /// <remarks>
+        /// Read from the optimized plan rather than from what the validator resolved, so a view has
+        /// already been expanded and contributes the tables its definition reads rather than itself. A
+        /// view <em>replaced on the schema directly</em> — not through DDL, which moves the cache's
+        /// generation — is therefore not detected; its base tables did not change. A table that does not
+        /// unwrap to a schema table cannot be validated later, so the whole plan is recorded as having no
+        /// dependencies, which a cache reads as uncacheable rather than as depending on nothing.
+        /// </remarks>
+        protected void RecordDependencies(RelNode rel)
+        {
+            var list = new List<PlanDependency>();
+            Dependencies = Collect(rel, list) ? list : null;
+        }
+
+        /// <summary>
+        /// Walks a plan, collecting each node's table. Returns whether every table found was resolvable.
+        /// </summary>
+        static bool Collect(RelNode node, List<PlanDependency> list)
+        {
+            if (node.getTable() is { } table)
+            {
+                var resolved = (org.apache.calcite.schema.Table?)table.unwrap((java.lang.Class)typeof(org.apache.calcite.schema.Table));
+                if (resolved is null)
+                    return false;
+
+                var names = table.getQualifiedName();
+                var path = new string[names.size()];
+                for (int i = 0; i < path.Length; i++)
+                    path[i] = (string)names.get(i);
+
+                list.Add(new PlanDependency(path, resolved));
+            }
+
+            for (var i = node.getInputs().iterator(); i.hasNext();)
+                if (Collect((RelNode)i.next(), list) == false)
+                    return false;
+
+            return true;
         }
 
         /// <summary>
@@ -246,6 +298,8 @@ namespace Apache.Calcite.Extensions.Prepare
                 root = root.withKind(sqlNodeOriginal.getKind());
 
             org.apache.calcite.runtime.Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
+
+            RecordDependencies(root.rel);
 
             return Implement(root);
         }

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
@@ -37,7 +37,7 @@ namespace Apache.Calcite.Extensions.Prepare
     /// <para>What is replaced is the outer driver, because its one exit is a <c>Bindable</c>: it calls
     /// <c>preparedResult.getBindable(cursorFactory)</c> and puts the result in a <c>CalciteSignature</c>,
     /// whose only row-producing member binds it to a linq4j <c>Enumerable</c>. A plan of this convention is
-    /// a compiled delegate, so it leaves through <see cref="ClrSignature"/> instead.</para>
+    /// a compiled delegate, so it leaves through <see cref="PreparedPlan"/> instead.</para>
     ///
     /// <para>Nothing of Calcite's prepare is inherited. <c>Prepare.implement</c> is declared to return a
     /// <c>PreparedResult</c>, whose reason for existing is <c>getBindable</c> — a linq4j <c>Enumerable</c> —
@@ -65,7 +65,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// list holds exactly one too — so the loop is a single call, and a plan that cannot be found
         /// throws rather than falling back.
         /// </remarks>
-        public ClrSignature Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount)
+        public PreparedPlan Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount)
         {
             return Prepare(context, sql, elementType, maxRowCount, false);
         }
@@ -94,7 +94,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// throws, rather than the caller being handed a plan that would block a thread per row while looking
         /// asynchronous. A caller that wants the synchronous plan asks for it.</para>
         /// </remarks>
-        public ClrSignature Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount, bool async)
+        public PreparedPlan Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount, bool async)
         {
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(sql);
@@ -124,7 +124,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <c>RelRunner</c>. The result is described from the plan's own row type, and the statement is
         /// always a SELECT — a plan carries no statement kind.
         /// </remarks>
-        public ClrSignature PrepareRel(CalcitePrepare.Context context, org.apache.calcite.rel.RelNode rel, long maxRowCount)
+        public PreparedPlan PrepareRel(CalcitePrepare.Context context, org.apache.calcite.rel.RelNode rel, long maxRowCount)
         {
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(rel);
@@ -226,6 +226,54 @@ namespace Apache.Calcite.Extensions.Prepare
         }
 
         /// <summary>
+        /// Parses one statement, with the connection's parser configuration.
+        /// </summary>
+        /// <remarks>
+        /// The head of <c>prepare2_</c>, split out so a statement can be classified without being
+        /// prepared.
+        /// </remarks>
+        SqlNode Parse(CalcitePrepare.Context context, string sql)
+        {
+            var config = context.config();
+
+            var parseConfig = ParserConfig()
+                .withQuotedCasing(config.quotedCasing())
+                .withUnquotedCasing(config.unquotedCasing())
+                .withQuoting(config.quoting())
+                .withConformance((org.apache.calcite.sql.validate.SqlConformance)config.conformance())
+                .withCaseSensitive(config.caseSensitive());
+
+            var parserFactory = (SqlParserImplFactory)config.parserFactory((java.lang.Class)typeof(SqlParserImplFactory), null);
+            if (parserFactory != null)
+                parseConfig = parseConfig.withParserFactory(parserFactory);
+
+            try
+            {
+                return SqlParser.create(sql, parseConfig).parseStmt();
+            }
+            catch (SqlParseException e)
+            {
+                throw new java.lang.RuntimeException("parse failed: " + e.getMessage(), e);
+            }
+        }
+
+        /// <summary>
+        /// Returns whether a statement parses to DDL, without preparing it.
+        /// </summary>
+        /// <remarks>
+        /// For a caller that must not execute DDL by accident: preparing a DDL statement executes it,
+        /// exactly as Calcite's prepare does, so an ADO.NET <c>Prepare()</c> asks first. It costs one
+        /// extra parse, paid only for the statements it admits.
+        /// </remarks>
+        public bool IsDdl(CalcitePrepare.Context context, string sql)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(sql);
+
+            return Parse(context, sql).getKind().belongsTo(SqlKind.DDL);
+        }
+
+        /// <summary>
         /// Executes a DDL statement.
         /// </summary>
         /// <remarks>
@@ -285,31 +333,11 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <c>CalcitePrepareImpl.prepare2_</c>, in its order, less the <c>queryable</c> and <c>rel</c>
         /// branches — this pipeline is reached with SQL text and nothing else.
         /// </remarks>
-        ClrSignature Prepare2(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount, CalciteCatalogReader catalogReader, ClrPreparingStmt preparingStmt)
+        PreparedPlan Prepare2(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount, CalciteCatalogReader catalogReader, ClrPreparingStmt preparingStmt)
         {
             var typeFactory = context.getTypeFactory();
-            var config = context.config();
 
-            var parseConfig = ParserConfig()
-                .withQuotedCasing(config.quotedCasing())
-                .withUnquotedCasing(config.unquotedCasing())
-                .withQuoting(config.quoting())
-                .withConformance((org.apache.calcite.sql.validate.SqlConformance)config.conformance())
-                .withCaseSensitive(config.caseSensitive());
-
-            var parserFactory = (SqlParserImplFactory)config.parserFactory((java.lang.Class)typeof(SqlParserImplFactory), null);
-            if (parserFactory != null)
-                parseConfig = parseConfig.withParserFactory(parserFactory);
-
-            SqlNode sqlNode;
-            try
-            {
-                sqlNode = SqlParser.create(sql, parseConfig).parseStmt();
-            }
-            catch (SqlParseException e)
-            {
-                throw new java.lang.RuntimeException("parse failed: " + e.getMessage(), e);
-            }
+            var sqlNode = Parse(context, sql);
 
             var statementType = GetStatementType(sqlNode.getKind());
 
@@ -321,7 +349,7 @@ namespace Apache.Calcite.Extensions.Prepare
             {
                 ExecuteDdl(context, sqlNode);
 
-                return new ClrSignature(
+                return new PreparedPlan(
                     sql,
                     com.google.common.collect.ImmutableList.of(),
                     new java.util.LinkedHashMap(),
@@ -364,7 +392,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// The tail of <c>prepare2_</c>, shared by both entry points because a statement is described the
         /// same way however its plan was arrived at.
         /// </remarks>
-        ClrSignature Describe(
+        PreparedPlan Describe(
             CalcitePrepare.Context context,
             string sql,
             RelDataType x,
@@ -405,7 +433,7 @@ namespace Apache.Calcite.Extensions.Prepare
                 _ => throw new java.lang.IllegalStateException($"{preparedResult.GetType()} has no plan."),
             };
 
-            return new ClrSignature(
+            return new PreparedPlan(
                 sql,
                 parameters,
                 preparingStmt.InternalParameters,
@@ -416,7 +444,10 @@ namespace Apache.Calcite.Extensions.Prepare
                 preparedResult.Collations,
                 maxRowCount,
                 bindable,
-                statementType);
+                statementType)
+            {
+                Dependencies = preparingStmt.Dependencies,
+            };
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPreparingStmt.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPreparingStmt.cs
@@ -142,6 +142,8 @@ namespace Apache.Calcite.Extensions.Prepare
 
             org.apache.calcite.runtime.Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
 
+            RecordDependencies(root.rel);
+
             return Implement(root);
         }
 

--- a/src/Apache.Calcite.Extensions/Prepare/IPlanCache.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/IPlanCache.cs
@@ -1,0 +1,45 @@
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// A store for prepared plans.
+    /// </summary>
+    /// <remarks>
+    /// An implementation owns retention and eviction and nothing else. What may be cached, what the key
+    /// is, whether a hit is still valid against the live schema, and when a generation moves are all
+    /// decided by the prepare pipeline before an implementation is consulted — so an implementation can
+    /// cost hit rate, and cannot cost correctness. Every method may be called concurrently when the
+    /// instance is shared between connections.
+    ///
+    /// <para>A plan is an in-process compiled delegate. It cannot be serialized, so a cache cannot be
+    /// distributed, which is why the contract is synchronous: there is no I/O a legitimate implementation
+    /// could be doing.</para>
+    /// </remarks>
+    public interface IPlanCache
+    {
+
+        /// <summary>
+        /// Returns the plan stored under <paramref name="key"/>, or <see langword="null"/> where there is
+        /// none.
+        /// </summary>
+        PreparedPlan? Get(in PlanCacheKey key);
+
+        /// <summary>
+        /// Offers a plan for <paramref name="key"/>. An implementation may decline to retain it.
+        /// </summary>
+        void Add(in PlanCacheKey key, PreparedPlan plan);
+
+        /// <summary>
+        /// Removes the plan stored under <paramref name="key"/>, which the pipeline has found stale.
+        /// </summary>
+        void Remove(in PlanCacheKey key);
+
+        /// <summary>
+        /// Drops every entry belonging to <paramref name="scope"/>. Called when the owning session is
+        /// disposed, so a shared cache does not hold a dead session's plans until eviction finds them.
+        /// </summary>
+        void Clear(PlanCacheScope scope);
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/LruPlanCache.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/LruPlanCache.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// A bounded, least-recently-used <see cref="IPlanCache"/>.
+    /// </summary>
+    /// <remarks>
+    /// Bounded by entry count rather than by weight: a plan is a compiled delegate whose size nothing can
+    /// measure honestly. One lock over a map and a recency list — a plan cache is consulted once per
+    /// statement, not per row, so the lock is not on a hot path even when the instance is shared between
+    /// connections.
+    /// </remarks>
+    public sealed class LruPlanCache : IPlanCache
+    {
+
+        readonly object gate = new();
+        readonly int capacity;
+        readonly Dictionary<PlanCacheKey, LinkedListNode<KeyValuePair<PlanCacheKey, PreparedPlan>>> map = new();
+        readonly LinkedList<KeyValuePair<PlanCacheKey, PreparedPlan>> order = new();
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="capacity">The most entries the cache will hold.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="capacity"/> is not
+        /// positive.</exception>
+        public LruPlanCache(int capacity)
+        {
+            if (capacity <= 0)
+                throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "A plan cache needs room for at least one plan.");
+
+            this.capacity = capacity;
+        }
+
+        /// <summary>
+        /// Gets the most entries the cache will hold.
+        /// </summary>
+        public int Capacity => capacity;
+
+        /// <summary>
+        /// Gets the number of entries currently held.
+        /// </summary>
+        public int Count
+        {
+            get { lock (gate) return map.Count; }
+        }
+
+        /// <inheritdoc />
+        public PreparedPlan? Get(in PlanCacheKey key)
+        {
+            lock (gate)
+            {
+                if (map.TryGetValue(key, out var node) == false)
+                    return null;
+
+                order.Remove(node);
+                order.AddFirst(node);
+                return node.Value.Value;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Add(in PlanCacheKey key, PreparedPlan plan)
+        {
+            ArgumentNullException.ThrowIfNull(plan);
+
+            lock (gate)
+            {
+                if (map.TryGetValue(key, out var node))
+                {
+                    order.Remove(node);
+                    map.Remove(key);
+                }
+
+                map.Add(key, order.AddFirst(new KeyValuePair<PlanCacheKey, PreparedPlan>(key, plan)));
+
+                while (map.Count > capacity && order.Last is { } last)
+                {
+                    order.RemoveLast();
+                    map.Remove(last.Value.Key);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Remove(in PlanCacheKey key)
+        {
+            lock (gate)
+            {
+                if (map.TryGetValue(key, out var node))
+                {
+                    order.Remove(node);
+                    map.Remove(key);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void Clear(PlanCacheScope scope)
+        {
+            ArgumentNullException.ThrowIfNull(scope);
+
+            lock (gate)
+            {
+                var node = order.First;
+                while (node is not null)
+                {
+                    var next = node.Next;
+                    if (ReferenceEquals(node.Value.Key.Scope, scope))
+                    {
+                        order.Remove(node);
+                        map.Remove(node.Value.Key);
+                    }
+
+                    node = next;
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/PlanCacheKey.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PlanCacheKey.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// What a prepared plan is stored under.
+    /// </summary>
+    /// <remarks>
+    /// Everything the prepare pipeline is given that changes its answer, and nothing it derives: the SQL
+    /// text, the convention asked for, the element type, the row limit, and the scope and its generation.
+    /// The session-invariant inputs — schema instance, type factory, configuration, default schema path —
+    /// are the scope's identity and are not repeated here.
+    ///
+    /// <para>The scope and element type compare by reference. A scope has no value to compare, and an
+    /// element type is a <c>java.lang.Class</c>, one instance per class.</para>
+    /// </remarks>
+    public readonly struct PlanCacheKey : IEquatable<PlanCacheKey>
+    {
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        internal PlanCacheKey(PlanCacheScope scope, long generation, string sql, bool async, java.lang.reflect.Type elementType, long maxRowCount)
+        {
+            Scope = scope ?? throw new ArgumentNullException(nameof(scope));
+            Generation = generation;
+            Sql = sql ?? throw new ArgumentNullException(nameof(sql));
+            Async = async;
+            ElementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+            MaxRowCount = maxRowCount;
+        }
+
+        /// <summary>
+        /// Gets the session partition the entry belongs to.
+        /// </summary>
+        public PlanCacheScope Scope { get; }
+
+        /// <summary>
+        /// Gets the scope's schema generation the plan was built under.
+        /// </summary>
+        public long Generation { get; }
+
+        /// <summary>
+        /// Gets the statement's text.
+        /// </summary>
+        public string Sql { get; }
+
+        /// <summary>
+        /// Gets whether the plan was prepared into the asynchronous convention.
+        /// </summary>
+        public bool Async { get; }
+
+        /// <summary>
+        /// Gets what a caller asked a row to be.
+        /// </summary>
+        public java.lang.reflect.Type ElementType { get; }
+
+        /// <summary>
+        /// Gets the row limit, or a negative number for none.
+        /// </summary>
+        public long MaxRowCount { get; }
+
+        /// <inheritdoc />
+        public bool Equals(PlanCacheKey other)
+        {
+            return ReferenceEquals(Scope, other.Scope)
+                && Generation == other.Generation
+                && string.Equals(Sql, other.Sql, StringComparison.Ordinal)
+                && Async == other.Async
+                && ReferenceEquals(ElementType, other.ElementType)
+                && MaxRowCount == other.MaxRowCount;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => obj is PlanCacheKey other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                RuntimeHelpers.GetHashCode(Scope),
+                Generation,
+                Sql is null ? 0 : StringComparer.Ordinal.GetHashCode(Sql),
+                Async,
+                RuntimeHelpers.GetHashCode(ElementType),
+                MaxRowCount);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/PlanCacheScope.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PlanCacheScope.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// One session's partition of a plan cache.
+    /// </summary>
+    /// <remarks>
+    /// A prepared plan is meaningful only to the session that planned it: its row types are interned by
+    /// that session's type factory, and a scannable table it reads may be held in the compiled tree as the
+    /// instance the schema answered at plan time. Entries are therefore partitioned by scope, and a cache
+    /// instance shared between sessions shares capacity and eviction — never plans.
+    ///
+    /// <para>The generation is the scope's schema version, and it lives here rather than on a plan because
+    /// it is relative: a plan does not know what version it was built under, a key does. Executing DDL
+    /// bumps it, which strands every key built under the old generation — the version-in-key pattern,
+    /// which needs no invalidation callback and so cannot miss one. Stranded entries leave the cache
+    /// through its own eviction.</para>
+    /// </remarks>
+    public sealed class PlanCacheScope
+    {
+
+        long generation;
+
+        /// <summary>
+        /// Gets the scope's current schema generation.
+        /// </summary>
+        internal long Generation => Interlocked.Read(ref generation);
+
+        /// <summary>
+        /// Moves the scope to a new generation, stranding every key built under the old one.
+        /// </summary>
+        internal void BumpGeneration() => Interlocked.Increment(ref generation);
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/PlanDependency.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PlanDependency.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// One table a plan reads or writes: the qualified name it was resolved by, and the instance it
+    /// resolved to.
+    /// </summary>
+    /// <remarks>
+    /// The instance matters as much as the name. A Calcite-SPI table is looked up by name when the plan
+    /// runs, so a replacement would be found — but an <c>IClrScannableTable</c> is held in the compiled
+    /// tree as the instance itself, and a replacement under the same name would go silently unread.
+    /// Comparing the instance the name resolves to now against the one it resolved to at plan time catches
+    /// both, without knowing which kind of table it is looking at.
+    /// </remarks>
+    sealed class PlanDependency
+    {
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="path">The table's qualified name, from the root schema down.</param>
+        /// <param name="table">The table the name resolved to at plan time.</param>
+        public PlanDependency(string[] path, org.apache.calcite.schema.Table table)
+        {
+            Path = path ?? throw new ArgumentNullException(nameof(path));
+            Table = table ?? throw new ArgumentNullException(nameof(table));
+        }
+
+        /// <summary>
+        /// Gets the table's qualified name, from the root schema down.
+        /// </summary>
+        public string[] Path { get; }
+
+        /// <summary>
+        /// Gets the table the name resolved to at plan time.
+        /// </summary>
+        public org.apache.calcite.schema.Table Table { get; }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/PreparedPlan.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PreparedPlan.cs
@@ -24,8 +24,15 @@ namespace Apache.Calcite.Extensions.Prepare
     /// bind this type to a constructor it gains nothing from. The members it contributes —
     /// <see cref="Sql"/>, <see cref="Parameters"/>, <see cref="InternalParameters"/>,
     /// <see cref="Columns"/>, <see cref="CursorFactory"/>, <see cref="StatementType"/> — are all here.</para>
+    ///
+    /// <para>The type is public and its members are not: an <see cref="IPlanCache"/> holds and returns
+    /// prepared plans without reading them, and the prepare pipeline that produces and runs them is not
+    /// part of the public API surface. The compiled plan takes everything per-execution — parameters,
+    /// timestamps, the cancel flag, the schema it resolves names against — through the
+    /// <see cref="DataContext"/> it is bound to, which is what makes one instance reusable across
+    /// executions.</para>
     /// </remarks>
-    sealed class ClrSignature
+    public sealed class PreparedPlan
     {
 
         /// <summary>
@@ -44,7 +51,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <param name="bindable">The compiled plan, or <see langword="null"/> where there is nothing to
         /// run — a DDL statement has already taken effect by the time this exists.</param>
         /// <param name="statementType">What kind of statement this is.</param>
-        public ClrSignature(
+        internal PreparedPlan(
             string sql,
             java.util.List parameters,
             java.util.Map internalParameters,
@@ -73,12 +80,12 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <summary>
         /// Gets the statement's text.
         /// </summary>
-        public string Sql { get; }
+        internal string Sql { get; }
 
         /// <summary>
         /// Gets one <see cref="AvaticaParameter"/> per dynamic parameter.
         /// </summary>
-        public java.util.List Parameters { get; }
+        internal java.util.List Parameters { get; }
 
         /// <summary>
         /// Gets the values the query reads through the <see cref="DataContext"/> rather than from the plan.
@@ -88,37 +95,37 @@ namespace Apache.Calcite.Extensions.Prepare
         /// Calcite's own signature carries <c>CalcitePreparingStmt</c>'s private field, which a subclass
         /// that overrides <c>implement</c> never writes to.
         /// </remarks>
-        public java.util.Map InternalParameters { get; }
+        internal java.util.Map InternalParameters { get; }
 
         /// <summary>
         /// Gets the result's row type, or <see langword="null"/> for DDL.
         /// </summary>
-        public RelDataType? RowType { get; }
+        internal RelDataType? RowType { get; }
 
         /// <summary>
         /// Gets one <see cref="ColumnMetaData"/> per result column.
         /// </summary>
-        public java.util.List Columns { get; }
+        internal java.util.List Columns { get; }
 
         /// <summary>
         /// Gets how a row is read back.
         /// </summary>
-        public Meta.CursorFactory CursorFactory { get; }
+        internal Meta.CursorFactory CursorFactory { get; }
 
         /// <summary>
         /// Gets the schema the statement was planned against.
         /// </summary>
-        public CalciteSchema? RootSchema { get; }
+        internal CalciteSchema? RootSchema { get; }
 
         /// <summary>
         /// Gets the collations the result is known to carry.
         /// </summary>
-        public java.util.List Collations { get; }
+        internal java.util.List Collations { get; }
 
         /// <summary>
         /// Gets the row limit, or a negative number for none.
         /// </summary>
-        public long MaxRowCount { get; }
+        internal long MaxRowCount { get; }
 
         /// <summary>
         /// Gets the compiled plan, or <see langword="null"/> where there is nothing to run.
@@ -132,12 +139,25 @@ namespace Apache.Calcite.Extensions.Prepare
         /// is held is a rendered string rather than a plan, and there is no pull behind it for an awaited
         /// reader to hide.</para>
         /// </remarks>
-        public IClrBindableBase? Bindable { get; }
+        internal IClrBindableBase? Bindable { get; }
 
         /// <summary>
         /// Gets what kind of statement this is.
         /// </summary>
-        public Meta.StatementType StatementType { get; }
+        internal Meta.StatementType StatementType { get; }
+
+        /// <summary>
+        /// Gets the tables the plan reads or writes, or <see langword="null"/> where they could not be
+        /// established.
+        /// </summary>
+        /// <remarks>
+        /// Recorded from the optimized plan, so a view contributes the tables its definition reads rather
+        /// than itself. <see cref="CachingPrepare"/> validates a cache hit against these — a name that no
+        /// longer resolves, or resolves to a different table instance, makes the plan stale — and declines
+        /// to store a plan whose dependencies are <see langword="null"/>, because such a plan cannot be
+        /// validated.
+        /// </remarks>
+        internal IReadOnlyList<PlanDependency>? Dependencies { get; set; }
 
         /// <summary>
         /// Runs the plan against a <see cref="DataContext"/> and returns its rows.
@@ -151,7 +171,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// past the signature to the bindable would silently lose that. In JDBC zero means no limit; here,
         /// as there, a negative number means no limit and zero is a limit of zero.
         /// </remarks>
-        public IEnumerable<object> Bind(DataContext root)
+        internal IEnumerable<object> Bind(DataContext root)
         {
             ArgumentNullException.ThrowIfNull(root);
 
@@ -180,7 +200,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <para>An <c>EXPLAIN</c> passes, because <c>ClrExplainBindable</c> is both. Not an exception to
         /// that rule — there is no plan behind it to pull.</para>
         /// </remarks>
-        public IAsyncEnumerable<object> BindAsync(DataContext root)
+        internal IAsyncEnumerable<object> BindAsync(DataContext root)
         {
             ArgumentNullException.ThrowIfNull(root);
 

--- a/src/Apache.Calcite.Extensions/README.md
+++ b/src/Apache.Calcite.Extensions/README.md
@@ -91,7 +91,9 @@ A Spark handler is not supported: `ToBindable` throws `UnsupportedOperationExcep
 
 The nodes (`ClrEnumerableCalc`, `ClrEnumerableHashJoin`, `ClrEnumerableWindow`, and the rest) and their rules are public too, so you can subclass or re-register them.
 
-**The SQL-text prepare pipeline is internal to these packages.** `ClrPrepareImpl`, `ClrSignature` and the rest of `Apache.Calcite.Extensions.Prepare` are not part of the public API surface — `Apache.Calcite.Data` reaches them through `InternalsVisibleTo`. To run SQL text, use `Apache.Calcite.Data`; to drive the planner directly, use the public types above.
+**The SQL-text prepare pipeline is internal to these packages.** `ClrPrepareImpl` and the rest of `Apache.Calcite.Extensions.Prepare` are not part of the public API surface — `Apache.Calcite.Data` reaches them through `InternalsVisibleTo`. To run SQL text, use `Apache.Calcite.Data`; to drive the planner directly, use the public types above.
+
+What the namespace does expose is the plan cache: `IPlanCache` is the contract a caller-supplied cache implements — retention and eviction only; admission, keying and hit validation stay in the pipeline — with `LruPlanCache` as the built-in bounded implementation, `PlanCacheKey`/`PlanCacheScope` as what entries are stored under, and `PreparedPlan` as the opaque handle a cache holds without reading. Associate one with a connection through `CalcitePlanCacheFactory` on `Apache.Calcite.Data`, or the `PlanCacheSize` connection-string key.
 
 ## `CalciteConnectionProperties`
 

--- a/src/Apache.Calcite.Extensions/Runtime/ClrPlan.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/ClrPlan.cs
@@ -27,7 +27,7 @@ namespace Apache.Calcite.Extensions.Runtime
     /// sequence has to be produced by calling out. Deferring the compile is what is available.</para>
     ///
     /// <para>It compiles at most once per prepared statement, because the converter stashes it in the
-    /// internal parameters and those belong to the <c>ClrSignature</c>. Two threads reaching an uncompiled
+    /// internal parameters and those belong to the <c>PreparedPlan</c>. Two threads reaching an uncompiled
     /// one at the same moment may both compile it; that is idempotent and cheaper than locking a path taken
     /// once.</para>
     /// </remarks>

--- a/src/Apache.Calcite.Extensions/Runtime/IClrBindableBase.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/IClrBindableBase.cs
@@ -8,7 +8,7 @@ namespace Apache.Calcite.Extensions.Runtime
     /// </summary>
     /// <remarks>
     /// One member, because it is the only one a caller reads without knowing which convention prepared the
-    /// statement: <c>ClrSignature</c> holds a plan as this, and <c>ClrPrepareImpl.Describe</c> reads nothing
+    /// statement: <c>PreparedPlan</c> holds a plan as this, and <c>ClrPrepareImpl.Describe</c> reads nothing
     /// else off it. Binding is on <see cref="IClrBindable"/> and <see cref="IClrAsyncBindable"/>, because
     /// the two return different sequences and a common <c>Bind</c> could only return one neither of them
     /// wants.

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
@@ -147,7 +147,7 @@ namespace Apache.Calcite.Tests
         /// that demand is stated. So the text names this convention's nodes.
         ///
         /// <para>It used to throw: <c>ClrExplainBindable</c> was an <c>IClrBindable</c> alone and
-        /// <c>ClrSignature.BindAsync</c> refused it as "prepared into a synchronous convention", which was
+        /// <c>PreparedPlan.BindAsync</c> refused it as "prepared into a synchronous convention", which was
         /// never true of an <c>EXPLAIN</c> and left a caller holding only <c>ExecuteReaderAsync</c> unable to
         /// explain anything at all.</para>
         /// </remarks>

--- a/src/Apache.Calcite.Tests/ClrPrepareMetadataTests.cs
+++ b/src/Apache.Calcite.Tests/ClrPrepareMetadataTests.cs
@@ -177,7 +177,7 @@ namespace Apache.Calcite.Tests
 
         /// <summary>
         /// <c>maxRowCount</c> lives inside <c>CalciteSignature.enumerable</c> in Calcite and inside
-        /// <see cref="ClrSignature.Bind"/> here. Nothing else exercises it, because every caller in this
+        /// <see cref="PreparedPlan.Bind"/> here. Nothing else exercises it, because every caller in this
         /// project passes -1.
         /// </summary>
         [TestMethod]

--- a/src/Apache.Calcite.Tests/LruPlanCacheTests.cs
+++ b/src/Apache.Calcite.Tests/LruPlanCacheTests.cs
@@ -1,0 +1,127 @@
+using Apache.Calcite.Extensions.Prepare;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Tests for <see cref="LruPlanCache"/>'s retention policy: bounded, least-recently-used out first,
+    /// and cleared per scope.
+    /// </summary>
+    [TestClass]
+    public class LruPlanCacheTests
+    {
+
+        static readonly java.lang.reflect.Type ElementType = (java.lang.Class)typeof(java.lang.Object[]);
+
+        static PlanCacheKey Key(PlanCacheScope scope, string sql, long generation = 0) =>
+            new(scope, generation, sql, async: true, ElementType, -1);
+
+        static PreparedPlan Plan(string sql) =>
+            new(sql,
+                com.google.common.collect.ImmutableList.of(),
+                new java.util.LinkedHashMap(),
+                null,
+                com.google.common.collect.ImmutableList.of(),
+                org.apache.calcite.avatica.Meta.CursorFactory.OBJECT,
+                null,
+                com.google.common.collect.ImmutableList.of(),
+                -1,
+                null,
+                org.apache.calcite.avatica.Meta.StatementType.SELECT);
+
+        [TestMethod]
+        public void ShouldStoreAndReturnByKey()
+        {
+            var cache = new LruPlanCache(2);
+            var scope = new PlanCacheScope();
+            var plan = Plan("SELECT 1");
+
+            cache.Add(Key(scope, "SELECT 1"), plan);
+
+            cache.Get(Key(scope, "SELECT 1")).Should().BeSameAs(plan);
+            cache.Get(Key(scope, "SELECT 2")).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldTreatADifferentGenerationAsADifferentKey()
+        {
+            var cache = new LruPlanCache(2);
+            var scope = new PlanCacheScope();
+
+            cache.Add(Key(scope, "SELECT 1", generation: 0), Plan("SELECT 1"));
+
+            cache.Get(Key(scope, "SELECT 1", generation: 1)).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldEvictTheLeastRecentlyUsedEntryBeyondCapacity()
+        {
+            var cache = new LruPlanCache(2);
+            var scope = new PlanCacheScope();
+
+            cache.Add(Key(scope, "a"), Plan("a"));
+            cache.Add(Key(scope, "b"), Plan("b"));
+
+            // touch a, so b is the one to go
+            cache.Get(Key(scope, "a")).Should().NotBeNull();
+
+            cache.Add(Key(scope, "c"), Plan("c"));
+
+            cache.Count.Should().Be(2);
+            cache.Get(Key(scope, "a")).Should().NotBeNull();
+            cache.Get(Key(scope, "b")).Should().BeNull();
+            cache.Get(Key(scope, "c")).Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void ShouldReplaceTheEntryWhenAddingTheSameKey()
+        {
+            var cache = new LruPlanCache(2);
+            var scope = new PlanCacheScope();
+            var second = Plan("a");
+
+            cache.Add(Key(scope, "a"), Plan("a"));
+            cache.Add(Key(scope, "a"), second);
+
+            cache.Count.Should().Be(1);
+            cache.Get(Key(scope, "a")).Should().BeSameAs(second);
+        }
+
+        [TestMethod]
+        public void ShouldDropTheEntryOnRemove()
+        {
+            var cache = new LruPlanCache(2);
+            var scope = new PlanCacheScope();
+
+            cache.Add(Key(scope, "a"), Plan("a"));
+            cache.Remove(Key(scope, "a"));
+
+            cache.Count.Should().Be(0);
+            cache.Get(Key(scope, "a")).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldClearOneScopeAndLeaveTheOther()
+        {
+            var cache = new LruPlanCache(4);
+            var mine = new PlanCacheScope();
+            var theirs = new PlanCacheScope();
+
+            cache.Add(Key(mine, "a"), Plan("a"));
+            cache.Add(Key(theirs, "a"), Plan("a"));
+            cache.Add(Key(mine, "b"), Plan("b"));
+
+            cache.Clear(mine);
+
+            cache.Count.Should().Be(1);
+            cache.Get(Key(mine, "a")).Should().BeNull();
+            cache.Get(Key(theirs, "a")).Should().NotBeNull();
+        }
+
+    }
+
+}


### PR DESCRIPTION
A per-connection plan cache, behind an interface a caller can implement and a factory on the connection. Off by default; nothing changes until a connection asks for it, which the unchanged differential suite confirms.

## Why it is cheap to have

A compiled plan already takes everything per-execution through the `DataContext` it is bound to — parameters, timestamps, the cancel flag, the schema it resolves names against — so one plan serves every execution of the same text. Parameters are never inlined at plan time. The work was keying, admission and invalidation, and it lives with whoever prepares, which is what the note in `ClrEnumerableInterpretable` had already concluded: Calcite's `BINDABLE_CACHE` keys on generated Java source, a plan of this convention has no source text, and a cache "belongs to whoever prepares rather than to whoever compiles."

## Shape

- **`ClrSignature` → `PreparedPlan`**, public with internal members: the opaque handle a cache holds without reading. The prepare pipeline stays internal.
- **`IPlanCache`** (Extensions, public): retention and eviction only. Admission, the key, hit validity and the generation are the pipeline's, decided in the internal `CachingPrepare` before an implementation is consulted — an implementation can cost hit rate, not correctness. `LruPlanCache` is the built-in, bounded by entry count.
- **Key** = SQL text under a per-session `PlanCacheScope` and its generation, plus the convention, element type and row limit. Session invariants (schema, type factory, config, default path) are the scope's identity and are not repeated.
- **Association**: `CalcitePlanCacheFactory` on `CalciteConnection` or `CalciteDataSource`, consulted once when the session is created and frozen after, like the connection string. `From(cache)` shares one bounded cache across connections — entries are scope-partitioned, so capacity is shared and plans never are. `PlanCacheSize=N` in the connection string installs a private LRU with no code.

## Invalidation

- **DDL** executes inside prepare, so the generation bump is made where its effect is first visible; every prior key becomes unreachable, and a DDL text is never stored — a hit would silently skip the DDL. Admission is store-side because a statement's kind is not known until parsed, and an uncacheable statement has by then simply been prepared the ordinary way.
- **Direct schema mutation** (`RootSchema.add` from outside the pipeline) is caught by dependency validation: the optimized plan records each table's qualified name and resolved instance, and a hit re-resolves them against the live schema, requiring the same instance. That includes an `IClrScannableTable`, whose instance is baked into the compiled tree as a constant. The same check runs before store, so a plan whose tables do not resolve stably is never cached rather than evicted on every later lookup.
- **Hooks** bypass the cache entirely: a planning-phase hook can rewrite what prepare produces (`SQL2REL_CONVERTER_CONFIG_BUILDER` does exactly that) and expects to observe the phases as they run; a cached plan would neither reflect them nor fire them.
- **Known limit, stated where the dependencies are recorded**: a view replaced directly on the schema — not through DDL — is not detected, because the plan depends on the tables the view expanded to, which did not change.

## `Prepare()`

`DbCommand.Prepare()` and `CalciteBatch.Prepare()` plan eagerly into the cache, parsing first to refuse DDL — planning DDL executes it, and `Prepare` must not have effects; the test proves the table does not exist after `Prepare()` and does after `ExecuteNonQuery()`. On a connectionless command `Prepare()` now throws `InvalidOperationException`, the ADO.NET norm, where it was a silent no-op.

## Results

- Apache.Calcite.Tests: 674/674, differential tests included.
- Apache.Calcite.Data.Tests: 342/342 on net8.0 and net10.0, seventeen of them new — identity reuse, parameter reuse, table-replacement invalidation, DDL generation stranding, hooks bypass, EXPLAIN admission, shared-cache partitioning and clear-on-dispose, data-source factory propagation, Prepare warm and DDL refusal, both conventions.
- Apache.Calcite.Adapter.AdoNet.Tests: 345/345 — dependency recording now runs on every plan, cached or not, and the adapter's trees exercise it.
- Measured on a two-way join over `VALUES`: 25 cache hits 2.0 ms, 25 plans 1329.6 ms — about 53 ms saved per statement.
