### PR TITLE
Add a reflective schema over .NET objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,15 @@ read linq4j state slots; a table's own `getExpression(Queryable.class)`, which t
 linq4j; and the block Calcite's implementor produces for an `EnumerableConvention` sub-plan at a converter.
 Everything else is `System.Linq.Expressions` directly.
 
+**A block is the one thing composed before it is translated**, and the row it ends in is built in linq4j
+with it. `translateProjects` and an `AggImplementor` declare their own variables in the `BlockBuilder` and
+the expressions they answer refer to them, so those expressions cannot be translated one at a time; the
+block crosses whole, and a block ends in one expression rather than a list. So the calc, both aggregates
+and the window call `record` on a **Calcite** `PhysType` built beside the `ClrPhysType` — six sites, and
+they are not a lapse. `TranslateBody` is what brings the result to `ClrPhysType.RowType`, which is the
+boxed one. Everywhere the row is built from expressions of ours — the merge join's keys, `Values`,
+`ClrEnumUtils` — it is `ClrPhysType.Record`.
+
 **A physical type is not one of them.** `ClrPhysType` answers every question about a row in
 `System.Linq.Expressions` — it mirrors `PhysType` member for member and `ClrPhysTypeImpl` mirrors
 `PhysTypeImpl`, private helpers included — and `JavaRowFormatExtensions` answers the members of
@@ -160,6 +169,68 @@ other and so is its physical type; there is no adapter between them and none is 
 boundary. Calcite can leave the choice to its callers — there is no `Enumerable<int>` in Java, so the
 element is a reference whatever the physical type says, and javac inserts the conversion. Here it is
 decided once, and `ClrEnumerableRelImplementor.Result` refuses a sequence that disagrees.
+
+**A row of `Adapter/Clr` is a .NET object, and it has two Java identities.** The reflective adapter —
+`ClrReflectiveSchema` over any object, tables from its sequence-valued members — keeps the element type, so
+a query that projects nothing hands back your instances rather than copies (`ShouldHandBackTheObjectsThemselves`
+asserts reference equality). It has to, because **IKVM shows Java nothing of a .NET property**: measured,
+`getFields()` on a class of properties is *empty*, so `JavaTypeFactoryImpl.createType` over one answers
+`RecordType()` — a row of no columns — and says nothing, and `Types.nthField` throws. So building a row is
+`new_(clazz, …)` and wants the `java.lang.Class`, which rides on `ClrRowType : JavaRecordType` exactly as
+`createStructType(Class)` rides it for `ReflectiveSchema`; while *reading* a member goes through
+`JavaRowFormat.CUSTOM.field`, which branches on the declared type of the row **expression**, and so wants
+`ClrRecordType` — a `Types.RecordType` that is not a type at all but an index over the members, the only
+door into the by-ordinal branch. No type factory is subclassed and nothing is connection-wide.
+
+**So a row parameter is declared from `ClrPhysType.JavaRowType`, never from a Calcite `PhysType`'s
+`getJavaRowType()`.** The two are the same call for every row that is a record, an array, a list or a value —
+694 tests say so, the sweep changing nothing that was green — and part only for a CLR class. Both calcs, both
+aggregates, both sorted aggregates, both correlates, both conditional correlates, both batch nested loop
+joins, `ClrEnumUtils.GeneratePredicate` and both windows read it from the `ClrPhysType`; the window had to
+thread it through `WindowLoop`, `PartitionSelector`, `WindowRelInputGetter` and `ClrWinAggFrameResultContext`,
+none of which had a `ClrPhysType` in reach. **A Calcite `PhysType`'s `getJavaRowType()` in a new node is the
+bug this rule exists to stop**, and it fails as `IndexOutOfRange` inside `Types.nthField`, which names nothing.
+
+**The scan's reformat path had never run, and a one-column row is what reaches it.** `ToRows` passes the
+sequence straight through when the physical format is the one the element type already has, which is every
+table the suite had. `JavaRowFormat.optimize` turning a one-field CUSTOM row into SCALAR is what makes the two
+differ, and the path then held two defects at once: the row parameter was declared from the element *class*,
+and the selector returned Calcite's java row class where a sequence of this convention states the **boxed**
+one — `int` against `java.lang.Integer`. Calcite has nowhere for the second to show, there being no
+`Enumerable<int>` in Java and javac inserting the conversion at the boundary. `ShouldReadARowOfOneColumn`
+holds both. **A one-column row has now broken this convention three times**; add one to any new node's tests.
+
+**`EnumUtils.convert` will not cast to a record type, and says nothing about it.** `Types.needTypeCast`
+answers false for any `RecordType`, so the operand comes back unchanged. That is right where a record type is
+a variable's declared type and wrong where a value is an element of an `Object[]` — the window's partition
+array — and Calcite never meets it, a row of a class handing it a `Class`. Both windows write the cast
+themselves for a `ClrRecordType` and for nothing else; a synthetic record still gets none, which is Calcite's
+behaviour whether or not it is Calcite's intent.
+
+**Which of the two tables a type gets is `ClrTypeMapper.IsObjectRow`, and neither condition is taste.** Every
+member has to be one Calcite reads as it stands, because a field read of an object row is
+`Expression.Property` with nowhere to put a conversion; and the type has to have a constructor taking every
+member, because `CUSTOM.record` rebuilds a row with `new_(clazz, …)`. A positional record passes both and
+keeps its instances. Anything else — a `decimal`, a `DateTime`, an `int?`, or a class of settable properties
+— gets `ClrProjectingTable`, which reads each object once into an `object?[]` through a compiled
+`ClrRowConverter` and gives up object identity to do it. **A member is never silently dropped and never
+silently zero-column**: what cannot be converted is refused by name.
+
+**`ClrValues` is the adapter, and what each conversion answers is `getJavaClass`'s to say** — TIMESTAMP is a
+`long` of milliseconds, DATE an `int` of days, TIME an `int` of milliseconds in the day. The one policy in it
+is `DecimalScale`, six: a .NET `decimal` carries its scale per value and a column has one for all its rows,
+and the *normalisation* matters more than the number, because a group key is compared with
+`BigDecimal.equals`, which is scale sensitive — `1.10m` and `1.1m` would group apart otherwise.
+`ClrProjectingTableTests` asserts every conversion by comparing the column to the SQL literal it was written
+from, so **Calcite is the oracle and not arithmetic repeated in the test**; asserting the epoch offset would
+be the same sum `ClrValues` does, wrong the same way.
+
+**Nullability is Java's — a reference is nullable, a value type is not — deliberately.** The NRT annotations
+would give a better row type, `string` and `string?` differing where Java has to call every reference
+nullable, and nothing enforces them at run time. NOT NULL is a promise the planner generates code against, so
+reading them makes the row type a claim about the source rather than a fact about it. `int?` is the exception
+that costs nothing: it is a *type*, so it is honoured, and it is the one thing .NET says here that Java
+cannot.
 
 **`JavaCast` is for what Java the language converts and an expression tree will not** — boxing, unboxing,
 numeric promotion, `byte` sign extension. It is not a way to make one type into another where they ought

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregate.cs
@@ -108,7 +108,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     implementor.Translator.TranslateBody(initBlock.toBlock(), accType)),
                 accType);
 
-            var in_ = J.Expressions.parameter(inputCalcite.getJavaRowType(), "in");
+            var in_ = J.Expressions.parameter(inputPhysType.JavaRowType, "in");
             var acc_ = J.Expressions.parameter(accPhysType.getJavaRowType(), "acc");
             var inParameter = Expression.Parameter(sourceType, "in");
             var accParameter = Expression.Parameter(accType, "acc");

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableBatchNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableBatchNestedLoopJoin.cs
@@ -133,7 +133,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the getters registered below are ones Calcite's Rex translation reads the outer row through,
             // so they are given their physical type, built here from the three values ours carries
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftResult.PhysType.RelRowType, leftResult.PhysType.Format, false);
-            var corrVarType = leftCalcite.getJavaRowType();
+            var corrVarType = leftResult.PhysType.JavaRowType;
             var corrArgList = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, (java.lang.reflect.Type)(java.lang.Class)typeof(java.util.List), "corrList");
             var listParameter = Expression.Parameter(typeof(java.util.List), "corrList");
             implementor.Translator.Bind(corrArgList, listParameter);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCalc.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCalc.cs
@@ -117,10 +117,23 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // a calc is Rex and nothing else: the condition and the projects are both Calcite's to
             // translate, and each takes its own physical type -- one to read a field of the input with, one
             // to read the storage types of the output off. So both are built here, where they are used.
+            //
+            // the output one builds the row as well, at the end of the block, which is a question about a
+            // row and so would otherwise be ClrPhysType.Record's. It cannot be: translateProjects declares
+            // its own variables in the BlockBuilder and the expressions it answers refer to them, so they
+            // cannot be translated one at a time -- the block crosses whole, and a block ends in one
+            // expression rather than a list. The row is therefore built in linq4j and translated with the
+            // rest, and TranslateBody below is what brings it to physType.RowType, which is the boxed one.
+            // The same seam is why the aggregates and the window call record on a Calcite physical type.
             var inputCalcite = PhysTypeImpl.of(typeFactory, result.PhysType.RelRowType, result.PhysType.Format, false);
             var outputCalcite = PhysTypeImpl.of(typeFactory, physType.RelRowType, physType.Format, false);
 
-            var inputJavaType = inputCalcite.getJavaRowType();
+            // the ClrPhysType's, not inputCalcite's. The two are the same call -- format.javaRowClass over the
+            // same row type and format -- for every row that is a record, an array, a list or a value, and
+            // they part only where the row is an instance of a CLR class: there the class has no fields Java
+            // can see, and what a row expression must be declared with is the record type. Which branch
+            // CUSTOM.field takes is decided by this line and nowhere else.
+            var inputJavaType = result.PhysType.JavaRowType;
             var inputType = result.PhysType.RowType;
             var outputType = physType.RowType;
 

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConditionalCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableConditionalCorrelate.cs
@@ -122,7 +122,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the getter registered below is one Calcite's Rex translation reads the outer row through,
             // so it is given their physical type, built here from the three values ours carries
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftResult.PhysType.RelRowType, leftResult.PhysType.Format, false);
-            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftCalcite.getJavaRowType(), getCorrelVariable());
+            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftResult.PhysType.JavaRowType, getCorrelVariable());
 
             var corrParameter = Expression.Parameter(leftResult.PhysType.RowType, getCorrelVariable());
             implementor.Translator.Bind(corrArg, corrParameter);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableCorrelate.cs
@@ -102,7 +102,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the getter registered below is one Calcite's Rex translation reads the outer row through,
             // so it is given their physical type, built here from the three values ours carries
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftResult.PhysType.RelRowType, leftResult.PhysType.Format, false);
-            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftCalcite.getJavaRowType(), getCorrelVariable());
+            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftResult.PhysType.JavaRowType, getCorrelVariable());
 
             // boxed, because the selector Calcite's join builds always takes boxed rows — see JoinSelector,
             // which boxes both of its parameter types. Every other join here boxes its sequences for that

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
@@ -142,7 +142,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                     implementor.Translator.TranslateBody(initBlock.toBlock(), accType)),
                 accType);
 
-            var in_ = J.Expressions.parameter(inputCalcite.getJavaRowType(), "in");
+            var in_ = J.Expressions.parameter(inputPhysType.JavaRowType, "in");
             var acc_ = J.Expressions.parameter(accPhysType.getJavaRowType(), "acc");
             var inParameter = Expression.Parameter(sourceType, "in");
             var accParameter = Expression.Parameter(accType, "acc");

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableTableScan.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableTableScan.cs
@@ -333,7 +333,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the selector is the one Calcite writes, built against their physical type and translated whole.
             var calcite = PhysTypeImpl.of(implementor.TypeFactory, physType.RelRowType, physType.Format, false);
 
-            var row = J.Expressions.parameter(elementType, "row");
+            // the element type as linq4j has to name it. Calcite names the table's own, because a linq4j
+            // Enumerable erases its element and the physical type may have optimized to a format the sequence
+            // does not have -- a one column table declares Object[] and its physical type is SCALAR. That
+            // still holds; the one class it cannot cover is a row that is an instance of a CLR class, whose
+            // members Java cannot see at all, and there the same class named as a record type is the answer.
+            var row = J.Expressions.parameter(RowJavaType(), "row");
             var parameter = Expression.Parameter(element, "row");
             implementor.Translator.Bind(row, parameter);
 
@@ -342,10 +347,15 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             for (int i = 0; i < fieldCount; i++)
                 expressionList.add(FieldExpression(row, i, calcite, oldFormat));
 
+            // the row Calcite's record builds has the java row class, which is unboxed where a scalar row is a
+            // primitive; a sequence of this convention states its element type and ClrPhysType.RowType is that
+            // class boxed, so the two disagree by exactly one boxing. Calcite has nowhere for this to show --
+            // there is no Enumerable<int> in Java and javac inserts the conversion at the boundary -- and here
+            // it is a conversion the lambda has to carry, made the Java way as every other row element is.
             var rowType = physType.RowType;
             var selector = Expression.Lambda(
                 typeof(Func<,>).MakeGenericType(element, rowType),
-                implementor.Translator.Translate(calcite.record(expressionList)),
+                ClrEnumUtils.Convert(implementor.Translator.Translate(calcite.record(expressionList)), rowType),
                 parameter);
 
             return ClrAsyncBuiltInMethod.Call(ClrAsyncBuiltInMethod.Select.MakeGenericMethod(element, rowType), Source(element), selector);
@@ -357,6 +367,21 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="element"></param>
         /// <param name="source"></param>
         /// <returns></returns>
+        /// <summary>
+        /// Returns the type linq4j names one element of this table's sequence by.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// <see cref="elementType"/>, except where a row is an instance of a CLR class: <c>getFields()</c> on
+        /// one is empty, so a row expression declared with the class sends
+        /// <c>JavaRowFormat.CUSTOM.field</c> to <c>Types.nthField</c> and out of bounds. The record type is
+        /// the same class by the only name that can be read by ordinal.
+        /// </remarks>
+        java.lang.reflect.Type RowJavaType()
+        {
+            return getRowType() is Clr.ClrRowType clr && clr.Clazz == elementType ? clr.RecordType : elementType;
+        }
+
         static Expression FromJava(Type element, Expression source)
         {
             return ClrAsyncBuiltInMethod.Call(ClrAsyncBuiltInMethod.FromJavaAsync.MakeGenericMethod(element), source);

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
@@ -215,8 +215,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 Hoist(translator, variables, body, keyComparator_, collationComparator ?? throw new java.lang.NullPointerException("keyComparator"), typeof(java.util.Comparator));
             }
 
-            var loop = new WindowLoop(inputCalcite);
-            var inputGetter = new WindowRelInputGetter(loop.Row, inputCalcite, result.PhysType.RelRowType.getFieldCount(), translatedConstants);
+            var loop = new WindowLoop(inputCalcite, inputPhysType.JavaRowType);
+            var inputGetter = new WindowRelInputGetter(loop.Row, inputCalcite, inputPhysType.JavaRowType, result.PhysType.RelRowType.getFieldCount(), translatedConstants);
 
             // the output row is every input field, and then whatever each aggregate last computed
             var inputFieldCount = inputPhysType.RelRowType.getFieldCount();
@@ -281,7 +281,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             var frame = new java.util.function.DelegateFunction<J.BlockBuilder, WinAggFrameResultContext>(
                 block => new ClrWinAggFrameResultContext(
-                    block, typeFactory, implementor.Conformance, inputCalcite, result.PhysType.RelRowType.getFieldCount(),
+                    block, typeFactory, implementor.Conformance, inputCalcite, inputPhysType.JavaRowType, result.PhysType.RelRowType.getFieldCount(),
                     translatedConstants, comparator_, loop.Rows, loop.Index, loop.Start, loop.End, min_, loop.MaxX,
                     loop.HasRows, loop.FrameRowCount, loop.PartitionRowCount, loop.Position));
 
@@ -325,7 +325,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var selector = loop.Lambda(translator, selectorBuilder.toBlock(), outputType, accType);
 
             // the partition key, which is the one thing here that reads a row outside the loop
