### PR TITLE
Close the divergences a second read of prepare turned up

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncBuiltInMethod.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncBuiltInMethod.cs
@@ -64,9 +64,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         public static readonly MethodInfo Skip = Of(nameof(ClrAsyncEnumerableDefaults.Skip));
 
         /// <summary>
-        /// <see cref="ClrAsyncEnumerableDefaults.Take"/>.
+        /// <c>ClrAsyncEnumerableDefaults.Take</c>.
         /// </summary>
-        public static readonly MethodInfo Take = Of(nameof(ClrAsyncEnumerableDefaults.Take));
+        /// <remarks>
+        /// The <c>int</c> overload, as <c>ClrBuiltInMethod.Take</c> is; a plan's fetch is an <c>int</c>. The
+        /// <c>long</c> one is the row limit a caller asks a prepared statement for.
+        /// </remarks>
+        public static readonly MethodInfo Take = Of(nameof(ClrAsyncEnumerableDefaults.Take), null, typeof(int), typeof(System.Threading.CancellationToken));
 
         /// <summary>
         /// <see cref="ClrAsyncEnumerableDefaults.OrderByWithFetchAndOffset"/>.
@@ -280,14 +284,48 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <summary>
-        /// Returns the named operator.
+        /// Returns the named operator, picked out by parameter type where the name is overloaded.
         /// </summary>
         /// <param name="name"></param>
+        /// <param name="parameterTypes">One entry per parameter, <see langword="null"/> where the parameter
+        /// is generic and so has no <see cref="Type"/> to name. Empty where the name is enough.</param>
         /// <returns></returns>
-        static MethodInfo Of(string name)
+        /// <remarks>
+        /// <c>ClrBuiltInMethod.Of</c>'s, for the same reason: a name alone does not pick an overload, and
+        /// <see cref="Type.GetMethod(string, BindingFlags)"/> throws on the ambiguity.
+        /// </remarks>
+        static MethodInfo Of(string name, params Type?[] parameterTypes)
         {
-            return typeof(ClrAsyncEnumerableDefaults).GetMethod(name, BindingFlags.Public | BindingFlags.Static)
-                ?? throw new InvalidOperationException($"'{name}' is missing from {nameof(ClrAsyncEnumerableDefaults)}.");
+            MethodInfo? found = null;
+
+            foreach (var method in typeof(ClrAsyncEnumerableDefaults).GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (method.Name != name || Matches(method) == false)
+                    continue;
+
+                if (found != null)
+                    throw new InvalidOperationException($"'{name}' is ambiguous in {nameof(ClrAsyncEnumerableDefaults)}; name its parameter types.");
+
+                found = method;
+            }
+
+            return found ?? throw new InvalidOperationException($"'{name}' is missing from {nameof(ClrAsyncEnumerableDefaults)}.");
+
+            bool Matches(MethodInfo method)
+            {
+                if (parameterTypes.Length == 0)
+                    return true;
+
+                var parameters = method.GetParameters();
+                if (parameters.Length != parameterTypes.Length)
+                    return false;
+
+                for (var i = 0; i < parameters.Length; i++)
+                    if (parameterTypes[i] != null && parameters[i].ParameterType != parameterTypes[i])
+                        return false;
+
+                return true;
+            }
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableDefaults.cs
@@ -285,11 +285,43 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         }
 
         /// <summary>
