### PR TITLE
Answer metadata without Janino, and open the prepare to a caller's own

### DIFF
--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -87,6 +87,7 @@ namespace Apache.Calcite.Data.Internal
         readonly CalciteConnectionConfig _config;
         readonly IReadOnlyList<string> _defaultSchemaPath;
         readonly bool _synchronous;
+        readonly Func<ClrPrepareImpl> _prepareFactory;
         bool _disposed;
 
         /// <summary>
@@ -104,9 +105,11 @@ namespace Apache.Calcite.Data.Internal
         /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
         /// converter carrying its rows.
         /// </remarks>
-        public CalciteSession(CalciteConnectionStringBuilder options)
+        public CalciteSession(CalciteConnectionStringBuilder options, Func<ClrPrepareImpl>? prepareFactory = null)
         {
             ArgumentNullException.ThrowIfNull(options);
+
+            _prepareFactory = prepareFactory ?? (static () => new ClrPrepareImpl());
 
             try
             {
@@ -233,7 +236,7 @@ namespace Apache.Calcite.Data.Internal
             CalcitePrepare.Dummy.push(ctx);
             try
             {
-                return new ClrPrepareImpl().Prepare(ctx, request.Sql, (java.lang.Class)typeof(java.lang.Object[]), -1, async);
+                return _prepareFactory().Prepare(ctx, request.Sql, (java.lang.Class)typeof(java.lang.Object[]), -1, async);
             }
             finally
             {

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableInterpretable.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableInterpretable.cs
@@ -38,22 +38,16 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// </summary>
         /// <param name="internalParameters">Values the query reads through the <see cref="DataContext"/>
         /// rather than from the plan. The same map must be served by the context it is bound with.</param>
-        /// <param name="spark">The Spark handler, or <see langword="null"/> where there is none. This
-        /// convention cannot use one — see the exception.</param>
         /// <param name="rel">The chosen plan, whose root must be of this convention.</param>
         /// <param name="prefer">How the caller wants rows represented. <see cref="ClrEnumerablePrefer.Array"/>
         /// is what a prepared statement asks for.</param>
         /// <returns>The compiled plan, to bind to a <see cref="DataContext"/> and enumerate.</returns>
-        /// <exception cref="java.lang.UnsupportedOperationException">
-        /// <paramref name="spark"/> is enabled. A Spark handler compiles generated Java source, and a plan of
-        /// this convention is an expression tree; use <c>EnumerableConvention</c> for such a query.
-        /// </exception>
         /// <exception cref="java.lang.IllegalStateException">
         /// A node of the plan could not be implemented. The message names the plan.
         /// </exception>
         /// <remarks>
-        /// Takes what <c>EnumerableInterpretable.toBindable</c> takes, in its order, so a caller holding one
-        /// convention's compiler can hold the other's.
+        /// What <c>EnumerableInterpretable.toBindable</c> is for this convention: a plan here is an
+        /// expression tree, compiled to a delegate rather than to a generated class.
         /// </remarks>
         /// <remarks>
         /// Calcite caches its compiled bindables — <c>EnumerableInterpretable.BINDABLE_CACHE</c>, keyed on
@@ -62,20 +56,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// no key. A cache here would have to be built on the SQL and the schema's version instead, which is
         /// a different thing and belongs to whoever prepares rather than to whoever compiles.
         /// </remarks>
-        public static IClrAsyncBindable ToBindable(java.util.Map internalParameters, org.apache.calcite.jdbc.CalcitePrepare.SparkHandler? spark, ClrAsyncEnumerableRel rel, ClrEnumerablePrefer prefer)
+        public static IClrAsyncBindable ToBindable(java.util.Map internalParameters, ClrAsyncEnumerableRel rel, ClrEnumerablePrefer prefer)
         {
             ArgumentNullException.ThrowIfNull(internalParameters);
             ArgumentNullException.ThrowIfNull(rel);
 
-            if (spark != null && spark.enabled())
-                throw new java.lang.UnsupportedOperationException(
-                    "ClrAsyncEnumerableConvention cannot compile with a Spark handler: it has no generated class to hand one. Use EnumerableConvention for a Spark-enabled plan.");
 
             var implementor = new ClrAsyncEnumerableRelImplementor(rel.getCluster().getRexBuilder(), internalParameters);
             var lambda = implementor.ImplementRoot(rel, prefer);
             var plan = (Func<DataContext, IAsyncEnumerable<object>>)lambda.Compile();
 
-            return new ClrAsyncBindable(plan, Linq4j.Tree.ClrTypes.Resolve(PhysTypeImpl.of(implementor.TypeFactory, rel.getRowType(), prefer.PreferArray()).getJavaRowType()));
+            return new ClrAsyncBindable(plan, Linq4j.Tree.ClrTypes.Resolve(ClrPhysTypeImpl.Of(implementor.TypeFactory, rel.getRowType(), prefer.PreferArray()).JavaRowType));
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableInterpretable.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableInterpretable.cs
@@ -36,22 +36,16 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// </summary>
         /// <param name="internalParameters">Values the query reads through the <see cref="DataContext"/>
         /// rather than from the plan. The same map must be served by the context it is bound with.</param>
-        /// <param name="spark">The Spark handler, or <see langword="null"/> where there is none. This
-        /// convention cannot use one — see the exception.</param>
         /// <param name="rel">The chosen plan, whose root must be of this convention.</param>
         /// <param name="prefer">How the caller wants rows represented. <see cref="ClrEnumerablePrefer.Array"/>
         /// is what a prepared statement asks for.</param>
         /// <returns>The compiled plan, to bind to a <see cref="DataContext"/> and enumerate.</returns>
-        /// <exception cref="java.lang.UnsupportedOperationException">
-        /// <paramref name="spark"/> is enabled. A Spark handler compiles generated Java source, and a plan of
-        /// this convention is an expression tree; use <c>EnumerableConvention</c> for such a query.
-        /// </exception>
         /// <exception cref="java.lang.IllegalStateException">
         /// A node of the plan could not be implemented. The message names the plan.
         /// </exception>
         /// <remarks>
-        /// Takes what <c>EnumerableInterpretable.toBindable</c> takes, in its order, so a caller holding one
-        /// convention's compiler can hold the other's.
+        /// What <c>EnumerableInterpretable.toBindable</c> is for this convention: a plan here is an
+        /// expression tree, compiled to a delegate rather than to a generated class.
         /// </remarks>
         /// <remarks>
         /// Calcite caches its compiled bindables — <c>EnumerableInterpretable.BINDABLE_CACHE</c>, keyed on
@@ -60,20 +54,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// no key. A cache here would have to be built on the SQL and the schema's version instead, which is
         /// a different thing and belongs to whoever prepares rather than to whoever compiles.
         /// </remarks>
-        public static IClrBindable ToBindable(java.util.Map internalParameters, org.apache.calcite.jdbc.CalcitePrepare.SparkHandler? spark, ClrEnumerableRel rel, ClrEnumerablePrefer prefer)
+        public static IClrBindable ToBindable(java.util.Map internalParameters, ClrEnumerableRel rel, ClrEnumerablePrefer prefer)
         {
             ArgumentNullException.ThrowIfNull(internalParameters);
             ArgumentNullException.ThrowIfNull(rel);
 
-            if (spark != null && spark.enabled())
-                throw new java.lang.UnsupportedOperationException(
-                    "ClrEnumerableConvention cannot compile with a Spark handler: it has no generated class to hand one. Use EnumerableConvention for a Spark-enabled plan.");
 
             var implementor = new ClrEnumerableRelImplementor(rel.getCluster().getRexBuilder(), internalParameters);
             var lambda = implementor.ImplementRoot(rel, prefer);
             var plan = (Func<DataContext, IEnumerable<object>>)lambda.Compile();
 
-            return new ClrBindable(plan, Linq4j.Tree.ClrTypes.Resolve(PhysTypeImpl.of(implementor.TypeFactory, rel.getRowType(), prefer.PreferArray()).getJavaRowType()));
+            return new ClrBindable(plan, Linq4j.Tree.ClrTypes.Resolve(ClrPhysTypeImpl.Of(implementor.TypeFactory, rel.getRowType(), prefer.PreferArray()).JavaRowType));
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysType.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysType.cs
@@ -53,6 +53,16 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         Type RowType { get; }
 
         /// <summary>
+        /// Gets the Java type a row of this physical type is, unboxed.
+        /// </summary>
+        /// <remarks>
+        /// <c>PhysType.getJavaRowType</c>. <see cref="RowType"/> is this boxed, because a CLR sequence states
+        /// its element type; this is the type factory's own answer, which is what a caller asking what a row
+        /// <em>is</em> — <c>Meta.CursorFactory.deduce</c>, say — wants.
+        /// </remarks>
+        java.lang.reflect.Type JavaRowType { get; }
+
+        /// <summary>
         /// Returns the CLR type used to store the field with the given ordinal.
         /// </summary>
         /// <param name="field"></param>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysTypeImpl.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrPhysTypeImpl.cs
@@ -153,6 +153,9 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         public Type RowType => javaRowClass;
 
         /// <inheritdoc />
+        public java.lang.reflect.Type JavaRowType => javaRowType;
+
+        /// <inheritdoc />
         public Type FieldType(int field) => format.JavaFieldClass(typeFactory, rowType, field);
 
         /// <inheritdoc />

--- a/src/Apache.Calcite.Extensions/Prepare/AsyncEnumerable/ClrAsyncEnumerablePreparingStmt.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/AsyncEnumerable/ClrAsyncEnumerablePreparingStmt.cs
@@ -85,7 +85,7 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
 
             InternalParameters.put("_conformance", Context.config().conformance());
 
-            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(InternalParameters, null, node, prefer);
+            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(InternalParameters, node, prefer);
 
             var collations = root.collation.getFieldCollations().isEmpty()
                 ? (java.util.List)com.google.common.collect.ImmutableList.of()
@@ -101,10 +101,10 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
                 isDml,
                 bindable,
                 // the type factory's answer, which is what the cursor factory is deduced from
-                org.apache.calcite.adapter.enumerable.PhysTypeImpl.of(
+                Apache.Calcite.Extensions.Adapter.Enumerable.ClrPhysTypeImpl.Of(
                     (org.apache.calcite.adapter.java.JavaTypeFactory)node.getCluster().getTypeFactory(),
                     node.getRowType(),
-                    prefer.PreferArray()).getJavaRowType());
+                    prefer.PreferArray()).JavaRowType);
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepare.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepare.cs
@@ -36,7 +36,7 @@ namespace Apache.Calcite.Extensions.Prepare
     /// <c>Enumerable</c>. Our conventions compile to a delegate, so there is nothing to hand back through
     /// it. <see cref="ClrPrepareResult"/> is that interface without the member.</para>
     /// </remarks>
-    abstract class ClrPrepare
+    public abstract class ClrPrepare
     {
 
         readonly CalcitePrepare.Context context;
@@ -81,7 +81,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <c>Prepare.getSqlValidator</c>, abstract there as here: building one needs a type factory, which
         /// this half does not have.
         /// </remarks>
-        protected abstract SqlValidator Validator { get; }
+        protected internal abstract SqlValidator SqlValidator { get; }
 
         /// <summary>
         /// Gets or sets the row type of the statement's dynamic parameters.
@@ -183,7 +183,7 @@ namespace Apache.Calcite.Extensions.Prepare
             var configHolder = Holder.of(config);
             org.apache.calcite.runtime.Hook.SQL2REL_CONVERTER_CONFIG_BUILDER.run(configHolder);
 
-            var sqlToRelConverter = GetSqlToRelConverter(Validator, catalogReader, (SqlToRelConverter.Config)configHolder.get());
+            var sqlToRelConverter = GetSqlToRelConverter(SqlValidator, catalogReader, (SqlToRelConverter.Config)configHolder.get());
 
             SqlExplain? sqlExplain = null;
             if (sqlQuery.getKind() == SqlKind.EXPLAIN)
@@ -203,9 +203,9 @@ namespace Apache.Calcite.Extensions.Prepare
             root = root.withRel(checkedConv.visit(root.rel));
             org.apache.calcite.runtime.Hook.CONVERTED.run(root.rel);
 
-            var resultType = Validator.getValidatedNodeType(sqlQuery);
-            FieldOrigins = Validator.getFieldOrigins(sqlQuery);
-            ParameterRowType = Validator.getParameterRowType(sqlQuery);
+            var resultType = SqlValidator.getValidatedNodeType(sqlQuery);
+            FieldOrigins = SqlValidator.getFieldOrigins(sqlQuery);
+            ParameterRowType = SqlValidator.getParameterRowType(sqlQuery);
 
             // the logical plan, before view expansion, physical storage and decorrelation
             if (sqlExplain != null)
@@ -284,7 +284,7 @@ namespace Apache.Calcite.Extensions.Prepare
                 .withExpand(((java.lang.Boolean)org.apache.calcite.prepare.Prepare.THREAD_EXPAND.get()).booleanValue())
                 .withInSubQueryThreshold(((java.lang.Integer)org.apache.calcite.prepare.Prepare.THREAD_INSUBQUERY_THRESHOLD.get()).intValue());
 
-            var converter = GetSqlToRelConverter(Validator, catalogReader, config);
+            var converter = GetSqlToRelConverter(SqlValidator, catalogReader, config);
             var ordered = root.collation.getFieldCollations().isEmpty() == false;
             var dml = SqlKind.DML.contains(root.kind);
 

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 
 using Apache.Calcite.Extensions;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
 using Apache.Calcite.Extensions.Prepare.AsyncEnumerable;
 using Apache.Calcite.Extensions.Runtime;
+using Apache.Calcite.Extensions.Rel.Metadata;
 using Apache.Calcite.Extensions.Prepare.Enumerable;
 
 using org.apache.calcite;
@@ -13,6 +15,7 @@ using org.apache.calcite.config;
 using org.apache.calcite.jdbc;
 using org.apache.calcite.plan;
 using org.apache.calcite.prepare;
+using org.apache.calcite.rel.metadata;
 using org.apache.calcite.rel.type;
 using org.apache.calcite.rex;
 using org.apache.calcite.sql;
@@ -48,7 +51,7 @@ namespace Apache.Calcite.Extensions.Prepare
     /// <para>The type-and-column metadata below is ported rather than reused: every piece of it is a
     /// private static of <c>CalcitePrepareImpl</c>.</para>
     /// </remarks>
-    sealed class ClrPrepareImpl
+    public class ClrPrepareImpl
     {
 
         /// <summary>
@@ -61,9 +64,9 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <returns>The planned statement.</returns>
         /// <remarks>
         /// <c>CalcitePrepareImpl.prepare_</c> loops over <c>createPlannerFactories</c>, trying each planner
-        /// until one does not throw <c>CannotPlanException</c>. There is one factory here — Calcite's own
-        /// list holds exactly one too — so the loop is a single call, and a plan that cannot be found
-        /// throws rather than falling back.
+        /// until one does not throw <c>CannotPlanException</c>, and rethrowing the last failure when none
+        /// does. <see cref="CreatePlannerFactories"/> answers one factory, as Calcite's does; a subclass
+        /// that answers several gets the fallback.
         /// </remarks>
         public ClrSignature Prepare(CalcitePrepare.Context context, string sql, java.lang.reflect.Type elementType, long maxRowCount)
         {
@@ -106,10 +109,28 @@ namespace Apache.Calcite.Extensions.Prepare
                 typeFactory,
                 context.config());
 
-            var planner = CreatePlanner(context, async);
-            var preparingStmt = GetPreparingStmt(context, elementType, catalogReader, planner, async);
+            var plannerFactories = CreatePlannerFactories(async);
+            if (plannerFactories.Count == 0)
+                throw new InvalidOperationException("no planner factories");
 
-            return Prepare2(context, sql, elementType, maxRowCount, catalogReader, preparingStmt);
+            Exception? exception = null;
+
+            foreach (var plannerFactory in plannerFactories)
+            {
+                var planner = plannerFactory(context) ?? throw new InvalidOperationException("factory returned null planner");
+
+                try
+                {
+                    var preparingStmt = GetPreparingStmt(context, elementType, catalogReader, planner, async);
+                    return Prepare2(context, sql, elementType, maxRowCount, catalogReader, preparingStmt);
+                }
+                catch (RelOptPlanner.CannotPlanException e)
+                {
+                    exception = e;
+                }
+            }
+
+            throw exception!;
         }
 
         /// <summary>
@@ -175,9 +196,34 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <c>EnumerableConvention</c>, with a converter carrying its rows. That is how a table
         /// modification works here.
         /// </remarks>
-        RelOptPlanner CreatePlanner(CalcitePrepare.Context context, bool async = false)
+        protected virtual RelOptPlanner CreatePlanner(CalcitePrepare.Context context, bool async = false)
         {
-            var planner = new org.apache.calcite.plan.volcano.VolcanoPlanner(null, Contexts.of(context.config()));
+            return CreatePlanner(context, null, null, async);
+        }
+
+        /// <summary>
+        /// Creates a query planner over a given planner context and cost model, and initializes it with a
+        /// default set of rules.
+        /// </summary>
+        /// <param name="context">The schema, type factory and configuration to plan against.</param>
+        /// <param name="externalContext">The planner's context, or <see langword="null"/> for one over the
+        /// connection configuration.</param>
+        /// <param name="costFactory">The cost model, or <see langword="null"/> for the planner's own.</param>
+        /// <param name="async">Whether to plan into the asynchronous convention.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>CalcitePrepareImpl.createPlanner(Context, Context, RelOptCostFactory)</c>, which the one above
+        /// calls with neither.
+        /// </remarks>
+        protected virtual RelOptPlanner CreatePlanner(
+            CalcitePrepare.Context context,
+            org.apache.calcite.plan.Context? externalContext,
+            RelOptCostFactory? costFactory,
+            bool async)
+        {
+            externalContext ??= Contexts.of(context.config());
+
+            var planner = new org.apache.calcite.plan.volcano.VolcanoPlanner(costFactory, externalContext);
             planner.setExecutor(new RexExecutorImpl(DataContexts.EMPTY));
             planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
 
@@ -198,13 +244,32 @@ namespace Apache.Calcite.Extensions.Prepare
                 foreach (var rule in ClrEnumerableRules.Rules())
                     planner.addRule(rule);
 
+            // lets a test add or remove rules, as it does upstream
+            org.apache.calcite.runtime.Hook.PLANNER.run(planner);
+
             return planner;
+        }
+
+        /// <summary>
+        /// Creates the planner factories to try, in order.
+        /// </summary>
+        /// <param name="async">Whether the planners are to plan into the asynchronous convention.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>CalcitePrepareImpl.createPlannerFactories</c>. The collection must not be empty and no factory
+        /// may answer null. More than one lets a subclass try a smaller, faster rule set first and fall back
+        /// to a costlier planner for a query it cannot plan; <see cref="Prepare"/> runs that fallback.
+        /// Calcite's factory is a linq4j <c>Function1</c> and this one is a delegate.
+        /// </remarks>
+        protected virtual IReadOnlyList<Func<CalcitePrepare.Context, RelOptPlanner>> CreatePlannerFactories(bool async)
+        {
+            return [context => CreatePlanner(context, async)];
         }
 
         /// <summary>
         /// Factory method for default convertlet table.
         /// </summary>
-        SqlRexConvertletTable CreateConvertletTable()
+        protected virtual SqlRexConvertletTable CreateConvertletTable()
         {
             return StandardConvertletTable.INSTANCE;
         }
@@ -212,15 +277,61 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <summary>
         /// Factory method for cluster.
         /// </summary>
-        RelOptCluster CreateCluster(RelOptPlanner planner, RexBuilder rexBuilder)
+        /// <remarks>
+        /// The cluster answers metadata through <see cref="ClrRelMetadataProvider"/> rather than
+        /// <c>JaninoRelMetadataProvider</c>, which <c>RelOptCluster.create</c> reaches by way of
+        /// <c>RelMetadataQuery.instance()</c>. The supplier is the only way in:
+        /// <c>RelMetadataQueryBase.THREAD_PROVIDERS</c> is typed to Janino's provider.
+        ///
+        /// <para>The provider is <c>DefaultRelMetadataProvider.INSTANCE</c>, which is the only one Calcite's
+        /// own prepare uses: <c>Prepare.getProgram</c> answers <c>Programs.standard()</c>, there is no
+        /// connection property for one, and no adapter ships one. An adapter's metadata arrives by the routes
+        /// that provider already reads — <c>estimateRowCount</c> and <c>computeSelfCost</c> on its rels, and
+        /// its tables' <c>Statistic</c>. Calcite's provider-level routes are dead upstream as well:
+        /// <c>setMetadataProvider</c> and <c>Programs.of(…, provider)</c> reach only
+        /// <c>THREAD_PROVIDERS</c>, which nothing but <c>RelMetadataQuery.instance()</c> reads, and the
+        /// providers a planner registers — <c>VolcanoRelMetadataProvider</c> and
+        /// <c>HepRelMetadataProvider</c> — are deprecated and answer <c>handlers</c> with an empty list.
+        /// <c>HepRelVertex</c> is a <c>DelegatingMetadataRel</c> now, and a <c>RelSubset</c> is answered by
+        /// the overloads the <c>RelMd*</c> classes declare for it.</para>
+        /// </remarks>
+        protected virtual RelOptCluster CreateCluster(RelOptPlanner planner, RexBuilder rexBuilder)
         {
-            return RelOptCluster.create(planner, rexBuilder);
+            var cluster = RelOptCluster.create(planner, rexBuilder);
+            cluster.setMetadataQuerySupplier(ClrRelMetadataProvider.QuerySupplier(DefaultRelMetadataProvider.INSTANCE));
+            cluster.invalidateMetadataQuery();
+            return cluster;
+        }
+
+        /// <summary>
+        /// Factory method for default SQL parser.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        protected virtual SqlParser CreateParser(string sql)
+        {
+            return CreateParser(sql, ParserConfig());
+        }
+
+        /// <summary>
+        /// Factory method for SQL parser with a given configuration.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <param name="parserConfig"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Calcite has a third overload taking a <c>SqlParser.ConfigBuilder</c>, deprecated for removal
+        /// before 2.0 along with the builder it serves; it is not written.
+        /// </remarks>
+        protected virtual SqlParser CreateParser(string sql, SqlParser.Config parserConfig)
+        {
+            return SqlParser.create(sql, parserConfig);
         }
 
         /// <summary>
         /// Factory method for SQL parser configuration.
         /// </summary>
-        SqlParser.Config ParserConfig()
+        protected virtual SqlParser.Config ParserConfig()
         {
             return SqlParser.config();
         }
@@ -251,7 +362,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <c>CalcitePrepareImpl.getPreparingStmt</c>, deciding the row format the same way — an
         /// <c>Object[]</c> element type asks for an array and anything else asks for a custom row.
         /// </remarks>
-        ClrPreparingStmt GetPreparingStmt(CalcitePrepare.Context context, java.lang.reflect.Type elementType, CalciteCatalogReader catalogReader, RelOptPlanner planner, bool async = false)
+        protected virtual ClrPreparingStmt GetPreparingStmt(CalcitePrepare.Context context, java.lang.reflect.Type elementType, CalciteCatalogReader catalogReader, RelOptPlanner planner, bool async = false)
         {
             var typeFactory = context.getTypeFactory();
             var prefer = elementType == (java.lang.reflect.Type)(java.lang.Class)typeof(object[])
@@ -304,7 +415,7 @@ namespace Apache.Calcite.Extensions.Prepare
             SqlNode sqlNode;
             try
             {
-                sqlNode = SqlParser.create(sql, parseConfig).parseStmt();
+                sqlNode = CreateParser(sql, parseConfig).parseStmt();
             }
             catch (SqlParseException e)
             {

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareResult.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareResult.cs
@@ -21,7 +21,7 @@ namespace Apache.Calcite.Extensions.Prepare
     /// reaches it only by being in the same package. And <see cref="RowType"/> is nullable, because an
     /// <c>EXPLAIN</c> of a type has none.</para>
     /// </remarks>
-    abstract class ClrPrepareResult
+    public abstract class ClrPrepareResult
     {
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPreparingStmt.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPreparingStmt.cs
@@ -28,7 +28,7 @@ namespace Apache.Calcite.Extensions.Prepare
     /// in, the program that gets it there, and the compiler at the end. A subclass supplies those, and that
     /// is the whole of what a second convention writes.</para>
     /// </remarks>
-    abstract class ClrPreparingStmt : ClrPrepare, RelOptTable.ViewExpander
+    public abstract class ClrPreparingStmt : ClrPrepare, RelOptTable.ViewExpander
     {
 
         readonly CalciteSchema schema;
@@ -83,19 +83,13 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <remarks>
         /// <c>CalcitePreparingStmt.getSqlValidator</c>, which caches so that one statement cannot end up
         /// with two.
+        ///
+        /// <para>Protected there and protected internal here: the driver reads it, which Java allows because
+        /// <c>CalcitePreparingStmt</c> is a nested class of <c>CalcitePrepareImpl</c> and an outer class
+        /// reaches a nested one's protected members. <c>internal</c> is what says the same thing in .NET,
+        /// and it does not widen what a subclass outside this assembly can see.</para>
         /// </remarks>
-        protected override SqlValidator Validator => validator ??= CreateSqlValidator(CatalogReader, c => c);
-
-        /// <summary>
-        /// Gets the validator the statement was validated with, for the driver.
-        /// </summary>
-        /// <remarks>
-        /// Calcite's driver reads <c>getSqlValidator</c> even though it is protected, because
-        /// <c>CalcitePreparingStmt</c> is a nested class of <c>CalcitePrepareImpl</c> and Java lets an outer
-        /// class reach a nested one's protected members. C# has no equivalent, so the accessor is public
-        /// rather than the member's protection being widened.
-        /// </remarks>
-        public SqlValidator SqlValidator => Validator;
+        protected internal override SqlValidator SqlValidator => validator ??= CreateSqlValidator(CatalogReader, c => c);
 
         /// <summary>
         /// Prepares a plan that was built rather than parsed.
@@ -193,9 +187,8 @@ namespace Apache.Calcite.Extensions.Prepare
 
         /// <inheritdoc />
         /// <remarks>
-        /// <c>CalcitePreparingStmt.flattenTypes</c>, which flattens only under a Spark handler and otherwise
-        /// hands the plan back. This convention cannot use a Spark handler at all — it has no generated
-        /// class to give one — so this is the branch Calcite takes without one.
+        /// <c>CalcitePreparingStmt.flattenTypes</c>, whose default branch hands the plan back unchanged.
+        /// That is the branch this convention always takes.
         /// </remarks>
         protected override RelNode FlattenTypes(RelNode rootRel, bool restructure)
         {
@@ -252,7 +245,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <remarks>
         /// <c>CalcitePrepareImpl.createSqlValidator</c>, which is a private static there.
         /// </remarks>
-        SqlValidator CreateSqlValidator(CalciteCatalogReader catalogReader, Func<SqlValidator.Config, SqlValidator.Config> configTransform)
+        protected virtual SqlValidator CreateSqlValidator(CalciteCatalogReader catalogReader, Func<SqlValidator.Config, SqlValidator.Config> configTransform)
         {
             var connectionConfig = Context.config();
             var opTab0 = (SqlOperatorTable)connectionConfig.fun((java.lang.Class)typeof(SqlOperatorTable), org.apache.calcite.sql.fun.SqlStdOperatorTable.instance());

--- a/src/Apache.Calcite.Extensions/Prepare/ClrSignature.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrSignature.cs
@@ -25,7 +25,7 @@ namespace Apache.Calcite.Extensions.Prepare
     /// <see cref="Sql"/>, <see cref="Parameters"/>, <see cref="InternalParameters"/>,
     /// <see cref="Columns"/>, <see cref="CursorFactory"/>, <see cref="StatementType"/> — are all here.</para>
     /// </remarks>
-    sealed class ClrSignature
+    public sealed class ClrSignature
     {
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Prepare/Enumerable/ClrEnumerablePreparingStmt.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/Enumerable/ClrEnumerablePreparingStmt.cs
@@ -84,7 +84,7 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
 
             InternalParameters.put("_conformance", Context.config().conformance());
 
-            var bindable = ClrEnumerableInterpretable.ToBindable(InternalParameters, null, node, prefer);
+            var bindable = ClrEnumerableInterpretable.ToBindable(InternalParameters, node, prefer);
 
             var collations = root.collation.getFieldCollations().isEmpty()
                 ? (java.util.List)com.google.common.collect.ImmutableList.of()
@@ -100,10 +100,10 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
                 isDml,
                 bindable,
                 // the type factory's answer, which is what the cursor factory is deduced from
-                org.apache.calcite.adapter.enumerable.PhysTypeImpl.of(
+                ClrPhysTypeImpl.Of(
                     (org.apache.calcite.adapter.java.JavaTypeFactory)node.getCluster().getTypeFactory(),
                     node.getRowType(),
-                    prefer.PreferArray()).getJavaRowType());
+                    prefer.PreferArray()).JavaRowType);
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataCacheKey.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataCacheKey.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+using org.apache.calcite.rel.metadata.janino;
+
+namespace Apache.Calcite.Extensions.Rel.Metadata
+{
+
+    /// <summary>
+    /// Which of the five shapes a metadata call's cache key takes, and the objects that shape needs.
+    /// </summary>
+    /// <remarks>
+    /// <c>CacheGeneratorUtil.CacheKeyStrategy</c>, which picks a shape from the method's parameters, writes
+    /// the keys it needs as fields of the generated class, and writes the block that chooses between them
+    /// into each call. Only the objects are built here; the block is emitted by
+    /// <see cref="ClrMetadataHandlerEmitter"/>.
+    ///
+    /// <para>A key is compared by reference — <see cref="DescriptiveCacheKey"/> says so and overrides
+    /// nothing — so each is built once, when the handler is built, and the generated class holds it.</para>
+    /// </remarks>
+    static class ClrMetadataCacheKey
+    {
+
+        /// <summary>
+        /// The lowest and highest int a key is kept ready for.
+        /// </summary>
+        public const int Min = -256;
+        public const int Max = 256;
+
+        /// <summary>
+        /// The five shapes.
+        /// </summary>
+        public enum Strategy
+        {
+
+            /// <summary>One key, for a method taking nothing but the rel and the query.</summary>
+            NoArg,
+
+            /// <summary>One key per value of a single boolean argument.</summary>
+            Boolean,
+
+            /// <summary>One key per constant of a single enum argument, and one for null.</summary>
+            Enum,
+
+            /// <summary>One key per int in a fixed range, and a list outside it.</summary>
+            Int,
+
+            /// <summary>A list of the method's key and its arguments.</summary>
+            List,
+
+        }
+
+        /// <summary>
+        /// A shape and what it holds.
+        /// </summary>
+        /// <param name="Kind"></param>
+        /// <param name="Constants">
+        /// The objects the block reads: one key for <see cref="Strategy.NoArg"/> and
+        /// <see cref="Strategy.List"/>, the true and the false key for <see cref="Strategy.Boolean"/>, the
+        /// null key and the table for <see cref="Strategy.Enum"/>, and the key and the table for
+        /// <see cref="Strategy.Int"/>.
+        /// </param>
+        public readonly record struct Plan(Strategy Kind, object[] Constants);
+
+        /// <summary>
+        /// Returns the shape a call of <paramref name="method"/> is cached under.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        public static Plan Of(MethodInfo method)
+        {
+            ArgumentNullException.ThrowIfNull(method);
+
+            var parameters = method.GetParameters();
+            if (parameters.Length < 2)
+                throw new ArgumentException($"'{method}' takes fewer than the rel and the query.", nameof(method));
+
+            if (parameters.Length == 2)
+                return new Plan(Strategy.NoArg, [Describe(method, "")]);
+
+            if (parameters.Length == 3)
+            {
+                var type = parameters[2].ParameterType;
+
+                if (type == typeof(bool))
+                    return new Plan(Strategy.Boolean, [Describe(method, "true"), Describe(method, "false")]);
+
+                if (typeof(java.lang.Enum).IsAssignableFrom(type))
+                {
+                    var values = (Array)type.GetMethod("values", BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null)!.Invoke(null, null)!;
+                    return new Plan(Strategy.Enum,
+                    [
+                        Describe(method, "null"),
+                        CacheUtil.generateEnum($"{method.ReturnType.Name} {method.Name}", (java.lang.Enum[])values)
+                    ]);
+                }
+
+                if (type == typeof(int))
+                    return new Plan(Strategy.Int,
+                    [
+                        Describe(method, Arguments(method)),
+                        CacheUtil.generateRange($"{((java.lang.Class)method.ReturnType).getName()} {method.Name}", Min, Max)
+                    ]);
+            }
+
+            return new Plan(Strategy.List, [Describe(method, Arguments(method))]);
+        }
+
+        /// <summary>
+        /// Returns the key describing <paramref name="method"/> called with <paramref name="arguments"/>.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        static DescriptiveCacheKey Describe(MethodInfo method, string arguments)
+        {
+            return new DescriptiveCacheKey($"{method.ReturnType.Name} {method.DeclaringType!.Name}.{method.Name}({arguments})");
+        }
+
+        /// <summary>
+        /// Returns the parameter types of <paramref name="method"/>, as the description names them.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        static string Arguments(MethodInfo method)
+        {
+            return string.Join(", ", method.GetParameters().Select(p => p.ParameterType.Name));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataHandlerEmitter.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataHandlerEmitter.cs
@@ -1,0 +1,574 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.metadata;
+using org.apache.calcite.rex;
+using org.apache.calcite.runtime;
+
+using J = org.apache.calcite.linq4j.tree;
+
+namespace Apache.Calcite.Extensions.Rel.Metadata
+{
+
+    /// <summary>
+    /// Emits the class behind a <see cref="MetadataHandler"/>.
+    /// </summary>
+    /// <remarks>
+    /// What <c>JaninoRelMetadataProvider</c> writes out as Java source and hands to Janino, emitted as IL
+    /// instead. The class is the same class: a field per underlying handler, a public method per handler
+    /// method holding the cache protocol, a private <c>name_</c> beneath it holding the <c>instanceof</c>
+    /// chain, and <c>getDef</c> answering the first handler's.
+    ///
+    /// <para>So a metadata call is a virtual call into a method that tests the rel's class, calls the
+    /// handler's own method directly, and reads and writes the query's table — the same instructions the
+    /// generated Java compiles to, with no delegate, no argument array and no boxing that Java would not
+    /// do. What Janino cannot do is name a CLR class: the generated source spells out the handler and every
+    /// rel class, and IKVM's name for one of ours begins <c>cli.</c>, which it refuses.</para>
+    ///
+    /// <para>Two things are not literal. The keys and lookup tables cannot be constants of an emitted method,
+    /// so they are held in one array the constructor takes rather than in a field each. And the catch is
+    /// <c>System.Exception</c> where Calcite's is <c>java.lang.Exception</c>: IKVM maps a CLR exception into
+    /// the Java hierarchy when Java code catches it, and that mapping is not reproducible in raw IL. Ours
+    /// therefore clears the row in the few cases — an <c>Error</c>, and a CLR exception with no Java
+    /// counterpart — where Calcite's would let it stand.</para>
+    /// </remarks>
+    static class ClrMetadataHandlerEmitter
+    {
+
+        static readonly MethodInfo TableGet = typeof(com.google.common.collect.Table).GetMethod("get", [typeof(object), typeof(object)])!;
+        static readonly MethodInfo TablePut = typeof(com.google.common.collect.Table).GetMethod("put", [typeof(object), typeof(object), typeof(object)])!;
+        static readonly MethodInfo TableRow = typeof(com.google.common.collect.Table).GetMethod("row", [typeof(object)])!;
+        static readonly MethodInfo MapClear = typeof(java.util.Map).GetMethod("clear", Type.EmptyTypes)!;
+        static readonly MethodInfo Mask = typeof(NullSentinel).GetMethod("mask", [typeof(object)])!;
+        static readonly MethodInfo Delegate = typeof(DelegatingMetadataRel).GetMethod("getMetadataDelegateRel", Type.EmptyTypes)!;
+        static readonly MethodInfo Ordinal = typeof(java.lang.Enum).GetMethod("ordinal", Type.EmptyTypes)!;
+        static readonly MethodInfo GetDef = typeof(MetadataHandler).GetMethod("getDef", Type.EmptyTypes)!;
+        static readonly MethodInfo IntegerValueOf = typeof(java.lang.Integer).GetMethod("valueOf", [typeof(int)])!;
+        static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(string), typeof(string), typeof(string)])!;
+        static readonly MethodInfo GetTypeOf = typeof(object).GetMethod(nameof(object.GetType), Type.EmptyTypes)!;
+        static readonly MethodInfo ToStringOf = typeof(object).GetMethod(nameof(object.ToString), Type.EmptyTypes)!;
+        static readonly ConstructorInfo Cyclic = typeof(CyclicMetadataException).GetConstructor(Type.EmptyTypes)!;
+        static readonly ConstructorInfo IllegalArgument = typeof(java.lang.IllegalArgumentException).GetConstructor([typeof(string)])!;
+
+        static readonly object sync = new();
+        static readonly HashSet<string> reachable = [];
+        static AssemblyBuilder? assembly;
+        static ModuleBuilder? module;
+        static ConstructorInfo? ignoresAccessChecks;
+        static int count;
+
+        /// <summary>
+        /// Returns a handler of <paramref name="handlerInterface"/> answering <paramref name="methods"/> out
+        /// of <paramref name="handlers"/>.
+        /// </summary>
+        /// <param name="handlerInterface"></param>
+        /// <param name="methods"></param>
+        /// <param name="handlers"></param>
+        /// <returns></returns>
+        public static MetadataHandler Emit(Type handlerInterface, MethodInfo[] methods, IReadOnlyList<MetadataHandler> handlers)
+        {
+            ArgumentNullException.ThrowIfNull(handlerInterface);
+            ArgumentNullException.ThrowIfNull(methods);
+            ArgumentNullException.ThrowIfNull(handlers);
+
+            var plans = methods.Select(ClrMetadataCacheKey.Of).ToArray();
+            var targets = methods.Select(m => ClrMetadataTargets.Of(m, handlers)).ToArray();
+
+            // every key and lookup table the generated blocks read, in one array, because an emitted method
+            // cannot carry an object as a constant the way a Java field initialiser does
+            var constants = new List<object>();
+            var slots = plans.Select(p => p.Constants.Select(c => { constants.Add(c); return constants.Count - 1; }).ToArray()).ToArray();
+
+            lock (sync)
+            {
+                var type = Build(handlerInterface, methods, plans, slots, targets, handlers);
+
+                // one argument array holding the two, because a bare pair of object[] binds to the overload
+                // taking activation attributes
+                object[] arguments = [handlers.Cast<object>().ToArray(), constants.ToArray()];
+                return (MetadataHandler)Activator.CreateInstance(type, arguments)!;
+            }
+        }
+
+        /// <summary>
+        /// Emits the type.
+        /// </summary>
+        static Type Build(
+            Type handlerInterface,
+            MethodInfo[] methods,
+            ClrMetadataCacheKey.Plan[] plans,
+            int[][] slots,
+            ClrMetadataTargets.Target[][] targets,
+            IReadOnlyList<MetadataHandler> handlers)
+        {
+            if (module is null)
+            {
+                assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Apache.Calcite.Extensions.Rel.Metadata"), AssemblyBuilderAccess.RunAndCollect);
+                module = assembly.DefineDynamicModule("Apache.Calcite.Extensions.Rel.Metadata");
+                ignoresAccessChecks = EmitIgnoresAccessChecksTo(module);
+            }
+
+            // three of Calcite's handlers are private static nested classes, and the generated Java names
+            // them as field types and calls them directly. Janino resolves such a name through the class
+            // loader without an access check — javac would refuse it — so the emitted assembly is told to
+            // do the same rather than routing around what Calcite wrote
+            foreach (var handler in handlers)
+                AllowAccessTo(handler.GetType());
+            foreach (var target in targets.SelectMany(t => t))
+            {
+                AllowAccessTo(target.RelClass);
+                AllowAccessTo(target.Method.DeclaringType!);
+            }
+
+            // one provider generates one class per handler interface, and a second provider over a different
+            // set of underlying handlers generates another of the same shape
+            var builder = module.DefineType(
+                $"GeneratedMetadata_{handlerInterface.DeclaringType?.Name ?? handlerInterface.Name}_{++count}",
+                TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
+                typeof(object),
+                [handlerInterface]);
+
+            var providers = handlers
+                .Select((h, i) => builder.DefineField($"provider{i}", h.GetType(), FieldAttributes.Public | FieldAttributes.InitOnly))
+                .ToArray();
+            var constants = builder.DefineField("constants", typeof(object[]), FieldAttributes.Private | FieldAttributes.InitOnly);
+
+            EmitConstructor(builder, providers, constants);
+
+            for (int i = 0; i < methods.Length; i++)
+            {
+                var dispatch = EmitDispatchMethod(builder, methods[i], targets[i], providers);
+                EmitCachedMethod(builder, methods[i], dispatch, plans[i], slots[i], constants);
+            }
+
+            EmitGetDef(builder, providers.FirstOrDefault());
+
+            return builder.CreateType();
+        }
+
+        /// <summary>
+        /// Defines the attribute that lets the emitted assembly name a type another assembly keeps to itself,
+        /// which is the standard one and has to be declared somewhere because the runtime library does not
+        /// expose it.
+        /// </summary>
+        static ConstructorInfo EmitIgnoresAccessChecksTo(ModuleBuilder module)
+        {
+            var builder = module.DefineType("System.Runtime.CompilerServices.IgnoresAccessChecksToAttribute", TypeAttributes.Public, typeof(Attribute));
+            var constructor = builder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [typeof(string)]);
+
+            var il = constructor.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, typeof(Attribute).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, Type.EmptyTypes, null)!);
+            il.Emit(OpCodes.Ret);
+
+            return builder.CreateType().GetConstructor([typeof(string)])!;
+        }
+
+        /// <summary>
+        /// Lets the emitted assembly reach whatever <paramref name="type"/> lives in.
+        /// </summary>
+        static void AllowAccessTo(Type type)
+        {
+            if (type.Assembly.GetName().Name is string name && reachable.Add(name))
+                assembly!.SetCustomAttribute(new CustomAttributeBuilder(ignoresAccessChecks!, [name]));
+        }
+
+        /// <summary>
+        /// Emits the constructor, which takes the handlers and the constants.
+        /// </summary>
+        static void EmitConstructor(TypeBuilder builder, FieldBuilder[] providers, FieldBuilder constants)
+        {
+            var constructor = builder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [typeof(object[]), typeof(object[])]);
+            var il = constructor.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+
+            for (int i = 0; i < providers.Length; i++)
+            {
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldc_I4, i);
+                il.Emit(OpCodes.Ldelem_Ref);
+                il.Emit(OpCodes.Castclass, providers[i].FieldType);
+                il.Emit(OpCodes.Stfld, providers[i]);
+            }
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Stfld, constants);
+            il.Emit(OpCodes.Ret);
+        }
+
+        /// <summary>
+        /// Emits the public method: the cache protocol around a call of the dispatch beneath it.
+        /// </summary>
+        static void EmitCachedMethod(
+            TypeBuilder builder,
+            MethodInfo declared,
+            MethodBuilder dispatch,
+            ClrMetadataCacheKey.Plan plan,
+            int[] slots,
+            FieldBuilder constants)
+        {
+            var types = declared.GetParameters().Select(p => p.ParameterType).ToArray();
+
+            // a cache hit on a masked null returns null, which a primitive return could not
+            if (declared.ReturnType.IsValueType)
+                throw new NotSupportedException($"'{declared}' returns a value type, which the cache protocol cannot answer null for.");
+
+            var method = builder.DefineMethod(
+                declared.Name,
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.NewSlot | MethodAttributes.HideBySig,
+                declared.ReturnType,
+                types);
+
+            var il = method.GetILGenerator();
+            var key = il.DeclareLocal(typeof(object));
+            var v = il.DeclareLocal(typeof(object));
+            var x = il.DeclareLocal(declared.ReturnType);
+
+            // while (r instanceof DelegatingMetadataRel) r = ((DelegatingMetadataRel) r).getMetadataDelegateRel();
+            var loop = il.DefineLabel();
+            var unwound = il.DefineLabel();
+            il.MarkLabel(loop);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Isinst, typeof(DelegatingMetadataRel));
+            il.Emit(OpCodes.Brfalse, unwound);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Castclass, typeof(DelegatingMetadataRel));
+            il.Emit(OpCodes.Callvirt, Delegate);
+            il.Emit(OpCodes.Starg_S, (byte)1);
+            il.Emit(OpCodes.Br, loop);
+            il.MarkLabel(unwound);
+
+            EmitKey(il, declared, plan, slots, constants);
+            il.Emit(OpCodes.Stloc, key);
+
+            // final Object v = mq.map.get(r, key);
+            EmitMap(il);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, key);
+            il.Emit(OpCodes.Callvirt, TableGet);
+            il.Emit(OpCodes.Stloc, v);
+
+            var miss = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, v);
+            il.Emit(OpCodes.Brfalse, miss);
+
+            var notActive = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, v);
+            EmitSentinel(il, nameof(NullSentinel.ACTIVE));
+            il.Emit(OpCodes.Bne_Un, notActive);
+            il.Emit(OpCodes.Newobj, Cyclic);
+            il.Emit(OpCodes.Throw);
+            il.MarkLabel(notActive);
+
+            var notNull = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, v);
+            EmitSentinel(il, nameof(NullSentinel.INSTANCE));
+            il.Emit(OpCodes.Bne_Un, notNull);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notNull);
+
+            il.Emit(OpCodes.Ldloc, v);
+            il.Emit(OpCodes.Castclass, declared.ReturnType);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(miss);
+
+            // mq.map.put(r, key, NullSentinel.ACTIVE);
+            EmitMap(il);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, key);
+            EmitSentinel(il, nameof(NullSentinel.ACTIVE));
+            il.Emit(OpCodes.Callvirt, TablePut);
+            il.Emit(OpCodes.Pop);
+
+            il.BeginExceptionBlock();
+
+            il.Emit(OpCodes.Ldarg_0);
+            for (int i = 1; i <= types.Length; i++)
+                il.Emit(OpCodes.Ldarg_S, (byte)i);
+            il.Emit(OpCodes.Call, dispatch);
+            il.Emit(OpCodes.Stloc, x);
+
+            EmitMap(il);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, key);
+            il.Emit(OpCodes.Ldloc, x);
+            il.Emit(OpCodes.Call, Mask);
+            il.Emit(OpCodes.Callvirt, TablePut);
+            il.Emit(OpCodes.Pop);
+
+            il.BeginCatchBlock(typeof(Exception));
+            il.Emit(OpCodes.Pop);
+            EmitMap(il);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, TableRow);
+            il.Emit(OpCodes.Callvirt, MapClear);
+            il.Emit(OpCodes.Rethrow);
+            il.EndExceptionBlock();
+
+            il.Emit(OpCodes.Ldloc, x);
+            il.Emit(OpCodes.Ret);
+
+            builder.DefineMethodOverride(method, declared);
+        }
+
+        /// <summary>
+        /// Emits the private method beneath it: the chain that finds the handler declaring the rel's class.
+        /// </summary>
+        static MethodBuilder EmitDispatchMethod(TypeBuilder builder, MethodInfo declared, ClrMetadataTargets.Target[] targets, FieldBuilder[] providers)
+        {
+            var types = declared.GetParameters().Select(p => p.ParameterType).ToArray();
+            var method = builder.DefineMethod(
+                declared.Name + "_",
+                MethodAttributes.Private | MethodAttributes.HideBySig,
+                declared.ReturnType,
+                types);
+
+            var il = method.GetILGenerator();
+
+            foreach (var target in targets)
+            {
+                var next = il.DefineLabel();
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Isinst, target.RelClass);
+                il.Emit(OpCodes.Brfalse, next);
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, providers[target.Provider]);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Castclass, target.RelClass);
+                for (int i = 2; i <= types.Length; i++)
+                    il.Emit(OpCodes.Ldarg_S, (byte)i);
+                il.Emit(OpCodes.Callvirt, target.Method);
+                il.Emit(OpCodes.Ret);
+
+                il.MarkLabel(next);
+            }
+
+            il.Emit(OpCodes.Ldstr, $"No handler for method [{declared}] applied to argument of type [");
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, GetTypeOf);
+            il.Emit(OpCodes.Callvirt, ToStringOf);
+            il.Emit(OpCodes.Ldstr, "]; we recommend you create a catch-all (RelNode) handler");
+            il.Emit(OpCodes.Call, Concat);
+            il.Emit(OpCodes.Newobj, IllegalArgument);
+            il.Emit(OpCodes.Throw);
+
+            return method;
+        }
+
+        /// <summary>
+        /// Emits <c>getDef</c>, which answers the first handler's.
+        /// </summary>
+        static void EmitGetDef(TypeBuilder builder, FieldBuilder? provider)
+        {
+            var method = builder.DefineMethod(
+                GetDef.Name,
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.NewSlot | MethodAttributes.HideBySig,
+                GetDef.ReturnType,
+                Type.EmptyTypes);
+
+            var il = method.GetILGenerator();
+            if (provider is null)
+            {
+                il.Emit(OpCodes.Ldnull);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, provider);
+                il.Emit(OpCodes.Callvirt, GetDef);
+            }
+
+            il.Emit(OpCodes.Ret);
+            builder.DefineMethodOverride(method, GetDef);
+        }
+
+        /// <summary>
+        /// Emits the block computing the cache key, leaving it on the stack.
+        /// </summary>
+        static void EmitKey(ILGenerator il, MethodInfo declared, ClrMetadataCacheKey.Plan plan, int[] slots, FieldBuilder constants)
+        {
+            void Constant(int slot)
+            {
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, constants);
+                il.Emit(OpCodes.Ldc_I4, slot);
+                il.Emit(OpCodes.Ldelem_Ref);
+            }
+
+            switch (plan.Kind)
+            {
+                case ClrMetadataCacheKey.Strategy.NoArg:
+                    Constant(slots[0]);
+                    break;
+
+                case ClrMetadataCacheKey.Strategy.Boolean:
+                {
+                    var no = il.DefineLabel();
+                    var done = il.DefineLabel();
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Brfalse, no);
+                    Constant(slots[0]);
+                    il.Emit(OpCodes.Br, done);
+                    il.MarkLabel(no);
+                    Constant(slots[1]);
+                    il.MarkLabel(done);
+                    break;
+                }
+
+                case ClrMetadataCacheKey.Strategy.Enum:
+                {
+                    var some = il.DefineLabel();
+                    var done = il.DefineLabel();
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Brtrue, some);
+                    Constant(slots[0]);
+                    il.Emit(OpCodes.Br, done);
+                    il.MarkLabel(some);
+                    Constant(slots[1]);
+                    il.Emit(OpCodes.Castclass, typeof(object[]));
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Callvirt, Ordinal);
+                    il.Emit(OpCodes.Ldelem_Ref);
+                    il.MarkLabel(done);
+                    break;
+                }
+
+                case ClrMetadataCacheKey.Strategy.Int:
+                {
+                    var wide = il.DefineLabel();
+                    var done = il.DefineLabel();
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Ldc_I4, ClrMetadataCacheKey.Min);
+                    il.Emit(OpCodes.Blt, wide);
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Ldc_I4, ClrMetadataCacheKey.Max);
+                    il.Emit(OpCodes.Bge, wide);
+                    Constant(slots[1]);
+                    il.Emit(OpCodes.Castclass, typeof(object[]));
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Ldc_I4, -ClrMetadataCacheKey.Min);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Ldelem_Ref);
+                    il.Emit(OpCodes.Br, done);
+                    il.MarkLabel(wide);
+                    Constant(slots[0]);
+                    il.Emit(OpCodes.Ldarg_S, (byte)3);
+                    il.Emit(OpCodes.Call, IntegerValueOf);
+                    il.Emit(OpCodes.Call, ListOf(2));
+                    il.MarkLabel(done);
+                    break;
+                }
+
+                case ClrMetadataCacheKey.Strategy.List:
+                {
+                    var parameters = declared.GetParameters();
+                    Constant(slots[0]);
+
+                    for (int i = 2; i < parameters.Length; i++)
+                        EmitSafeArgument(il, (byte)(i + 1), parameters[i].ParameterType);
+
+                    il.Emit(OpCodes.Call, ListOf(parameters.Length - 1));
+                    break;
+                }
+
+                default:
+                    throw new NotSupportedException($"'{plan.Kind}' is not a cache key strategy.");
+            }
+        }
+
+        /// <summary>
+        /// Emits one argument as the key list holds it.
+        /// </summary>
+        /// <remarks>
+        /// <c>safeArgList</c>: a primitive or a <c>RexNode</c> goes in as it is, and anything else through
+        /// <c>NullSentinel.mask</c>, because the list cannot hold a null. A primitive is boxed the way javac
+        /// boxes it for the same call — <c>Integer.valueOf</c>, not a CLR box.
+        /// </remarks>
+        static void EmitSafeArgument(ILGenerator il, byte argument, Type type)
+        {
+            il.Emit(OpCodes.Ldarg_S, argument);
+
+            if (J.Primitive.@is((java.lang.Class)type))
+            {
+                var box = Apache.Calcite.Extensions.Linq4j.Tree.ClrTypes.FromClass(J.Primitive.of((java.lang.Class)type).boxClass);
+                il.Emit(OpCodes.Call, box.GetMethod("valueOf", BindingFlags.Public | BindingFlags.Static, null, [type], null)!);
+                return;
+            }
+
+            if (typeof(RexNode).IsAssignableFrom(type))
+                return;
+
+            il.Emit(OpCodes.Call, Mask);
+        }
+
+        /// <summary>
+        /// Returns the list factory Calcite builds a key of <paramref name="arity"/> elements with.
+        /// </summary>
+        static MethodInfo ListOf(int arity)
+        {
+            // Calcite reaches for ImmutableList instead once the method takes six parameters — the key and
+            // four arguments. The widest metadata method takes four, so that branch is unreachable today,
+            // and it is written anyway because it is a different list class under the same key
+            var declaring = arity < 5 ? typeof(FlatLists) : typeof(com.google.common.collect.ImmutableList);
+
+            return declaring.GetMethod("of", Enumerable.Repeat(typeof(object), arity).ToArray())
+                ?? throw new NotSupportedException($"'{declaring}' has no of taking {arity} objects.");
+        }
+
+        /// <summary>
+        /// Emits a read of the query's table, which the query holds as a field Java declares final.
+        /// </summary>
+        static void EmitMap(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldarg_2);
+            EmitRead(il, typeof(RelMetadataQueryBase), "map");
+        }
+
+        /// <summary>
+        /// Emits a read of one of the sentinels, which Java declares as enum constants.
+        /// </summary>
+        static void EmitSentinel(ILGenerator il, string name)
+        {
+            EmitRead(il, typeof(NullSentinel), name);
+        }
+
+        /// <summary>
+        /// Emits a read of a Java field, whose target is already on the stack where it has one.
+        /// </summary>
+        /// <remarks>
+        /// IKVM emits a property over a renamed backing field for a Java <c>static final</c>, so that reading
+        /// it from the CLR still runs the class initializer Java guarantees. Neither the query's table nor a
+        /// sentinel can be assumed to be a field of that name.
+        /// </remarks>
+        static void EmitRead(ILGenerator il, Type declaring, string name)
+        {
+            const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+
+            if (declaring.GetField(name, All) is FieldInfo field)
+            {
+                il.Emit(field.IsStatic ? OpCodes.Ldsfld : OpCodes.Ldfld, field);
+                return;
+            }
+
+            if (declaring.GetProperty(name, All)?.GetMethod is MethodInfo getter)
+            {
+                il.Emit(getter.IsStatic ? OpCodes.Call : OpCodes.Callvirt, getter);
+                return;
+            }
+
+            throw new NotSupportedException($"'{declaring}' has no field or property '{name}'.");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataTargets.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataTargets.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.metadata;
+
+namespace Apache.Calcite.Extensions.Rel.Metadata
+{
+
+    /// <summary>
+    /// Which underlying handler answers a metadata method for a rel of a given class, and in what order the
+    /// classes are tried.
+    /// </summary>
+    /// <remarks>
+    /// <c>DispatchGenerator</c>. Calcite asks each handler which rel classes it declares the method for,
+    /// orders the classes so that no class comes before one it is a supertype of, and writes an
+    /// <c>instanceof</c> chain in that order; where two candidates are unrelated it is their Java names that
+    /// decide, and where two handlers declare the same class the first handler wins.
+    /// </remarks>
+    static class ClrMetadataTargets
+    {
+
+        /// <summary>
+        /// One branch of the chain.
+        /// </summary>
+        /// <param name="RelClass">The class the rel is tested against.</param>
+        /// <param name="Provider">Which of the handlers answers.</param>
+        /// <param name="Method">The method of that handler to call.</param>
+        public readonly record struct Target(Type RelClass, int Provider, MethodInfo Method);
+
+        /// <summary>
+        /// Returns the chain for <paramref name="superMethod"/> over <paramref name="handlers"/>.
+        /// </summary>
+        /// <param name="superMethod"></param>
+        /// <param name="handlers"></param>
+        /// <returns></returns>
+        public static Target[] Of(MethodInfo superMethod, IReadOnlyList<MetadataHandler> handlers)
+        {
+            ArgumentNullException.ThrowIfNull(superMethod);
+            ArgumentNullException.ThrowIfNull(handlers);
+
+            var declared = handlers.Select(h => RelClasses(superMethod, h)).ToArray();
+            var classes = TopologicalSort(declared.SelectMany(d => d).Distinct());
+
+            return classes.Select(c =>
+            {
+                var provider = Array.FindIndex(declared, d => d.Contains(c));
+                var method = handlers[provider].GetType().GetMethod(superMethod.Name, Parameters(superMethod, c))
+                    ?? throw new InvalidOperationException($"'{handlers[provider].GetType()}' does not declare {superMethod.Name} for '{c}'.");
+
+                return new Target(c, provider, method);
+            }).ToArray();
+        }
+
+        /// <summary>
+        /// Returns the parameters of the underlying method: the method's own, with the rel narrowed.
+        /// </summary>
+        /// <param name="superMethod"></param>
+        /// <param name="relClass"></param>
+        /// <returns></returns>
+        static Type[] Parameters(MethodInfo superMethod, Type relClass)
+        {
+            var parameters = superMethod.GetParameters();
+            var types = new Type[parameters.Length];
+            types[0] = relClass;
+            for (int i = 1; i < parameters.Length; i++)
+                types[i] = parameters[i].ParameterType;
+
+            return types;
+        }
+
+        /// <summary>
+        /// Returns the rel classes <paramref name="handler"/> declares <paramref name="superMethod"/> for.
+        /// </summary>
+        /// <param name="superMethod"></param>
+        /// <param name="handler"></param>
+        /// <returns></returns>
+        static HashSet<Type> RelClasses(MethodInfo superMethod, MetadataHandler handler)
+        {
+            var set = new HashSet<Type>();
+
+            foreach (var candidate in handler.GetType().GetMethods())
+                if (ToRelClass(superMethod, candidate) is Type relClass)
+                    set.Add(relClass);
+
+            return set;
+        }
+
+        /// <summary>
+        /// Returns the rel class <paramref name="candidate"/> answers <paramref name="superMethod"/> for, or
+        /// null where it does not answer it at all.
+        /// </summary>
+        /// <param name="superMethod"></param>
+        /// <param name="candidate"></param>
+        /// <returns></returns>
+        static Type? ToRelClass(MethodInfo superMethod, MethodInfo candidate)
+        {
+            if (candidate.Name != superMethod.Name)
+                return null;
+
+            var cpt = candidate.GetParameters();
+            var smpt = superMethod.GetParameters();
+            if (cpt.Length != smpt.Length)
+                return null;
+            if (!typeof(RelNode).IsAssignableFrom(cpt[0].ParameterType))
+                return null;
+            if (cpt[1].ParameterType != typeof(RelMetadataQuery))
+                return null;
+
+            for (int i = 2; i < smpt.Length; i++)
+                if (cpt[i].ParameterType != smpt[i].ParameterType)
+                    return null;
+
+            return cpt[0].ParameterType;
+        }
+
+        /// <summary>
+        /// Orders <paramref name="classes"/> so that no class comes before one it is a supertype of.
+        /// </summary>
+        /// <param name="classes"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Ordering by the Java name, which is what decides between two candidates neither of which is the
+        /// other's supertype — and is not the CLR name for a class of this project's own.
+        /// </remarks>
+        static List<Type> TopologicalSort(IEnumerable<Type> classes)
+        {
+            var sorted = new List<Type>();
+            var remaining = new Queue<Type>(classes.OrderBy(t => ((java.lang.Class)t).getName(), StringComparer.Ordinal));
+
+            while (remaining.Count > 0)
+            {
+                var next = remaining.Dequeue();
+                if (remaining.Any(other => next.IsAssignableFrom(other)))
+                    remaining.Enqueue(next);
+                else
+                    sorted.Add(next);
+            }
+
+            return sorted;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrRelMetadataProvider.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrRelMetadataProvider.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.metadata;
+
+namespace Apache.Calcite.Extensions.Rel.Metadata
+{
+
+    /// <summary>
+    /// Provides the metadata handlers a <see cref="RelMetadataQuery"/> asks for, built as CLR types and
+    /// <c>System.Linq.Expressions</c> rather than generated as Java source and compiled by Janino.
+    /// </summary>
+    /// <remarks>
+    /// <c>JaninoRelMetadataProvider</c>, and it answers the same questions the same way: the handlers come
+    /// from the same <see cref="RelMetadataProvider"/>, the class a rel dispatches to is chosen by the same
+    /// rule, and the results are cached in the query's own table under the same keys, cycles included.
+    ///
+    /// <para>Two things move. A handler is built once per provider and handler interface, as Janino's is, but
+    /// building one no longer runs a Java compiler. And a handler written in .NET works: Calcite's generated
+    /// source names the handler class and each rel class in Java, and IKVM's name for a CLR class begins
+    /// <c>cli.</c>, which Janino refuses — "Cannot determine simple type name cli", measured. Nothing here
+    /// writes a name.</para>
+    ///
+    /// <para>Reached through <see cref="RelOptCluster.setMetadataQuerySupplier"/>:
+    /// <c>RelMetadataQueryBase.THREAD_PROVIDERS</c> is typed to Janino's provider and cannot hold this one,
+    /// and <c>RelMetadataQuery.instance()</c> is the only thing that reads it.</para>
+    /// </remarks>
+    public sealed class ClrRelMetadataProvider : MetadataHandlerProvider
+    {
+
+        /// <summary>
+        /// The provider over Calcite's own handlers.
+        /// </summary>
+        public static readonly ClrRelMetadataProvider Default = Of(DefaultRelMetadataProvider.INSTANCE);
+
+        static readonly ConcurrentDictionary<(RelMetadataProvider, Type), MetadataHandler> handlers = new();
+
+        /// <summary>
+        /// Returns a provider over <paramref name="provider"/>'s handlers.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        public static ClrRelMetadataProvider Of(RelMetadataProvider provider)
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+
+            return new ClrRelMetadataProvider(provider);
+        }
+
+        /// <summary>
+        /// Returns a supplier of queries over <paramref name="provider"/>, for
+        /// <see cref="RelOptCluster.setMetadataQuerySupplier"/>, which requires a fresh query each time.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        public static java.util.function.Supplier QuerySupplier(RelMetadataProvider provider)
+        {
+            return new Supplier(Of(provider));
+        }
+
+        readonly RelMetadataProvider provider;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="provider"></param>
+        ClrRelMetadataProvider(RelMetadataProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        /// <summary>
+        /// Answers with a handler that refuses every rel, so that a query builds only the handlers it reaches.
+        /// </summary>
+        /// <param name="handlerClass"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// What Janino's provider does, and for the same reason: <see cref="RelMetadataQuery"/> asks for all
+        /// twenty-seven when it is constructed, which is once per query, and a statement touches a third of
+        /// them. The refusal is caught there and answered by <see cref="revise"/>.
+        /// </remarks>
+        public MetadataHandler handler(java.lang.Class handlerClass)
+        {
+            ArgumentNullException.ThrowIfNull(handlerClass);
+
+            return (MetadataHandler)java.lang.reflect.Proxy.newProxyInstance(
+                ((java.lang.Class)typeof(RelMetadataQuery)).getClassLoader(),
+                [handlerClass],
+                new Refusing());
+        }
+
+        /// <summary>
+        /// Returns the handler of <paramref name="handlerClass"/>, building it the first time a provider is
+        /// asked for it.
+        /// </summary>
+        /// <param name="handlerClass"></param>
+        /// <returns></returns>
+        public MetadataHandler revise(java.lang.Class handlerClass)
+        {
+            ArgumentNullException.ThrowIfNull(handlerClass);
+
+            var type = (Type)ikvm.runtime.Util.getInstanceTypeFromClass(handlerClass);
+            return handlers.GetOrAdd((provider, type), k => Build(k.Item1, k.Item2, handlerClass));
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj) || (obj is ClrRelMetadataProvider other && provider.Equals(other.provider));
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return 109 + provider.GetHashCode();
+        }
+
+        /// <summary>
+        /// Builds the handler of <paramref name="handlerClass"/> over <paramref name="provider"/>.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="type"></param>
+        /// <param name="handlerClass"></param>
+        /// <returns></returns>
+        static MetadataHandler Build(RelMetadataProvider provider, Type type, java.lang.Class handlerClass)
+        {
+            // handlers().stream().distinct(): the first of each, in the order the provider gave them, which
+            // is the order the chain resolves a rel class in
+            var list = provider.handlers(handlerClass);
+            var underlying = new List<MetadataHandler>(list.size());
+            for (int i = 0; i < list.size(); i++)
+            {
+                var handler = (MetadataHandler)list.get(i);
+                if (underlying.Contains(handler) is false)
+                    underlying.Add(handler);
+            }
+
+            return ClrMetadataHandlerEmitter.Emit(type, Methods(type), underlying);
+        }
+
+        /// <summary>
+        /// Returns the methods of a handler interface, in the order Calcite indexes them.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>MetadataHandler.handlerMethods</c>: what the interface itself declares, less <c>getDef</c> and
+        /// anything static or synthetic, by name. Reading it from the CLR rather than calling it keeps the
+        /// members in the reflection the dispatch and the emitter are written in.
+        /// </remarks>
+        static MethodInfo[] Methods(Type type)
+        {
+            return type.GetMethods()
+                .Where(m => m.Name != "getDef" && m.IsAbstract && !m.IsStatic)
+                .OrderBy(m => m.Name, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// The handler <see cref="handler"/> answers with, which refuses every rel it is asked about.
+        /// </summary>
+        sealed class Refusing : java.lang.reflect.InvocationHandler
+        {
+
+            /// <inheritdoc />
+            public object invoke(object proxy, java.lang.reflect.Method method, object[] args)
+            {
+                var r = (RelNode)args[0];
+                throw new MetadataHandlerProvider.NoHandler((java.lang.Class)r.GetType());
+            }
+
+        }
+
+        /// <summary>
+        /// Supplies a fresh query over this provider, which is what a cluster requires.
+        /// </summary>
+        /// <param name="provider"></param>
+        sealed class Supplier(ClrRelMetadataProvider provider) : java.util.function.Supplier
+        {
+
+            /// <inheritdoc />
+            public object get() => new RelMetadataQuery(provider);
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -130,13 +130,13 @@ namespace Apache.Calcite.Tests
 
             if (async)
             {
-                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
                 await foreach (var row in bindable.Bind(context))
                     rows.Add(Render(row));
             }
             else
             {
-                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
                 foreach (var row in bindable.Bind(context))
                     rows.Add(Render(row));
             }
@@ -208,13 +208,13 @@ namespace Apache.Calcite.Tests
 
             if (async)
             {
-                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
                 await foreach (var row in bindable.Bind(context))
                     rows.Add(Render(row));
             }
             else
             {
-                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
                 foreach (var row in bindable.Bind(context))
                     rows.Add(Render(row));
             }

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerablePlanCancellationTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerablePlanCancellationTests.cs
@@ -88,7 +88,7 @@ namespace Apache.Calcite.Tests
             var physical = planner.transform(2, chosen.getTraitSet(), chosen);
 
             var parameters = new java.util.HashMap();
-            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
 
             return (bindable.Bind(new PlanDataContext(rootSchema, parameters)), leaf);
         }

--- a/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
+++ b/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
@@ -137,7 +137,7 @@ namespace Apache.Calcite.Tests
         {
             var physical = Plan(sql, rootSchema, ClrEnumerableConvention.Instance, rules, calcRules);
             var parameters = new java.util.HashMap();
-            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
 
             var rows = new List<string>();
             foreach (var row in bindable.Bind(new TestDataContext(rootSchema, parameters)))
@@ -153,7 +153,7 @@ namespace Apache.Calcite.Tests
         {
             var physical = Plan(sql, rootSchema, ClrAsyncEnumerableConvention.Instance, rules, calcRules);
             var parameters = new java.util.HashMap();
-            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
 
             var rows = new List<string>();
             await foreach (var row in bindable.Bind(new TestDataContext(rootSchema, parameters)))
@@ -334,7 +334,7 @@ namespace Apache.Calcite.Tests
 
             var physical = Plan("SELECT ID, LABEL FROM SALES", rootSchema, ClrEnumerableConvention.Instance, rules, calcRules);
             var parameters = new java.util.HashMap();
-            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
 
             using (var enumerator = bindable.Bind(new TestDataContext(rootSchema, parameters)).GetEnumerator())
             {

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -438,7 +438,7 @@ namespace Apache.Calcite.Tests
             var parameters = new java.util.HashMap();
             var context = new TestDataContext(rootSchema, parameters);
             var source = physical is ClrEnumerableRel node
-                ? TestRows.Of(ClrEnumerableInterpretable.ToBindable(parameters, null, node, ClrEnumerablePrefer.Array), context)
+                ? TestRows.Of(ClrEnumerableInterpretable.ToBindable(parameters, node, ClrEnumerablePrefer.Array), context)
                 : TestRows.Of(EnumerableInterpretable.toBindable(parameters, null, (EnumerableRel)physical, EnumerableRel.Prefer.ARRAY), context);
 
             var rows = new List<string>();
@@ -519,7 +519,7 @@ namespace Apache.Calcite.Tests
             var parameters = new java.util.HashMap();
             var context = new TestDataContext(rootSchema, parameters);
             var source = physical is ClrEnumerableRel node
-                ? TestRows.Of(ClrEnumerableInterpretable.ToBindable(parameters, null, node, ClrEnumerablePrefer.Array), context)
+                ? TestRows.Of(ClrEnumerableInterpretable.ToBindable(parameters, node, ClrEnumerablePrefer.Array), context)
                 : TestRows.Of(EnumerableInterpretable.toBindable(parameters, null, (EnumerableRel)physical, EnumerableRel.Prefer.ARRAY), context);
 
             var rows = new List<string>();

--- a/src/Apache.Calcite.Tests/ClrEnumerableMixedConventionTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableMixedConventionTests.cs
@@ -126,7 +126,7 @@ namespace Apache.Calcite.Tests
             var parameters = new java.util.HashMap();
             var context = new TestDataContext(rootSchema);
             var source = physical is ClrEnumerableRel clr
-                ? TestRows.Of(ClrEnumerableInterpretable.ToBindable(parameters, null, clr, ClrEnumerablePrefer.Array), context)
+                ? TestRows.Of(ClrEnumerableInterpretable.ToBindable(parameters, clr, ClrEnumerablePrefer.Array), context)
                 : TestRows.Of(EnumerableInterpretable.toBindable(parameters, null, (EnumerableRel)physical, EnumerableRel.Prefer.ARRAY), context);
 
             var rows = new List<object[]>();
@@ -188,7 +188,7 @@ namespace Apache.Calcite.Tests
             var physical = planner.transform(1, chosen.getTraitSet(), chosen);
 
             var rows = new List<object[]>();
-            var bindable = ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+            var bindable = ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
 
             foreach (var current in bindable.Bind(new TestDataContext(rootSchema)))
                 rows.Add(current as object[] ?? [current]);

--- a/src/Apache.Calcite.Tests/ClrEnumerableQueryTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableQueryTests.cs
@@ -154,7 +154,7 @@ namespace Apache.Calcite.Tests
             IClrBindable bindable;
             try
             {
-                bindable = ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), null, physical, ClrEnumerablePrefer.Array);
+                bindable = ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), physical, ClrEnumerablePrefer.Array);
             }
             catch (Exception e)
             {
@@ -191,51 +191,11 @@ namespace Apache.Calcite.Tests
 
             var project = Apache.Calcite.Extensions.Adapter.Enumerable.ClrEnumerableProject.Create(physical, identity, physical.getRowType());
 
-            var act = () => ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), null, project, ClrEnumerablePrefer.Array);
+            var act = () => ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), project, ClrEnumerablePrefer.Array);
 
             act.Should().Throw<java.lang.IllegalStateException>()
                 .WithMessage("Unable to implement ClrEnumerableProject*")
                 .WithInnerException<java.lang.UnsupportedOperationException>();
-        }
-
-        /// <summary>
-        /// A Spark handler is refused rather than ignored.
-        /// </summary>
-        /// <remarks>
-        /// Calcite hands the generated class and its source to <c>SparkHandler.compile</c>. There is neither
-        /// here, so the parameter is taken — so that a caller's configuration is seen — and refused.
-        /// </remarks>
-        [TestMethod]
-        public void ShouldRefuseASparkHandler()
-        {
-            var (physical, _) = Plan("SELECT \"ID\", \"NAME\" FROM \"PEOPLE\"");
-
-            var act = () => ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), new EnabledSparkHandler(), physical, ClrEnumerablePrefer.Array);
-
-            act.Should().Throw<java.lang.UnsupportedOperationException>().WithMessage("*Spark*");
-        }
-
-        /// <summary>
-        /// A Spark handler that says it is on, which is the only thing asked of it before it is refused.
-        /// </summary>
-        sealed class EnabledSparkHandler : org.apache.calcite.jdbc.CalcitePrepare.SparkHandler
-        {
-
-            /// <inheritdoc />
-            public bool enabled() => true;
-
-            /// <inheritdoc />
-            public org.apache.calcite.rel.RelNode flattenTypes(RelOptPlanner planner, org.apache.calcite.rel.RelNode rootRel, bool restructure) => throw new java.lang.UnsupportedOperationException();
-
-            /// <inheritdoc />
-            public void registerRules(org.apache.calcite.jdbc.CalcitePrepare.SparkHandler.RuleSetBuilder builder) => throw new java.lang.UnsupportedOperationException();
-
-            /// <inheritdoc />
-            public org.apache.calcite.runtime.ArrayBindable compile(org.apache.calcite.linq4j.tree.ClassDeclaration expr, string s) => throw new java.lang.UnsupportedOperationException();
-
-            /// <inheritdoc />
-            public object sparkContext() => throw new java.lang.UnsupportedOperationException();
-
         }
 
         /// <summary>
