### PR TITLE
Declare json-path's jackson dependencies, on the released IKVM.Maven.Sdk 1.12.0

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.11.0">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
@@ -25,7 +25,7 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
@@ -30,7 +30,16 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
-        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0" />
+        <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
+             declare the missing edge, optional like json-path's own bundled descriptor intends, so the
+             version sorts ahead when the closure asks for jackson. The version matches the
+             jackson-databind that calcite-core itself manages. -->
+        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
+            <Dependencies>
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6,optional=true;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
+            </Dependencies>
+        </MavenReference>
         <MavenReference Include="org.jooq:joou-java-6" Version="0.9.5" />
     </ItemGroup>
     

--- a/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0</TargetFrameworks>
@@ -25,7 +25,7 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.11.0">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
+++ b/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
@@ -29,7 +29,16 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.43.0-SNAPSHOT" />
+        <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
+             declare the missing edge, optional like json-path's own bundled descriptor intends, so the
+             version sorts ahead when the closure asks for jackson. The version matches the
+             jackson-databind that calcite-core itself manages. -->
+        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.43.0-SNAPSHOT">
+            <Dependencies>
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6,optional=true;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
+            </Dependencies>
+        </MavenReference>
         <MavenReference Include="org.apache.calcite:calcite-server" Version="1.43.0-SNAPSHOT" />
     </ItemGroup>
 

--- a/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
+++ b/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.11.0">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
+++ b/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Data.Tests/CalciteJsonFunctionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteJsonFunctionTests.cs
@@ -1,0 +1,53 @@
+using Xunit;
+
+namespace Apache.Calcite.Data.Tests
+{
+
+    /// <summary>
+    /// Verifies the SQL JSON functions execute end-to-end. Calcite implements these through json-path's
+    /// jackson providers, whose dependencies are undeclared in json-path's published POM and are supplied
+    /// by the <c>Dependencies</c> declaration on the calcite-core reference; a regression here most likely
+    /// means json.path.dll is once again compiling against jackson stubs.
+    /// </summary>
+    public class CalciteJsonFunctionTests
+    {
+
+        [Fact]
+        public void JsonValue_should_extract_scalar()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES JSON_VALUE('{\"a\": 7}', '$.a')";
+
+            var v = cmd.ExecuteScalar();
+            Assert.Equal("7", v);
+        }
+
+        [Fact]
+        public void JsonExists_should_return_true_for_present_path()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES JSON_EXISTS('{\"a\": {\"b\": 1}}', '$.a.b')";
+
+            var v = cmd.ExecuteScalar();
+            Assert.Equal(true, v);
+        }
+
+        [Fact]
+        public void JsonQuery_should_return_object()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES JSON_QUERY('{\"a\": {\"b\": 1}}', '$.a')";
+
+            var v = cmd.ExecuteScalar();
+            Assert.Equal("{\"b\":1}", v);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
+++ b/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
@@ -29,12 +29,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
-             declare the missing edge so its jackson providers compile against the real assembly. The
-             version matches the jackson-databind that calcite-core itself manages. -->
+             declare the missing edge, optional like json-path's own bundled descriptor intends, so its
+             jackson providers compile against the real assembly and the version sorts ahead when the
+             closure asks for jackson. The version matches the jackson-databind that calcite-core itself
+             manages. -->
         <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
             <Dependencies>
-                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6;
-                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6,optional=true;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
             </Dependencies>
         </MavenReference>
         <MavenReference Include="org.jooq:joou-java-6" Version="0.9.5" />

--- a/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
+++ b/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0</TargetFrameworks>
@@ -24,11 +24,19 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.11.0">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0" />
+        <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
+             declare the missing edge so its jackson providers compile against the real assembly. The
+             version matches the jackson-databind that calcite-core itself manages. -->
+        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
+            <Dependencies>
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6
+            </Dependencies>
+        </MavenReference>
         <MavenReference Include="org.jooq:joou-java-6" Version="0.9.5" />
     </ItemGroup>
 

--- a/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
+++ b/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
+++ b/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -25,7 +25,7 @@
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.11.0">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -34,7 +34,16 @@
              1.43 — Apache.Calcite.Data.Tests does, for calcite-server — resolves core to 1.43, and 1.43's
              BuiltInMethod initializer looks for ExtendedEnumerable.update, which 1.42's linq4j does not
              have. Every test in that project then fails in a type initializer. -->
-        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0" />
+        <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082), so
+             its jackson-based providers would compile against hard-throwing stubs and Calcite's JSON
+             functions would fail with NoClassDefFoundError. Declare the missing edge; the version matches
+             the jackson-databind that calcite-core itself manages. -->
+        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
+            <Dependencies>
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6
+            </Dependencies>
+        </MavenReference>
         <MavenReference Include="org.jooq:joou-java-6" Version="0.9.5" />
     </ItemGroup>
 

--- a/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
+++ b/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
+++ b/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
@@ -36,12 +36,13 @@
              have. Every test in that project then fails in a type initializer. -->
         <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082), so
              its jackson-based providers would compile against hard-throwing stubs and Calcite's JSON
-             functions would fail with NoClassDefFoundError. Declare the missing edge; the version matches
-             the jackson-databind that calcite-core itself manages. -->
+             functions would fail with NoClassDefFoundError. Declare the missing edge, optional like
+             json-path's own bundled descriptor intends, so the version sorts ahead when the closure asks
+             for jackson. The version matches the jackson-databind that calcite-core itself manages. -->
         <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
             <Dependencies>
