### PR TITLE
Mark convention bridge rules guaranteed; trim CHAR padding on read

### DIFF
--- a/src/Apache.Calcite.Data/Internal/CalciteResultValue.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResultValue.cs
@@ -189,7 +189,7 @@ namespace Apache.Calcite.Data.Internal
 
             {
                 if (_value is null) return DBNull.Value;
-                if (_value is string) return _value;
+                if (_value is string sv) return TrimCharPadding(sv);
                 if (_value is java.math.BigDecimal bd) return BigDecimalConverter.ToDecimal(bd);
                 if (_value is java.lang.Boolean b) return b.booleanValue();
                 if (_value is java.lang.Byte by) return (sbyte)by.byteValue();
@@ -234,9 +234,25 @@ namespace Apache.Calcite.Data.Internal
         {
             return _value switch
             {
-                string s => s,
+                string s => TrimCharPadding(s),
                 _ => throw new InvalidCastException($"Cannot convert value of type '{_value?.GetType().Name}' with value '{_value}' (SQL type: {_sqlType}) to 'String'"),
             };
+        }
+
+        /// <summary>
+        /// Removes the trailing pad spaces from a CHAR value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// SQL pads a CHAR(n) value to its declared length, and Calcite's engine hands the padded value
+        /// back. The padding is storage, not data: a reader asked for the string wants the value that was
+        /// written, so the pad is removed at the boundary, the way most ADO.NET providers do. VARCHAR is
+        /// untouched -- its trailing spaces are data.
+        /// </remarks>
+        string TrimCharPadding(string value)
+        {
+            return _sqlType.name() == nameof(SqlTypeName.CHAR) ? value.TrimEnd(' ') : value;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverterRule.cs
@@ -42,6 +42,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new ClrEnumerableToClrAsyncEnumerableConverter(

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverterRule.cs
@@ -41,6 +41,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new EnumerableToClrAsyncEnumerableConverter(

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverterRule.cs
@@ -42,6 +42,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new ClrAsyncEnumerableToClrEnumerableConverter(

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverterRule.cs
@@ -40,6 +40,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new EnumerableToClrEnumerableConverter(


### PR DESCRIPTION
## Guaranteed convention bridges

The four unconditional convention bridge rules — `EnumerableToClrEnumerableConverterRule`, `EnumerableToClrAsyncEnumerableConverterRule`, `ClrEnumerableToClrAsyncEnumerableConverterRule`, and `ClrAsyncEnumerableToClrEnumerableConverterRule` — now override `isGuaranteed()` to return `true`.

Each of these rules converts *any* node of its input convention, which is exactly the contract `ConverterRule.isGuaranteed` documents. Leaving it at the default `false` kept them out of `ConventionTraitDef`'s conversion graph, and that graph is the **only** conversion route available when the input is itself a `Converter`: Calcite's `ConverterRelOptRuleOperand.matches` refuses to apply a converter rule to a `Converter` of the same trait def (the n² guard in `RelOptRule`), and expects abstract-converter expansion to walk the conversion graph instead. With an empty graph, the `AbstractConverter`s sit at infinite cost and the statement fails with `CannotPlanException`.

Reproduction: a third-party convention (the EF Core adapter in `ikvmnet/calcite-efcore`) registers only a converter into `CLR_ASYNC_ENUMERABLE`; every synchronous statement then fails with

```
CannotPlanException: ... Missing conversion is EfCoreEntityScan[convention: EFCORE.efcore -> CLR_ENUMERABLE]
```

even though `ClrAsyncEnumerableToClrEnumerableConverterRule` is registered on the planner. With `isGuaranteed()` true, the same configuration plans and the adapter's full suite passes.

## CHAR padding trimmed at the reader boundary

`CalciteResultValue` now removes trailing pad spaces when the column's SQL type is `CHAR`, in both `GetString()` and the general `GetValue()` path. SQL pads a `CHAR(n)` value to its declared length and the engine hands the padded value back; the padding is storage, not data, so it is removed at the reader boundary the way most ADO.NET providers do. `VARCHAR` is untouched — its trailing spaces are data.

This restores the 1.x reader behavior. The visible symptom in 2.0: `CASE` arms of different lengths unify to `CHAR` of the longest, so `SELECT CASE WHEN ... THEN 'Mid' ... END` returns `'Mid      '` from a query that never mentions `CHAR`.

## Validation

- `Apache.Calcite.Data.Tests`: 324/324 (net8.0 and net10.0)
- `Apache.Calcite.Tests`: 672/672 (net8.0 and net10.0)
- `Apache.Calcite.Adapter.AdoNet.Tests`: 140 passed / 205 skipped / 0 failed (both TFMs)
- End-to-end: packed these changes as local packages and ran the `calcite-efcore` adapter suite against them — 105/110 passed, 0 failed (5 skipped), including the previously failing CHAR `CASE` test, and the async-only converter registration now plans synchronous statements.

Note: the `2.0.0-pre.3` tag points at a commit without these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcGLiefiDH3Bx4dkudv8oj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcGLiefiDH3Bx4dkudv8oj)_