@@ -289,7 +249,7 @@ namespace Apache.Calcite.Tests
 
             physical.Should().BeOfType<Apache.Calcite.Extensions.Adapter.Enumerable.ClrEnumerableCombine>();
 
-            var bindable = ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), null, physical, ClrEnumerablePrefer.Array);
+            var bindable = ClrEnumerableInterpretable.ToBindable(new java.util.HashMap(), physical, ClrEnumerablePrefer.Array);
 
             var rows = new List<object[]>();
             foreach (var current in bindable.Bind(new TestDataContext(rootSchema)))

--- a/src/Apache.Calcite.Tests/ClrRelMetadataProviderTests.cs
+++ b/src/Apache.Calcite.Tests/ClrRelMetadataProviderTests.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Apache.Calcite.Extensions.Rel.Metadata;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.core;
+using org.apache.calcite.rel.logical;
+using org.apache.calcite.rel.metadata;
+using org.apache.calcite.rex;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.fun;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.util;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// <see cref="ClrRelMetadataProvider"/> against <c>JaninoRelMetadataProvider</c>, which is the only
+    /// oracle for it: the two are asked the same question about the same rel and have to answer the same
+    /// thing.
+    /// </summary>
+    /// <remarks>
+    /// A row-level differential test cannot see this. Metadata decides which plan the planner picks, and a
+    /// worse plan returns the same rows; the whole of what a defect here looks like is a slower query, until
+    /// it is a cost model that never converges. So the comparison is direct, method by method and rel by rel.
+    /// </remarks>
+    [TestClass]
+    public class ClrRelMetadataProviderTests
+    {
+
+        /// <summary>
+        /// A cluster whose planner is Volcano's, because a cost is asked of one.
+        /// </summary>
+        /// <returns></returns>
+        static RelOptCluster Cluster()
+        {
+            var typeFactory = new org.apache.calcite.jdbc.JavaTypeFactoryImpl();
+            var planner = new org.apache.calcite.plan.volcano.VolcanoPlanner();
+            planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
+            return RelOptCluster.create(planner, new RexBuilder(typeFactory));
+        }
+
+        /// <summary>
+        /// A plan holding the node kinds the dispatch chain separates: values, filter, project, join, union
+        /// and sort.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <returns></returns>
+        static RelNode Plan(RelOptCluster cluster)
+        {
+            var typeFactory = cluster.getTypeFactory();
+            var rexBuilder = cluster.getRexBuilder();
+            var intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+            var rowType = typeFactory.builder().add("A", intType).add("B", intType).build();
+
+            RexLiteral Literal(int i) => (RexLiteral)rexBuilder.makeExactLiteral(java.math.BigDecimal.valueOf(i), intType);
+
+            com.google.common.collect.ImmutableList Row(int a, int b) =>
+                com.google.common.collect.ImmutableList.copyOf(java.util.Arrays.asList([Literal(a), Literal(b)]));
+
+            var tuples = com.google.common.collect.ImmutableList.copyOf(java.util.Arrays.asList([Row(1, 2), Row(3, 4), Row(5, 6)]));
+
+            var left = LogicalValues.create(cluster, rowType, tuples);
+            var right = LogicalValues.create(cluster, rowType, tuples);
+
+            var filter = LogicalFilter.create(left,
+                rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, rexBuilder.makeInputRef(left, 0), Literal(1)));
+
+            var project = LogicalProject.create(filter, java.util.Collections.emptyList(),
+                java.util.Arrays.asList([rexBuilder.makeInputRef(filter, 1), rexBuilder.makeInputRef(filter, 0)]),
+                java.util.Arrays.asList(["B", "A"]));
+
+            var union = LogicalUnion.create(java.util.Arrays.asList([(RelNode)project, right]), true);
+
+            var join = LogicalJoin.create(union, right, java.util.Collections.emptyList(),
+                rexBuilder.makeCall(SqlStdOperatorTable.EQUALS,
+                    rexBuilder.makeInputRef(intType, 0),
+                    rexBuilder.makeInputRef(intType, 2)),
+                java.util.Collections.emptySet(),
+                JoinRelType.INNER);
+
+            return LogicalSort.create(join,
+                RelCollations.of(0),
+                null,
+                Literal(2));
+        }
+
+        /// <summary>
+        /// Every rel in the plan, deepest first.
+        /// </summary>
+        /// <param name="rel"></param>
+        /// <returns></returns>
+        static IEnumerable<RelNode> Nodes(RelNode rel)
+        {
+            var inputs = rel.getInputs();
+            for (int i = 0; i < inputs.size(); i++)
+                foreach (var child in Nodes((RelNode)inputs.get(i)))
+                    yield return child;
+
+            yield return rel;
+        }
+
+        /// <summary>
+        /// The questions, one per handler method that a plan of this shape can be asked.
+        /// </summary>
+        /// <param name="rel"></param>
+        /// <returns></returns>
+        static (string Name, Func<RelMetadataQuery, object?> Ask)[] Questions(RelNode rel)
+        {
+            var bits = ImmutableBitSet.of(0);
+            var all = ImmutableBitSet.range(0, rel.getRowType().getFieldCount());
+            var rexBuilder = rel.getCluster().getRexBuilder();
+
+            return
+            [
+                ("getRowCount", q => q.getRowCount(rel)),
+                ("getMaxRowCount", q => q.getMaxRowCount(rel)),
+                ("getMinRowCount", q => q.getMinRowCount(rel)),
+                ("getPercentageOriginalRows", q => q.getPercentageOriginalRows(rel)),
+                ("getCumulativeCost", q => q.getCumulativeCost(rel)),
+                ("getNonCumulativeCost", q => q.getNonCumulativeCost(rel)),
+                ("getColumnOrigins(0)", q => q.getColumnOrigins(rel, 0)),
+                ("getColumnOrigins(1)", q => q.getColumnOrigins(rel, 1)),
+                ("getSelectivity(null)", q => q.getSelectivity(rel, null)),
+                ("getUniqueKeys", q => q.getUniqueKeys(rel)),
+                ("areColumnsUnique(true)", q => q.areColumnsUnique(rel, bits, true)),
+                ("areColumnsUnique(false)", q => q.areColumnsUnique(rel, bits, false)),
+                ("areColumnsUnique(all)", q => q.areColumnsUnique(rel, all)),
+                ("collations", q => q.collations(rel)),
+                ("distribution", q => q.distribution(rel)),
+                ("getPopulationSize", q => q.getPopulationSize(rel, bits)),
+                ("getAverageRowSize", q => q.getAverageRowSize(rel)),
+                ("getAverageColumnSizes", q => q.getAverageColumnSizes(rel)),
+                ("getDistinctRowCount", q => q.getDistinctRowCount(rel, bits, null)),
+                ("getPulledUpPredicates", q => q.getPulledUpPredicates(rel).pulledUpPredicates),
+                ("getAllPredicates", q => q.getAllPredicates(rel)),
+                ("isVisibleInExplain(ALL)", q => q.isVisibleInExplain(rel, SqlExplainLevel.ALL_ATTRIBUTES)),
+                ("isVisibleInExplain(NO)", q => q.isVisibleInExplain(rel, SqlExplainLevel.NO_ATTRIBUTES)),
+                ("getNodeTypes", q => q.getNodeTypes(rel)),
+                ("memory", q => q.memory(rel)),
+                ("cumulativeMemoryWithinPhase", q => q.cumulativeMemoryWithinPhase(rel)),
+                ("isPhaseTransition", q => q.isPhaseTransition(rel)),
+                ("splitCount", q => q.splitCount(rel)),
+                ("getTableReferences", q => q.getTableReferences(rel)),
+                ("getExpressionLineage", q => q.getExpressionLineage(rel, rexBuilder.makeInputRef(rel, 0))),
+                ("getLowerBoundCost", q => q.getLowerBoundCost(rel, (org.apache.calcite.plan.volcano.VolcanoPlanner)rel.getCluster().getPlanner())),
+            ];
+        }
+
+        /// <summary>
+        /// Asks, and answers with what came back or with what was thrown.
+        /// </summary>
+        /// <param name="ask"></param>
+        /// <param name="mq"></param>
+        /// <returns></returns>
+        static string Answer(Func<RelMetadataQuery, object?> ask, RelMetadataQuery mq)
+        {
+            try
+            {
+                return ask(mq)?.ToString() ?? "null";
+            }
+            catch (Exception e)
+            {
+                while (e.InnerException is Exception inner)
+                    e = inner;
+
+                return "threw " + e.GetType().Name + ": " + e.Message;
+            }
+        }
+
+        /// <summary>
+        /// The two providers answer the same, for every method and every node of a plan.
+        /// </summary>
+        [TestMethod]
+        public void Should_answer_what_janino_answers()
+        {
+            var cluster = Cluster();
+            var plan = Plan(cluster);
+
+            var differences = new List<string>();
+
+            foreach (var rel in Nodes(plan))
+            {
+                // a fresh query per rel on each side, so neither can answer from what the other's walk left
+                // in a shared cache
+                foreach (var (name, ask) in Questions(rel))
+                {
+                    var janino = Answer(ask, new RelMetadataQuery(JaninoRelMetadataProvider.DEFAULT));
+                    var clr = Answer(ask, new RelMetadataQuery(ClrRelMetadataProvider.Default));
+
+                    if (janino != clr)
+                        differences.Add($"{rel.getRelTypeName()}.{name}: janino={janino} clr={clr}");
+                }
+            }
+
+            Assert.AreEqual(0, differences.Count, string.Join(Environment.NewLine, differences));
+        }
+
+        /// <summary>
+        /// One query's answers are the same when every node is asked through one query, which is what a
+        /// planner does and what the cache is for.
+        /// </summary>
+        [TestMethod]
+        public void Should_answer_what_janino_answers_through_one_query()
+        {
+            var cluster = Cluster();
+            var plan = Plan(cluster);
+
+            var janinoQuery = new RelMetadataQuery(JaninoRelMetadataProvider.DEFAULT);
+            var clrQuery = new RelMetadataQuery(ClrRelMetadataProvider.Default);
+
+            var differences = new List<string>();
+
+            foreach (var rel in Nodes(plan))
+                foreach (var (name, ask) in Questions(rel))
+                {
+                    var janino = Answer(ask, janinoQuery);
+                    var clr = Answer(ask, clrQuery);
+
+                    if (janino != clr)
+                        differences.Add($"{rel.getRelTypeName()}.{name}: janino={janino} clr={clr}");
+                }
+
+            Assert.AreEqual(0, differences.Count, string.Join(Environment.NewLine, differences));
+        }
+
+        /// <summary>
+        /// A handler written in .NET. Calcite's own provider cannot take one.
+        /// </summary>
+        public class ClrValuesRowCount : MetadataHandler
+        {
+
+            public java.lang.Double getRowCount(Values rel, RelMetadataQuery mq) => java.lang.Double.valueOf(7d);
+
+            public MetadataDef getDef() => BuiltInMetadata.RowCount.DEF;
+
+        }
+
+        /// <summary>
+        /// A metadata handler written in .NET answers here, and does not compile under Janino.
+        /// </summary>
+        /// <remarks>
+        /// The generated source names the handler class and the rel class the way Java names them, and IKVM's
+        /// name for a CLR class begins <c>cli.</c>. Janino answers "Cannot determine simple type name cli",
+        /// which is what stops a .NET user-defined function under <c>EnumerableConvention</c> as well. It is
+        /// the reason this provider exists; the compile it saves is the other one.
+        /// </remarks>
+        [TestMethod]
+        public void Should_take_a_handler_written_in_dotnet()
+        {
+            var handlerClass = (java.lang.Class)typeof(BuiltInMetadata.RowCount.Handler);
+            var source = ReflectiveRelMetadataProvider.reflectiveSource(new ClrValuesRowCount(), handlerClass);
+            var chained = ChainedRelMetadataProvider.of(java.util.Arrays.asList([source, DefaultRelMetadataProvider.INSTANCE]));
+
+            var cluster = Cluster();
+            var typeFactory = cluster.getTypeFactory();
+            var rowType = typeFactory.builder().add("A", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+            var values = LogicalValues.createEmpty(cluster, rowType);
+
+            var mq = new RelMetadataQuery(ClrRelMetadataProvider.Of(chained));
+            Assert.AreEqual(7d, mq.getRowCount(values).doubleValue(), 0.0001);
+
+            var refused = Assert.ThrowsException<java.lang.RuntimeException>(
+                () => JaninoRelMetadataProvider.of(chained).revise(handlerClass));
+            StringAssert.Contains(refused.ToString(), "cli");
+        }
+
+        /// <summary>
+        /// Preparing a statement compiles no metadata handler.
+        /// </summary>
+        /// <remarks>
+        /// The cache <c>JaninoRelMetadataProvider</c> holds its generated handlers in is the only thing that
+        /// can say so — a handler is generated once per process, so a second statement would pay nothing and
+        /// a timing would not tell. It is a private static, and IKVM renames the backing field of a Java
+        /// <c>static final</c>, so it is looked up under both names.
+        ///
+        /// <para>Measured before this provider: a statement of this shape generated nine of the twenty-seven
+        /// handlers, and that was two to three seconds of a cold first prepare.</para>
+        /// </remarks>
+        [TestMethod]
+        public void Should_prepare_without_compiling_a_handler()
+        {
+            var field = typeof(JaninoRelMetadataProvider).GetField("HANDLERS", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? typeof(JaninoRelMetadataProvider).GetField("__<>HANDLERS", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.IsNotNull(field, "JaninoRelMetadataProvider.HANDLERS could not be read, so nothing was measured.");
+
+            var cache = (com.google.common.cache.LoadingCache)field.GetValue(null)!;
+
+            const string sql = "SELECT REGION, COUNT(*) FROM SALES GROUP BY REGION ORDER BY REGION";
+            JaninoRelMetadataProvider.clearStaticCache();
+
+            ClrPrepareFixture.WithContext(sql, (context, _) =>
+                new Apache.Calcite.Extensions.Prepare.ClrPrepareImpl().Prepare(context, sql, (java.lang.Class)typeof(object[]), -1));
+
+            Assert.AreEqual(0L, cache.size(), "Janino generated a metadata handler while preparing.");
+        }
+
+        /// <summary>
+        /// A handler counting what it is asked, so that a prepare can be seen to have used it.
+        /// </summary>
+        public class CountingRowCount : MetadataHandler
+        {
+
+            public static int Asked;
+
+            public java.lang.Double getRowCount(TableScan rel, RelMetadataQuery mq)
+            {
+                Asked++;
+                return java.lang.Double.valueOf(rel.estimateRowCount(mq));
+            }
+
+            public MetadataDef getDef() => BuiltInMetadata.RowCount.DEF;
+
+        }
+
+        /// <summary>
+        /// A prepare of one's own, which is how Calcite says to install a metadata provider: subclass the
+        /// prepare, override the cluster factory, and set the query supplier there.
+        /// </summary>
+        sealed class PrepareWithProvider(RelMetadataProvider provider) : Apache.Calcite.Extensions.Prepare.ClrPrepareImpl
+        {
+
+            protected override RelOptCluster CreateCluster(RelOptPlanner planner, RexBuilder rexBuilder)
+            {
+                var cluster = base.CreateCluster(planner, rexBuilder);
+                cluster.setMetadataQuerySupplier(ClrRelMetadataProvider.QuerySupplier(provider));
+                cluster.invalidateMetadataQuery();
+                return cluster;
+            }
+
+        }
+
+        /// <summary>
+        /// A provider installed the way Calcite documents answers a real statement's metadata.
+        /// </summary>
+        /// <remarks>
+        /// <c>CalcitePrepareImpl.createCluster</c> is protected on a class that is not final, and
+        /// <c>RelMetadataQueryBase</c>'s own comment ends its recipe by setting the supplier on the cluster
+        /// and planning with that cluster. This is that recipe, and it is the whole of why the prepare is
+        /// open.
+        /// </remarks>
+        [TestMethod]
+        public void Should_take_a_provider_from_a_prepare_of_ones_own()
+        {
+            var source = ReflectiveRelMetadataProvider.reflectiveSource(
+                new CountingRowCount(), (java.lang.Class)typeof(BuiltInMetadata.RowCount.Handler));
+            var chained = ChainedRelMetadataProvider.of(java.util.Arrays.asList([source, DefaultRelMetadataProvider.INSTANCE]));
+
+            const string sql = "SELECT REGION, COUNT(*) FROM SALES GROUP BY REGION";
+
+            CountingRowCount.Asked = 0;
+            ClrPrepareFixture.WithContext(sql, (context, _) =>
+                new PrepareWithProvider(chained).Prepare(context, sql, (java.lang.Class)typeof(object[]), -1));
+
+            Assert.IsTrue(CountingRowCount.Asked > 0, "the provider the prepare installed was never asked.");
+        }
+
+        /// <summary>
+        /// A handler that asks the question it is answering.
+        /// </summary>
+        public class CyclicRowCount : MetadataHandler
+        {
+
+            public java.lang.Double getRowCount(Values rel, RelMetadataQuery mq) => mq.getRowCount(rel);
+
+            public MetadataDef getDef() => BuiltInMetadata.RowCount.DEF;
+
+        }
+
+        /// <summary>
+        /// A question that depends on itself is reported as a cycle rather than running out of stack, and
+        /// the rel's row is cleared on the way out.
+        /// </summary>
+        /// <remarks>
+        /// The mark the call leaves under its own key before dispatching is what sees the second call, and
+        /// the catch around the dispatch is what clears the row. Neither branch is reached by a query that
+        /// answers, so nothing else here covers them.
+        /// </remarks>
+        [TestMethod]
+        public void Should_report_a_cycle_and_clear_the_row()
+        {
+            var handlerClass = (java.lang.Class)typeof(BuiltInMetadata.RowCount.Handler);
+            var source = ReflectiveRelMetadataProvider.reflectiveSource(new CyclicRowCount(), handlerClass);
+
+            var cluster = Cluster();
+            var typeFactory = cluster.getTypeFactory();
+            var rowType = typeFactory.builder().add("A", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+            var values = LogicalValues.createEmpty(cluster, rowType);
+
+            var mq = new RelMetadataQuery(ClrRelMetadataProvider.Of(source));
+
+            Assert.ThrowsException<CyclicMetadataException>(() => mq.getRowCount(values));
+            Assert.AreEqual(0, mq.map.row(values).size(), "the rel's row was left behind.");
+        }
+
+        /// <summary>
+        /// A handler interface no handler answers refuses the rel, as Calcite's generated chain does when it
+        /// runs off the end.
+        /// </summary>
+        [TestMethod]
+        public void Should_refuse_a_rel_no_handler_declares()
+        {
+            var source = ReflectiveRelMetadataProvider.reflectiveSource(
+                new ClrValuesRowCount(), (java.lang.Class)typeof(BuiltInMetadata.RowCount.Handler));
+
+            var cluster = Cluster();
+            var typeFactory = cluster.getTypeFactory();
+            var rowType = typeFactory.builder().add("A", typeFactory.createSqlType(SqlTypeName.INTEGER)).build();
+            var values = LogicalValues.createEmpty(cluster, rowType);
+
+            var mq = new RelMetadataQuery(ClrRelMetadataProvider.Of(source));
+
+            Assert.AreEqual(7d, mq.getRowCount(values).doubleValue(), 0.0001);
+
+            var refused = Assert.ThrowsException<java.lang.IllegalArgumentException>(() => mq.getMaxRowCount(values));
+            StringAssert.Contains(refused.Message, "No handler for method");
+            StringAssert.Contains(refused.Message, "catch-all");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrTableSpiTests.cs
+++ b/src/Apache.Calcite.Tests/ClrTableSpiTests.cs
@@ -207,7 +207,7 @@ namespace Apache.Calcite.Tests
 
             if (async)
             {
-                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, null, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                var bindable = ClrAsyncEnumerableInterpretable.ToBindable(parameters, (ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
                 var reader = bindable.Bind(context).GetAsyncEnumerator();
                 try
                 {
@@ -221,7 +221,7 @@ namespace Apache.Calcite.Tests
             }
             else
             {
-                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, null, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+                var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
                 foreach (var row in bindable.Bind(context))
                     rows.Add(Render(row));
             }


### PR DESCRIPTION
`JaninoRelMetadataProvider` generates a Java class per metadata handler interface and compiles it with Janino. Two things follow from that.

A statement pays for the compiles. Measured on this machine, Debug: a first `SELECT … GROUP BY … ORDER BY` takes 4.2–6.2s, and the same prepare with every handler already generated takes 1.35–2.2s. It generates nine of the twenty-seven handlers; the second statement in the process is ~25ms.

And a metadata handler written in .NET cannot be used at all. The generated source names the handler class and every rel class the way Java names them, IKVM's name for a CLR class begins `cli.`, and Janino answers `Cannot determine simple type name "cli"` — the same wall a .NET user-defined function hits under `EnumerableConvention`.

## The provider

`ClrRelMetadataProvider` emits the same class as IL: a field per underlying handler, a public method per handler method holding the cache protocol, a private `name_` beneath it holding the `instanceof` chain, and `getDef` answering the first handler's. The five cache key strategies, the `DelegatingMetadataRel` unwind, the mark that detects a cycle and the catch that clears the rel's row are Calcite's, and the chain is in `topologicalSort` order with first-handler-wins.

Three of Calcite's handlers — `RelMdCumulativeCost`, `RelMdNonCumulativeCost`, `RelMdPercentageOriginalRowsHandler` — are `private static final` nested classes that the generated source names as field types and calls directly. Janino resolves such a name through the class loader without an access check; javac would refuse it. The emitted assembly carries `IgnoresAccessChecksTo` so it can do the same thing, rather than routing around what Calcite wrote.

It is reached through `RelOptCluster.setMetadataQuerySupplier`, which is the only way in — `RelMetadataQueryBase.THREAD_PROVIDERS` is typed to Janino's provider, and nothing but `RelMetadataQuery.instance()` reads it.

## The prepare surface

`ClrPrepareImpl` had drifted to `internal sealed` with private factory methods, where `CalcitePrepareImpl` is a public non-final class with protected ones. That closed off the route Calcite documents for custom metadata — subclass the prepare, override `createCluster`, set the query supplier — so it is open again:

| `CalcitePrepareImpl` | here |
|---|---|
| `createParser(String)` / `(String, Config)` | `CreateParser(string)` / `(string, SqlParser.Config)` |
| `parserConfig()` | `ParserConfig()` |
| `createConvertletTable()` | `CreateConvertletTable()` |
| `createCluster(RelOptPlanner, RexBuilder)` | `CreateCluster(RelOptPlanner, RexBuilder)` |
| `createPlannerFactories()` | `CreatePlannerFactories(bool async)` |
| `createPlanner(Context)` / `(Context, Context, RelOptCostFactory)` | `CreatePlanner(Context, bool)` / `(Context, plan.Context?, RelOptCostFactory?, bool)` |
| `getPreparingStmt(…)` | `GetPreparingStmt(…, bool async)` |
| `CalcitePreparingStmt.createSqlValidator` | `ClrPreparingStmt.CreateSqlValidator` |
| `CalcitePreparingStmt.getSqlValidator` | `ClrPreparingStmt.SqlValidator` |

`Function1` became `Func<>`; the rest is name-for-name in .NET casing. `Prepare` now walks the planner factories for real, catching `CannotPlanException` and falling through to the next, and `Hook.PLANNER` runs so a test can add or remove rules. `ClrPrepare`, `ClrPreparingStmt`, `ClrPrepareResult` and `ClrSignature` are public with it.

Not written, each for a stated reason: `createParser(String, ConfigBuilder)` and `createParserConfig()`, both deprecated for removal before 2.0 along with the builder they serve; and the spark rule-set block, whose builder's two methods are empty upstream.

## Three smaller things

- `ClrPhysType` answers `JavaRowType`, which `PhysType` has and it lacked. Four sites built Calcite's `PhysTypeImpl` only to ask it what Java type a row is — none of them a site where the shared Rex machinery takes a `PhysType` — and they now ask this convention's own.
- The `SparkHandler` parameter both `ToBindable`s took only in order to refuse is gone.
- `CalciteSession` takes its prepare from a delegate it holds, which is what `CalciteConnectionImpl.prepareFactory` is. Nothing passes a non-default one yet; how a connection supplies one is an ADO.NET surface question and is not decided here.

## Tests

`ClrRelMetadataProviderTests` is the oracle, because a row-level differential test cannot see this: metadata decides which plan is picked, and a worse plan returns the same rows. It asks both providers the same question about the same rel, method by method over every node of a plan, per query and through one shared query; it exercises the cycle and the clear-the-row path, an empty chain refusing a rel, a handler written in .NET that Janino will not compile, and a provider installed by subclassing the prepare; and it reads Janino's generated-handler cache after a prepare and finds it empty.

| | |
|---|---|
| `Apache.Calcite.Tests` | 674 passed, 0 failed |
| `Apache.Calcite.Adapter.AdoNet.Tests` | 345 passed, 0 failed |
| `Apache.Calcite.Data.Tests` | 324 passed, 0 failed |

674 is one fewer than before: `ShouldRefuseASparkHandler` covered a refusal that no longer exists.

## What this does not do

Janino still runs. `RexExecutable` cooks constant reduction with `ClassBodyEvaluator`, and any subtree left in `EnumerableConvention` still compiles. This is the metadata layer only.

Three handler interfaces — `Measure`, `FunctionalDependency`, `InputFieldsUsed` — are never asked by a test, so their emitted IL is unverified. `ClrRelMetadataProvider` implements `MetadataHandlerProvider` but not `RelMetadataProvider`, which Janino's does, so it cannot be handed where one is expected. Its handler cache is unbounded where Janino's is sized by `METADATA_HANDLER_CACHE_MAXIMUM_SIZE`, and it has no `clearStaticCache`.
