### PR TITLE
Answer for a handler with the handler, not a proxy

### DIFF
--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrRelMetadataProvider.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrRelMetadataProvider.cs
@@ -75,23 +75,26 @@ namespace Apache.Calcite.Extensions.Rel.Metadata
         }
 
         /// <summary>
-        /// Answers with a handler that refuses every rel, so that a query builds only the handlers it reaches.
+        /// Returns the handler of <paramref name="handlerClass"/>.
         /// </summary>
         /// <param name="handlerClass"></param>
         /// <returns></returns>
         /// <remarks>
-        /// What Janino's provider does, and for the same reason: <see cref="RelMetadataQuery"/> asks for all
-        /// twenty-seven when it is constructed, which is once per query, and a statement touches a third of
-        /// them. The refusal is caught there and answered by <see cref="revise"/>.
+        /// The handler itself, where Janino's provider answers a <c>java.lang.reflect.Proxy</c> that throws
+        /// <c>NoHandler</c> so that <see cref="revise"/> builds one only for the handlers a statement
+        /// reaches. That deferral buys Janino a Java compile it may not have to run; there is nothing here to
+        /// defer, because a handler is emitted once per provider and interface and then answered from a
+        /// dictionary.
+        ///
+        /// <para>The proxy was also a cost and a hazard. <see cref="RelMetadataQuery"/> asks for all
+        /// twenty-seven every time one is constructed, and the planner constructs one whenever a rule
+        /// transforms — so the proxy route meant twenty-seven dynamic proxy classes and reflection accessors
+        /// per transformation, built through IKVM's own <c>Reflection.Emit</c> path, which is where
+        /// <c>InvalidProgramException</c> was coming from.</para>
         /// </remarks>
         public MetadataHandler handler(java.lang.Class handlerClass)
         {
-            ArgumentNullException.ThrowIfNull(handlerClass);
-
-            return (MetadataHandler)java.lang.reflect.Proxy.newProxyInstance(
-                ((java.lang.Class)typeof(RelMetadataQuery)).getClassLoader(),
-                [handlerClass],
-                new Refusing());
+            return revise(handlerClass);
         }
 
         /// <summary>
@@ -159,21 +162,6 @@ namespace Apache.Calcite.Extensions.Rel.Metadata
                 .Where(m => m.Name != "getDef" && m.IsAbstract && !m.IsStatic)
                 .OrderBy(m => m.Name, StringComparer.Ordinal)
                 .ToArray();