-        /// The row loop of <see cref="Take"/>, over an enumerator the factory acquired.
+        /// The row loop of <see cref="Take{TSource}(IAsyncEnumerable{TSource}, int, CancellationToken)"/>,
+        /// over an enumerator the factory acquired.
         /// </summary>
         static async IAsyncEnumerator<TSource> TakeRows<TSource>(IAsyncEnumerator<TSource> source, int count)
         {
             var n = -1;
+
+            while (await source.MoveNextAsync() && ++n < count)
+                yield return source.Current;
+        }
+
+        /// <summary>
+        /// Takes a number of rows.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="count"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <see cref="ClrEnumerableDefaults.Take{TSource}(IEnumerable{TSource}, long)"/>, which is
+        /// <c>EnumerableDefaults.take(source, long)</c>.
+        /// </remarks>
+        public static IAsyncEnumerable<TSource> Take<TSource>(IAsyncEnumerable<TSource> source, long count, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return source.Acquiring((e, token) => TakeRows(e, count));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Take{TSource}(IAsyncEnumerable{TSource}, long, CancellationToken)"/>,
+        /// over an enumerator the factory acquired.
+        /// </summary>
+        static async IAsyncEnumerator<TSource> TakeRows<TSource>(IAsyncEnumerator<TSource> source, long count)
+        {
+            var n = -1L;
 
             while (await source.MoveNextAsync() && ++n < count)
                 yield return source.Current;

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrBuiltInMethod.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrBuiltInMethod.cs
@@ -48,9 +48,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         public static readonly MethodInfo Skip = Of(nameof(ClrEnumerableDefaults.Skip));
 
         /// <summary>
-        /// <see cref="ClrEnumerableDefaults.Take"/>.
+        /// <see cref="ClrEnumerableDefaults.Take{TSource}(System.Collections.Generic.IEnumerable{TSource}, int)"/>.
         /// </summary>
-        public static readonly MethodInfo Take = Of(nameof(ClrEnumerableDefaults.Take));
+        /// <remarks>
+        /// The <c>int</c> overload, which is <c>BuiltInMethod.TAKE</c>; a plan's fetch is an <c>int</c>. The
+        /// <c>long</c> one is the row limit a caller asks a prepared statement for.
+        /// </remarks>
+        public static readonly MethodInfo Take = Of(nameof(ClrEnumerableDefaults.Take), null, typeof(int));
 
         /// <summary>
         /// <see cref="ClrEnumerableDefaults.Concat"/>.
@@ -220,14 +224,50 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             ?? throw new InvalidOperationException($"'{nameof(JavaSequences.ToJava)}' is missing.");
 
         /// <summary>
-        /// Returns the named operator.
+        /// Returns the named operator, picked out by parameter type where the name is overloaded.
         /// </summary>
         /// <param name="name"></param>
+        /// <param name="parameterTypes">One entry per parameter, <see langword="null"/> where the parameter
+        /// is generic and so has no <see cref="Type"/> to name. Empty where the name is enough.</param>
         /// <returns></returns>
-        static MethodInfo Of(string name)
+        /// <remarks>
+        /// <c>BuiltInMethod</c> names a method by its parameter types — <c>TAKE(ExtendedEnumerable.class,
+        /// "take", int.class)</c> — because a name alone does not pick an overload, and
+        /// <c>EnumerableDefaults.take</c> has two. <see cref="Type.GetMethod(string, BindingFlags)"/> throws
+        /// on the ambiguity rather than reporting it, so the choice is made here.
+        /// </remarks>
+        static MethodInfo Of(string name, params Type?[] parameterTypes)
         {
-            return typeof(ClrEnumerableDefaults).GetMethod(name, BindingFlags.Public | BindingFlags.Static)
-                ?? throw new InvalidOperationException($"'{name}' is missing from {nameof(ClrEnumerableDefaults)}.");
+            MethodInfo? found = null;
+
+            foreach (var method in typeof(ClrEnumerableDefaults).GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (method.Name != name || Matches(method) == false)
+                    continue;
+
+                if (found != null)
+                    throw new InvalidOperationException($"'{name}' is ambiguous in {nameof(ClrEnumerableDefaults)}; name its parameter types.");
+
+                found = method;
+            }
+
+            return found ?? throw new InvalidOperationException($"'{name}' is missing from {nameof(ClrEnumerableDefaults)}.");
+
+            bool Matches(MethodInfo method)
+            {
+                if (parameterTypes.Length == 0)
+                    return true;
+
+                var parameters = method.GetParameters();
+                if (parameters.Length != parameterTypes.Length)
+                    return false;
+
+                for (var i = 0; i < parameters.Length; i++)
+                    if (parameterTypes[i] != null && parameters[i].ParameterType != parameterTypes[i])
+                        return false;
+
+                return true;
+            }
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableDefaults.cs
@@ -240,11 +240,42 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         }
 
         /// <summary>
-        /// The row loop of <see cref="Take"/>, over an enumerator the factory acquired.
+        /// The row loop of <see cref="Take{TSource}(IEnumerable{TSource}, int)"/>, over an enumerator the
+        /// factory acquired.
         /// </summary>
         static IEnumerator<TSource> TakeRows<TSource>(IEnumerator<TSource> source, int count)
         {
             var n = -1;
+
+            while (source.MoveNext() && ++n < count)
+                yield return source.Current;
+        }
+
+        /// <summary>
+        /// Takes a number of rows.
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="source"></param>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>EnumerableDefaults.take(source, long)</c>, which is <c>takeWhileLong</c> where the other is
+        /// <c>takeWhile</c>. Same operator, a counter wide enough for a row limit.
+        /// </remarks>
+        public static IEnumerable<TSource> Take<TSource>(IEnumerable<TSource> source, long count)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+
+            return source.Acquiring(e => TakeRows(e, count));
+        }
+
+        /// <summary>
+        /// The row loop of <see cref="Take{TSource}(IEnumerable{TSource}, long)"/>, over an enumerator the
+        /// factory acquired.
+        /// </summary>
+        static IEnumerator<TSource> TakeRows<TSource>(IEnumerator<TSource> source, long count)
+        {
+            var n = -1L;
 
             while (source.MoveNext() && ++n < count)
                 yield return source.Current;

--- a/src/Apache.Calcite.Extensions/Prepare/AsyncEnumerable/ClrAsyncEnumerablePrepareResult.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/AsyncEnumerable/ClrAsyncEnumerablePrepareResult.cs
@@ -53,7 +53,7 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
         public IClrAsyncBindable Bindable { get; }
 
         /// <inheritdoc />
-        public override System.Type? ElementType => elementType;
+        public override System.Type ElementType => elementType;
 
         readonly System.Type elementType;
 

--- a/src/Apache.Calcite.Extensions/Prepare/AsyncEnumerable/ClrAsyncEnumerablePreparingStmt.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/AsyncEnumerable/ClrAsyncEnumerablePreparingStmt.cs
@@ -1,10 +1,13 @@
 using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
+using Apache.Calcite.Extensions.Runtime;
 
 using org.apache.calcite.jdbc;
 using org.apache.calcite.plan;
 using org.apache.calcite.prepare;
 using org.apache.calcite.rel;
+using org.apache.calcite.rel.metadata;
+using org.apache.calcite.rel.type;
 using org.apache.calcite.rex;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql2rel;
@@ -19,8 +22,6 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
     sealed class ClrAsyncEnumerablePreparingStmt : ClrPrepareImpl.PreparingStmt
     {
 
-        readonly ClrEnumerablePrefer prefer;
-
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
@@ -28,20 +29,30 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
             ClrPrepareImpl prepare,
             CalcitePrepare.Context context,
             CalciteCatalogReader catalogReader,
+            RelDataTypeFactory typeFactory,
             CalciteSchema schema,
+            ClrEnumerablePrefer prefer,
             RelOptCluster cluster,
-            SqlRexConvertletTable convertletTable,
-            ClrEnumerablePrefer prefer) :
-            base(prepare, context, catalogReader, schema, cluster, ClrAsyncEnumerableConvention.Instance, convertletTable)
+            SqlRexConvertletTable convertletTable) :
+            base(prepare, context, catalogReader, typeFactory, schema, prefer, cluster, ClrAsyncEnumerableConvention.Instance, convertletTable)
         {
-            this.prefer = prefer;
+
         }
 
         /// <inheritdoc />
-        protected override Program GetProgram()
+        /// <remarks>
+        /// <c>Programs.standard()</c>'s six passes, in its order. The last two are this convention's:
+        /// <c>PlannerRules</c> is the planner pass written out, and <c>PlannerCalcRules</c> is
+        /// <c>calc(metadataProvider)</c> with this convention's calc rules added to
+        /// <c>RelOptRules.CALC_RULES</c>.
+        /// </remarks>
+        protected override Program GetStandardProgram()
         {
             return Programs.sequence(
                 ClrAsyncEnumerablePrograms.SubQuery(),
+                Programs.decorrelate(),
+                Programs.measure(DefaultRelMetadataProvider.INSTANCE),
+                Programs.trim(),
                 ClrAsyncEnumerablePrograms.PlannerRules(),
                 ClrAsyncEnumerablePrograms.PlannerCalcRules());
         }
@@ -49,6 +60,8 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
         /// <inheritdoc />
         protected override ClrPrepare.IPreparedResult Implement(RelRoot root)
         {
+            org.apache.calcite.runtime.Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
+
             var resultType = root.rel.getRowType();
             var isDml = root.kind.belongsTo(SqlKind.DML);
 
@@ -65,9 +78,17 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
                 node = Apache.Calcite.Extensions.Adapter.AsyncEnumerable.ClrAsyncEnumerableCalc.Create(node, program);
             }
 
-            InternalParameters.put("_conformance", Context.config().conformance());
-
-            var bindable = ClrAsyncEnumerableInterpretable.ToBindable(InternalParameters, node, prefer);
+            IClrAsyncBindable bindable;
+            try
+            {
+                org.apache.calcite.prepare.Prepare.CatalogReader.THREAD_LOCAL.set(CatalogReader);
+                InternalParameters.put("_conformance", Context.config().conformance());
+                bindable = ClrAsyncEnumerableInterpretable.ToBindable(InternalParameters, node, Prefer);
+            }
+            finally
+            {
+                org.apache.calcite.prepare.Prepare.CatalogReader.THREAD_LOCAL.remove();
+            }
 
             var collations = root.collation.getFieldCollations().isEmpty()
                 ? (java.util.List)com.google.common.collect.ImmutableList.of()
@@ -86,7 +107,7 @@ namespace Apache.Calcite.Extensions.Prepare.AsyncEnumerable
                 Apache.Calcite.Extensions.Adapter.Enumerable.ClrPhysTypeImpl.Of(
                     (org.apache.calcite.adapter.java.JavaTypeFactory)node.getCluster().getTypeFactory(),
                     node.getRowType(),
-                    prefer.PreferArray()).RowType);
+                    Prefer.PreferArray()).RowType);
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepare.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepare.cs
@@ -66,7 +66,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <summary>
         /// Gets the validator the statement is validated with.
         /// </summary>
-        protected internal abstract SqlValidator SqlValidator { get; }
+        protected abstract SqlValidator SqlValidator { get; }
 
         /// <summary>
         /// Gets or sets the row type of the statement's dynamic parameters.
@@ -89,7 +89,27 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <summary>
         /// Returns the program that takes a logical plan to <see cref="ResultConvention"/>.
         /// </summary>
-        protected abstract Program GetProgram();
+        protected virtual Program GetProgram()
+        {
+            // allow a test to override the default program
+            var holder = Holder.empty();
+            org.apache.calcite.runtime.Hook.PROGRAM.run(holder);
+            if (holder.get() is Program holderValue)
+                return holderValue;
+
+            return GetStandardProgram();
+        }
+
+        /// <summary>
+        /// Returns this convention's counterpart of <c>Programs.standard</c>.
+        /// </summary>
+        /// <remarks>
+        /// <c>Prepare.getProgram</c> ends in the constant <c>Programs.standard()</c>, there being one calling
+        /// convention to plan into. There are two here and their last two passes differ, so the constant is a
+        /// method. Everything else about <c>getProgram</c> is unchanged — the hook is read here rather than at
+        /// the call site, and <see cref="Optimize"/> calls nothing else.
+        /// </remarks>
+        protected abstract Program GetStandardProgram();
 
         /// <summary>
         /// Returns the traits the root of the plan must satisfy.