-            var partitionSelector = PartitionSelector(translator, inputCalcite, group, sourceType);
+            var partitionSelector = PartitionSelector(translator, inputCalcite, inputPhysType.JavaRowType, group, sourceType);
             var keyType = partitionSelector?.ReturnType ?? typeof(object);
 
             return ClrAsyncBuiltInMethod.Call(ClrAsyncBuiltInMethod.Window.MakeGenericMethod(sourceType, keyType, accType, outputType),
@@ -386,12 +386,12 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// The key <c>getPartitionIterator</c> builds, which is a synthetic record for several keys and the
         /// field itself for one.
         /// </remarks>
-        static LambdaExpression? PartitionSelector(LixToClrTranslator translator, PhysType inputPhysType, Group group, Type sourceType)
+        static LambdaExpression? PartitionSelector(LixToClrTranslator translator, PhysType inputPhysType, java.lang.reflect.Type javaRowType, Group group, Type sourceType)
         {
             if (group.keys.isEmpty())
                 return null;
 
-            var v_ = J.Expressions.parameter(inputPhysType.getJavaRowType(), "v");
+            var v_ = J.Expressions.parameter(javaRowType, "v");
             var selector = inputPhysType.selector(v_, group.keys.asList(), JavaRowFormat.CUSTOM);
 
             var builder = new J.BlockBuilder();
@@ -420,7 +420,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // the rows arrive boxed, because the partition they go into is an Object[], so the row is unboxed
             // on the way in exactly as a join's predicate unboxes its two
             var parameter = Expression.Parameter(sourceType, "v");
-            var row = Expression.Variable(ClrTypes.Resolve(inputPhysType.getJavaRowType()), "v");
+            var row = Expression.Variable(ClrTypes.Resolve(javaRowType), "v");
             translator.Bind(v_, row);
 
             // the key is a map's, so a key that is a primitive is boxed the way the type factory says: what
@@ -686,7 +686,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// lambda assigns from the <see cref="WindowFrame"/> it is given. That is the same thing a row
         /// parameter is everywhere else in this convention.
         /// </remarks>
-        sealed class WindowLoop(PhysType inputPhysType)
+        sealed class WindowLoop(PhysType inputPhysType, java.lang.reflect.Type javaRowType)
         {
 
             static readonly java.lang.reflect.Type IntType = J.Primitive.INT.primitiveClass;
@@ -720,7 +720,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             public J.ParameterExpression Position { get; } = J.Expressions.parameter(IntType, "j");
 
             /// <summary>The row being evaluated.</summary>
-            public J.ParameterExpression Row { get; } = J.Expressions.parameter(inputPhysType.getJavaRowType(), "row");
+            public J.ParameterExpression Row { get; } = J.Expressions.parameter(javaRowType, "row");
 
             /// <summary>The accumulator, which is not known until its record type has been built.</summary>
             public J.ParameterExpression? Accumulator { get; set; }
@@ -736,7 +736,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             public LambdaExpression Lambda(LixToClrTranslator translator, J.BlockStatement block, Type returnType, Type? accumulatorType)
             {
                 var frame = Expression.Parameter(typeof(WindowFrame), "frame");
-                var rowType = ClrTypes.Resolve(inputPhysType.getJavaRowType());
+                var rowType = ClrTypes.Resolve(javaRowType);
 
                 // fresh variables each time, because a lambda declares its own and two of them are siblings
                 var rows = Expression.Variable(typeof(object[]), "rows");
@@ -803,7 +803,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <remarks>
         /// <c>EnumerableWindow.WindowRelInputGetter</c>, which is private.
         /// </remarks>
-        sealed class WindowRelInputGetter(J.Expression row, PhysType rowPhysType, int actualInputFieldCount, java.util.List constants) : RexToLixTranslator.InputGetter
+        sealed class WindowRelInputGetter(J.Expression row, PhysType rowPhysType, java.lang.reflect.Type javaRowType, int actualInputFieldCount, java.util.List constants) : RexToLixTranslator.InputGetter
         {
 
             /// <inheritdoc />
@@ -877,6 +877,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             JavaTypeFactory typeFactory,
             SqlConformance conformance,
             PhysType inputPhysType,
+            java.lang.reflect.Type javaRowType,
             int actualInputFieldCount,
             java.util.List constants,
             J.Expression comparator,
@@ -898,7 +899,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 return RexToLixTranslator.forAggregation(
                     typeFactory,
                     block,
-                    new WindowRelInputGetter(GetRow(rowIndex), inputPhysType, actualInputFieldCount, constants),
+                    new WindowRelInputGetter(GetRow(rowIndex), inputPhysType, javaRowType, actualInputFieldCount, constants),
                     conformance);
             }
 
@@ -957,7 +958,21 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             /// <returns></returns>
             J.Expression GetRow(J.Expression rowIndex)
             {
-                return block.append("jRow", EnumUtils.convert(J.Expressions.arrayIndex(rows, rowIndex), inputPhysType.getJavaRowType()));
+                // EnumUtils.convert declines a row of a CLR class, and quietly: Types.needTypeCast answers
+                // false for any RecordType, so the operand comes back as it went in and the row stays an
+                // Object -- which then reaches CUSTOM.field and asks Object.class for its fields. The rule is
+                // right where a record type is the declared type of a variable, a synthetic record carrying
+                // its own and a cast being noise; it is wrong here, where the value is an element of an
+                // Object[] and there is nothing else to say what it is. Calcite never meets it, a row of a
+                // class handing it a Class and needTypeCast then answering true.
+                //
+                // So the cast is written for our record type and for nothing else. A synthetic record still
+                // goes through EnumUtils and still gets no cast, which is Calcite's behaviour whether or not
+                // it is Calcite's intent.
+                var element = (J.Expression)J.Expressions.arrayIndex(rows, rowIndex);
+                return block.append("jRow", javaRowType is Clr.ClrRecordType
+                    ? J.Expressions.convert_(element, javaRowType)
+                    : EnumUtils.convert(element, javaRowType));
             }
 
             /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrObjectTable.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrObjectTable.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+using Apache.Calcite.Extensions.Schema;
+
+using org.apache.calcite.adapter.java;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// A table over a sequence of .NET objects, whose rows are those objects.
+    /// </summary>
+    /// <remarks>
+    /// <c>ReflectiveSchema.ReflectiveTable</c>, for a .NET class. The row type is the members broken out as
+    /// columns, so SQL sees <c>EMPID, NAME</c>; the row itself stays the object, so a scan with nothing
+    /// projected over it hands back your instances rather than copies of them. Both, rather than a choice
+    /// between them, which is what Calcite's reflective schema gives and the reason to keep the object.
+    ///
+    /// <para>An <see cref="IClrQueryableTable"/> rather than a scannable one: there is a sequence in hand and
+    /// no reason to call anything per row. The expression is a constant, an expression tree being able to hold
+    /// an object where a plan Janino compiles cannot.</para>
+    /// </remarks>
+    public class ClrObjectTable : AbstractTable, IClrQueryableTable, TranslatableTable
+    {
+
+        readonly Type elementType;
+        readonly object source;
+        readonly Type sequenceType;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="elementType">The type one row is an instance of.</param>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> of <paramref name="elementType"/>.</param>
+        public ClrObjectTable(Type elementType, object source)
+        {
+            this.elementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+            this.source = source ?? throw new ArgumentNullException(nameof(source));
+
+            sequenceType = typeof(IEnumerable<>).MakeGenericType(elementType);
+            if (sequenceType.IsInstanceOfType(source) == false)
+                throw new ArgumentException($"'{source.GetType()}' is not an '{sequenceType}'.", nameof(source));
+        }
+
+        /// <inheritdoc />
+        public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+        {
+            return ClrTypeMapper.RowType((JavaTypeFactory)typeFactory, elementType);
+        }
+
+        /// <inheritdoc />
+        public Type ElementType => elementType;
+
+        /// <inheritdoc />
+        public Expression GetExpression(SchemaPlus? schema, string tableName)
+        {
+            return Expression.Constant(source, sequenceType);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>ReflectiveSchema.getRowCount</c>: a collection knows how many rows it has and a bare sequence
+        /// does not, and counting one would run it.
+        /// </remarks>
+        public override Statistic getStatistic()
+        {
+            return source is ICollection collection
+                ? Statistics.of(collection.Count, null)
+                : Statistics.UNKNOWN;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The same node <c>RelOptTableImpl.toRel</c> would have built without this. It is here so that a
+        /// table macro can return one, <c>TableMacro.apply</c> being declared to answer a
+        /// <see cref="TranslatableTable"/>.
+        /// </remarks>
+        public org.apache.calcite.rel.RelNode toRel(org.apache.calcite.plan.RelOptTable.ToRelContext context, org.apache.calcite.plan.RelOptTable relOptTable)
+        {
+            return org.apache.calcite.rel.logical.LogicalTableScan.create(context.getCluster(), relOptTable, context.getTableHints());
+        }
+
+        /// <inheritdoc />
+        public override string toString() => $"ClrObjectTable({elementType})";
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrProjectingTable.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrProjectingTable.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Apache.Calcite.Extensions.Schema;
+
+using org.apache.calcite;
+using org.apache.calcite.adapter.java;
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.logical;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// A table over a sequence of .NET objects, whose rows are those objects broken into columns.
+    /// </summary>
+    /// <remarks>
+    /// The half of the pair a <see cref="ClrObjectTable"/> cannot be, taken when the element type has a
+    /// member Calcite has no representation for — a <see cref="decimal"/>, a <see cref="DateTime"/>, a
+    /// <c>Guid</c>, an <c>int?</c> — or has no constructor to build a row back with. Both are things a row
+    /// that <em>is</em> the object cannot do: a field read of one is <c>Expression.Property</c> with nowhere
+    /// to put a conversion, and <c>JavaRowFormat.CUSTOM.record</c> rebuilds one by calling a constructor.
+    ///
+    /// <para>So the objects are read once each into an <c>object?[]</c> by <see cref="ClrRowConverter"/>, and
+    /// everything above the scan is what already runs over any <see cref="IClrScannableTable"/>. What is
+    /// given up is object identity — a query over this returns rows, not your instances.</para>
+    /// </remarks>
+    public class ClrProjectingTable : AbstractTable, IClrScannableTable, TranslatableTable
+    {
+
+        readonly Type elementType;
+        readonly IEnumerable source;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="elementType">The type one object is an instance of.</param>
+        /// <param name="source">A sequence of <paramref name="elementType"/>.</param>
+        public ClrProjectingTable(Type elementType, IEnumerable source)
+        {
+            this.elementType = elementType ?? throw new ArgumentNullException(nameof(elementType));
+            this.source = source ?? throw new ArgumentNullException(nameof(source));
+        }
+
+        /// <inheritdoc />
+        public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+        {
+            return ClrTypeMapper.ColumnRowType((JavaTypeFactory)typeFactory, elementType);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<object?[]> Scan(DataContext root)
+        {
+            var read = ClrRowConverter.Of(elementType);
+
+            foreach (var item in source)
+                yield return read(item);
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>ReflectiveSchema.getRowCount</c>: a collection knows how many rows it has and a bare sequence
+        /// does not, and counting one would run it.
+        /// </remarks>
+        public override Statistic getStatistic()
+        {
+            return source is ICollection collection ? Statistics.of(collection.Count, null) : Statistics.UNKNOWN;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// The same node <c>RelOptTableImpl.toRel</c> would have built without this. It is here so that a
+        /// table macro can return one, <c>TableMacro.apply</c> being declared to answer a
+        /// <see cref="TranslatableTable"/>.
+        /// </remarks>
+        public RelNode toRel(RelOptTable.ToRelContext context, RelOptTable relOptTable)
+        {
+            return LogicalTableScan.create(context.getCluster(), relOptTable, context.getTableHints());
+        }
+
+        /// <inheritdoc />
+        public override string toString() => $"ClrProjectingTable({elementType})";
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrRecordType.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrRecordType.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+using J = org.apache.calcite.linq4j.tree;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// A CLR type presented to linq4j as a record, so that its members can be reached by ordinal.
+    /// </summary>
+    /// <remarks>
+    /// <b>Not a type.</b> The type is <see cref="ClrType"/>, and this adds nothing to it: the members are the
+    /// ones <see cref="ClrReflect"/> already found. What it is, is an index — member <em>i</em> of a row is
+    /// named <em>N</em> — wearing <c>java.lang.reflect.Type</c> because that is the slot linq4j has.
+    ///
+    /// <para>It exists because <c>JavaRowFormat.CUSTOM.field</c> has exactly two branches: a
+    /// <c>Types.RecordType</c> is asked for its field by ordinal, and anything else goes to
+    /// <c>Types.nthField</c>, which is <c>getFields()[ordinal]</c>. A .NET class answers nothing from
+    /// <c>getFields()</c>, so the second branch throws and there is no third. Being one of these is the only
+    /// way in, and it is the same shape <c>JavaTypeFactoryImpl.SyntheticRecordType</c> already has.</para>
+    ///
+    /// <para>Interned per CLR type, because a row type is compared and a record type is what a row expression
+    /// is declared with in more than one place.</para>
+    /// </remarks>
+    public sealed class ClrRecordType : J.Types.RecordType
+    {
+
+        static readonly ConcurrentDictionary<Type, ClrRecordType> Cache = new();
+
+        /// <summary>
+        /// Returns the record type of a CLR type.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static ClrRecordType Of(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            return Cache.GetOrAdd(type, static t => new ClrRecordType(t));
+        }
+
+        readonly Type clrType;
+        readonly java.util.List fields;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="clrType"></param>
+        ClrRecordType(Type clrType)
+        {
+            this.clrType = clrType;
+
+            // the fields name this as their declaring type, which is what sends a member access back through
+            // ClrTypes.Resolve to the CLR type rather than to a Java class with no fields on it
+            var members = ClrReflect.Members(clrType);
+            var list = new java.util.ArrayList(members.Count);
+            for (int i = 0; i < members.Count; i++)
+                list.add(new ClrRecordField(this, members[i].Member, members[i].Type, members[i].Nullable));
+
+            fields = java.util.Collections.unmodifiableList(list);
+        }
+
+        /// <summary>
+        /// The CLR type a row of this is an instance of.
+        /// </summary>
+        public Type ClrType => clrType;
+
+        /// <inheritdoc />
+        public java.util.List getRecordFields() => fields;
+
+        /// <inheritdoc />
+        public string getName() => clrType.FullName ?? clrType.Name;
+
+        /// <inheritdoc />
+        public string getTypeName() => getName();
+
+        /// <inheritdoc />
+        public override string ToString() => getName();
+
+    }
+
+    /// <summary>
+    /// One member of a CLR type, presented to linq4j as a field of a record.
+    /// </summary>
+    /// <remarks>
+    /// <c>JavaTypeFactoryImpl.RecordFieldImpl</c>, over a member that exists rather than one that is going to
+    /// be emitted.
+    /// </remarks>
+    public sealed class ClrRecordField : J.Types.RecordField
+    {
+
+        readonly ClrRecordType declaring;
+        readonly MemberInfo member;
+        readonly Type clrType;
+        readonly bool nullability;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="declaring"></param>
+        /// <param name="member"></param>
+        /// <param name="clrType"></param>
+        /// <param name="nullability"></param>
+        internal ClrRecordField(ClrRecordType declaring, MemberInfo member, Type clrType, bool nullability)
+        {
+            this.declaring = declaring;
+            this.member = member;
+            this.clrType = clrType;
+            this.nullability = nullability;
+        }
+
+        /// <summary>
+        /// The property or field itself, which is what an access compiles to.
+        /// </summary>
+        public MemberInfo Member => member;
+
+        /// <inheritdoc />
+        public string getName() => member.Name;
+
+        /// <inheritdoc />
+        public java.lang.reflect.Type getType() => (java.lang.Class)clrType;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Every member here is public and none is static, a static one not being a column of a row.
+        /// </remarks>
+        public int getModifiers() => java.lang.reflect.Modifier.PUBLIC;
+
+        /// <inheritdoc />
+        public bool nullable() => nullability;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// <c>RecordFieldImpl</c> throws here, and rightly: a synthetic record has no member to read, the
+        /// class not existing yet. This one does, so it answers. Nothing on the plan path calls it —
+        /// <c>OptimizeShuttle</c> reaches <c>PseudoField.get</c> only for a constant receiver — but refusing
+        /// would be copying an admission of absence rather than a behaviour.
+        /// </remarks>
+        public object? get(object? o)
+        {
+            return member switch
+            {
+                PropertyInfo property => property.GetValue(o),
+                FieldInfo field => field.GetValue(o),
+                _ => throw new NotSupportedException($"'{member}' is neither a property nor a field.")
+            };
+        }
+
+        /// <inheritdoc />
+        public java.lang.reflect.Type getDeclaringClass() => declaring;
+
+        /// <inheritdoc />
+        public override string ToString() => $"{declaring.getName()}.{member.Name}";
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrReflect.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrReflect.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// The members of a CLR type that make up a row, in the order they make it up.
+    /// </summary>
+    /// <remarks>
+    /// The one answer to "what are this type's columns", asked by the row type and by the field access alike,
+    /// so that an ordinal cannot come to mean two things. <c>ReflectiveSchema</c> has no counterpart to this
+    /// because Java's answer is <c>Class.getFields()</c> and nothing else: the members it exposes are fields,
+    /// they are already ordered, and there is nothing to decide.
+    ///
+    /// <para><b>.NET has properties, and IKVM does not show one to Java at all.</b> Measured: a class whose
+    /// members are properties answers nothing from <c>getFields()</c> — a property is a <c>get_</c>/<c>set_</c>
+    /// method pair to Java and its backing field is private under a mangled name. So
+    /// <c>JavaTypeFactoryImpl.createType</c> over such a class returns <c>RecordType()</c>, a row of no
+    /// columns, and does not complain. Everything here exists because that walk cannot be reused.</para>
+    /// </remarks>
+    public static class ClrReflect
+    {
+
+        /// <summary>
+        /// One member of a row, before it is presented to Calcite as anything.
+        /// </summary>
+        /// <param name="Member">The property or field itself, which is what an access compiles to.</param>
+        /// <param name="Type">Its type.</param>
+        /// <param name="Nullable">Whether a value of it can be null.</param>
+        public readonly record struct Column(MemberInfo Member, Type Type, bool Nullable);
+
+        static readonly ConcurrentDictionary<Type, IReadOnlyList<Column>> Cache = new();
+
+        /// <summary>
+        /// Returns the members of <paramref name="type"/> that are columns of a row of it.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static IReadOnlyList<Column> Members(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            return Cache.GetOrAdd(type, Discover);
+        }
+
+        const BindingFlags Instance = BindingFlags.Public | BindingFlags.Instance;
+
+        /// <summary>
+        /// Works out the members of a type and their order.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Public instance properties that can be read, and public instance fields — the fields because a type
+        /// written the way Java writes one keeps working, and it is what <c>ReflectiveSchema</c> would have
+        /// taken. An indexer is not a column: it is not a value the row has, and there is no name to give it.
+        /// A write-only property has nothing to read.
+        /// </remarks>
+        static IReadOnlyList<Column> Discover(Type type)
+        {
+            var members = new List<Column>();
+
+            foreach (var property in type.GetProperties(Instance))
+            {
+                if (property.GetMethod is not { IsPublic: true })
+                    continue;
+                if (property.GetIndexParameters().Length > 0)
+                    continue;
+
+                members.Add(new Column(property, property.PropertyType, Nullable(property.PropertyType)));
+            }
+
+            foreach (var field in type.GetFields(Instance))
+                members.Add(new Column(field, field.FieldType, Nullable(field.FieldType)));
+
+            // .NET promises no order from GetProperties or GetFields, and SELECT * is positional. The token is
+            // declaration order for a type declared in one place, which is every type this is meant for, and it
+            // is at least stable for one that is not.
+            members.Sort(static (x, y) => x.Member.MetadataToken.CompareTo(y.Member.MetadataToken));
+
+            return Reorder(type, members);
+        }
+
+        /// <summary>
+        /// Returns whether a value of a type can be null.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A reference is nullable and a value type is not, which is the answer Java gives and the answer the
+        /// runtime enforces. <b>The nullable reference annotations are deliberately not read.</b> They would
+        /// give a better row type — <c>string</c> and <c>string?</c> differ, where Java has to call every
+        /// reference nullable — but nothing enforces them, and a column declared NOT NULL is a promise Calcite
+        /// generates code against. Reading them makes the row type a claim about the source rather than a fact
+        /// about it, and the failure is a null arriving where a plan was built on there being none.
+        /// </remarks>
+        static bool Nullable(Type type)
+        {
+            return type.IsValueType == false || System.Nullable.GetUnderlyingType(type) != null;
+        }
+
+        /// <summary>
+        /// Returns the constructor that takes every member of <paramref name="type"/>, or
+        /// <see langword="null"/> where there is none.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// What <c>JavaRowFormat.CUSTOM.record</c> will call to build a row of this type back, so its absence
+        /// is what decides that a table over the type has to project rather than keep its objects.
+        /// </remarks>
+        public static System.Reflection.ConstructorInfo? Constructor(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            var members = Members(type);
+            foreach (var constructor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+                if (Matches(constructor, members))
+                    return constructor;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns whether a constructor takes exactly the given members, by name and type.
+        /// </summary>
+        static bool Matches(ConstructorInfo constructor, IReadOnlyList<Column> members)
+        {
+            var parameters = constructor.GetParameters();
+            if (parameters.Length != members.Count || parameters.Length == 0)
+                return false;
+
+            for (int i = 0; i < parameters.Length; i++)
+                if (string.Equals(parameters[i].Name, members[i].Member.Name, StringComparison.OrdinalIgnoreCase) == false
+                    || parameters[i].ParameterType != members[i].Type)
+                    return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Puts the members in the order a constructor takes them, where one takes them all.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="members"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A row of this type is built by calling a constructor of exactly these members — Calcite's
+        /// <c>JavaRowFormat.CUSTOM.record</c> emits <c>new_(rowClass, expressions)</c> in field order — so
+        /// where such a constructor exists its parameter order is the authority on which column is which. That
+        /// is a positional record's primary constructor, and a type written with one.
+        ///
+        /// <para>Where there is none the token order stands, and a query that projects every column will fail
+        /// to find a constructor rather than build a row with the values transposed.</para>
+        /// </remarks>
+        static IReadOnlyList<Column> Reorder(Type type, List<Column> members)
+        {
+            foreach (var constructor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var parameters = constructor.GetParameters();
+                if (parameters.Length != members.Count || parameters.Length == 0)
+                    continue;
+
+                var ordered = new List<Column>(members.Count);
+                foreach (var parameter in parameters)
+                {
+                    var index = members.FindIndex(m => string.Equals(m.Member.Name, parameter.Name, StringComparison.OrdinalIgnoreCase));
+                    if (index < 0 || members[index].Type != parameter.ParameterType)
+                    {
+                        ordered.Clear();
+                        break;
+                    }
+
+                    ordered.Add(members[index]);
+                }
+
+                if (ordered.Count == members.Count)
+                    return ordered;
+            }
+
+            return members;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrReflectiveSchema.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrReflectiveSchema.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// A schema whose tables are the sequences a .NET object exposes.
+    /// </summary>
+    /// <remarks>
+    /// <c>ReflectiveSchema</c>, for .NET. The same idea — hand it an object, its members become tables — and
+    /// three differences forced by what IKVM shows Java of a .NET type, each measured rather than assumed:
+    ///
+    /// <para>Its members are properties as well as fields, and a property is invisible to Java. So the walk is
+    /// <see cref="ClrReflect"/>'s rather than <c>getFields()</c>.</para>
+    ///
+    /// <para>A sequence is an <see cref="IEnumerable{T}"/>, which is <b>not</b> a <c>java.lang.Iterable</c> —
+    /// measured — so <c>ReflectiveSchema.getElementType</c> would refuse a <c>List&lt;Employee&gt;</c>
+    /// outright. Here it is the candidate that matters, and an array is one too, as it is there.</para>
+    ///
+    /// <para>The element type is read off the sequence rather than being <c>Object.class</c>. Java erases it;
+    /// .NET does not, so a table knows what its rows are without being told.</para>
+    ///
+    /// <para>Which of the two tables a member gets is <see cref="ClrTypeMapper.IsObjectRow"/>'s answer and not
+    /// a setting: a type Calcite can read as it stands and can build back keeps its objects, and anything
+    /// else is projected into columns. So a positional record round-trips as instances and a class of
+    /// settable properties or of <see cref="decimal"/>s still queries, one row at a time.</para>
+    /// </remarks>
+    public class ClrReflectiveSchema : AbstractSchema
+    {
+
+        readonly object target;
+        java.util.Map? tables;
+        com.google.common.collect.Multimap? functions;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="target">The object whose members become the tables of this schema.</param>
+        public ClrReflectiveSchema(object target)
+        {
+            this.target = target ?? throw new ArgumentNullException(nameof(target));
+        }
+
+        /// <summary>
+        /// The object this schema reflects over.
+        /// </summary>
+        public object Target => target;
+
+        /// <inheritdoc />
+        protected override java.util.Map getTableMap() => tables ??= CreateTableMap();
+
+        /// <inheritdoc />
+        protected override com.google.common.collect.Multimap getFunctionMultimap() => functions ??= CreateFunctionMultimap();
+
+        const BindingFlags Instance = BindingFlags.Public | BindingFlags.Instance;
+
+        /// <summary>
+        /// Builds the tables from the members of the target.
+        /// </summary>
+        /// <returns></returns>
+        java.util.Map CreateTableMap()
+        {
+            var map = new java.util.LinkedHashMap();
+
+            foreach (var property in target.GetType().GetProperties(Instance))
+                if (property.GetMethod is { IsPublic: true } && property.GetIndexParameters().Length == 0)
+                    Add(map, property.Name, property.PropertyType, () => property.GetValue(target));
+
+            foreach (var field in target.GetType().GetFields(Instance))
+                Add(map, field.Name, field.FieldType, () => field.GetValue(target));
+
+            return map;
+        }
+
+        /// <summary>
+        /// Builds the table macros from the methods of the target.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>ReflectiveSchema.createFunctionMap</c>, which takes every method returning a
+        /// <c>TranslatableTable</c>. Here it is every method returning a <see cref="Table"/>, both of this
+        /// adapter's being one, and a method returning a sequence is <em>not</em> among them: that would be a
+        /// table function rather than a macro, and it would have to answer its row type without being called.
+        /// </remarks>
+        com.google.common.collect.Multimap CreateFunctionMultimap()
+        {
+            var builder = com.google.common.collect.ImmutableMultimap.builder();
+
+            foreach (var method in target.GetType().GetMethods(Instance))
+            {
+                if (method.DeclaringType == typeof(object) || method.IsSpecialName)
+                    continue;
+                if (typeof(Table).IsAssignableFrom(method.ReturnType) == false)
+                    continue;
+
+                builder.put(method.Name, new ClrTableMacro(target, method));
+            }
+
+            return builder.build();
+        }
+
+        /// <summary>
+        /// Adds a table for one member, where the member is a sequence of something with columns.
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="name"></param>
+        /// <param name="type"></param>
+        /// <param name="read"></param>
+        /// <remarks>
+        /// A member that is not a sequence is not a table and is passed over in silence, as
+        /// <c>fieldRelation</c> passes over a field that is not a collection. A member that is a sequence of
+        /// something with no columns at all is passed over too — <see cref="string"/> is the case that
+        /// matters, being a sequence of <see cref="char"/> — and a sequence of something whose members cannot
+        /// be represented becomes a table that refuses by name when its row type is asked for.
+        /// </remarks>
+        static void Add(java.util.Map map, string name, Type type, Func<object?> read)
+        {
+            var elementType = ElementTypeOf(type);
+            if (elementType == null || ClrReflect.Members(elementType).Count == 0)
+                return;
+
+            var value = read();
+            if (value == null)
+                throw new InvalidOperationException($"'{name}' is null, so there is no table to read.");
+
+            map.put(name, Of(elementType, value));
+        }
+
+        /// <summary>
+        /// Returns the table a sequence of a given element type gets.
+        /// </summary>
+        /// <param name="elementType"></param>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static Table Of(Type elementType, object source)
+        {
+            ArgumentNullException.ThrowIfNull(elementType);
+            ArgumentNullException.ThrowIfNull(source);
+
+            return ClrTypeMapper.IsObjectRow(elementType)
+                ? new ClrObjectTable(elementType, source)
+                : new ClrProjectingTable(elementType, (IEnumerable)source);
+        }
+
+        /// <summary>
+        /// Returns what a sequence type yields, or null where the type is not a sequence.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>ReflectiveSchema.getElementType</c>. An array answers with its element type there and here
+        /// alike; where it answers <c>Object.class</c> for an <c>Iterable</c>, having nothing else to say, an
+        /// <see cref="IEnumerable{T}"/> states its own.
+        /// </remarks>
+        static Type? ElementTypeOf(Type type)
+        {
+            if (type == typeof(string))
+                return null;
+
+            if (type.IsArray)
+                return type.GetElementType();
+
+            foreach (var iface in type.IsInterface ? [type, .. type.GetInterfaces()] : type.GetInterfaces())
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    return iface.GetGenericArguments()[0];
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        public override string toString() => $"ClrReflectiveSchema(target={target})";
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrReflectiveSchemaFactory.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrReflectiveSchemaFactory.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+
+using org.apache.calcite.schema;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// Builds a <see cref="ClrReflectiveSchema"/> from the operands of a model file.
+    /// </summary>
+    /// <remarks>
+    /// <c>ReflectiveSchema.Factory</c>. Two operands, as it has: <c>type</c>, the assembly-qualified name of
+    /// the class to reflect over, and an optional <c>staticMethod</c> or <c>staticProperty</c> naming a
+    /// member of it that answers the instance. Without either, the parameterless constructor is called.
+    ///
+    /// <para>Calcite's operand is called <c>class</c> and takes a name <c>Class.forName</c> resolves; this one
+    /// is called <c>type</c> and takes a name <see cref="Type.GetType(string)"/> resolves, because the two
+    /// name spaces are not the same one and a <c>cli.</c> prefixed name would be neither.</para>
+    /// </remarks>
+    public class ClrReflectiveSchemaFactory : SchemaFactory
+    {
+
+        /// <inheritdoc />
+        public org.apache.calcite.schema.Schema create(SchemaPlus parentSchema, string name, java.util.Map operand)
+        {
+            ArgumentNullException.ThrowIfNull(operand);
+
+            var typeName = (string?)operand.get("type")
+                ?? throw new java.lang.IllegalArgumentException("Operand 'type' is required.");
+
+            var type = Type.GetType(typeName, false)
+                ?? throw new java.lang.IllegalArgumentException($"No type '{typeName}'.");
+
+            return new ClrReflectiveSchema(Instance(type, operand));
+        }
+
+        const BindingFlags Static = BindingFlags.Public | BindingFlags.Static;
+
+        /// <summary>
+        /// Returns the object to reflect over.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="operand"></param>
+        /// <returns></returns>
+        static object Instance(Type type, java.util.Map operand)
+        {
+            if ((string?)operand.get("staticMethod") is string methodName)
+            {
+                var method = type.GetMethod(methodName, Static, [])
+                    ?? throw new java.lang.IllegalArgumentException($"'{type}' has no static method '{methodName}()'.");
+
+                return method.Invoke(null, null)
+                    ?? throw new java.lang.IllegalStateException($"'{methodName}()' returned null.");
+            }
+
+            if ((string?)operand.get("staticProperty") is string propertyName)
+            {
+                var property = type.GetProperty(propertyName, Static)
+                    ?? throw new java.lang.IllegalArgumentException($"'{type}' has no static property '{propertyName}'.");
+
+                return property.GetValue(null)
+                    ?? throw new java.lang.IllegalStateException($"'{propertyName}' returned null.");
+            }
+
+            return Activator.CreateInstance(type)
+                ?? throw new java.lang.IllegalStateException($"'{type}' could not be created.");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrRowConverter.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrRowConverter.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// Reads one .NET object as a row of the values Calcite holds.
+    /// </summary>
+    /// <remarks>
+    /// The other half of <see cref="ClrTypeMapper.ColumnRowType"/>: that says a member is a
+    /// <c>DECIMAL(19, 6)</c>, and this is what makes the value one. Compiled once per type, so a scan is a
+    /// delegate call and a property read per column rather than reflection per row.
+    ///
+    /// <para><b>Every element is boxed the Java way.</b> A row of an <see cref="ClrObjectTable"/> never
+    /// reaches this, its values already being Calcite's; a row of a <see cref="ClrProjectingTable"/> is an
+    /// <c>object?[]</c>, and an <see cref="int"/> put in one by the CLR is a <c>System.Int32</c> that
+    /// <c>SqlFunctions.toInt</c> refuses. <c>ClrEnumUtils.Convert</c> to <see cref="object"/> is what boxes
+    /// it as a <c>java.lang.Integer</c>, which is the same call <c>JavaRowFormatExtensions.ObjectArray</c>
+    /// makes for every array row this convention builds.</para>
+    /// </remarks>
+    public static class ClrRowConverter
+    {
+
+        static readonly ConcurrentDictionary<Type, Func<object, object?[]>> Cache = new();
+
+        /// <summary>
+        /// Returns the reader of one row of <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static Func<object, object?[]> Of(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            return Cache.GetOrAdd(type, static t => Compile(t));
+        }
+
+        /// <summary>
+        /// Builds and compiles the reader.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        static Func<object, object?[]> Compile(Type type)
+        {
+            var members = ClrReflect.Members(type);
+            var parameter = Expression.Parameter(typeof(object), "row");
+            var row = Expression.Convert(parameter, type);
+
+            var elements = new Expression[members.Count];
+            for (int i = 0; i < members.Count; i++)
+                elements[i] = Value(Expression.MakeMemberAccess(row, members[i].Member), members[i].Type);
+
+            return Expression.Lambda<Func<object, object?[]>>(
+                Expression.NewArrayInit(typeof(object), elements), parameter).Compile();
+        }
+
+        /// <summary>
+        /// Returns the expression yielding one member as the value its column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        static Expression Value(Expression value, Type type)
+        {
+            // a nullable value type is a null or the value it wraps, and asking HasValue first is the whole
+            // of the difference between it and a Java box
+            if (Nullable.GetUnderlyingType(type) is Type underlying)
+                return Expression.Condition(
+                    Expression.Property(value, "HasValue"),
+                    Value(Expression.Property(value, "Value"), underlying),
+                    Expression.Constant(null, typeof(object)),
+                    typeof(object));
+
+            if (ClrTypeMapper.IsNativelyRepresented(type))
+                return ClrEnumUtils.Convert(value, typeof(object));
+
+            if (type.IsEnum)
+                return ClrEnumUtils.Convert(Expression.Convert(value, Enum.GetUnderlyingType(type)), typeof(object));
+
+            var converter = ClrValues.Converter(type)
+                ?? throw new NotSupportedException($"There is no conversion from '{type}' to a value Calcite holds.");
+
+            // the converted value is a long, an int or a string; the first two are still the CLR's and are
+            // boxed the Java way on the way into the array, exactly as a native member is
+            return ClrEnumUtils.Convert(Expression.Call(null, converter, value), typeof(object));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrRowType.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrRowType.cs
@@ -1,0 +1,68 @@
+using System;
+
+using org.apache.calcite.jdbc;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// The row type of a table whose rows are instances of a CLR class.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="JavaRecordType"/>, which is the whole of how the class survives: <c>getJavaClass</c> tests
+    /// for one and answers with its <c>clazz</c>, before it can reach <c>createSyntheticType</c> and lose it.
+    /// That is the same mechanism <c>ReflectiveSchema</c> rides — <c>createStructType(Class)</c> ends in
+    /// <c>canonize(new JavaRecordType(list, type))</c> — and the only difference here is that the fields are
+    /// found by <see cref="ClrReflect"/> rather than by <c>getFields()</c>, which for a .NET class is empty.
+    ///
+    /// <para>It carries a <see cref="ClrRecordType"/> as well because a row of it has two Java identities, for
+    /// two different questions. Building one is <c>new_(clazz, ...)</c> and wants the class. Reading a member
+    /// of one goes through <c>JavaRowFormat.CUSTOM.field</c>, which branches on the declared type of the row
+    /// <em>expression</em> and would call <c>getFields()[i]</c> on a class — so what declares a row of this is
+    /// the record type. Both resolve to the same CLR type, so nothing downstream sees a disagreement.</para>
+    ///
+    /// <para><b>Two things this does not get that Calcite's own does.</b> <c>canonize</c> is protected, so
+    /// this is not interned; the type is built once per table and <c>RelOptTableImpl</c> caches
+    /// <c>getRowType</c>, so a single instance circulates and structural equality still holds, but it is an
+    /// agreement rather than an identity. And <c>createTypeWithNullability</c> asked for a nullability this
+    /// does not have goes through <c>copyRecordType</c> to <c>createStructType</c>, which drops the class;
+    /// what saves it is that a row type is NOT NULL and asking for NOT NULL returns the same object, so the
+    /// loss only reaches a reflective row used as a nullable struct <em>column</em>. Calcite degrades
+    /// identically there, and this reproduces it rather than working around it.</para>
+    /// </remarks>
+    public sealed class ClrRowType : JavaRecordType
+    {
+
+        readonly java.lang.Class clazz;
+        readonly ClrRecordType recordType;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="fields">One <c>RelDataTypeField</c> per member, in <see cref="ClrReflect"/>'s order.</param>
+        /// <param name="clazz">The CLR class a row is an instance of.</param>
+        /// <param name="recordType">The same class, presented so its members can be reached by ordinal.</param>
+        public ClrRowType(java.util.List fields, java.lang.Class clazz, ClrRecordType recordType) :
+            base(fields, clazz)
+        {
+            this.clazz = clazz ?? throw new ArgumentNullException(nameof(clazz));
+            this.recordType = recordType ?? throw new ArgumentNullException(nameof(recordType));
+        }
+
+        /// <summary>
+        /// The class a row is an instance of.
+        /// </summary>
+        /// <remarks>
+        /// Kept rather than read back off <see cref="JavaRecordType"/>, whose <c>clazz</c> is package private
+        /// in Java and so <c>internal</c> in what IKVM compiled — nameable from here and not readable.
+        /// </remarks>
+        public java.lang.Class Clazz => clazz;
+
+        /// <summary>
+        /// The class of a row, presented so that a member can be reached by ordinal.
+        /// </summary>
+        public ClrRecordType RecordType => recordType;
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrTableMacro.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrTableMacro.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Reflection;
+
+using org.apache.calcite.adapter.java;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// A table macro over a .NET method that returns a table.
+    /// </summary>
+    /// <remarks>
+    /// <c>ReflectiveSchema.MethodTableMacro</c>. Calcite builds one from a <c>java.lang.reflect.Method</c>
+    /// through <c>ReflectiveFunctionBase</c>, which reads the parameters and their <c>@Parameter</c>
+    /// annotations; .NET gives parameter names without an annotation and optionality with them, so the
+    /// parameters are read directly and <c>ReflectiveFunctionBase</c> is not used.
+    ///
+    /// <para><b>An argument arrives as Calcite's value and the method wants .NET's.</b> That is the reverse
+    /// of every other crossing in this adapter and it is a boundary like any other: a <c>java.lang.Integer</c>
+    /// is not an <see cref="int"/> to a <c>MethodInfo.Invoke</c>. Only the types
+    /// <see cref="ClrTypeMapper.IsNativelyRepresented"/> admits are accepted as parameters, so the
+    /// conversion is an unboxing and nothing more; a parameter of any other type is refused when the macro is
+    /// built rather than when it is called.</para>
+    /// </remarks>
+    public class ClrTableMacro : TableMacro
+    {
+
+        readonly object target;
+        readonly MethodInfo method;
+        readonly java.util.List parameters;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="target">The object the method is called on.</param>
+        /// <param name="method">A method returning a <see cref="Table"/>.</param>
+        public ClrTableMacro(object target, MethodInfo method)
+        {
+            this.target = target ?? throw new ArgumentNullException(nameof(target));
+            this.method = method ?? throw new ArgumentNullException(nameof(method));
+
+            var list = new java.util.ArrayList();
+            var infos = method.GetParameters();
+            for (int i = 0; i < infos.Length; i++)
+            {
+                if (ClrTypeMapper.IsNativelyRepresented(infos[i].ParameterType) == false)
+                    throw new NotSupportedException(
+                        $"'{method.DeclaringType}.{method.Name}' takes a '{infos[i].ParameterType}', which is not a type an argument can arrive as.");
+
+                list.add(new ClrFunctionParameter(i, infos[i]));
+            }
+
+            parameters = java.util.Collections.unmodifiableList(list);
+        }
+
+        /// <inheritdoc />
+        public java.util.List getParameters() => parameters;
+
+        /// <inheritdoc />
+        public TranslatableTable apply(java.util.List arguments)
+        {
+            var infos = method.GetParameters();
+            var values = new object?[infos.Length];
+            for (int i = 0; i < values.Length; i++)
+                values[i] = Argument(arguments.get(i), infos[i].ParameterType);
+
+            var table = method.Invoke(target, values)
+                ?? throw new java.lang.IllegalStateException($"'{method.Name}' returned null.");
+
+            return table as TranslatableTable
+                ?? throw new NotSupportedException(
+                    $"'{method.Name}' returned a '{table.GetType()}', which is not a TranslatableTable, so a macro cannot expand to it.");
+        }
+
+        /// <summary>
+        /// Returns one argument as the .NET value the method takes.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The arguments are the values Calcite computed, so a number is a <c>java.lang.Number</c> and a
+        /// string is a <c>java.lang.String</c>, which IKVM has already made a <see cref="string"/>. Unboxing
+        /// through <c>Number</c> rather than through a cast to a particular box is what lets a literal
+        /// <c>1</c> — which Calcite may have made an <c>Integer</c>, a <c>Long</c> or a <c>BigDecimal</c>
+        /// depending on where it came from — reach a parameter of any width.
+        /// </remarks>
+        static object? Argument(object? value, Type type)
+        {
+            if (value == null)
+                return null;
+
+            var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+            if (value is java.lang.Number number)
+            {
+                if (underlying == typeof(int)) return number.intValue();
+                if (underlying == typeof(long)) return number.longValue();
+                if (underlying == typeof(short)) return number.shortValue();
+                if (underlying == typeof(double)) return number.doubleValue();
+                if (underlying == typeof(float)) return number.floatValue();
+            }
+
+            if (value is java.lang.Boolean boolean && underlying == typeof(bool))
+                return boolean.booleanValue();
+
+            if (underlying.IsInstanceOfType(value))
+                return value;
+
+            throw new NotSupportedException($"'{value.GetType()}' is not a '{type}'.");
+        }
+
+        /// <inheritdoc />
+        public override string ToString() => $"ClrTableMacro({method})";
+
+    }
+
+    /// <summary>
+    /// One parameter of a <see cref="ClrTableMacro"/>.
+    /// </summary>
+    /// <remarks>
+    /// <c>ReflectiveFunctionBase.ParameterListBuilder</c>'s parameter, over a <see cref="ParameterInfo"/>.
+    /// .NET names a parameter always, where Java names one only under a <c>@Parameter</c> annotation and
+    /// falls back to <c>a0</c>, <c>a1</c>; and it states optionality in the signature, where Java states it
+    /// in the annotation.
+    /// </remarks>
+    public class ClrFunctionParameter : FunctionParameter
+    {
+
+        readonly int ordinal;
+        readonly ParameterInfo parameter;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="ordinal"></param>
+        /// <param name="parameter"></param>
+        public ClrFunctionParameter(int ordinal, ParameterInfo parameter)
+        {
+            this.ordinal = ordinal;
+            this.parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
+        }
+
+        /// <inheritdoc />
+        public int getOrdinal() => ordinal;
+
+        /// <inheritdoc />
+        public string getName() => parameter.Name ?? $"a{ordinal}";
+
+        /// <inheritdoc />
+        public RelDataType getType(RelDataTypeFactory typeFactory)
+        {
+            return ClrTypeMapper.ColumnType((JavaTypeFactory)typeFactory, parameter.ParameterType)
+                ?? throw new NotSupportedException($"'{parameter.ParameterType}' has no SQL type.");
+        }
+
+        /// <inheritdoc />
+        public bool isOptional() => parameter.IsOptional;
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrTypeMapper.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrTypeMapper.cs
@@ -1,0 +1,217 @@
+using System;
+
+using org.apache.calcite.adapter.java;
+using org.apache.calcite.avatica.util;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.parser;
+using org.apache.calcite.sql.type;
+
+using J = org.apache.calcite.linq4j.tree;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// The relational type of a CLR type.
+    /// </summary>
+    /// <remarks>
+    /// The row type is the one thing here that is not already in the CLR type: names, SQL types, nullability
+    /// and order are the schema, and <c>typeof(Employee)</c> says a member is a <see cref="decimal"/> without
+    /// saying it is the third column of a <c>DECIMAL(19, 6)</c>. Calcite requires it and .NET has no
+    /// equivalent, so it is built.
+    ///
+    /// <para>A member Calcite reads as it stands goes through <c>JavaTypeFactory.createType</c>, exactly as
+    /// <c>createStructType(Class)</c> sends a field's through it; only the walk that finds the members
+    /// differs. A member it does not is given a SQL type here and converted per value by
+    /// <see cref="ClrRowConverter"/> — and that pair is what decides which table a schema builds, because a
+    /// row that is the object itself has nowhere to put a conversion.</para>
+    /// </remarks>
+    public static class ClrTypeMapper
+    {
+
+        /// <summary>
+        /// Returns the row type of a table whose rows are instances of <paramref name="type"/>.
+        /// </summary>
+        /// <param name="typeFactory"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A <see cref="ClrRowType"/>, which carries the class so that <c>getJavaClass</c> answers with it,
+        /// and the record type so that a member can be reached by ordinal. Only for a type every member of
+        /// which Calcite reads as it stands — <see cref="IsObjectRow"/> is the question, and
+        /// <see cref="ColumnRowType"/> is the answer for everything else.
+        /// </remarks>
+        public static RelDataType RowType(JavaTypeFactory typeFactory, Type type)
+        {
+            ArgumentNullException.ThrowIfNull(typeFactory);
+            ArgumentNullException.ThrowIfNull(type);
+
+            var members = ClrReflect.Members(type);
+            var fields = new java.util.ArrayList(members.Count);
+            for (int i = 0; i < members.Count; i++)
+            {
+                var member = members[i];
+                if (IsNativelyRepresented(member.Type) == false)
+                    throw new NotSupportedException(
+                        $"'{type}.{member.Member.Name}' is a '{member.Type}', which Calcite has no representation for, " +
+                        $"so a row of '{type}' cannot be the object itself.");
+
+                fields.add(new RelDataTypeFieldImpl(member.Member.Name, i, typeFactory.createType((java.lang.Class)member.Type)));
+            }
+
+            return new ClrRowType(fields, (java.lang.Class)type, ClrRecordType.Of(type));
+        }
+
+        /// <summary>
+        /// Returns the row type of a table that breaks instances of <paramref name="type"/> into columns.
+        /// </summary>
+        /// <param name="typeFactory"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// An ordinary <c>RelRecordType</c>, the rows being <c>object?[]</c> and the class having nothing to
+        /// do with them. Every member goes through <see cref="ColumnType"/>, which refuses by name what it
+        /// cannot convert.
+        /// </remarks>
+        public static RelDataType ColumnRowType(JavaTypeFactory typeFactory, Type type)
+        {
+            ArgumentNullException.ThrowIfNull(typeFactory);
+            ArgumentNullException.ThrowIfNull(type);
+
+            var members = ClrReflect.Members(type);
+            var builder = typeFactory.builder();
+            for (int i = 0; i < members.Count; i++)
+            {
+                var member = members[i];
+                builder.add(
+                    member.Member.Name,
+                    ColumnType(typeFactory, member.Type)
+                        ?? throw new NotSupportedException($"'{type}.{member.Member.Name}' is a '{member.Type}', which has no SQL type."));
+            }
+
+            return builder.build();
+        }
+
+        /// <summary>
+        /// Returns the SQL type of one column, or <see langword="null"/> where the CLR type has none.
+        /// </summary>
+        /// <param name="typeFactory"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Each of these is paired with a method of <see cref="ClrValues"/>, and the pairing is what
+        /// <c>JavaTypeFactoryImpl.getJavaClass</c> dictates rather than what the SQL type is called: a
+        /// TIMESTAMP column holds a <see cref="long"/>, so the conversion answers one.
+        /// </remarks>
+        public static RelDataType? ColumnType(JavaTypeFactory typeFactory, Type type)
+        {
+            ArgumentNullException.ThrowIfNull(typeFactory);
+            ArgumentNullException.ThrowIfNull(type);
+
+            // a nullable value type is the type it wraps, and the one place .NET says something Java cannot
+            if (Nullable.GetUnderlyingType(type) is Type underlying)
+                return ColumnType(typeFactory, underlying) is RelDataType inner
+                    ? typeFactory.createTypeWithNullability(inner, true)
+                    : null;
+
+            if (IsNativelyRepresented(type))
+                return typeFactory.createType((java.lang.Class)type);
+
+            // an enum is its underlying integer. Calcite's SYMBOL is for its own enums and reaches no SQL
+            if (type.IsEnum)
+                return typeFactory.createType((java.lang.Class)Enum.GetUnderlyingType(type));
+
+            if (type == typeof(decimal))
+                return typeFactory.createSqlType(SqlTypeName.DECIMAL, ClrValues.DecimalPrecision, ClrValues.DecimalScale);
+
+            if (type == typeof(DateTime))
+                return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+
+            if (type == typeof(DateOnly))
+                return typeFactory.createSqlType(SqlTypeName.DATE);
+
+            if (type == typeof(TimeOnly))
+                return typeFactory.createSqlType(SqlTypeName.TIME);
+
+            if (type == typeof(TimeSpan))
+                return typeFactory.createSqlIntervalType(new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO));
+
+            if (type == typeof(Guid))
+                return typeFactory.createSqlType(SqlTypeName.CHAR, 36);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns whether a table over <paramref name="type"/> can keep its rows as the objects.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Two conditions, and both are about what a row has to be able to do rather than about taste.
+        ///
+        /// <para>Every member must be one Calcite reads as it stands, because a field read of an object row
+        /// is <c>Expression.Property</c> and there is nowhere to put a conversion.</para>
+        ///
+        /// <para>And the type must have a constructor taking every member, because
+        /// <c>JavaRowFormat.CUSTOM.record</c> builds a row back with <c>new_(clazz, …)</c> — which any
+        /// projection that keeps the row shape will do. A positional record has one; a type of settable
+        /// properties does not, and gets a table that projects rather than a failure at plan time.</para>
+        /// </remarks>
+        public static bool IsObjectRow(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            var members = ClrReflect.Members(type);
+            if (members.Count == 0)
+                return false;
+
+            if (ClrReflect.Constructor(type) == null)
+                return false;
+
+            for (int i = 0; i < members.Count; i++)
+                if (IsNativelyRepresented(members[i].Type) == false)
+                    return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns whether a value of a CLR type is one Calcite reads as it stands.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <b>Calcite's own test, not a table written again here.</b> <c>JavaTypeFactoryImpl.createType</c>
+        /// answers a primitive or a box with <c>createJavaType</c>, answers anything
+        /// <c>JavaToSqlTypeConversionRules</c> knows the same way, and sends everything else to
+        /// <c>createStructType</c> — which over a .NET class is the silent zero-column row. Asking the same
+        /// question here is what turns that silence into a refusal.
+        ///
+        /// <para>So <see cref="int"/>, <see cref="long"/>, <see cref="string"/> and the rest are in, IKVM
+        /// showing them to Java as <c>int</c>, <c>long</c> and <c>java.lang.String</c>; so is a member whose
+        /// type is a Java one already, a <c>BigDecimal</c> or a <c>java.sql.Timestamp</c>.
+        /// <see cref="decimal"/>, <see cref="DateTime"/>, <see cref="Guid"/> and <c>int?</c> are out — they
+        /// arrive as <c>cli.System.Decimal</c> and friends, which Calcite has never heard of — and each is
+        /// converted per value instead, by <see cref="ColumnType"/> and <see cref="ClrValues"/>.</para>
+        /// </remarks>
+        public static bool IsNativelyRepresented(Type type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+
+            var clazz = (java.lang.Class)type;
+
+            switch (J.Primitive.flavor(clazz).name())
+            {
+                case nameof(J.Primitive.Flavor.PRIMITIVE):
+                case nameof(J.Primitive.Flavor.BOX):
+                    return true;
+            }
+
+            return JavaToSqlTypeConversionRules.instance().lookup(clazz) != null;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Clr/ClrValues.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Clr/ClrValues.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Reflection;
+
+namespace Apache.Calcite.Extensions.Adapter.Clr
+{
+
+    /// <summary>
+    /// The .NET values Calcite has no representation for, as the values it does.
+    /// </summary>
+    /// <remarks>
+    /// <b>An adapter, in the sense the whole port means by one.</b> A <see cref="decimal"/> is not a
+    /// <c>BigDecimal</c> and a <see cref="DateTime"/> is not a number of milliseconds; handing either across
+    /// as it stands leaves two representations of one value in a plan, and Calcite's own comparators fail on
+    /// them. Every method here is one direction of one boundary, and the reverse of each is
+    /// <see cref="ClrValues"/>'s to add when something needs to read one back.
+    ///
+    /// <para>What each answers is not a choice: it is what <c>JavaTypeFactoryImpl.getJavaClass</c> says a
+    /// column of that SQL type holds. TIMESTAMP is a <see cref="long"/> of milliseconds, DATE an
+    /// <see cref="int"/> of days, TIME an <see cref="int"/> of milliseconds in the day. Reading that method
+    /// is what settles each of these, not SQL and not what the value ought to be.</para>
+    /// </remarks>
+    public static class ClrValues
+    {
+
+        /// <summary>
+        /// The scale a <see cref="decimal"/> column is declared and normalised to.
+        /// </summary>
+        /// <remarks>
+        /// <b>A policy, and the only one here.</b> A .NET <see cref="decimal"/> carries its scale per value
+        /// rather than per type — <c>1.10m</c> and <c>1.1m</c> are different values of the same type — and a
+        /// SQL column has one scale for all its rows, so a number has to be chosen. Six covers money and most
+        /// measures inside the thirteen integral digits that leaves.
+        ///
+        /// <para>The normalisation matters more than the number. <c>BigDecimal.equals</c> is scale sensitive
+        /// where <c>compareTo</c> is not, and a group key is compared by <c>equals</c> — so <c>1.10m</c> and
+        /// <c>1.1m</c> would group apart if each kept the scale it arrived with. Rounding every value to one
+        /// scale is what makes GROUP BY and DISTINCT mean what they say.</para>
+        /// </remarks>
+        public const int DecimalScale = 6;
+
+        /// <summary>
+        /// The precision a <see cref="decimal"/> column is declared with.
+        /// </summary>
+        /// <remarks>
+        /// <c>RelDataTypeSystem.getMaxPrecision(DECIMAL)</c> is 19 and a .NET <see cref="decimal"/> holds up
+        /// to 29 significant digits, so the ceiling is Calcite's rather than ours and a value wider than it is
+        /// outside what the column can describe.
+        /// </remarks>
+        public const int DecimalPrecision = 19;
+
+        static readonly java.math.RoundingMode HalfUp = java.math.RoundingMode.HALF_UP;
+
+        /// <summary>
+        /// Returns a <see cref="decimal"/> as the <c>BigDecimal</c> a DECIMAL column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Through the invariant-culture string rather than through a <see cref="double"/>, which would round
+        /// at the fifteenth digit and is the whole reason a decimal type exists.
+        /// </remarks>
+        public static java.math.BigDecimal ToBigDecimal(decimal value)
+        {
+            return new java.math.BigDecimal(value.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .setScale(DecimalScale, HalfUp);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DateTime"/> as the milliseconds a TIMESTAMP column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The wall clock reading, whatever the <see cref="DateTimeKind"/>. A Calcite TIMESTAMP has no time
+        /// zone — the type that does is TIMESTAMP_TZ — so a local time and a UTC time that read the same are
+        /// the same TIMESTAMP, and shifting one of them would be inventing a zone the column does not have.
+        /// </remarks>
+        public static long ToTimestamp(DateTime value)
+        {
+            return (value.Ticks - DateTime.UnixEpoch.Ticks) / TimeSpan.TicksPerMillisecond;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DateOnly"/> as the days a DATE column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static int ToDate(DateOnly value)
+        {
+            return value.DayNumber - UnixEpochDay;
+        }
+
+        static readonly int UnixEpochDay = new DateOnly(1970, 1, 1).DayNumber;
+
+        /// <summary>
+        /// Returns a <see cref="TimeOnly"/> as the milliseconds a TIME column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static int ToTime(TimeOnly value)
+        {
+            return (int)(value.Ticks / TimeSpan.TicksPerMillisecond);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="TimeSpan"/> as the milliseconds a day-to-second interval holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static long ToInterval(TimeSpan value)
+        {
+            return value.Ticks / TimeSpan.TicksPerMillisecond;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Guid"/> as the 36 character string a CHAR(36) column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The hyphenated form, which is what <c>AdoTable</c> already maps a <c>DbType.Guid</c> to and what
+        /// every database that has no native type for one stores.
+        /// </remarks>
+        public static string ToChars(Guid value)
+        {
+            return value.ToString("D", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="char"/> as the one character string a CHAR(1) column holds.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static string ToChars(char value)
+        {
+            return value.ToString();
+        }
+
+        /// <summary>
+        /// The methods above, by the CLR type each converts from.
+        /// </summary>
+        internal static MethodInfo? Converter(Type type)
+        {
+            return type switch
+            {
+                _ when type == typeof(decimal) => Method(nameof(ToBigDecimal), typeof(decimal)),
+                _ when type == typeof(DateTime) => Method(nameof(ToTimestamp), typeof(DateTime)),
+                _ when type == typeof(DateOnly) => Method(nameof(ToDate), typeof(DateOnly)),
+                _ when type == typeof(TimeOnly) => Method(nameof(ToTime), typeof(TimeOnly)),
+                _ when type == typeof(TimeSpan) => Method(nameof(ToInterval), typeof(TimeSpan)),
+                _ when type == typeof(Guid) => Method(nameof(ToChars), typeof(Guid)),
+                _ when type == typeof(char) => Method(nameof(ToChars), typeof(char)),
+                _ => null
+            };
+        }
+
+        static MethodInfo Method(string name, Type parameter)
+        {
+            return typeof(ClrValues).GetMethod(name, BindingFlags.Public | BindingFlags.Static, [parameter])
+                ?? throw new InvalidOperationException($"'{name}({parameter})' is missing.");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumUtils.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumUtils.cs
@@ -267,8 +267,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftPhysType.RelRowType, leftPhysType.Format, false);
             var rightCalcite = PhysTypeImpl.of(implementor.TypeFactory, rightPhysType.RelRowType, rightPhysType.Format, false);
 
-            var left_ = J.Expressions.parameter(leftCalcite.getJavaRowType(), "left");
-            var right_ = J.Expressions.parameter(rightCalcite.getJavaRowType(), "right");
+            var left_ = J.Expressions.parameter(leftPhysType.JavaRowType, "left");
+            var right_ = J.Expressions.parameter(rightPhysType.JavaRowType, "right");
 
             // the rows arrive boxed, because the sequence a join runs over is boxed for the selector, so the
             // predicate takes them boxed and unboxes on the way in
@@ -277,8 +277,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             // unboxed, because the linq4j parameter the Rex condition is built against is the Java row
             // class and the two have to be the same type for the binding to mean anything
-            var leftRow = Expression.Variable(ClrTypes.Resolve(leftCalcite.getJavaRowType()), "leftRow");
-            var rightRow = Expression.Variable(ClrTypes.Resolve(rightCalcite.getJavaRowType()), "rightRow");
+            var leftRow = Expression.Variable(ClrTypes.Resolve(leftPhysType.JavaRowType), "leftRow");
+            var rightRow = Expression.Variable(ClrTypes.Resolve(rightPhysType.JavaRowType), "rightRow");
             implementor.Translator.Bind(left_, leftRow);
             implementor.Translator.Bind(right_, rightRow);
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregate.cs
@@ -106,7 +106,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     implementor.Translator.TranslateBody(initBlock.toBlock(), accType)),
                 accType);
 
-            var in_ = J.Expressions.parameter(inputCalcite.getJavaRowType(), "in");
+            var in_ = J.Expressions.parameter(inputPhysType.JavaRowType, "in");
             var acc_ = J.Expressions.parameter(accPhysType.getJavaRowType(), "acc");
             var inParameter = Expression.Parameter(sourceType, "in");
             var accParameter = Expression.Parameter(accType, "acc");

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableBatchNestedLoopJoin.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableBatchNestedLoopJoin.cs
@@ -131,7 +131,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // the getters registered below are ones Calcite's Rex translation reads the outer row through,
             // so they are given their physical type, built here from the three values ours carries
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftResult.PhysType.RelRowType, leftResult.PhysType.Format, false);
-            var corrVarType = leftCalcite.getJavaRowType();
+            var corrVarType = leftResult.PhysType.JavaRowType;
             var corrArgList = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, (java.lang.reflect.Type)(java.lang.Class)typeof(java.util.List), "corrList");
             var listParameter = Expression.Parameter(typeof(java.util.List), "corrList");
             implementor.Translator.Bind(corrArgList, listParameter);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCalc.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCalc.cs
@@ -115,10 +115,23 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // a calc is Rex and nothing else: the condition and the projects are both Calcite's to
             // translate, and each takes its own physical type -- one to read a field of the input with, one
             // to read the storage types of the output off. So both are built here, where they are used.
+            //
+            // the output one builds the row as well, at the end of the block, which is a question about a
+            // row and so would otherwise be ClrPhysType.Record's. It cannot be: translateProjects declares
+            // its own variables in the BlockBuilder and the expressions it answers refer to them, so they
+            // cannot be translated one at a time -- the block crosses whole, and a block ends in one
+            // expression rather than a list. The row is therefore built in linq4j and translated with the
+            // rest, and TranslateBody below is what brings it to physType.RowType, which is the boxed one.
+            // The same seam is why the aggregates and the window call record on a Calcite physical type.
             var inputCalcite = PhysTypeImpl.of(typeFactory, result.PhysType.RelRowType, result.PhysType.Format, false);
             var outputCalcite = PhysTypeImpl.of(typeFactory, physType.RelRowType, physType.Format, false);
 
-            var inputJavaType = inputCalcite.getJavaRowType();
+            // the ClrPhysType's, not inputCalcite's. The two are the same call -- format.javaRowClass over the
+            // same row type and format -- for every row that is a record, an array, a list or a value, and
+            // they part only where the row is an instance of a CLR class: there the class has no fields Java
+            // can see, and what a row expression must be declared with is the record type. Which branch
+            // CUSTOM.field takes is decided by this line and nowhere else.
+            var inputJavaType = result.PhysType.JavaRowType;
             var inputType = result.PhysType.RowType;
             var outputType = physType.RowType;
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableConditionalCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableConditionalCorrelate.cs
@@ -120,7 +120,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // the getter registered below is one Calcite's Rex translation reads the outer row through,
             // so it is given their physical type, built here from the three values ours carries
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftResult.PhysType.RelRowType, leftResult.PhysType.Format, false);
-            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftCalcite.getJavaRowType(), getCorrelVariable());
+            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftResult.PhysType.JavaRowType, getCorrelVariable());
 
             var corrParameter = Expression.Parameter(leftResult.PhysType.RowType, getCorrelVariable());
             implementor.Translator.Bind(corrArg, corrParameter);

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCorrelate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableCorrelate.cs
@@ -100,7 +100,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // the getter registered below is one Calcite's Rex translation reads the outer row through,
             // so it is given their physical type, built here from the three values ours carries
             var leftCalcite = PhysTypeImpl.of(implementor.TypeFactory, leftResult.PhysType.RelRowType, leftResult.PhysType.Format, false);
-            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftCalcite.getJavaRowType(), getCorrelVariable());
+            var corrArg = J.Expressions.parameter(java.lang.reflect.Modifier.FINAL, leftResult.PhysType.JavaRowType, getCorrelVariable());
 
             // boxed, because the selector Calcite's join builds always takes boxed rows — see JoinSelector,
             // which boxes both of its parameter types. Every other join here boxes its sequences for that

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
@@ -140,7 +140,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     implementor.Translator.TranslateBody(initBlock.toBlock(), accType)),
                 accType);
 
-            var in_ = J.Expressions.parameter(inputCalcite.getJavaRowType(), "in");
+            var in_ = J.Expressions.parameter(inputPhysType.JavaRowType, "in");
             var acc_ = J.Expressions.parameter(accPhysType.getJavaRowType(), "acc");
             var inParameter = Expression.Parameter(sourceType, "in");
             var accParameter = Expression.Parameter(accType, "acc");

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableScan.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableTableScan.cs
@@ -316,7 +316,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // the selector is the one Calcite writes, built against their physical type and translated whole.
             var calcite = PhysTypeImpl.of(implementor.TypeFactory, physType.RelRowType, physType.Format, false);
 
-            var row = J.Expressions.parameter(elementType, "row");
+            // the element type as linq4j has to name it. Calcite names the table's own, because a linq4j
+            // Enumerable erases its element and the physical type may have optimized to a format the sequence
+            // does not have -- a one column table declares Object[] and its physical type is SCALAR. That
+            // still holds; the one class it cannot cover is a row that is an instance of a CLR class, whose
+            // members Java cannot see at all, and there the same class named as a record type is the answer.
+            var row = J.Expressions.parameter(RowJavaType(), "row");
             var parameter = Expression.Parameter(element, "row");
             implementor.Translator.Bind(row, parameter);
 
@@ -325,13 +330,33 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             for (int i = 0; i < fieldCount; i++)
                 expressionList.add(FieldExpression(row, i, calcite, oldFormat));
 
+            // the row Calcite's record builds has the java row class, which is unboxed where a scalar row is a
+            // primitive; a sequence of this convention states its element type and ClrPhysType.RowType is that
+            // class boxed, so the two disagree by exactly one boxing. Calcite has nowhere for this to show --
+            // there is no Enumerable<int> in Java and javac inserts the conversion at the boundary -- and here
+            // it is a conversion the lambda has to carry, made the Java way as every other row element is.
             var rowType = physType.RowType;
             var selector = Expression.Lambda(
                 typeof(Func<,>).MakeGenericType(element, rowType),
-                implementor.Translator.Translate(calcite.record(expressionList)),
+                ClrEnumUtils.Convert(implementor.Translator.Translate(calcite.record(expressionList)), rowType),
                 parameter);
 
             return Expression.Call(null, ClrBuiltInMethod.Select.MakeGenericMethod(element, rowType), Source(element), selector);
+        }
+
+        /// <summary>
+        /// Returns the type linq4j names one element of this table's sequence by.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// <see cref="elementType"/>, except where a row is an instance of a CLR class: <c>getFields()</c> on
+        /// one is empty, so a row expression declared with the class sends
+        /// <c>JavaRowFormat.CUSTOM.field</c> to <c>Types.nthField</c> and out of bounds. The record type is
+        /// the same class by the only name that can be read by ordinal.
+        /// </remarks>
+        java.lang.reflect.Type RowJavaType()
+        {
+            return getRowType() is Clr.ClrRowType clr && clr.Clazz == elementType ? clr.RecordType : elementType;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
@@ -213,8 +213,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 Hoist(translator, variables, body, keyComparator_, collationComparator ?? throw new java.lang.NullPointerException("keyComparator"), typeof(java.util.Comparator));
             }
 
-            var loop = new WindowLoop(inputCalcite);
-            var inputGetter = new WindowRelInputGetter(loop.Row, inputCalcite, result.PhysType.RelRowType.getFieldCount(), translatedConstants);
+            var loop = new WindowLoop(inputCalcite, inputPhysType.JavaRowType);
+            var inputGetter = new WindowRelInputGetter(loop.Row, inputCalcite, inputPhysType.JavaRowType, result.PhysType.RelRowType.getFieldCount(), translatedConstants);
 
             // the output row is every input field, and then whatever each aggregate last computed
             var inputFieldCount = inputPhysType.RelRowType.getFieldCount();
@@ -279,7 +279,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var frame = new java.util.function.DelegateFunction<J.BlockBuilder, WinAggFrameResultContext>(
                 block => new ClrWinAggFrameResultContext(
-                    block, typeFactory, implementor.Conformance, inputCalcite, result.PhysType.RelRowType.getFieldCount(),
+                    block, typeFactory, implementor.Conformance, inputCalcite, inputPhysType.JavaRowType, result.PhysType.RelRowType.getFieldCount(),
                     translatedConstants, comparator_, loop.Rows, loop.Index, loop.Start, loop.End, min_, loop.MaxX,
                     loop.HasRows, loop.FrameRowCount, loop.PartitionRowCount, loop.Position));
 
@@ -323,7 +323,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var selector = loop.Lambda(translator, selectorBuilder.toBlock(), outputType, accType);
 
             // the partition key, which is the one thing here that reads a row outside the loop
-            var partitionSelector = PartitionSelector(translator, inputCalcite, group, sourceType);
+            var partitionSelector = PartitionSelector(translator, inputCalcite, inputPhysType.JavaRowType, group, sourceType);
             var keyType = partitionSelector?.ReturnType ?? typeof(object);
 
             return Expression.Call(null,
@@ -385,12 +385,12 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// The key <c>getPartitionIterator</c> builds, which is a synthetic record for several keys and the
         /// field itself for one.
         /// </remarks>
-        static LambdaExpression? PartitionSelector(LixToClrTranslator translator, PhysType inputPhysType, Group group, Type sourceType)
+        static LambdaExpression? PartitionSelector(LixToClrTranslator translator, PhysType inputPhysType, java.lang.reflect.Type javaRowType, Group group, Type sourceType)
         {
             if (group.keys.isEmpty())
                 return null;
 
-            var v_ = J.Expressions.parameter(inputPhysType.getJavaRowType(), "v");
+            var v_ = J.Expressions.parameter(javaRowType, "v");
             var selector = inputPhysType.selector(v_, group.keys.asList(), JavaRowFormat.CUSTOM);
 
             var builder = new J.BlockBuilder();
@@ -419,7 +419,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // the rows arrive boxed, because the partition they go into is an Object[], so the row is unboxed
             // on the way in exactly as a join's predicate unboxes its two
             var parameter = Expression.Parameter(sourceType, "v");
-            var row = Expression.Variable(ClrTypes.Resolve(inputPhysType.getJavaRowType()), "v");
+            var row = Expression.Variable(ClrTypes.Resolve(javaRowType), "v");
             translator.Bind(v_, row);
 
             // the key is a map's, so a key that is a primitive is boxed the way the type factory says: what
@@ -685,7 +685,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// lambda assigns from the <see cref="WindowFrame"/> it is given. That is the same thing a row
         /// parameter is everywhere else in this convention.
         /// </remarks>
-        sealed class WindowLoop(PhysType inputPhysType)
+        sealed class WindowLoop(PhysType inputPhysType, java.lang.reflect.Type javaRowType)
         {
 
             static readonly java.lang.reflect.Type IntType = J.Primitive.INT.primitiveClass;
@@ -719,7 +719,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             public J.ParameterExpression Position { get; } = J.Expressions.parameter(IntType, "j");
 
             /// <summary>The row being evaluated.</summary>
-            public J.ParameterExpression Row { get; } = J.Expressions.parameter(inputPhysType.getJavaRowType(), "row");
+            public J.ParameterExpression Row { get; } = J.Expressions.parameter(javaRowType, "row");
 
             /// <summary>The accumulator, which is not known until its record type has been built.</summary>
             public J.ParameterExpression? Accumulator { get; set; }
@@ -735,7 +735,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             public LambdaExpression Lambda(LixToClrTranslator translator, J.BlockStatement block, Type returnType, Type? accumulatorType)
             {
                 var frame = Expression.Parameter(typeof(WindowFrame), "frame");
-                var rowType = ClrTypes.Resolve(inputPhysType.getJavaRowType());
+                var rowType = ClrTypes.Resolve(javaRowType);
 
                 // fresh variables each time, because a lambda declares its own and two of them are siblings
                 var rows = Expression.Variable(typeof(object[]), "rows");
@@ -802,7 +802,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <remarks>
         /// <c>EnumerableWindow.WindowRelInputGetter</c>, which is private.
         /// </remarks>
-        sealed class WindowRelInputGetter(J.Expression row, PhysType rowPhysType, int actualInputFieldCount, java.util.List constants) : RexToLixTranslator.InputGetter
+        sealed class WindowRelInputGetter(J.Expression row, PhysType rowPhysType, java.lang.reflect.Type javaRowType, int actualInputFieldCount, java.util.List constants) : RexToLixTranslator.InputGetter
         {
 
             /// <inheritdoc />
@@ -876,6 +876,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             JavaTypeFactory typeFactory,
             SqlConformance conformance,
             PhysType inputPhysType,
+            java.lang.reflect.Type javaRowType,
             int actualInputFieldCount,
             java.util.List constants,
             J.Expression comparator,
@@ -897,7 +898,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 return RexToLixTranslator.forAggregation(
                     typeFactory,
                     block,
-                    new WindowRelInputGetter(GetRow(rowIndex), inputPhysType, actualInputFieldCount, constants),
+                    new WindowRelInputGetter(GetRow(rowIndex), inputPhysType, javaRowType, actualInputFieldCount, constants),
                     conformance);
             }
 
@@ -956,7 +957,21 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             /// <returns></returns>
             J.Expression GetRow(J.Expression rowIndex)
             {
-                return block.append("jRow", EnumUtils.convert(J.Expressions.arrayIndex(rows, rowIndex), inputPhysType.getJavaRowType()));
+                // EnumUtils.convert declines a row of a CLR class, and quietly: Types.needTypeCast answers
+                // false for any RecordType, so the operand comes back as it went in and the row stays an
+                // Object -- which then reaches CUSTOM.field and asks Object.class for its fields. The rule is
+                // right where a record type is the declared type of a variable, a synthetic record carrying
+                // its own and a cast being noise; it is wrong here, where the value is an element of an
+                // Object[] and there is nothing else to say what it is. Calcite never meets it, a row of a
+                // class handing it a Class and needTypeCast then answering true.
+                //
+                // So the cast is written for our record type and for nothing else. A synthetic record still
+                // goes through EnumUtils and still gets no cast, which is Calcite's behaviour whether or not
+                // it is Calcite's intent.
+                var element = (J.Expression)J.Expressions.arrayIndex(rows, rowIndex);
+                return block.append("jRow", javaRowType is Clr.ClrRecordType
+                    ? J.Expressions.convert_(element, javaRowType)
+                    : EnumUtils.convert(element, javaRowType));
             }
 
             /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/JavaRowFormatExtensions.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/JavaRowFormatExtensions.cs
@@ -198,7 +198,25 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         {
 
             /// <inheritdoc />
-            public override java.lang.reflect.Type JavaRowType(JavaTypeFactory typeFactory, RelDataType rowType) => typeFactory.getJavaClass(rowType);
+            /// <remarks>
+            /// A row that is an instance of a CLR class answers with its record type rather than with the
+            /// class, because what this names is what a row <em>expression</em> gets declared with, and
+            /// <c>JavaRowFormat.CUSTOM.field</c> reads a member of a class through <c>getFields()[i]</c> —
+            /// which a .NET class answers nothing from. The record type takes the by-ordinal branch instead.
+            /// Both resolve to the same CLR type, so <see cref="ClrPhysType.RowType"/> is unchanged either
+            /// way; it is only the route to a member that differs.
+            ///
+            /// <para>Calcite's own <c>PhysTypeImpl</c>, built beside this one wherever the shared Rex
+            /// machinery takes one, still gets the class from <c>getJavaClass</c> — and wants it, that being
+            /// what <c>record</c> constructs.</para>
+            /// </remarks>
+            public override java.lang.reflect.Type JavaRowType(JavaTypeFactory typeFactory, RelDataType rowType)
+            {
+                if (rowType is Clr.ClrRowType clr)
+                    return clr.RecordType;
+
+                return typeFactory.getJavaClass(rowType);
+            }
 
             /// <inheritdoc />
             public override Type JavaFieldClass(JavaTypeFactory typeFactory, RelDataType rowType, int index)

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/ClrTypes.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/ClrTypes.cs
@@ -39,6 +39,11 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
             {
                 java.lang.Class c => FromClass(c),
                 org.apache.calcite.jdbc.JavaTypeFactoryImpl.SyntheticRecordType r => SyntheticRecordEmitter.Emit(r),
+
+                // the opposite direction to the one above: a synthetic record names a type that has to be
+                // emitted, and this names one that already exists and only had to be described by ordinal
+                // because Java cannot see a .NET property
+                Adapter.Clr.ClrRecordType r => r.ClrType,
                 java.lang.reflect.ParameterizedType p => FromParameterizedType(p),
                 java.lang.reflect.GenericArrayType g => Resolve(g.getGenericComponentType()).MakeArrayType(),
                 _ => throw new NotSupportedException($"Cannot resolve a CLR type for '{type}' ({type.GetType()}).")
@@ -305,8 +310,17 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
             if (info != null)
                 return Expression.Field(info.IsStatic ? null : target, info);
 
-            // IKVM exposes a .NET property to Java as a field of the same name, so a linq4j tree reaching one
-            // of ours reads it the same way it reads a Java field
+            // a Java `static final` field is not a CLR field of that name. IKVM emits a property over a
+            // backing field it renames to __<>NAME, so that reading it still runs the class initializer the
+            // way Java guarantees, and a tree naming such a field lands here with nothing to find.
+            // `Unit.INSTANCE` -- what Calcite's own CUSTOM.record answers for a row of no fields -- is one;
+            // JavaRowFormatExtensions.StaticMember measured that and FlatLists.COMPARABLE_EMPTY_LIST both.
+            //
+            // it is *not* that a .NET property is visible to Java as a field, which this said for a while.
+            // Measured: a class whose members are properties answers nothing at all from getFields(). A
+            // property is a get_/set_ method pair to Java and its backing field is private under a mangled
+            // name, so nothing reaches here by naming one -- a row whose fields are .NET properties has to
+            // name them through a Types.RecordType rather than a Class to be reachable by name.
             var property = declaring.GetProperty(name, All);
             if (property != null)
                 return Expression.Property(property.GetMethod?.IsStatic == true ? null : target, property);

--- a/src/Apache.Calcite.Tests/ClrProjectingTableTests.cs
+++ b/src/Apache.Calcite.Tests/ClrProjectingTableTests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Apache.Calcite.Extensions.Adapter.Clr;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite;
+using org.apache.calcite.linq4j;
+using org.apache.calcite.plan;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.tools;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Queries a schema whose rows cannot be the objects, because their members are types Calcite has no
+    /// representation for.
+    /// </summary>
+    /// <remarks>
+    /// The other half of <see cref="ClrReflectiveSchemaTests"/>. There the row is the object and nothing is
+    /// converted; here every value crosses a boundary on the way in, and the assertions are on the values
+    /// themselves rather than against another table — a differential test would only compare the plumbing to
+    /// itself, the oracle having to hold the converted values to begin with.
+    /// </remarks>
+    [TestClass]
+    public class ClrProjectingTableTests
+    {
+
+        static ClrProjectingTableTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.CalciteJdbc41Factory).Assembly);
+        }
+
+        public enum Grade
+        {
+
+            Junior = 1,
+
+            Senior = 2,
+
+        }
+
+        /// <summary>
+        /// One of every kind of member that has to be converted.
+        /// </summary>
+        public record Payment(
+            int Id,
+            decimal Amount,
+            DateTime Taken,
+            DateOnly Day,
+            TimeOnly At,
+            TimeSpan Took,
+            Guid Reference,
+            Grade Grade,
+            int? Approver,
+            string Note);
+
+        /// <summary>
+        /// A type of settable properties, which can be read and cannot be built back.
+        /// </summary>
+        public class Settable
+        {
+
+            public int Id { get; set; }
+
+            public string Name { get; set; } = "";
+
+        }
+
+        public class PaymentSchema
+        {
+
+            public IReadOnlyList<Payment> Payments { get; } =
+            [
+                new Payment(1, 12.5m, new DateTime(2020, 1, 2, 3, 4, 5), new DateOnly(2020, 1, 2), new TimeOnly(3, 4, 5),
+                    TimeSpan.FromSeconds(90), Guid.Parse("00000000-0000-0000-0000-0000000000ff"), Grade.Senior, null, "first"),
+                new Payment(2, 1.1m, new DateTime(1970, 1, 1, 0, 0, 0), new DateOnly(1970, 1, 1), new TimeOnly(0, 0, 0),
+                    TimeSpan.Zero, Guid.Empty, Grade.Junior, 7, "second"),
+            ];
+
+            public IReadOnlyList<Settable> Settables { get; } =
+            [
+                new Settable { Id = 1, Name = "one" },
+                new Settable { Id = 2, Name = "two" },
+            ];
+
+        }
+
+        /// <summary>
+        /// A type with a member Calcite cannot read gets a table that projects, not a failure.
+        /// </summary>
+        [TestMethod]
+        public void ShouldProjectATypeCalciteCannotReadAsItStands()
+        {
+            ClrTypeMapper.IsObjectRow(typeof(Payment)).Should().BeFalse();
+            ClrReflectiveSchema.Of(typeof(Payment), new PaymentSchema().Payments).Should().BeOfType<ClrProjectingTable>();
+        }
+
+        /// <summary>
+        /// A type that cannot be built back gets one too, rather than failing when a row is rebuilt.
+        /// </summary>
+        /// <remarks>
+        /// Every member of <see cref="Settable"/> is one Calcite reads as it stands, so the only thing
+        /// stopping it being an object row is that <c>JavaRowFormat.CUSTOM.record</c> has no constructor to
+        /// call. Deciding that here is what keeps it from being an <c>InvalidOperationException</c> deep in a
+        /// projection.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldProjectATypeThatCannotBeBuiltBack()
+        {
+            ClrTypeMapper.IsObjectRow(typeof(Settable)).Should().BeFalse();
+            ClrReflect.Constructor(typeof(Settable)).Should().BeNull();
+            ClrReflectiveSchema.Of(typeof(Settable), new PaymentSchema().Settables).Should().BeOfType<ClrProjectingTable>();
+
+            Run("SELECT \"Name\" FROM \"Settables\" WHERE \"Id\" = 2").Should().Equal("two");
+        }
+
+        /// <summary>
+        /// Each converted value equals the SQL literal it was written from.
+        /// </summary>
+        /// <remarks>
+        /// <b>Calcite is the oracle, not arithmetic repeated in the test.</b> A TIMESTAMP is a number of
+        /// milliseconds and a DATE a number of days, so asserting on the rendered value would mean computing
+        /// an epoch offset here — the same sum <see cref="ClrValues"/> does, and wrong in the same way if it
+        /// is wrong. Comparing to a literal asks Calcite instead: the conversion is right exactly when
+        /// Calcite agrees the column holds the value it was written from.
+        ///
+        /// <para>The second row is the epoch in every one of its columns, so that a zero has to be a zero
+        /// rather than an offset that happens to cancel.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldConvertEachValueToWhatItsColumnHolds()
+        {
+            Matches("\"Amount\" = 12.5", 1);
+            Matches("\"Taken\" = TIMESTAMP '2020-01-02 03:04:05'", 1);
+            Matches("\"Day\" = DATE '2020-01-02'", 1);
+            Matches("\"At\" = TIME '03:04:05'", 1);
+            Matches("\"Took\" = INTERVAL '0 00:01:30' DAY TO SECOND", 1);
+            Matches("\"Reference\" = '00000000-0000-0000-0000-0000000000ff'", 1);
+            Matches("\"Grade\" = 2", 1);
+            Matches("\"Note\" = 'first'", 1);
+
+            Matches("\"Taken\" = TIMESTAMP '1970-01-01 00:00:00'", 2);
+            Matches("\"Day\" = DATE '1970-01-01'", 2);
+            Matches("\"At\" = TIME '00:00:00'", 2);
+            Matches("\"Took\" = INTERVAL '0' DAY", 2);
+        }
+
+        /// <summary>
+        /// Requires that exactly the payment of the given id satisfies a predicate.
+        /// </summary>
+        static void Matches(string predicate, int id)
+        {
+            Run($"SELECT \"Id\" FROM \"Payments\" WHERE {predicate}")
+                .Should().Equal([id.ToString()], "of {0}", predicate);
+        }
+
+        /// <summary>
+        /// A nullable value type is null where it has no value, which is the thing Java cannot say.
+        /// </summary>
+        [TestMethod]
+        public void ShouldReadANullableValueTypeAsNull()
+        {
+            Run("SELECT \"Id\" FROM \"Payments\" WHERE \"Approver\" IS NULL").Should().Equal("1");
+            Run("SELECT \"Approver\" FROM \"Payments\" WHERE \"Id\" = 2").Should().Equal("7");
+            Run("SELECT \"Approver\" FROM \"Payments\" WHERE \"Id\" = 1").Should().Equal("null");
+        }
+
+        /// <summary>
+        /// The converted values compare, group and aggregate as their types.
+        /// </summary>
+        /// <remarks>
+        /// The reason <see cref="ClrValues.DecimalScale"/> normalises rather than merely declares: a group key
+        /// is compared with <c>BigDecimal.equals</c>, which is scale sensitive, so two decimals that differ
+        /// only in trailing zeroes would group apart if each kept the scale it was written with.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCompareAndAggregateConvertedValues()
+        {
+            Run("SELECT SUM(\"Amount\") FROM \"Payments\"").Should().Equal("13.600000");
+            Run("SELECT COUNT(*) FROM \"Payments\" WHERE \"Taken\" > TIMESTAMP '2000-01-01 00:00:00'").Should().Equal("1");
+            Run("SELECT COUNT(*) FROM \"Payments\" WHERE \"Day\" = DATE '2020-01-02'").Should().Equal("1");
+            Run("SELECT COUNT(DISTINCT \"Amount\") FROM \"Payments\"").Should().Equal("2");
+        }
+
+        static List<string> Run(string sql)
+        {
+            var rootSchema = Frameworks.createRootSchema(true);
+            var added = rootSchema.add("PAY", new ClrReflectiveSchema(new PaymentSchema()));
+
+            var rules = new java.util.ArrayList();
+            var calcRules = new java.util.ArrayList();
+
+            foreach (var rule in ClrEnumerableRules.Rules())
+                rules.add(rule);
+            foreach (var rule in ClrEnumerableRules.CalcRules())
+                calcRules.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRules.add(rule);
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(added)
+                .programs(
+                    Programs.subQuery(org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE),
+                    new DefaultRulesProgram(rules, false, false, false, null, null),
+                    Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE))
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+            var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+            var expanded = planner.transform(0, logical.getTraitSet(), logical);
+            var chosen = planner.transform(1, expanded.getTraitSet().replace(ClrEnumerableConvention.Instance).simplify(), expanded);
+            var physical = planner.transform(2, chosen.getTraitSet(), chosen);
+
+            var parameters = new java.util.HashMap();
+            var context = new PayDataContext(rootSchema, parameters);
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+            var rows = new List<string>();
+            foreach (var row in bindable.Bind(context))
+                rows.Add(Render(row));
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Renders a row as the values it holds, which for a temporal column is the number Calcite keeps.
+        /// </summary>
+        static string Render(object? row)
+        {
+            if (row is object?[] array)
+                return string.Join("|", array.Select(Cell));
+
+            return Cell(row);
+        }
+
+        static string Cell(object? value) => value?.ToString() ?? "null";
+
+        sealed class PayDataContext(SchemaPlus rootSchema, java.util.Map parameters) : DataContext
+        {
+
+            /// <inheritdoc />
+            public SchemaPlus getRootSchema() => rootSchema;
+
+            /// <inheritdoc />
+            public org.apache.calcite.adapter.java.JavaTypeFactory getTypeFactory() => new org.apache.calcite.jdbc.JavaTypeFactoryImpl();
+
+            /// <inheritdoc />
+            public QueryProvider getQueryProvider() => null!;
+
+            /// <inheritdoc />
+            public object get(string name) => parameters.get(name);
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrRecordTypeTests.cs
+++ b/src/Apache.Calcite.Tests/ClrRecordTypeTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Extensions.Adapter.Clr;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// What IKVM shows Java of a .NET type, and what Calcite's type factory makes of it.
+    /// </summary>
+    /// <remarks>
+    /// Every one of these is a measurement the reflective schema is built on rather than a behaviour of ours,
+    /// and each was measured before a line of it was written. They are here because they are IKVM's answers
+    /// and not Calcite's: an upgrade that changes any of them changes what <see cref="ClrRecordType"/> is for,
+    /// and the failure should be this rather than a query returning nothing.
+    /// </remarks>
+    [TestClass]
+    public class ClrRecordTypeTests
+    {
+
+        static ClrRecordTypeTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
+        }
+
+        public class PropertyRow
+        {
+
+            public int Empid { get; set; }
+
+            public string Name { get; set; } = "";
+
+        }
+
+        public class FieldRow
+        {
+
+            public int Empid;
+
+            public string Name = "";
+
+        }
+
+        /// <summary>
+        /// A .NET property is not a field to Java, and a class of them has no fields at all.
+        /// </summary>
+        /// <remarks>
+        /// The fact the whole design turns on. A property is a <c>get_</c>/<c>set_</c> method pair and its
+        /// backing field is private under a mangled name, so there is nothing for <c>Types.nthField</c> to
+        /// index into and <c>JavaRowFormat.CUSTOM.field</c>'s second branch cannot be used.
+        /// </remarks>
+        [TestMethod]
+        public void APropertyIsNotAFieldToJava()
+        {
+            ((java.lang.Class)typeof(PropertyRow)).getFields().Should().BeEmpty();
+            ((java.lang.Class)typeof(FieldRow)).getFields().Should().HaveCount(2);
+        }
+
+        /// <summary>
+        /// So Calcite's type factory makes a row of no columns of one, and says nothing.
+        /// </summary>
+        /// <remarks>
+        /// <c>createStructType(Class)</c> walks <c>getFields()</c>. Over a class of properties that is a row
+        /// of nothing, and a plan over it would run and return no columns rather than fail. That silence is
+        /// what <c>ClrTypeMapper.RowType</c> replaces.
+        /// </remarks>
+        [TestMethod]
+        public void CalcitesTypeFactoryMakesAnEmptyRowOfAClassOfProperties()
+        {
+            var factory = new JavaTypeFactoryImpl();
+
+            factory.createType((java.lang.Class)typeof(PropertyRow)).getFieldCount().Should().Be(0);
+            factory.createType((java.lang.Class)typeof(FieldRow)).getFieldCount().Should().Be(2);
+        }
+
+        /// <summary>
+        /// A CLR sequence is not a Java one, so nothing of Calcite's would take it for a table.
+        /// </summary>
+        /// <remarks>
+        /// <c>ReflectiveSchema.getElementType</c> accepts an array or an <c>Iterable</c> and answers null
+        /// otherwise, so a member holding a <c>List&lt;Employee&gt;</c> is not a candidate table there at all.
+        /// </remarks>
+        [TestMethod]
+        public void AClrSequenceIsNotAJavaIterable()
+        {
+            ((java.lang.Class)typeof(java.lang.Iterable))
+                .isAssignableFrom((java.lang.Class)typeof(IEnumerable<PropertyRow>))
+                .Should().BeFalse();
+        }
+
+        /// <summary>
+        /// The CLR types Calcite has no representation for are refused by name rather than mapped to nothing.
+        /// </summary>
+        /// <remarks>
+        /// <c>decimal</c>, <c>DateTime</c> and <c>int?</c> reach Java as <c>cli.System.Decimal</c> and the
+        /// like, which no rule of Calcite's knows, so <c>createType</c> would send each to
+        /// <c>createStructType</c> and answer a column of no columns. Each has a representation Calcite would
+        /// accept and reaching it is a conversion per value, which a row that is the object itself has nowhere
+        /// to put.
+        /// </remarks>
+        [TestMethod]
+        public void ATypeCalciteCannotRepresentIsRefused()
+        {
+            ClrTypeMapper.IsNativelyRepresented(typeof(int)).Should().BeTrue();
+            ClrTypeMapper.IsNativelyRepresented(typeof(long)).Should().BeTrue();
+            ClrTypeMapper.IsNativelyRepresented(typeof(double)).Should().BeTrue();
+            ClrTypeMapper.IsNativelyRepresented(typeof(bool)).Should().BeTrue();
+            ClrTypeMapper.IsNativelyRepresented(typeof(string)).Should().BeTrue();
+
+            ClrTypeMapper.IsNativelyRepresented(typeof(decimal)).Should().BeFalse();
+            ClrTypeMapper.IsNativelyRepresented(typeof(DateTime)).Should().BeFalse();
+            ClrTypeMapper.IsNativelyRepresented(typeof(Guid)).Should().BeFalse();
+            ClrTypeMapper.IsNativelyRepresented(typeof(int?)).Should().BeFalse();
+
+            var refused = () => ClrTypeMapper.RowType(new JavaTypeFactoryImpl(), typeof(Unrepresentable));
+            refused.Should().Throw<NotSupportedException>().WithMessage("*Paid*System.Decimal*");
+        }
+
+        public record Unrepresentable(int Empid, decimal Paid);
+
+        /// <summary>
+        /// A record's columns are its constructor's parameters, in that order.
+        /// </summary>
+        /// <remarks>
+        /// .NET promises no order from <c>GetProperties</c>, and <c>SELECT *</c> is positional. Where a
+        /// constructor takes exactly the members it is the authority, because that constructor is what
+        /// <c>JavaRowFormat.CUSTOM.record</c> calls to build a row back.
+        /// </remarks>
+        [TestMethod]
+        public void ARecordsColumnsAreItsConstructorsParameters()
+        {
+            var members = ClrReflect.Members(typeof(Ordered));
+
+            members.Should().HaveCount(3);
+            members[0].Member.Name.Should().Be("Zebra");
+            members[1].Member.Name.Should().Be("Apple");
+            members[2].Member.Name.Should().Be("Mango");
+        }
+
+        public record Ordered(int Zebra, string Apple, int Mango);
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrReflectiveMacroTests.cs
+++ b/src/Apache.Calcite.Tests/ClrReflectiveMacroTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Apache.Calcite.Extensions.Adapter.Clr;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite;
+using org.apache.calcite.linq4j;
+using org.apache.calcite.plan;
+using org.apache.calcite.schema;
+using org.apache.calcite.tools;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// A method of the reflected object as a table macro, and the schema factory that builds a schema from a
+    /// model file's operands.
+    /// </summary>
+    /// <remarks>
+    /// The two members of <c>ReflectiveSchema</c> that are not tables: <c>createFunctionMap</c>, which takes
+    /// every method returning a table, and <c>Factory</c>, which is how a schema is named in JSON rather than
+    /// constructed in code.
+    /// </remarks>
+    [TestClass]
+    public class ClrReflectiveMacroTests
+    {
+
+        static ClrReflectiveMacroTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.CalciteJdbc41Factory).Assembly);
+        }
+
+        public record Employee(int Empid, string Name, int Deptno);
+
+        public class HrSchema
+        {
+
+            public IReadOnlyList<Employee> Emps { get; } =
+            [
+                new Employee(100, "Bill", 10),
+                new Employee(110, "Theodore", 10),
+                new Employee(150, "Sebastian", 20),
+                new Employee(200, "Eric", 20),
+            ];
+
+            /// <summary>
+            /// A method returning a table, which is a macro rather than a table.
+            /// </summary>
+            public Table Above(int empid)
+            {
+                return ClrReflectiveSchema.Of(typeof(Employee), Emps.Where(e => e.Empid >= empid).ToList());
+            }
+
+            /// <summary>
+            /// A method returning something that is not a table, which is not a macro and not an error.
+            /// </summary>
+            public int Count() => Emps.Count;
+
+            /// <summary>
+            /// The instance a model file would name.
+            /// </summary>
+            public static HrSchema Create() => new();
+
+        }
+
+        [TestMethod]
+        public void ShouldExpandAMethodAsATableMacro()
+        {
+            Run("SELECT \"Name\" FROM TABLE(\"Above\"(150)) ORDER BY \"Name\"", new ClrReflectiveSchema(new HrSchema()))
+                .Should().Equal("Eric", "Sebastian");
+        }
+
+        /// <summary>
+        /// A macro is a macro: its argument is known when the plan is built, so the table it answers is the
+        /// one the rest of the plan is built over.
+        /// </summary>
+        [TestMethod]
+        public void ShouldFilterAndJoinTheTableAMacroAnswers()
+        {
+            Run("SELECT COUNT(*) FROM TABLE(\"Above\"(110)) WHERE \"Deptno\" = 20", new ClrReflectiveSchema(new HrSchema()))
+                .Should().Equal("2");
+        }
+
+        /// <summary>
+        /// A method that does not return a table is not a macro, and does not stop the schema being built.
+        /// </summary>
+        [TestMethod]
+        public void ShouldIgnoreAMethodThatIsNotATable()
+        {
+            var schema = new ClrReflectiveSchema(new HrSchema());
+            var plus = Frameworks.createRootSchema(true).add("HR", schema);
+
+            plus.getFunctions("Above").size().Should().Be(1);
+            plus.getFunctions("Count").size().Should().Be(0);
+        }
+
+        /// <summary>
+        /// The factory builds the same schema from a type name and a static method.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBuildASchemaFromOperands()
+        {
+            var operand = new java.util.HashMap();
+            operand.put("type", typeof(HrSchema).AssemblyQualifiedName);
+            operand.put("staticMethod", nameof(HrSchema.Create));
+
+            var schema = new ClrReflectiveSchemaFactory().create(Frameworks.createRootSchema(true), "HR", operand);
+
+            schema.Should().BeOfType<ClrReflectiveSchema>();
+            Run("SELECT COUNT(*) FROM \"Emps\"", schema).Should().Equal("4");
+        }
+
+        /// <summary>
+        /// And without a static method, by constructing the type.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBuildASchemaByConstructingTheType()
+        {
+            var operand = new java.util.HashMap();
+            operand.put("type", typeof(HrSchema).AssemblyQualifiedName);
+
+            var schema = new ClrReflectiveSchemaFactory().create(Frameworks.createRootSchema(true), "HR", operand);
+
+            Run("SELECT COUNT(*) FROM \"Emps\"", schema).Should().Equal("4");
+        }
+
+        /// <summary>
+        /// A type it cannot find is named, rather than answering an empty schema.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseATypeThatIsNotThere()
+        {
+            var operand = new java.util.HashMap();
+            operand.put("type", "No.Such.Type, Nowhere");
+
+            var create = () => new ClrReflectiveSchemaFactory().create(Frameworks.createRootSchema(true), "HR", operand);
+
+            create.Should().Throw<java.lang.IllegalArgumentException>().WithMessage("*No.Such.Type*");
+        }
+
+        static List<string> Run(string sql, org.apache.calcite.schema.Schema schema)
+        {
+            var rootSchema = Frameworks.createRootSchema(true);
+            var added = rootSchema.add("HR", schema);
+
+            var rules = new java.util.ArrayList();
+            var calcRules = new java.util.ArrayList();
+
+            foreach (var rule in ClrEnumerableRules.Rules())
+                rules.add(rule);
+            foreach (var rule in ClrEnumerableRules.CalcRules())
+                calcRules.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRules.add(rule);
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(added)
+                .programs(
+                    Programs.subQuery(org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE),
+                    new DefaultRulesProgram(rules, false, false, false, null, null),
+                    Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE))
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+            var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+            var expanded = planner.transform(0, logical.getTraitSet(), logical);
+            var chosen = planner.transform(1, expanded.getTraitSet().replace(ClrEnumerableConvention.Instance).simplify(), expanded);
+            var physical = planner.transform(2, chosen.getTraitSet(), chosen);
+
+            var parameters = new java.util.HashMap();
+            var context = new MacroDataContext(rootSchema, parameters);
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+            var rows = new List<string>();
+            foreach (var row in bindable.Bind(context))
+                rows.Add(row is object?[] array ? string.Join("|", array.Select(x => x?.ToString() ?? "null")) : row?.ToString() ?? "null");
+
+            return rows;
+        }
+
+        sealed class MacroDataContext(SchemaPlus rootSchema, java.util.Map parameters) : DataContext
+        {
+
+            /// <inheritdoc />
+            public SchemaPlus getRootSchema() => rootSchema;
+
+            /// <inheritdoc />
+            public org.apache.calcite.adapter.java.JavaTypeFactory getTypeFactory() => new org.apache.calcite.jdbc.JavaTypeFactoryImpl();
+
+            /// <inheritdoc />
+            public QueryProvider getQueryProvider() => null!;
+
+            /// <inheritdoc />
+            public object get(string name) => parameters.get(name);
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrReflectiveSchemaTests.cs
+++ b/src/Apache.Calcite.Tests/ClrReflectiveSchemaTests.cs
@@ -1,0 +1,293 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Apache.Calcite.Extensions.Adapter.Clr;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite;
+using org.apache.calcite.linq4j;
+using org.apache.calcite.plan;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.tools;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Runs queries over a schema reflected from a .NET object, and requires the same rows as the same data
+    /// held by a <see cref="ScannableTable"/>.
+    /// </summary>
+    /// <remarks>
+    /// The oracle is a table of Calcite's own SPI holding the identical rows already broken out into
+    /// <c>object?[]</c>, which <c>ClrEnumerableDifferentialTests</c> already checks against Calcite itself. So
+    /// what is under test is the route — a row that is a .NET object, a column that is a .NET property — and
+    /// not the operators above it.
+    ///
+    /// <para>Calcite cannot be the oracle directly here: <c>ReflectiveSchema</c> over the same object gives a
+    /// schema of no columns, because IKVM shows Java nothing of a property. That is the whole reason this
+    /// exists, and <see cref="ClrRecordTypeTests"/> pins it.</para>
+    /// </remarks>
+    [TestClass]
+    public class ClrReflectiveSchemaTests
+    {
+
+        static ClrReflectiveSchemaTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.CalciteJdbc41Factory).Assembly);
+        }
+
+        /// <summary>
+        /// A row, written the way a .NET row is written: a positional record of properties.
+        /// </summary>
+        /// <remarks>
+        /// A record because a row of a custom type is built by calling a constructor of every column —
+        /// <c>JavaRowFormat.CUSTOM.record</c> emits <c>new_(rowClass, expressions)</c> — and a record is the
+        /// .NET type that has one. A type of settable properties and no such constructor can be read from and
+        /// cannot be rebuilt, which is a limit worth having a name for before something hits it.
+        /// </remarks>
+        public record Employee(int Empid, string Name, int Deptno);
+
+        /// <summary>
+        /// The object a schema is reflected from.
+        /// </summary>
+        public class HrSchema
+        {
+
+            public IReadOnlyList<Employee> Emps { get; } =
+            [
+                new Employee(100, "Bill", 10),
+                new Employee(110, "Theodore", 10),
+                new Employee(150, "Sebastian", 20),
+                new Employee(200, "Eric", 20),
+            ];
+
+        }
+
+        /// <summary>
+        /// The same rows, already broken out, read through Calcite's own SPI.
+        /// </summary>
+        sealed class EmpsTable : AbstractTable, ScannableTable
+        {
+
+            static readonly object?[][] Rows = new HrSchema().Emps
+                .Select(e => new object?[] { java.lang.Integer.valueOf(e.Empid), e.Name, java.lang.Integer.valueOf(e.Deptno) })
+                .ToArray();
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("Empid", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .add("Name", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.VARCHAR), true))
+                    .add("Deptno", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .build();
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root) => Linq4j.asEnumerable(Rows);
+
+        }
+
+        [TestMethod]
+        public void ShouldProjectAColumnThatIsAProperty()
+        {
+            Both("SELECT \"Empid\" FROM \"Emps\"");
+        }
+
+        [TestMethod]
+        public void ShouldProjectEveryColumn()
+        {
+            // reordered, so that it is a projection rather than the identity one below
+            Both("SELECT \"Deptno\", \"Name\", \"Empid\" FROM \"Emps\"");
+        }
+
+        /// <summary>
+        /// A query that projects nothing hands back the objects, and hands back the same ones.
+        /// </summary>
+        /// <remarks>
+        /// The half of this that a table of <c>object?[]</c> cannot give. The row type is the members broken
+        /// out, so the statement is ordinary SQL over three columns; the row is the object, so when the
+        /// planner works out that the projection is the identity there is no row to build and the sequence
+        /// arrives as it left. Reference equality is the assertion worth making — an <see cref="Employee"/>
+        /// that merely compares equal would mean a copy was made somewhere, which is the thing this design
+        /// exists to avoid.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldHandBackTheObjectsThemselves()
+        {
+            var schema = new HrSchema();
+            var rows = RunRaw("SELECT \"Empid\", \"Name\", \"Deptno\" FROM \"Emps\"", new ClrReflectiveSchema(schema));
+
+            rows.Should().HaveCount(schema.Emps.Count);
+            for (int i = 0; i < rows.Count; i++)
+                rows[i].Should().BeSameAs(schema.Emps[i]);
+        }
+
+        [TestMethod]
+        public void ShouldFilterOnAProperty()
+        {
+            Both("SELECT \"Name\" FROM \"Emps\" WHERE \"Deptno\" = 20");
+        }
+
+        [TestMethod]
+        public void ShouldSortOnAProperty()
+        {
+            Both("SELECT \"Name\", \"Empid\" FROM \"Emps\" ORDER BY \"Name\"");
+        }
+
+        [TestMethod]
+        public void ShouldAggregateOverAProperty()
+        {
+            Both("SELECT \"Deptno\", COUNT(*), SUM(\"Empid\") FROM \"Emps\" GROUP BY \"Deptno\"");
+        }
+
+        /// <summary>
+        /// A row of one column, which is the shape that has broken this convention twice.
+        /// </summary>
+        /// <remarks>
+        /// <c>JavaRowFormat.optimize</c> is what makes it interesting: a one field row can leave the scan
+        /// wanting a format its element type does not have, and then the scan reformats rather than passing
+        /// the sequence along — the one path in <c>ClrEnumerableTableScan</c> that still declares its row
+        /// parameter from the element class rather than from the physical type.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadARowOfOneColumn()
+        {
+            var schema = new OneColumnSchema();
+            var rows = Run("SELECT \"N\" FROM \"Ones\" ORDER BY \"N\"", new ClrReflectiveSchema(schema));
+
+            rows.Should().Equal("1", "2", "3");
+        }
+
+        public record One(int N);
+
+        public class OneColumnSchema
+        {
+
+            public IReadOnlyList<One> Ones { get; } = [new One(3), new One(1), new One(2)];
+
+        }
+
+        [TestMethod]
+        public void ShouldWindowOverAProperty()
+        {
+            Both("SELECT \"Name\", SUM(\"Empid\") OVER (PARTITION BY \"Deptno\" ORDER BY \"Empid\") FROM \"Emps\"");
+        }
+
+        [TestMethod]
+        public void ShouldJoinATableToItself()
+        {
+            Both("SELECT \"e\".\"Name\", \"m\".\"Name\" FROM \"Emps\" AS \"e\" JOIN \"Emps\" AS \"m\" ON \"e\".\"Deptno\" = \"m\".\"Deptno\" AND \"e\".\"Empid\" < \"m\".\"Empid\"");
+        }
+
+        /// <summary>
+        /// Runs the same statement over the reflected schema and over the flattened one, and requires the same
+        /// rows of both.
+        /// </summary>
+        /// <param name="sql"></param>
+        static void Both(string sql)
+        {
+            var reflected = Run(sql, new ClrReflectiveSchema(new HrSchema()));
+            var flattened = Run(sql, Flat());
+
+            reflected.Should().Equal(flattened);
+        }
+
+        /// <summary>
+        /// A schema of one table, holding the same rows already broken out.
+        /// </summary>
+        static Schema Flat()
+        {
+            var tables = new java.util.HashMap();
+            tables.put("Emps", new EmpsTable());
+
+            return new FlatSchema(tables);
+        }
+
+        sealed class FlatSchema(java.util.Map map) : AbstractSchema
+        {
+
+            protected override java.util.Map getTableMap() => map;
+
+        }
+
+        static List<string> Run(string sql, Schema schema)
+        {
+            return RunRaw(sql, schema).Select(Render).ToList();
+        }
+
+        static List<object> RunRaw(string sql, Schema schema)
+        {
+            var rootSchema = Frameworks.createRootSchema(true);
+            var added = rootSchema.add("HR", schema);
+
+            var rules = new java.util.ArrayList();
+            var calcRules = new java.util.ArrayList();
+
+            foreach (var rule in ClrEnumerableRules.Rules())
+                rules.add(rule);
+            foreach (var rule in ClrEnumerableRules.CalcRules())
+                calcRules.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRules.add(rule);
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(added)
+                .programs(
+                    Programs.subQuery(org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE),
+                    new DefaultRulesProgram(rules, false, false, false, null, null),
+                    Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE))
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+            var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+            var expanded = planner.transform(0, logical.getTraitSet(), logical);
+            var chosen = planner.transform(1, expanded.getTraitSet().replace(ClrEnumerableConvention.Instance).simplify(), expanded);
+            var physical = planner.transform(2, chosen.getTraitSet(), chosen);
+
+            var parameters = new java.util.HashMap();
+            var context = new ReflectDataContext(rootSchema, parameters);
+            var bindable = ClrEnumerableInterpretable.ToBindable(parameters, (ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+            var rows = new List<object>();
+            foreach (var row in bindable.Bind(context))
+                rows.Add(row);
+
+            return rows;
+        }
+
+        static string Render(object? row)
+        {
+            if (row is object?[] array)
+                return string.Join("|", array.Select(x => x?.ToString() ?? "null"));
+
+            return row?.ToString() ?? "null";
+        }
+
+        sealed class ReflectDataContext(SchemaPlus rootSchema, java.util.Map parameters) : DataContext
+        {
+
+            /// <inheritdoc />
+            public SchemaPlus getRootSchema() => rootSchema;
+
+            /// <inheritdoc />
+            public org.apache.calcite.adapter.java.JavaTypeFactory getTypeFactory() => new org.apache.calcite.jdbc.JavaTypeFactoryImpl();
+
+            /// <inheritdoc />
+            public QueryProvider getQueryProvider() => null!;
+
+            /// <inheritdoc />
+            public object get(string name) => parameters.get(name);
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
`ClrReflectiveSchema` takes any object and makes its sequence-valued members tables, the way `ReflectiveSchema` does for Java.

Calcite's own cannot be pointed at a .NET object, and the reasons are measured rather than assumed:

- **IKVM shows Java nothing of a .NET property.** `getFields()` on a class of properties is *empty* — a property is a `get_`/`set_` method pair and its backing field is private under a mangled name.
- **So `JavaTypeFactoryImpl.createType` over one answers `RecordType()`** — a row of no columns — and does not complain. A plan over it would run and return nothing.
- **`IEnumerable<T>` is not a `java.lang.Iterable`**, so `ReflectiveSchema.getElementType` would not treat a `List<Employee>` member as a candidate table at all.
- **CLR-only value types are opaque classes**: `int?` is `cli.System.Nullable$$00601...`, `decimal` is `cli.System.Decimal`.

`ClrRecordTypeTests` pins all four, since the design rests on them and an IKVM upgrade that changed any one should fail loudly rather than quietly.

## The shape

The row type is the members broken out as columns and the row stays the object — so SQL sees `Empid, Name, Deptno`, and a query that projects nothing hands back your instances. `ShouldHandBackTheObjectsThemselves` asserts reference equality, not just value equality.

That needs the row to carry two Java identities, for two different questions:

| question | wants | why |
|---|---|---|
| building a row | the `java.lang.Class` | `CUSTOM.record` emits `new_(clazz, …)` |
| reading a member | `ClrRecordType` | `CUSTOM.field` branches on the row *expression*'s declared type and would ask a class for fields it has none of |

The class rides on `ClrRowType : JavaRecordType`, which is the same mechanism `createStructType(Class)` uses for `ReflectiveSchema` — so **no type factory is subclassed and nothing is connection-wide**. `ClrRecordType` is a `Types.RecordType` that is not a type at all but an index over the members, and it is the only door into the by-ordinal branch.

## Two tables, and the choice is not taste

`ClrTypeMapper.IsObjectRow` decides. Every member must be one Calcite reads as it stands, because a field read of an object row is `Expression.Property` with nowhere to put a conversion; and the type must have a constructor taking every member, because `CUSTOM.record` rebuilds a row by calling one.

Anything else — a `decimal`, a `DateTime`, an `int?`, or a class of settable properties — gets `ClrProjectingTable`, which reads each object once into an `object?[]` through a compiled `ClrRowConverter` and gives up object identity to do it. **Nothing is dropped and nothing is silently zero-column**: what cannot be converted is refused by name.

`ClrValues` is the adapter, and what each conversion answers is `getJavaClass`'s to say rather than SQL's — TIMESTAMP is a `long` of milliseconds, DATE an `int` of days. Its one policy is a decimal scale of six, and the *normalisation* matters more than the number: a group key is compared with `BigDecimal.equals`, which is scale sensitive, so `1.10m` and `1.1m` would otherwise group apart. Every conversion is asserted by comparing the column to the SQL literal it was written from, so Calcite is the oracle rather than epoch arithmetic repeated in the test.

Also here: `ClrTableMacro` for a method returning a table, and `ClrReflectiveSchemaFactory` for the model-file route.

## The sweep

A row parameter now comes from `ClrPhysType.JavaRowType` rather than a Calcite `PhysType`'s `getJavaRowType()` — both calcs, both aggregates, both sorted aggregates, both correlates, both conditional correlates, both batch nested loop joins, `GeneratePredicate` and both windows. The two are the same call for every row that is a record, an array, a list or a value, so this changes nothing that was green; they part only for a CLR class.

## Three defects that running found and reading had not

- **`EnumUtils.convert` will not cast to a record type.** `Types.needTypeCast` answers false for any `RecordType`, so the operand comes back untouched and the window's row came out of its partition array as an `Object` and reached `CUSTOM.field`. Both windows now write that cast for a `ClrRecordType` and for nothing else; a synthetic record still gets none, which is Calcite's behaviour whether or not it is Calcite's intent.
- **The scan's reformat path had never run.** A one-column row is what reaches it, once `JavaRowFormat.optimize` turns a one-field CUSTOM row into SCALAR, and it held two faults at once: the row parameter was declared from the element *class*, and the selector returned Calcite's java row class where a sequence of this convention states the **boxed** one. Calcite has nowhere for the second to show, there being no `Enumerable<int>` in Java. That is the third time a one-column row has broken this convention.
- **A comment in `ClrTypes` had the property fallback's reason backwards** — it is there because a Java `static final` is a CLR *property*, not because a .NET property is visible to Java as a field, which it is not.

## Testing

- 706 in `Apache.Calcite.Tests`, 324 in `Apache.Calcite.Data.Tests`, none skipped, solution builds clean.
- 20 new tests across four files. The reflective ones are differential — the same statement over the reflected schema and over a `ScannableTable` holding the identical rows already flattened — covering projection, filter, sort, aggregate, window, self-join and a one-column row.

## Not in this change

Nullability is Java's — a reference is nullable, a value type is not. The NRT annotations would give a better row type, but nothing enforces them at run time and NOT NULL is a promise the planner generates code against. `int?` is the exception that costs nothing, being a type rather than an annotation, and it is the one thing .NET says here that Java cannot.