-                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6;
-                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6,optional=true;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
             </Dependencies>
         </MavenReference>
         <MavenReference Include="org.jooq:joou-java-6" Version="0.9.5" />

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/3.10.4">
+﻿<Project Sdk="MSTest.Sdk/3.10.4">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -13,7 +13,7 @@
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.11.0">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0-pre.1">
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -20,7 +20,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0" />
+        <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
+             declare the missing edge, optional like json-path's own bundled descriptor intends, so the
+             version sorts ahead when the closure asks for jackson. The version matches the
+             jackson-databind that calcite-core itself manages. -->
+        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
+            <Dependencies>
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6,optional=true;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
+            </Dependencies>
+        </MavenReference>
         <!-- Smalls.fibonacciTableWithLimit100 is a one-column table function written in Java, and the only
              oracle ClrEnumerableRowFormatTests can have: Janino cannot name a CLR class, so a table function
              of this project's own gives EnumerableConvention no plan to compare against. -->


### PR DESCRIPTION
Two commits. The first is the json-path fix, which was written against `1.12.0-pre.1` and had not been pushed; the second moves it to `1.12.0`, released today.

## `Dependencies` metadata on `MavenReference`

json-path's published POM declares no jackson dependency in any scope ([json-path/JsonPath#1082](https://github.com/json-path/JsonPath/issues/1082)), so IKVM compiled its jackson providers against hard-throwing stubs and Calcite's JSON functions failed with `NoClassDefFoundError` at run time. The new `Dependencies` metadata declares the missing edges — `jackson-databind` and `jackson-core`, at the version `calcite-core` itself manages — on the `calcite-core` reference in `Apache.Calcite.Data` and `Apache.Calcite.Extensions`. The declarations pack into the partial POMs, so package consumers inherit them. `CalciteJsonFunctionTests` covers `JSON_VALUE`, `JSON_EXISTS` and `JSON_QUERY`.

That metadata is the feature the prerelease existed for; it shipped unchanged in `1.12.0`.

## The bump

Six `PackageReference` lines, `1.12.0-pre.1` → `1.12.0`. What I checked is that the release resolves the same thing the prerelease did, since a green suite would not have shown the difference — the four jackson artifacts come out identical:

```
com.fasterxml.jackson.core:jackson-annotations:jar:2.18.6
com.fasterxml.jackson.core:jackson-core:jar:2.18.6
com.fasterxml.jackson.core:jackson-databind:jar:2.18.6
com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.18.6
```

696 tests in `Apache.Calcite.Tests`, 327 in `Apache.Calcite.Data.Tests`, all passing, none skipped.

## A build flake this is *not* the cause of

While verifying, parallel builds failed intermittently:

```
Could not transfer artifact org.apache.calcite:calcite-core:jar:1.43.0-20260812.031348-164:
  ...\.m2\repository\...\calcite-core-1.43.0-SNAPSHOT.jar:
  The process cannot access the file because it is being used by another process.
```

The `net8.0` and `net10.0` inner builds of `Apache.Calcite.Data.Tests` resolve `1.43.0-SNAPSHOT` concurrently and sometimes land on different timestamped snapshots of it — I saw `20260812.031348-164` and `20260813.124127-168` inside one session — while both write the single shared `calcite-core-1.43.0-SNAPSHOT.jar`.

**Why Maven's own locking doesn't prevent it.** It does lock, and I first described this wrongly. Even through the deprecated `MavenRepositorySystemUtils.newServiceLocator()` that IKVM.Maven.Sdk uses, resolver 1.9.24's `DefaultServiceLocator` binds `DefaultSyncContextFactory` and `NamedLockFactoryAdapterFactoryImpl`. But the default lock factory is `rwlock-local`, whose javadoc reads "A JVM-local named lock factory that uses named `ReentrantReadWriteLock`s" — it serialises threads within one process and knows nothing about other processes. The cross-process factory is `FileLockNamedLockFactory` (`file-lock`, since 1.7.3), selected with `aether.syncContext.named.factory=file-lock`.

A default `dotnet build` runs MSBuild worker processes, so the two inner builds get no mutual exclusion from each other; `-m:1` is a single node, one process, where `rwlock-local` does its job. That is why `-m:1` never collided in any run. The one step here inferred rather than observed is that the two inner builds were in separate MSBuild nodes — read from the error text plus `-m:1` being a reliable fix, not from process IDs.

The durable fix belongs in IKVM.Maven.Sdk rather than here: default the session to `file-lock`, or expose the setting, in the `CreateRepositorySystemSession` that already calls `session.setConfigProperty(...)`.

I first read this as a `1.12.0` regression, on the strength of a run of failures. It is not. Alternating parallel builds between the two versions collide in the same round and succeed in the same rounds:

| round | `1.12.0-pre.1` | `1.12.0` |
|---|---|---|
| 1 | ok | ok |
| 2 | collision | collision |
| 3 | ok | ok |

It tracks whether a snapshot re-check happens to put two processes in the local repository at once, not the SDK version. `dotnet build Apache.Calcite.sln -m:1` avoids it every time, and is worth knowing independently of this PR — it will bite any build that lands while the Calcite snapshot is refreshing.