@@ -244,8 +264,6 @@ namespace Apache.Calcite.Extensions.Prepare
             if (root.kind.belongsTo(SqlKind.DML) == false)
                 root = root.withKind(sqlNodeOriginal.getKind());
 
-            org.apache.calcite.runtime.Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
-
             return Implement(root);
         }
 
@@ -282,19 +300,9 @@ namespace Apache.Calcite.Extensions.Prepare
 
             var desiredTraits = GetDesiredRootTraitSet(root);
 
-            return root.withRel(Program().run(planner, root.rel, desiredTraits, materializationList, latticeList));
+            var program = GetProgram();
 
-            // Prepare.getProgram consults Hook.PROGRAM before answering, so that a test can swap the whole
-            // program. It can afford to put that inside getProgram because its own is concrete and no
-            // subclass overrides it; ours is abstract, because the program is one of the four things a
-            // convention supplies. So the hook is read at the one place the program is used instead.
-            Program Program()
-            {
-                var holder = Holder.empty();
-                org.apache.calcite.runtime.Hook.PROGRAM.run(holder);
-
-                return holder.get() as Program ?? GetProgram();
-            }
+            return root.withRel(program.run(planner, root.rel, desiredTraits, materializationList, latticeList));
         }
 
         /// <summary>
@@ -393,19 +401,21 @@ namespace Apache.Calcite.Extensions.Prepare
             /// Initializes a new instance.
             /// </summary>
             protected PreparedResultImpl(
-                RelDataType? rowType,
+                RelDataType rowType,
                 RelDataType parameterRowType,
                 java.util.List fieldOrigins,
                 java.util.List collations,
-                RelNode? rootRel,
+                RelNode rootRel,
                 TableModify.Operation? tableModOp,
                 bool isDml)
             {
-                RowType = rowType;
+                ArgumentNullException.ThrowIfNull(collations);
+
+                RowType = rowType ?? throw new ArgumentNullException(nameof(rowType));
                 ParameterRowType = parameterRowType ?? throw new ArgumentNullException(nameof(parameterRowType));
                 FieldOrigins = fieldOrigins ?? throw new ArgumentNullException(nameof(fieldOrigins));
-                Collations = collations ?? throw new ArgumentNullException(nameof(collations));
-                RootRel = rootRel;
+                Collations = com.google.common.collect.ImmutableList.copyOf(collations);
+                RootRel = rootRel ?? throw new ArgumentNullException(nameof(rootRel));
                 TableModOp = tableModOp;
                 IsDml = isDml;
             }
@@ -413,12 +423,13 @@ namespace Apache.Calcite.Extensions.Prepare
             /// <summary>
             /// Gets the row type of the result.
             /// </summary>
-            public RelDataType? RowType { get; }
+            public RelDataType RowType { get; }
 
             /// <summary>
-            /// Gets the physical row type of the prepared statement.
+            /// Gets the physical row type of the prepared statement, which the validator's need not be
+            /// identical to — its field names may have been made unique.
             /// </summary>
-            public RelDataType? PhysicalRowType => RowType;
+            public RelDataType PhysicalRowType => RowType;
 
             /// <inheritdoc />
             public RelDataType ParameterRowType { get; }
@@ -434,7 +445,7 @@ namespace Apache.Calcite.Extensions.Prepare
             /// <summary>
             /// Gets the root of the plan.
             /// </summary>
-            public RelNode? RootRel { get; }
+            public RelNode RootRel { get; }
 
             /// <inheritdoc />
             public TableModify.Operation? TableModOp { get; }
@@ -449,16 +460,20 @@ namespace Apache.Calcite.Extensions.Prepare
             public abstract Apache.Calcite.Extensions.Runtime.IClrBindableBase GetBindable(Meta.CursorFactory cursorFactory);
 
             /// <summary>
-            /// Gets the Java type of one row, which decides how a row is read back.
+            /// Gets the type of one row, which decides how a row is read back.
             /// </summary>
-            public abstract System.Type? ElementType { get; }
+            /// <remarks>
+            /// <c>Typed.getElementType</c>, which <c>PreparedResultImpl</c> declares abstract and the
+            /// interface does not carry.
+            /// </remarks>
+            public abstract System.Type ElementType { get; }
 
         }
 
         /// <summary>
-        /// An <c>EXPLAIN</c>, prepared.
+        /// An <c>EXPLAIN PLAN</c> statement, prepared. It is always good to have an explanation prepared.
         /// </summary>
-        public sealed class PreparedExplain : IPreparedResult
+        public abstract class PreparedExplain : IPreparedResult
         {
 
             readonly RelDataType? rowType;
@@ -474,7 +489,7 @@ namespace Apache.Calcite.Extensions.Prepare
             /// <param name="root">The plan to render, where the <c>EXPLAIN</c> is of a plan.</param>
             /// <param name="format">How the plan is rendered.</param>
             /// <param name="detailLevel">How much of the plan is rendered.</param>
-            public PreparedExplain(
+            protected PreparedExplain(
                 RelDataType? rowType,
                 RelDataType parameterRowType,
                 RelRoot? root,
@@ -509,10 +524,7 @@ namespace Apache.Calcite.Extensions.Prepare
             public TableModify.Operation? TableModOp => null;
 
             /// <inheritdoc />
-            public Apache.Calcite.Extensions.Runtime.IClrBindableBase GetBindable(Meta.CursorFactory cursorFactory)
-            {
-                return new ClrExplainBindable(Code, cursorFactory);
-            }
+            public abstract Apache.Calcite.Extensions.Runtime.IClrBindableBase GetBindable(Meta.CursorFactory cursorFactory);
 
         }
 

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
@@ -35,6 +35,19 @@ namespace Apache.Calcite.Extensions.Prepare
     {
 
         /// <summary>
+        /// The statements <see cref="SimplePrepare"/> answers without planning.
+        /// </summary>
+        static readonly HashSet<string> SIMPLE_SQLS =
+        [
+            "SELECT 1",
+            "select 1",
+            "SELECT 1 FROM DUAL",
+            "select 1 from dual",
+            "values 1",
+            "VALUES 1",
+        ];
+
+        /// <summary>
         /// Plans and compiles one query.
         /// </summary>
         /// <param name="context">The schema, type factory and configuration to plan against.</param>
@@ -69,6 +82,8 @@ namespace Apache.Calcite.Extensions.Prepare
         /// </summary>
         IClrPrepare.Signature Prepare_(CalcitePrepare.Context context, IClrPrepare.Query query, System.Type elementType, long maxRowCount, bool async)
         {
+            if (query.Sql is { } simpleSql && SIMPLE_SQLS.Contains(simpleSql))
+                return SimplePrepare(context, simpleSql);
 
             var typeFactory = context.getTypeFactory();
             var catalogReader = new CalciteCatalogReader(
@@ -246,19 +261,48 @@ namespace Apache.Calcite.Extensions.Prepare
                     this,
                     context,
                     catalogReader,
+                    typeFactory,
                     context.getRootSchema(),
+                    prefer,
                     cluster,
-                    CreateConvertletTable(),
-                    prefer);
+                    CreateConvertletTable());
 
             return new ClrEnumerablePreparingStmt(
                 this,
                 context,
                 catalogReader,
+                typeFactory,
                 context.getRootSchema(),
+                prefer,
                 cluster,
-                CreateConvertletTable(),
-                prefer);
+                CreateConvertletTable());
+        }
+
+        /// <summary>
+        /// Quickly prepares a simple statement, circumventing the usual preparation process.
+        /// </summary>
+        static IClrPrepare.Signature SimplePrepare(CalcitePrepare.Context context, string sql)
+        {
+            var typeFactory = context.getTypeFactory();
+            var x = typeFactory.builder().add(SqlUtil.deriveAliasFromOrdinal(0), SqlTypeName.INTEGER).build();
+            var origins = java.util.Collections.nCopies(x.getFieldCount(), null);
+            var columns = GetColumnMetaDataList(typeFactory, x, x, origins);
+            var cursorFactory = Meta.CursorFactory.deduce(columns, null);
+
+            return new IClrPrepare.Signature(
+                sql,
+                com.google.common.collect.ImmutableList.of(),
+                com.google.common.collect.ImmutableMap.of(),
+                x,
+                columns,
+                cursorFactory,
+                context.getRootSchema(),
+                com.google.common.collect.ImmutableList.of(),
+                -1,
+                // Calcite's one row is Linq4j.asEnumerable(ImmutableList.of(1)), so the value is a
+                // java.lang.Integer; a one-column result is the value rather than a one-element row
+                new ClrSimpleBindable(java.lang.Integer.valueOf(1)),
+                Meta.StatementType.SELECT);
         }
 
         /// <summary>
@@ -309,7 +353,7 @@ namespace Apache.Calcite.Extensions.Prepare
                     return new IClrPrepare.Signature(
                         sql,
                         com.google.common.collect.ImmutableList.of(),
-                        new java.util.LinkedHashMap(),
+                        com.google.common.collect.ImmutableMap.of(),
                         null,
                         com.google.common.collect.ImmutableList.of(),
                         Meta.CursorFactory.OBJECT,
@@ -320,7 +364,9 @@ namespace Apache.Calcite.Extensions.Prepare
                         Meta.StatementType.OTHER_DDL);
                 }
 