-        }
-
-        /// <summary>
-        /// The handler <see cref="handler"/> answers with, which refuses every rel it is asked about.
-        /// </summary>
-        sealed class Refusing : java.lang.reflect.InvocationHandler
-        {
-
-            /// <inheritdoc />
-            public object invoke(object proxy, java.lang.reflect.Method method, object[] args)
-            {
-                var r = (RelNode)args[0];
-                throw new MetadataHandlerProvider.NoHandler((java.lang.Class)r.GetType());
-            }
-
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/ClrRelMetadataProviderTests.cs
+++ b/src/Apache.Calcite.Tests/ClrRelMetadataProviderTests.cs
@@ -364,6 +364,99 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// Every handler interface, which is how many a query asks for.
+        /// </summary>
+        static Type[] HandlerInterfaces()
+        {
+            return typeof(BuiltInMetadata).GetNestedTypes()
+                .Select(t => t.GetNestedType("Handler"))
+                .Where(t => t is not null)
+                .ToArray()!;
+        }
+
+        /// <summary>
+        /// Asking for a handler answers the handler, not a stand-in.
+        /// </summary>
+        /// <remarks>
+        /// Janino's provider answers <c>handler</c> with a <c>java.lang.reflect.Proxy</c> that throws, so
+        /// that a Java compile is deferred until a statement proves it needs one. Nothing here is worth
+        /// deferring, and the proxy was not free: a query builds one per handler interface, and the planner
+        /// builds a query per rule transformation.
+        /// </remarks>
+        [TestMethod]
+        public void Should_answer_with_the_handler_itself()
+        {
+            var handlerClass = (java.lang.Class)typeof(BuiltInMetadata.RowCount.Handler);
+
+            var handler = ClrRelMetadataProvider.Default.handler(handlerClass);
+
+            StringAssert.StartsWith(handler.GetType().Name, "GeneratedMetadata_");
+            Assert.AreSame(handler, ClrRelMetadataProvider.Default.revise(handlerClass));
+        }
+
+        /// <summary>
+        /// Returns an argument for <paramref name="parameter"/>, so that a method can be called at all.
+        /// </summary>
+        static object? Argument(ParameterInfo parameter, RelNode rel, RelMetadataQuery mq)
+        {
+            var type = parameter.ParameterType;
+
+            if (typeof(RelNode).IsAssignableFrom(type))
+                return rel;
+            if (type == typeof(RelMetadataQuery))
+                return mq;
+            if (type == typeof(int))
+                return 0;
+            if (type == typeof(bool))
+                return false;
+            if (type == typeof(ImmutableBitSet))
+                return ImmutableBitSet.of(0);
+            if (typeof(java.lang.Enum).IsAssignableFrom(type))
+                return ((Array)type.GetMethod("values", BindingFlags.Public | BindingFlags.Static)!.Invoke(null, null)!).GetValue(0);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Every method of every handler interface is emitted correctly and answers what Janino's answers.
+        /// </summary>
+        /// <remarks>
+        /// A body that is emitted but never called is never verified: the runtime resolves it on the first
+        /// call, and malformed IL surfaces as <c>InvalidProgramException</c> then and not before. Three of
+        /// the interfaces — Measure, FunctionalDependency and InputFieldsUsed — are reached by no query in
+        /// this suite, so this calls all of them by hand rather than waiting for one that does.
+        /// </remarks>
+        [TestMethod]
+        public void Should_emit_every_handler_method_callably()
+        {
+            var cluster = Cluster();
+            var rel = Plan(cluster);
+
+            var differences = new List<string>();
+
+            foreach (var handlerInterface in HandlerInterfaces())
+            {
+                var handlerClass = (java.lang.Class)handlerInterface;
+                var clr = ClrRelMetadataProvider.Default.revise(handlerClass);
+                var janino = JaninoRelMetadataProvider.DEFAULT.revise(handlerClass);
+
+                foreach (var method in handlerInterface.GetMethods().Where(m => m.IsAbstract && !m.IsStatic))
+                {
+                    var clrQuery = new RelMetadataQuery(ClrRelMetadataProvider.Default);
+                    var janinoQuery = new RelMetadataQuery(JaninoRelMetadataProvider.DEFAULT);
+
+                    var ours = Answer(_ => method.Invoke(clr, method.GetParameters().Select(p => Argument(p, rel, clrQuery)).ToArray()), clrQuery);
+                    var theirs = Answer(_ => method.Invoke(janino, method.GetParameters().Select(p => Argument(p, rel, janinoQuery)).ToArray()), janinoQuery);
+
+                    if (ours != theirs)
+                        differences.Add($"{handlerInterface.DeclaringType!.Name}.{method.Name}: janino={theirs} clr={ours}");
+                }
+            }
+
+            Assert.AreEqual(0, differences.Count, string.Join(Environment.NewLine, differences));
+        }
+
+        /// <summary>
         /// A handler that asks the question it is answering.
         /// </summary>
         public class CyclicRowCount : MetadataHandler


### PR DESCRIPTION
Fixes the intermittent `InvalidProgramException` in `Apache.Calcite.Data.Tests`.

## It was the proxy, not the emitted IL

```
---- System.InvalidProgramException : Common Language Runtime detected an invalid program.
   at System.Reflection.Emit.DynamicResolver.ResolveToken(...)
   at __<FastConstructorAccessor>__com_sun_proxy_$Proxy27__<init>(Object[])
   at IKVM.Java.Externs.sun.reflect.ReflectionFactory.FastConstructorAccessorImpl.newInstance(...)
   at java.lang.reflect.Proxy.newProxyInstance(...)
   at ClrRelMetadataProvider.handler(Class handlerClass)
   at org.apache.calcite.rel.metadata.RelMetadataQuery..ctor(MetadataHandlerProvider provider)
   at org.apache.calcite.plan.RelOptCluster.getMetadataQuery()
```

Nothing this project emits appears in that trace. It is IKVM's own dynamic proxy machinery — `$Proxy27` and the `Reflection.Emit` constructor accessor behind it — failing to resolve a token.

`handler` was answering with a `java.lang.reflect.Proxy` that throws `NoHandler`, copied from `JaninoRelMetadataProvider`. Upstream that defers a Java compile until a statement proves it needs one. There is nothing here worth deferring: a handler is emitted once per provider and interface and answered from a dictionary after that. So `handler` is `revise`, and no proxy is created at all.

The cost was real as well as the hazard. `RelMetadataQuery` asks for all twenty-seven handlers every time one is constructed, and the planner constructs one whenever a rule transforms — so this was building twenty-seven proxy classes and their reflection accessors per transformation. `Apache.Calcite.Data.Tests` runs in 9–10s where it took 12–15s.

This removes the mechanism rather than the symptom: there is no longer a code path that reaches `Proxy.newProxyInstance`.

## Verifying what is emitted

`Should_emit_every_handler_method_callably` calls every method of every handler interface and compares the answer against Janino's. A body that is emitted but never called is never verified — the runtime resolves it on the first call, so malformed IL surfaces as `InvalidProgramException` then and not before. Three interfaces, `Measure`, `FunctionalDependency` and `InputFieldsUsed`, are reached by no query in this suite and so had never been called at all. All twenty-seven now emit, load and answer as Calcite's do.

`Should_answer_with_the_handler_itself` holds the fix: `handler` returns the emitted type, and the same instance `revise` returns.

## Results

| | |
|---|---|
| `Apache.Calcite.Tests` | 680 passed, 0 failed |
| `Apache.Calcite.Adapter.AdoNet.Tests` | 345 passed, 0 failed |
| `Apache.Calcite.Data.Tests` | 324 passed, 0 failed, four consecutive runs |

The failure was intermittent, so a green run is not proof on its own; the argument is that the call it came from no longer exists.
