### PR TITLE
Plan against a snapshot of the root schema, and execute against it too

### DIFF
--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -246,13 +246,15 @@ namespace Apache.Calcite.Data.Internal
         /// Mirrors the work done by <c>CalciteConnectionImpl.enumerable()</c> just before it calls
         /// <c>signature.enumerable(dataContext)</c>: bound parameters, stashed compile-time values
         /// from <c>signature.internalParameters</c>, cancel flag, and timeout are assembled into a
-        /// single <see cref="StatementDataContext"/>.
+        /// single <see cref="StatementDataContext"/> over <c>signature.rootSchema</c> — the snapshot
+        /// the statement was planned against, not the live root, so a statement executes against what
+        /// it planned against. Null for DDL, as upstream's is.
         /// </summary>
         void Bind(CalciteExecuteRequest request, ClrSignature signature, out DataContext dataContext, out AtomicBoolean cancelFlag)
         {
             cancelFlag = new AtomicBoolean(false);
             var boundParameters = ParameterBinder.Bind(request.Parameters);
-            dataContext = new StatementDataContext(_rootSchema.plus(), _typeFactory, cancelFlag, request.CommandTimeoutSeconds * 1000L, boundParameters, signature.InternalParameters);
+            dataContext = new StatementDataContext(signature.RootSchema?.plus(), _typeFactory, cancelFlag, request.CommandTimeoutSeconds * 1000L, boundParameters, signature.InternalParameters);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Prepare/PrepareContext.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PrepareContext.cs
@@ -21,6 +21,15 @@ namespace Apache.Calcite.Extensions.Prepare
     /// from any JDBC class. This is the boundary the Calcite planner uses to discover schemas,
     /// configuration, and the type factory.
     /// <para>
+    /// As there, the constructor stamps the moment of the prepare and takes
+    /// <c>createSnapshot(new LongSchemaVersion(now))</c> of the root schema: <c>getRootSchema()</c>
+    /// answers the snapshot, and the live root stays reachable only through
+    /// <c>getMutableRootSchema()</c>, which is where DDL executes. The snapshot is Calcite's, holes
+    /// included — <c>createSnapshot</c> shares the original's table and lattice maps so that
+    /// materializations can create tables on the fly, and a <c>Schema</c> is only as frozen as its
+    /// own <c>snapshot(version)</c> chooses to be.
+    /// </para>
+    /// <para>
     /// <c>getDataContext()</c> returns a minimal throwaway <see cref="DataContext"/> containing only
     /// the standard timestamp variables — exactly what <c>CalciteConnectionImpl.ContextImpl</c> does
     /// via <c>createDataContext(ImmutableMap.of(), rootSchema)</c>. It is used solely to back
@@ -32,6 +41,7 @@ namespace Apache.Calcite.Extensions.Prepare
     {
 
         readonly JavaTypeFactory _typeFactory;
+        readonly CalciteSchema _mutableRootSchema;
         readonly CalciteSchema _rootSchema;
         readonly CalciteConnectionConfig _config;
         readonly IReadOnlyList<string> _defaultSchemaPath;
@@ -43,7 +53,8 @@ namespace Apache.Calcite.Extensions.Prepare
             IReadOnlyList<string> defaultSchemaPath)
         {
             _typeFactory = typeFactory;
-            _rootSchema = rootSchema;
+            _mutableRootSchema = rootSchema;
+            _rootSchema = rootSchema.createSnapshot(new org.apache.calcite.schema.impl.LongSchemaVersion(java.lang.System.currentTimeMillis()));
             _config = config;
             _defaultSchemaPath = defaultSchemaPath;
         }
@@ -60,7 +71,7 @@ namespace Apache.Calcite.Extensions.Prepare
 
         public CalciteSchema getMutableRootSchema()
         {
-            return _rootSchema;
+            return _mutableRootSchema;
         }
 
         public List getDefaultSchemaPath()

--- a/src/Apache.Calcite.Extensions/Prepare/StatementDataContext.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/StatementDataContext.cs
@@ -19,7 +19,7 @@ namespace Apache.Calcite.Extensions.Prepare
     internal sealed class StatementDataContext : DataContext
     {
 
-        readonly SchemaPlus _rootSchema;
+        readonly SchemaPlus? _rootSchema;
         readonly JavaTypeFactory _typeFactory;
         readonly IReadOnlyDictionary<string, object?> _vars;
         readonly IReadOnlyList<object?> _parameters;
@@ -27,7 +27,9 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
-        /// <param name="rootSchema"></param>
+        /// <param name="rootSchema">The schema the statement was planned against, or
+        /// <see langword="null"/> for a DDL signature, which has no plan to run —
+        /// <c>DataContextImpl</c>'s root schema is nullable for the same statement.</param>
         /// <param name="typeFactory"></param>
         /// <param name="cancelFlag"></param>
         /// <param name="queryTimeoutMillis"></param>
@@ -38,7 +40,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// the generated <c>bind(root)</c> method retrieves via <c>root.get(name)</c> at execution time.
         /// Pass <see langword="null"/> when constructing a throwaway planning-only context.
         /// </param>
-        public StatementDataContext(SchemaPlus rootSchema, JavaTypeFactory typeFactory, AtomicBoolean cancelFlag, long queryTimeoutMillis, IReadOnlyList<object?> parameters, java.util.Map? internalParameters = null)
+        public StatementDataContext(SchemaPlus? rootSchema, JavaTypeFactory typeFactory, AtomicBoolean cancelFlag, long queryTimeoutMillis, IReadOnlyList<object?> parameters, java.util.Map? internalParameters = null)
         {
             _rootSchema = rootSchema;
             _typeFactory = typeFactory;
@@ -72,9 +74,9 @@ namespace Apache.Calcite.Extensions.Prepare
         }
 
         /// <summary>
-        /// Returns the root schema of the current session.
+        /// Returns the schema the statement was planned against, or <see langword="null"/> for DDL.
         /// </summary>
-        public SchemaPlus getRootSchema() => _rootSchema;
+        public SchemaPlus? getRootSchema() => _rootSchema;
 
         /// <summary>
         /// Returns the <see cref="JavaTypeFactory"/> used to create Java type representations.


### PR DESCRIPTION
## What

Takes the per-prepare schema snapshot that `CalciteConnectionImpl.ContextImpl` takes and this pipeline skipped, and executes against it the way `enumerable()` does.

- **`PrepareContext`** — the constructor now stamps the prepare's moment and takes `createSnapshot(new LongSchemaVersion(currentTimeMillis))`, exactly as `ContextImpl`'s constructor does. `getRootSchema()` answers the snapshot; the live root is reachable only through `getMutableRootSchema()`, which is where DDL executes. `ClrPrepareImpl` and the catalog reader already consume `context.getRootSchema()`, so the whole planning path — and `getDataContext()`'s constant-folding context — inherits the snapshot with no further changes, the same shape as upstream.
- **`CalciteSession.Bind`** — builds the `StatementDataContext` from `signature.RootSchema?.plus()`, the snapshot the statement was planned against, mirroring `enumerable()`'s `createDataContext(map, signature.rootSchema)`. The signature has carried that field, documented as "the schema the statement was planned against", since it was written; it was ignored in favor of the live root until now.
- **`StatementDataContext`** — root schema is nullable, because a DDL signature carries `null` there, as upstream's DDL branch does, and `DataContextImpl`'s root is `@Nullable` for the same statement. A DDL's data context is built and never read, in both codebases.

## Why

The two-method split on `CalcitePrepare.Context` — `getRootSchema` versus `getMutableRootSchema` — *is* Calcite's freeze mechanism: the connection surface stays mutable for its whole life, and each prepare plans and runs against a consistent snapshot. Collapsing both accessors onto the live schema was a divergence in a class whose doc comment claims to mirror `ContextImpl`.

The snapshot is reproduced holes included: `createSnapshot` shares the original's table and lattice maps so materializations can create tables on the fly, and a `Schema` SPI object is only as frozen as its own `snapshot(version)` chooses to be. All three members are confirmed present in the referenced 1.42.0 tag.

No caching of contexts, snapshots, or plans — every prepare builds a fresh context and pays for its own snapshot, as upstream does.

## Verified

- `Apache.Calcite.Tests`: 668/668, nothing skipped
- `Apache.Calcite.Data.Tests` (net8.0): 324/324, nothing skipped — covers DDL (the null-`RootSchema` path through `Bind`) and view expansion against the snapshot

Not run: the AdoNet adapter test projects, which need live external databases.