-                preparedResult = preparingStmt.PrepareSql(sqlNode, (java.lang.Class)typeof(java.lang.Object), preparingStmt.SqlValidator, true);
+                var validator = preparingStmt.CreateSqlValidator(catalogReader, c => c);
+
+                preparedResult = preparingStmt.PrepareSql(sqlNode, (java.lang.Class)typeof(java.lang.Object), validator, true);
 
                 switch (sqlNode.getKind().name())
                 {
@@ -333,7 +379,7 @@ namespace Apache.Calcite.Extensions.Prepare
                         x = RelOptUtil.createDmlRowType(sqlNode.getKind(), typeFactory);
                         break;
                     default:
-                        x = preparingStmt.SqlValidator.getValidatedNodeType(sqlNode);
+                        x = validator.getValidatedNodeType(sqlNode);
                         break;
                 }
             }
@@ -407,6 +453,31 @@ namespace Apache.Calcite.Extensions.Prepare
         static Meta.StatementType GetStatementType(ClrPrepare.IPreparedResult preparedResult)
         {
             return preparedResult.IsDml ? Meta.StatementType.IS_DML : Meta.StatementType.SELECT;
+        }
+
+        /// <summary>
+        /// Builds the validator a statement is validated with.
+        /// </summary>
+        static SqlValidator CreateSqlValidator(CalcitePrepare.Context context, CalciteCatalogReader catalogReader, Func<SqlValidator.Config, SqlValidator.Config> configTransform)
+        {
+            var opTab0 = (SqlOperatorTable)context.config().fun((java.lang.Class)typeof(SqlOperatorTable), org.apache.calcite.sql.fun.SqlStdOperatorTable.instance());
+
+            var list = new java.util.ArrayList();
+            list.add(opTab0);
+            list.add(catalogReader);
+
+            var opTab = org.apache.calcite.sql.util.SqlOperatorTables.chain(list);
+            var typeFactory = context.getTypeFactory();
+            var connectionConfig = context.config();
+
+            var config = configTransform(
+                SqlValidator.Config.DEFAULT
+                    .withLenientOperatorLookup(connectionConfig.lenientOperatorLookup())
+                    .withConformance(connectionConfig.conformance())
+                    .withDefaultNullCollation(connectionConfig.defaultNullCollation())
+                    .withIdentifierExpansion(true));
+
+            return new CalciteSqlValidator(opTab, catalogReader, typeFactory, config);
         }
 
         /// <summary>
@@ -594,28 +665,35 @@ namespace Apache.Calcite.Extensions.Prepare
         public abstract class PreparingStmt : ClrPrepare, RelOptTable.ViewExpander
         {
 
+            readonly RelOptPlanner planner;
+            readonly RexBuilder rexBuilder;
             readonly ClrPrepareImpl prepare;
             readonly CalciteSchema schema;
-            readonly RelOptCluster cluster;
-            readonly RexBuilder rexBuilder;
-            readonly JavaTypeFactory typeFactory;
+            readonly RelDataTypeFactory typeFactory;
             readonly SqlRexConvertletTable convertletTable;
+            readonly ClrEnumerablePrefer prefer;
+            readonly RelOptCluster cluster;
 
             /// <summary>
             /// The values the query reads through the <c>DataContext</c> rather than from the plan.
             /// </summary>
             readonly java.util.Map internalParameters = new java.util.LinkedHashMap();
 
+            int expansionDepth;
+
             SqlValidator? validator;
 
             /// <summary>
-            /// Initializes a new instance.
+            /// Initializes a new instance. Override this and <see cref="CreateSqlValidator"/> to supply
+            /// custom validation logic.
             /// </summary>
             protected PreparingStmt(
                 ClrPrepareImpl prepare,
                 CalcitePrepare.Context context,
                 CalciteCatalogReader catalogReader,
+                RelDataTypeFactory typeFactory,
                 CalciteSchema schema,
+                ClrEnumerablePrefer prefer,
                 RelOptCluster cluster,
                 Convention resultConvention,
                 SqlRexConvertletTable convertletTable) :
@@ -623,11 +701,12 @@ namespace Apache.Calcite.Extensions.Prepare
             {
                 this.prepare = prepare ?? throw new ArgumentNullException(nameof(prepare));
                 this.schema = schema ?? throw new ArgumentNullException(nameof(schema));
+                this.prefer = prefer;
                 this.cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
+                this.planner = cluster.getPlanner();
+                this.rexBuilder = cluster.getRexBuilder();
+                this.typeFactory = typeFactory ?? throw new ArgumentNullException(nameof(typeFactory));
                 this.convertletTable = convertletTable ?? throw new ArgumentNullException(nameof(convertletTable));
-
-                rexBuilder = cluster.getRexBuilder();
-                typeFactory = (JavaTypeFactory)cluster.getTypeFactory();
             }
 
             /// <summary>
@@ -636,12 +715,27 @@ namespace Apache.Calcite.Extensions.Prepare
             protected RelOptCluster Cluster => cluster;
 
             /// <summary>
+            /// Gets the planner that chooses the plan.
+            /// </summary>
+            protected RelOptPlanner Planner => planner;
+
+            /// <summary>
+            /// Gets the representation a consumer of the plan would prefer its rows to arrive in.
+            /// </summary>
+            protected ClrEnumerablePrefer Prefer => prefer;
+
+            /// <summary>
+            /// Gets the type factory the statement is prepared with.
+            /// </summary>
+            protected RelDataTypeFactory TypeFactory => typeFactory;
+
+            /// <summary>
             /// Gets the values the query reads through the <c>DataContext</c> rather than from the plan.
             /// </summary>
             public java.util.Map InternalParameters => internalParameters;
 
             /// <inheritdoc />
-            protected internal override SqlValidator SqlValidator => validator ??= CreateSqlValidator(CatalogReader, c => c);
+            protected override SqlValidator SqlValidator => validator ??= CreateSqlValidator(CatalogReader, c => c);
 
             /// <summary>
             /// Prepares a plan that was built rather than parsed.
@@ -680,8 +774,6 @@ namespace Apache.Calcite.Extensions.Prepare
                 // built is not a candidate for substitution
                 root = Optimize(root, com.google.common.collect.ImmutableList.of(), com.google.common.collect.ImmutableList.of());
 
-                org.apache.calcite.runtime.Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
-
                 return Implement(root);
             }
 
