### PR TITLE
Mark the convention bridge rules guaranteed

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrEnumerableToClrAsyncEnumerableConverterRule.cs
@@ -42,6 +42,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new ClrEnumerableToClrAsyncEnumerableConverter(

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/EnumerableToClrAsyncEnumerableConverterRule.cs
@@ -41,6 +41,17 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new EnumerableToClrAsyncEnumerableConverter(

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAsyncEnumerableToClrEnumerableConverterRule.cs
@@ -42,6 +42,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new ClrAsyncEnumerableToClrEnumerableConverter(

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/EnumerableToClrEnumerableConverterRule.cs
@@ -40,6 +40,17 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// <see langword="true"/>, because <see cref="convert"/> accepts any node of the input convention.
+        /// Guaranteed is what puts the rule into <c>ConventionTraitDef</c>'s conversion graph, which is the
+        /// only route a conversion has when its input is itself a <c>Converter</c>: Calcite's
+        /// <c>ConverterRelOptRuleOperand</c> refuses to stack a converter on a converter of the same trait
+        /// def, and expects the abstract-converter expansion to walk this graph instead. Without this, a
+        /// plan whose only node in this rule's input convention is a converter cannot be completed at all.
+        /// </remarks>
+        public override bool isGuaranteed() => true;
+
+        /// <inheritdoc />
         public override RelNode? convert(RelNode rel)
         {
             return new EnumerableToClrEnumerableConverter(

--- a/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
+++ b/src/Apache.Calcite.Tests/ClrConventionCrossingTests.cs
@@ -178,6 +178,31 @@ namespace Apache.Calcite.Tests
         /// when it is blocked on. A fixture that completed synchronously would exercise the fast path only
         /// and say nothing about the wait.
         /// </remarks>
+        /// <summary>
+        /// A convention is reached when the only route to it runs through a second converter.
+        /// </summary>
+        /// <remarks>
+        /// The two bridges registered make <c>Enumerable -&gt; ClrAsyncEnumerable -&gt; ClrEnumerable</c> the
+        /// only route to the root convention: the direct <c>Enumerable -&gt; ClrEnumerable</c> rule is left
+        /// out, so the second hop would have to be applied to the converter the first produced, and
+        /// <c>ConverterRule</c>'s operand refuses to stack a converter on a converter of the same trait def.
+        /// What is left is <c>ConventionTraitDef</c>'s conversion graph, which a rule enters only by
+        /// answering <c>isGuaranteed</c> — so without that this statement cannot be planned at all.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldBridgeThroughASecondConverter()
+        {
+            var rules = new List<RelOptRule>
+            {
+                ClrAsyncEnumerableRules.EnumerableToClrAsyncEnumerableConverterRule,
+                ClrEnumerableRules.ClrAsyncEnumerableToClrEnumerableConverterRule,
+            };
+
+            var rows = RunSync("SELECT K, V FROM SORTED WHERE K >= 2", Schema(), rules, []);
+
+            rows.Should().Equal(["2|B", "2|C", "4|D"]);
+        }
+
         [TestMethod]
         public void ShouldReadAnAsynchronousPlanSynchronously()
         {


### PR DESCRIPTION
Replaces #33, taking its `isGuaranteed` half and leaving the CHAR trimming out.

The four unconditional convention bridges — `EnumerableToClrEnumerableConverterRule`, `EnumerableToClrAsyncEnumerableConverterRule`, `ClrEnumerableToClrAsyncEnumerableConverterRule`, `ClrAsyncEnumerableToClrEnumerableConverterRule` — now answer `isGuaranteed()` with `true`.

## Why

`ConventionTraitDef.registerConverterRule` puts a rule into its conversion graph only `if (converterRule.isGuaranteed())`, and that graph is the only route a conversion has when its input is itself a `Converter`: `ConverterRule`'s own operand refuses to stack a converter on a converter of the same trait def — the n² guard — and expects the abstract-converter expansion to walk the graph instead. With the graph empty, the `AbstractConverter`s sit at infinite cost and the statement cannot be planned.

Each of the four constructs its converter for any node of the input convention, unconditionally, which is exactly what `isGuaranteed` asks about. So `true` is the honest answer to the contract rather than a departure from it.

Worth knowing: nothing in Calcite core overrides `isGuaranteed`, and nothing there needs to. Upstream a conversion is a single hop into `EnumerableConvention`, which the operand match already covers. Here there are three conventions, so a plan whose only route to the root runs through a second converter has nowhere else to go.

## Test

`ShouldBridgeThroughASecondConverter` registers only the `Enumerable → ClrAsyncEnumerable` and `ClrAsyncEnumerable → ClrEnumerable` bridges — leaving the direct one out, so the second hop has to be applied to the converter the first produced — and asks for a synchronous root. Without the four overrides it fails with

```
CannotPlanException: There are not enough rules to produce a node with desired properties: convention=CLR_ENUMERABLE, sort=[0]
```

and with them it returns the rows. Verified both ways by reverting the four files and rebuilding.

## Not included

#33 also trimmed CHAR pad spaces in `CalciteResultValue`, in `GetValue()` as well as `GetString()`. That is a separate change to what a reader hands back — `CASE` arms of different lengths unifying to `CHAR` of the longest is correct SQL, and SqlClient returns `char(n)` padded — so it belongs in its own PR argued on 1.x compatibility rather than on provider convention.

## Results

| | |
|---|---|
| `Apache.Calcite.Tests` | 679 passed, 0 failed |
| `Apache.Calcite.Adapter.AdoNet.Tests` | 345 passed, 0 failed |
| `Apache.Calcite.Data.Tests` | 324 passed, 0 failed |