@@ -712,6 +804,17 @@ namespace Apache.Calcite.Extensions.Prepare
             /// <inheritdoc />
             protected override RelNode Decorrelate(SqlToRelConverter sqlToRelConverter, SqlNode query, RelNode rootRel)
             {
+                if (Context.config().topDownGeneralDecorrelationEnabled())
+                {
+                    // Calcite writes this as sqlToRelConverter.config(), which reads as the converter's own
+                    // configuration and is not: SqlToRelConverter has no instance config() and Java resolves
+                    // the call to the static factory through the instance reference. So the builder is the
+                    // default one, and C# has to say so
+                    var relBuilder = SqlToRelConverter.config().getRelBuilderFactory().create(rootRel.getCluster(), null);
+
+                    return org.apache.calcite.sql2rel.TopDownGeneralDecorrelator.decorrelateQuery(rootRel, relBuilder);
+                }
+
                 return sqlToRelConverter.decorrelate(query, rootRel);
             }
 
@@ -731,36 +834,26 @@ namespace Apache.Calcite.Extensions.Prepare
                 SqlExplainFormat format,
                 SqlExplainLevel detailLevel)
             {
-                return new ClrPrepare.PreparedExplain(resultType, parameterRowType, root, format, detailLevel);
+                return new ClrPreparedExplain(resultType, parameterRowType, root, format, detailLevel);
             }
 
             /// <summary>
-            /// Creates the validator.
+            /// Creates the validator. Override this and this class to supply custom validation logic.
             /// </summary>
-            protected virtual SqlValidator CreateSqlValidator(CalciteCatalogReader catalogReader, Func<SqlValidator.Config, SqlValidator.Config> configTransform)
+            /// <remarks>
+            /// <c>protected internal</c> rather than <c>protected</c>: Java's protected is also package
+            /// access, and <see cref="Prepare2_"/> is the caller that relies on it.
+            /// </remarks>
+            protected internal virtual SqlValidator CreateSqlValidator(org.apache.calcite.prepare.Prepare.CatalogReader catalogReader, Func<SqlValidator.Config, SqlValidator.Config> configTransform)
             {
-                var connectionConfig = Context.config();
-                var opTab0 = (SqlOperatorTable)connectionConfig.fun((java.lang.Class)typeof(SqlOperatorTable), org.apache.calcite.sql.fun.SqlStdOperatorTable.instance());
-
-                var list = new java.util.ArrayList();
-                list.add(opTab0);
-                list.add(catalogReader);
-
-                var opTab = org.apache.calcite.sql.util.SqlOperatorTables.chain(list);
-
-                var config = configTransform(
-                    SqlValidator.Config.DEFAULT
-                        .withLenientOperatorLookup(connectionConfig.lenientOperatorLookup())
-                        .withConformance(connectionConfig.conformance())
-                        .withDefaultNullCollation(connectionConfig.defaultNullCollation())
-                        .withIdentifierExpansion(true));
-
-                return new CalciteSqlValidator(opTab, catalogReader, typeFactory, config);
+                return ClrPrepareImpl.CreateSqlValidator(Context, (CalciteCatalogReader)catalogReader, configTransform);
             }
 
             /// <inheritdoc />
             public RelRoot expandView(RelDataType rowType, string queryString, java.util.List schemaPath, java.util.List viewPath)
             {
+                expansionDepth++;
+
                 var parser = prepare.CreateParser(queryString);
 
                 SqlNode sqlNode;
@@ -777,8 +870,39 @@ namespace Apache.Calcite.Extensions.Prepare
                 var viewValidator = CreateSqlValidator(viewCatalogReader, c => c.withEmbeddedQuery(true));
                 var config = SqlToRelConverter.config().withTrimUnusedFields(true);
                 var sqlToRelConverter = GetSqlToRelConverter(viewValidator, viewCatalogReader, config);
+                var root = sqlToRelConverter.convertQuery(sqlNode, true, true);
 
-                return sqlToRelConverter.convertQuery(sqlNode, true, true);
+                --expansionDepth;
+
+                return root;
+            }
+
+        }
+
+        /// <summary>
+        /// An <c>EXPLAIN</c> statement, prepared and ready to execute.
+        /// </summary>
+        sealed class ClrPreparedExplain : ClrPrepare.PreparedExplain
+        {
+
+            /// <summary>
+            /// Initializes a new instance.
+            /// </summary>
+            public ClrPreparedExplain(
+                RelDataType? resultType,
+                RelDataType parameterRowType,
+                RelRoot? root,
+                SqlExplainFormat format,
+                SqlExplainLevel detailLevel) :
+                base(resultType, parameterRowType, root, format, detailLevel)
+            {
+
+            }
+
+            /// <inheritdoc />
+            public override IClrBindableBase GetBindable(Meta.CursorFactory cursorFactory)
+            {
+                return new ClrExplainBindable(Code, cursorFactory);
             }
 
         }

--- a/src/Apache.Calcite.Extensions/Prepare/ClrSimpleBindable.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrSimpleBindable.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Runtime;
+
+using org.apache.calcite;
+
+namespace Apache.Calcite.Extensions.Prepare
+{
+
+    /// <summary>
+    /// The one row a statement prepared by <c>ClrPrepareImpl.SimplePrepare</c> produces.
+    /// </summary>
+    /// <remarks>
+    /// <c>CalcitePrepareImpl.simplePrepare</c> writes this as the lambda
+    /// <c>dataContext -&gt; Linq4j.asEnumerable(list)</c>, which it can because a <c>Bindable</c> is one
+    /// method. It is a class here because a statement of either convention is prepared through the same
+    /// path, and the two bind to different sequences.
+    /// </remarks>
+    /// <param name="row">The row, which is the value itself — the result has one column.</param>
+    sealed class ClrSimpleBindable(object row) : IClrBindable, IClrAsyncBindable
+    {
+
+        readonly object row = row ?? throw new ArgumentNullException(nameof(row));
+
+        /// <inheritdoc />
+        IEnumerable<object> IClrBindable.Bind(DataContext root)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+
+            return [row];
+        }
+
+        /// <inheritdoc />
+        IAsyncEnumerable<object> IClrAsyncBindable.Bind(DataContext root)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+
+            return ClrAsyncEnumerableDefaults.Singleton(row);
+        }
+
+        /// <inheritdoc />
+        public Type ElementType => row.GetType();
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Prepare/Enumerable/ClrEnumerablePrepareResult.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/Enumerable/ClrEnumerablePrepareResult.cs
@@ -52,7 +52,7 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
         public IClrBindable Bindable { get; }
 
         /// <inheritdoc />
-        public override System.Type? ElementType => elementType;
+        public override System.Type ElementType => elementType;
 
         readonly System.Type elementType;
 

--- a/src/Apache.Calcite.Extensions/Prepare/Enumerable/ClrEnumerablePreparingStmt.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/Enumerable/ClrEnumerablePreparingStmt.cs
@@ -1,9 +1,12 @@
 using Apache.Calcite.Extensions.Adapter.Enumerable;
+using Apache.Calcite.Extensions.Runtime;
 
 using org.apache.calcite.jdbc;
 using org.apache.calcite.plan;
 using org.apache.calcite.prepare;
 using org.apache.calcite.rel;
+using org.apache.calcite.rel.metadata;
+using org.apache.calcite.rel.type;
 using org.apache.calcite.rex;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql2rel;
@@ -18,8 +21,6 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
     sealed class ClrEnumerablePreparingStmt : ClrPrepareImpl.PreparingStmt
     {
 
-        readonly ClrEnumerablePrefer prefer;
-
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
@@ -27,20 +28,30 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
             ClrPrepareImpl prepare,
             CalcitePrepare.Context context,
             CalciteCatalogReader catalogReader,
+            RelDataTypeFactory typeFactory,
             CalciteSchema schema,
+            ClrEnumerablePrefer prefer,
             RelOptCluster cluster,
-            SqlRexConvertletTable convertletTable,
-            ClrEnumerablePrefer prefer) :
-            base(prepare, context, catalogReader, schema, cluster, ClrEnumerableConvention.Instance, convertletTable)
+            SqlRexConvertletTable convertletTable) :
+            base(prepare, context, catalogReader, typeFactory, schema, prefer, cluster, ClrEnumerableConvention.Instance, convertletTable)
         {
-            this.prefer = prefer;
+
         }
 
         /// <inheritdoc />
-        protected override Program GetProgram()
+        /// <remarks>
+        /// <c>Programs.standard()</c>'s six passes, in its order. The last two are this convention's:
+        /// <c>PlannerRules</c> is the planner pass written out, and <c>PlannerCalcRules</c> is
+        /// <c>calc(metadataProvider)</c> with this convention's calc rules added to
+        /// <c>RelOptRules.CALC_RULES</c>.
+        /// </remarks>
+        protected override Program GetStandardProgram()
         {
             return Programs.sequence(
                 ClrEnumerablePrograms.SubQuery(),
+                Programs.decorrelate(),
+                Programs.measure(DefaultRelMetadataProvider.INSTANCE),
+                Programs.trim(),
                 ClrEnumerablePrograms.PlannerRules(),
                 ClrEnumerablePrograms.PlannerCalcRules());
         }
@@ -48,6 +59,8 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
         /// <inheritdoc />
         protected override ClrPrepare.IPreparedResult Implement(RelRoot root)
         {
+            org.apache.calcite.runtime.Hook.PLAN_BEFORE_IMPLEMENTATION.run(root);
+
             var resultType = root.rel.getRowType();
             var isDml = root.kind.belongsTo(SqlKind.DML);
 
@@ -64,9 +77,17 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
                 node = Apache.Calcite.Extensions.Adapter.Enumerable.ClrEnumerableCalc.Create(node, program);
             }
 
-            InternalParameters.put("_conformance", Context.config().conformance());
-
-            var bindable = ClrEnumerableInterpretable.ToBindable(InternalParameters, node, prefer);
+            IClrBindable bindable;
+            try
+            {
+                org.apache.calcite.prepare.Prepare.CatalogReader.THREAD_LOCAL.set(CatalogReader);
+                InternalParameters.put("_conformance", Context.config().conformance());
+                bindable = ClrEnumerableInterpretable.ToBindable(InternalParameters, node, Prefer);
+            }
+            finally
+            {
+                org.apache.calcite.prepare.Prepare.CatalogReader.THREAD_LOCAL.remove();
+            }
 
             var collations = root.collation.getFieldCollations().isEmpty()
                 ? (java.util.List)com.google.common.collect.ImmutableList.of()
@@ -85,7 +106,7 @@ namespace Apache.Calcite.Extensions.Prepare.Enumerable
                 ClrPhysTypeImpl.Of(
                     (org.apache.calcite.adapter.java.JavaTypeFactory)node.getCluster().getTypeFactory(),
                     node.getRowType(),
-                    prefer.PreferArray()).RowType);
+                    Prefer.PreferArray()).RowType);
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Prepare/IClrPrepare.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/IClrPrepare.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
 using Apache.Calcite.Extensions.Runtime;
 
 using org.apache.calcite;
@@ -86,7 +88,7 @@ namespace Apache.Calcite.Extensions.Prepare
         /// A planned statement: everything a caller needs to describe the result, plus the compiled plan that
         /// produces its rows.
         /// </summary>
-        public sealed class Signature
+        public sealed class Signature : Meta.Signature
         {
 
             /// <summary>
@@ -116,35 +118,30 @@ namespace Apache.Calcite.Extensions.Prepare
                 java.util.List collations,
                 long maxRowCount,
                 IClrBindableBase? bindable,
-                Meta.StatementType statementType)
+                Meta.StatementType statementType) :
+                base(columns, sql, parameters, internalParameters, cursorFactory, statementType)
             {
-                Sql = sql;
-                Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
-                InternalParameters = internalParameters ?? throw new ArgumentNullException(nameof(internalParameters));
                 RowType = rowType;
-                Columns = columns ?? throw new ArgumentNullException(nameof(columns));
-                CursorFactory = cursorFactory ?? throw new ArgumentNullException(nameof(cursorFactory));
                 RootSchema = rootSchema;
                 Collations = collations ?? throw new ArgumentNullException(nameof(collations));
                 this.maxRowCount = maxRowCount;
                 this.bindable = bindable;
-                StatementType = statementType ?? throw new ArgumentNullException(nameof(statementType));
             }
 
             /// <summary>
             /// Gets the statement's text.
             /// </summary>
-            public string? Sql { get; }
+            public string? Sql => sql;
 
             /// <summary>
             /// Gets one <see cref="AvaticaParameter"/> per dynamic parameter.
             /// </summary>
-            public java.util.List Parameters { get; }
+            public java.util.List Parameters => parameters;
 
             /// <summary>
             /// Gets the values the query reads through the <see cref="DataContext"/> rather than from the plan.
             /// </summary>
-            public java.util.Map InternalParameters { get; }
+            public java.util.Map InternalParameters => internalParameters;
 
             /// <summary>
             /// Gets the result's row type, or <see langword="null"/> for DDL.
@@ -154,12 +151,12 @@ namespace Apache.Calcite.Extensions.Prepare
             /// <summary>
             /// Gets one <see cref="ColumnMetaData"/> per result column.
             /// </summary>
-            public java.util.List Columns { get; }
+            public java.util.List Columns => columns;
 
             /// <summary>
             /// Gets how a row is read back.
             /// </summary>
-            public Meta.CursorFactory CursorFactory { get; }
+            public Meta.CursorFactory CursorFactory => cursorFactory;
 
             /// <summary>
             /// Gets the schema the statement was planned against.
@@ -178,7 +175,7 @@ namespace Apache.Calcite.Extensions.Prepare
             /// <summary>
             /// Gets what kind of statement this is.
             /// </summary>
-            public Meta.StatementType StatementType { get; }
+            public Meta.StatementType StatementType => statementType;
 
             /// <summary>
             /// Runs the plan against a <see cref="DataContext"/> and returns its rows.
@@ -197,7 +194,12 @@ namespace Apache.Calcite.Extensions.Prepare
 
                 var rows = sync.Bind(root);
 
-                return maxRowCount < 0 ? rows : Take(rows, maxRowCount);
+                // apply the limit; in JDBC 0 means "no limit", but for us -1 means "no limit" and 0 is a
+                // valid limit
+                if (maxRowCount >= 0)
+                    rows = ClrEnumerableDefaults.Take(rows, maxRowCount);
+
+                return rows;
             }
 
             /// <summary>
@@ -218,48 +220,12 @@ namespace Apache.Calcite.Extensions.Prepare
 
                 var rows = async.Bind(root);
 
-                return maxRowCount < 0 ? rows : TakeAsync(rows, maxRowCount);
-            }
+                // apply the limit; in JDBC 0 means "no limit", but for us -1 means "no limit" and 0 is a
+                // valid limit
+                if (maxRowCount >= 0)
+                    rows = ClrAsyncEnumerableDefaults.Take(rows, maxRowCount);
 
-            /// <summary>
-            /// Yields at most <paramref name="count"/> rows.
-            /// </summary>
-            static async IAsyncEnumerable<object> TakeAsync(IAsyncEnumerable<object> source, long count)
-            {
-                if (count <= 0)
-                    yield break;
-
-                var taken = 0L;
-
-                await foreach (var row in source)
-                {
-                    yield return row;
-
-                    if (++taken >= count)
-                        yield break;
-                }
-            }
-
-            /// <summary>
-            /// Yields at most <paramref name="count"/> rows.
-            /// </summary>
-            /// <param name="source"></param>
-            /// <param name="count"></param>
-            /// <returns></returns>
-            static IEnumerable<object> Take(IEnumerable<object> source, long count)
-            {
-                if (count <= 0)
-                    yield break;
-
-                var taken = 0L;
-
-                foreach (var row in source)
-                {
-                    yield return row;
-
-                    if (++taken >= count)
-                        yield break;
-                }
+                return rows;
             }
 
         }

--- a/src/Apache.Calcite.Extensions/Runtime/IClrBindableBase.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/IClrBindableBase.cs
@@ -8,8 +8,8 @@ namespace Apache.Calcite.Extensions.Runtime
     /// </summary>
     /// <remarks>
     /// One member, because it is the only one a caller reads without knowing which convention prepared the
-    /// statement: <c>IClrPrepare.Signature</c> holds a plan as this, and <c>ClrPrepareImpl.Describe</c> reads nothing
-    /// else off it. Binding is on <see cref="IClrBindable"/> and <see cref="IClrAsyncBindable"/>, because
+    /// statement: <c>IClrPrepare.Signature</c> holds a plan as this, and <c>ClrPrepareImpl.Prepare2_</c> reads
+    /// nothing else off it. Binding is on <see cref="IClrBindable"/> and <see cref="IClrAsyncBindable"/>, because
     /// the two return different sequences and a common <c>Bind</c> could only return one neither of them
     /// wants.
     ///
@@ -26,7 +26,7 @@ namespace Apache.Calcite.Extensions.Runtime
         /// The counterpart of <c>Typed.getElementType</c>, as a <see cref="Type"/> rather than a
         /// <c>java.lang.reflect.Type</c>. A compiled plan is a delegate over CLR types and its rows are CLR
         /// objects; what the type factory called the row is the prepare pipeline's business, and
-        /// <c>ClrPrepareResult.ElementType</c> is where that answer stays for
+        /// <c>ClrPrepare.PreparedResultImpl.ElementType</c> is where that answer stays for
         /// <c>Meta.CursorFactory.deduce</c>. Handing a Java type out of a runtime interface would make every
         /// caller convert one back.
         /// </remarks>

--- a/src/Apache.Calcite.Tests/ClrPrepareBehaviourTests.cs
+++ b/src/Apache.Calcite.Tests/ClrPrepareBehaviourTests.cs
@@ -302,6 +302,111 @@ namespace Apache.Calcite.Tests
                 "the map the plan was built against reaches the caller");
         }
 
+        /// <summary>
+        /// The six statements <c>SIMPLE_SQLS</c> names skip planning and answer one row of one column
+        /// called <c>EXPR$0</c>.
+        /// </summary>
+        /// <remarks>
+        /// <c>prepare_</c> tests <c>SIMPLE_SQLS.contains(query.sql)</c> before it builds a catalog reader,
+        /// and <c>simplePrepare</c> answers a signature over <c>ImmutableList.of(1)</c>. The column is
+        /// <c>SqlUtil.deriveAliasFromOrdinal(0)</c>, and the row is a <c>java.lang.Integer</c> because a
+        /// one-column result is the value.
+        /// </remarks>
+        [TestMethod]
+        [DataRow("SELECT 1")]
+        [DataRow("select 1")]
+        [DataRow("SELECT 1 FROM DUAL")]
+        [DataRow("select 1 from dual")]
+        [DataRow("values 1")]
+        [DataRow("VALUES 1")]
+        public void A_simple_statement_should_skip_planning(string sql)
+        {
+            var (columns, rows) = ClrPrepareFixture.WithContext(sql, (context, _) =>
+            {
+                var signature = new ClrPrepareImpl().PrepareSql(context, IClrPrepare.Query.Of(sql), typeof(object[]), -1);
+
+                return (signature.Columns, new List<object>(signature.Bind(context.getDataContext())));
+            });
+
+            Assert.AreEqual(1, columns.size());
+            Assert.AreEqual("EXPR$0", ((ColumnMetaData)columns.get(0)).columnName);
+            CollectionAssert.AreEqual(new object[] { java.lang.Integer.valueOf(1) }, rows);
+        }
+
+        /// <summary>
+        /// A statement <c>SIMPLE_SQLS</c> does not name is planned, and answers what the fast path would
+        /// have.
+        /// </summary>
+        /// <remarks>
+        /// The fast path is a short cut and not a different answer, which is the only thing about it worth
+        /// holding: <c>SELECT 1</c> is named and <c>SELECT  1</c>, two spaces, is not.
+        /// </remarks>
+        [TestMethod]
+        public void A_statement_the_fast_path_misses_should_answer_the_same()
+        {
+            var rows = ClrPrepareFixture.WithContext("SELECT  1", (context, _) =>
+            {
+                var signature = new ClrPrepareImpl().PrepareSql(context, IClrPrepare.Query.Of("SELECT  1"), typeof(object[]), -1);
+
+                return new List<object>(signature.Bind(context.getDataContext()));
+            });
+
+            CollectionAssert.AreEqual(new object[] { java.lang.Integer.valueOf(1) }, rows);
+        }
+
+        /// <summary>
+        /// <c>AGGREGATE</c> over a measure is expanded, which is what the <c>measure</c> pass does and
+        /// nothing else in the pipeline does.
+        /// </summary>
+        /// <remarks>
+        /// <c>Programs.measure</c> is <c>MeasureRules</c> guarded by <c>containsAggM2v</c> — a plan holding
+        /// an <c>AGG_M2V</c> aggregate call, which is what <c>AGGREGATE(m)</c> converts to. It is one of the
+        /// six passes <c>Programs.standard</c> runs, and without it the planner cannot implement the call.
+        /// The shape is <c>measure.iq</c>'s: <c>GROUP BY ()</c> is implicit under <c>AGGREGATE</c>.
+        /// </remarks>
+        [TestMethod]
+        public void An_aggregate_over_a_measure_should_be_expanded()
+        {
+            const string sql = "SELECT AGGREGATE(m) AS a FROM (SELECT REGION, AVG(AMOUNT) AS MEASURE m FROM SALES)";
+
+            var rows = ClrPrepareFixture.WithContext(sql, (context, _) =>
+            {
+                var signature = new ClrPrepareImpl().PrepareSql(context, IClrPrepare.Query.Of(sql), typeof(object[]), -1);
+
+                return new List<object>(signature.Bind(context.getDataContext()));
+            },
+            p => p.setProperty("fun", "calcite"));
+
+            // 10, 20, 20, 30, null, 10 -- AVG over the five that are not null, in INTEGER arithmetic
+            CollectionAssert.AreEqual(new object[] { java.lang.Integer.valueOf(18) }, rows);
+        }
+
+        /// <summary>
+        /// A correlated sub-query is decorrelated under <c>topDownGeneralDecorrelationEnabled</c>, which is
+        /// the flag that turns off the decorrelation <c>prepareSql</c> does.
+        /// </summary>
+        /// <remarks>
+        /// <c>Prepare.prepareSql</c> decorrelates only when <c>forceDecorrelate</c> is set and this flag is
+        /// not, because the flag's decorrelation belongs to <c>DecorrelateProgram</c>, which
+        /// <c>Programs.standard</c> runs and which dispatches to <c>TopDownGeneralDecorrelator</c>. Both
+        /// halves have to be there or the query is planned with its correlation intact.
+        /// </remarks>
+        [TestMethod]
+        public void A_correlated_sub_query_should_decorrelate_top_down()
+        {
+            const string sql = "SELECT ID FROM SALES s WHERE AMOUNT > (SELECT AVG(AMOUNT) FROM SALES t WHERE t.REGION = s.REGION)";
+
+            var plan = ClrPrepareFixture.WithContext(sql, (context, _) =>
+            {
+                var signature = new ClrPrepareImpl().PrepareSql(context, IClrPrepare.Query.Of("EXPLAIN PLAN FOR " + sql), typeof(object[]), -1);
+
+                return (string)new List<object>(signature.Bind(context.getDataContext()))[0];
+            },
+            p => p.setProperty("topDownGeneralDecorrelationEnabled", "true"));
+
+            StringAssert.DoesNotMatch(plan, new System.Text.RegularExpressions.Regex("Correlate"), plan);
+        }
+
     }
 
 }

--- a/src/Apache.Calcite.Tests/ClrPrepareFixture.cs
+++ b/src/Apache.Calcite.Tests/ClrPrepareFixture.cs
@@ -91,13 +91,15 @@ namespace Apache.Calcite.Tests
         /// <typeparam name="T"></typeparam>
         /// <param name="sql">The statement, for the caller's own use.</param>
         /// <param name="body"></param>
+        /// <param name="connectionProperties">Set on the connection configuration after the defaults, for a
+        /// test whose subject is a connection property.</param>
         /// <returns></returns>
         /// <remarks>
         /// The context is pushed onto <c>CalcitePrepare.Dummy</c>'s thread-local stack for the length of the
         /// call, because Calcite's parse-to-rel reads it from there. A fresh schema per call, so one test
         /// cannot see another's plan cache.
         /// </remarks>
-        public static T WithContext<T>(string sql, Func<CalcitePrepare.Context, CalciteSchema, T> body)
+        public static T WithContext<T>(string sql, Func<CalcitePrepare.Context, CalciteSchema, T> body, Action<java.util.Properties>? connectionProperties = null)
         {
             ArgumentNullException.ThrowIfNull(body);
 
@@ -111,6 +113,7 @@ namespace Apache.Calcite.Tests
             var properties = new java.util.Properties();
             properties.setProperty("lex", "JAVA");
             properties.setProperty("caseSensitive", "false");
+            connectionProperties?.Invoke(properties);
             var config = new CalciteConnectionConfigImpl(properties);
 
             var context = new PrepareContext(typeFactory, rootSchema, config, []);


### PR DESCRIPTION
Follow-on to #38. That PR took the pipeline back to Calcite's shape; this one is the result of reading the namespace against `calcite-1.42.0` again with a different question — not "does it work" but "for each member, is this Calcite's member". Eleven places were neither of the three divergences the port allows (two calling conventions, .NET naming, .NET types) nor the one feature it removes (Spark).

## `getProgram` was three passes where `Programs.standard` is six

```java
// Programs.standard(metadataProvider, enableFieldTrimming)
subQuery(mp), new DecorrelateProgram(), measure(mp), new TrimFieldsProgram(), program1, calc(mp)
```

**The missing `measure` pass is not a subtlety.** `MeasureRules` never ran, so a plan carrying an `AGG_M2V` call could not be implemented at all — `AGGREGATE` over a measure failed with `CannotPlanException`. Meanwhile `avaticaType`, `getTypeOrdinal` and `getTypeName` all carry the `MEASURE` cases, so the describe surface advertised support the pipeline could not deliver.

**The missing `decorrelate` pass is not a no-op either.** `forceDecorrelate` defaults to true, so Calcite decorrelates twice by default — once in `prepareSql`, once here after trimming — and this kept only the first. It compounds with the `topDownGeneralDecorrelationEnabled` branch that `CalcitePreparingStmt.decorrelate` has and this had dropped: `prepareSql` skips its own decorrelation on exactly that flag *because* `DecorrelateProgram` is meant to pick it up. With neither half present the flag turned decorrelation off rather than changing which decorrelator ran — while the converter config was threaded the flag the whole time.

**The missing `trim` pass** is the `RelFieldTrimmer` run whose comment on `DecorrelateProgram` says it must follow decorrelation (CALCITE-842).

`getProgram` itself is concrete again, with the `Hook.PROGRAM` read inside it where `Prepare` has it rather than at the one call site, and `optimize` calls it and nothing else. `Programs.standard()` is a constant there because there is one convention to plan into; there are two here and their last two passes differ, so the constant is `GetStandardProgram`. That is the only method in this PR that Calcite does not have.

## The rest

- **`prepare2_` builds its own validator**, leaving `getSqlValidator`'s cached one to `trimUnusedFields`. Two instances, deliberately. The accessibility widening on `SqlValidator` was the tell and is gone.
- **`Hook.PLAN_BEFORE_IMPLEMENTATION`** is the first statement of `implement` again, rather than of its two callers.
- **`CatalogReader.THREAD_LOCAL`** brackets code generation. Write-only across the whole 1.42 tree today, so nothing observable — but it is a step removed from the method being ported, and a Calcite change that starts reading it would break here silently.
- **`SIMPLE_SQLS` / `simplePrepare`** are back. The bindable is a class rather than Calcite's lambda because both conventions come through the same path.

## Shapes, one to one

`Signature` extends `Meta.Signature` instead of re-declaring its six fields. `PreparedExplain` splits into the abstract base and `ClrPreparedExplain`, as `Prepare.PreparedExplain` and `CalcitePrepareImpl.CalcitePreparedExplain`. `PreparedResultImpl` requires `rowType` and `rootRel` and copies its collations. `PreparingStmt` holds `planner`, `typeFactory`, `prefer` and `expansionDepth` in Calcite's constructor order, `prefer` moving up out of the two subclasses. `createSqlValidator` is a private static plus an instance forwarder.

## Two things that fell out of the work rather than the audit

**The row limit** goes through `ClrEnumerableDefaults.Take`, which needed the `long` overload `EnumerableDefaults` has and this lacked. The hand-written iterator it replaces also deferred acquisition, where linq4j acquires at `enumerator()`. Adding the overload broke `ClrBuiltInMethod.Of` — a name-only `GetMethod` that throws on ambiguity — and took out 120 tests at once. `BuiltInMethod` names parameter types for exactly this reason (`TAKE(ExtendedEnumerable.class, "take", int.class)`), so `Of` takes them too, with null standing for a generic parameter that has no `Type` to name.

**`CalcitePreparingStmt.decorrelate` writes `sqlToRelConverter.config()`**, which reads as the converter's own configuration and is not: `SqlToRelConverter` has no instance `config()`, so Java resolves it to the static factory through the instance reference and the builder is the default one. C# rejects the syntax, which is how it surfaced; the site says so now.

## Tests

696 in `Apache.Calcite.Tests` (nine new), 324 in `Apache.Calcite.Data.Tests`, all passing, none skipped.

Three of the new ones were each verified to fail with the change they cover removed:

- `An_aggregate_over_a_measure_should_be_expanded` — `CannotPlanException` without the `measure` pass, which is what a measure query did before this PR.
- `A_correlated_sub_query_should_decorrelate_top_down` — a `Correlate` survives without `decorrelate()` and the top-down branch.
- `A_simple_statement_should_skip_planning` over all six literals, plus a two-space `SELECT  1` that misses the fast path and must answer the same, because a short cut is not a different answer.

None of this is visible to a differential test. Every finding except the measure hole returns the same rows today.

## Still absent

Absent as features, not as divergences in what is present: `parse` / `convert` / `analyzeView`, `prepareQueryable` and the Lix translators, `CalciteMaterializer` and `populateMaterializations`, `perform`. Spark stays removed, at all four sites.
