### PR TITLE
Restore the VSTest testhost MSTest.Sdk 4 stopped bringing in

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -8,6 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- MSTest.Sdk 3.10.4 referenced Microsoft.NET.Test.Sdk from its runner profile
+             (Sdk/Runner/ClassicEngine.targets); 4.3.3 references it only under UseVSTest, so a build
+             under 4 puts no VSTest testhost in the output. CI runs `dotnet test <dll>`, which is
+             vstest.console, and every job aborted before a test ran -- the testhost could not resolve
+             Newtonsoft.Json. MSTest.TestAdapter still carries the VSTest bridge and still sets
+             GenerateProgramFile=false under EnableMSTestRunner, so declaring the package restores what
+             3.10.4 arranged, entry point included, and leaves the MSTest runner as it is. -->
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="IKVM" Version="8.15.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -11,8 +11,8 @@
         <!-- MSTest.Sdk 3.10.4 referenced Microsoft.NET.Test.Sdk from its runner profile
              (Sdk/Runner/ClassicEngine.targets); 4.3.3 references it only under UseVSTest, so a build
              under 4 puts no VSTest testhost in the output. CI runs `dotnet test <dll>`, which is
-             vstest.console, and every job aborted before a test ran -- the testhost could not resolve
-             Newtonsoft.Json. MSTest.TestAdapter still carries the VSTest bridge and still sets
+             vstest.console, and every job aborted before a test ran, the testhost having failed to
+             resolve Newtonsoft.Json. MSTest.TestAdapter still carries the VSTest bridge and still sets
              GenerateProgramFile=false under EnableMSTestRunner, so declaring the package restores what
              3.10.4 arranged, entry point included, and leaves the MSTest runner as it is. -->
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -8,6 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- MSTest.Sdk 3.10.4 referenced Microsoft.NET.Test.Sdk from its runner profile
+             (Sdk/Runner/ClassicEngine.targets); 4.3.3 references it only under UseVSTest, so a build
+             under 4 puts no VSTest testhost in the output. CI runs `dotnet test <dll>`, which is
+             vstest.console, and every job aborted before a test ran -- the testhost could not resolve
+             Newtonsoft.Json. MSTest.TestAdapter still carries the VSTest bridge and still sets
+             GenerateProgramFile=false under EnableMSTestRunner, so declaring the package restores what
+             3.10.4 arranged, entry point included, and leaves the MSTest runner as it is. -->
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="FastExpressionCompiler.LightExpression" Version="5.4.1" />
         <PackageReference Include="FluentAssertions" Version="8.10.0" />
         <PackageReference Include="IKVM" Version="8.15.0" />

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -11,8 +11,8 @@
         <!-- MSTest.Sdk 3.10.4 referenced Microsoft.NET.Test.Sdk from its runner profile
              (Sdk/Runner/ClassicEngine.targets); 4.3.3 references it only under UseVSTest, so a build
              under 4 puts no VSTest testhost in the output. CI runs `dotnet test <dll>`, which is
-             vstest.console, and every job aborted before a test ran -- the testhost could not resolve
-             Newtonsoft.Json. MSTest.TestAdapter still carries the VSTest bridge and still sets
+             vstest.console, and every job aborted before a test ran, the testhost having failed to
+             resolve Newtonsoft.Json. MSTest.TestAdapter still carries the VSTest bridge and still sets
              GenerateProgramFile=false under EnableMSTestRunner, so declaring the package restores what
              3.10.4 arranged, entry point included, and leaves the MSTest runner as it is. -->
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />


### PR DESCRIPTION
Run 174 on main finished 20 red and 10 green: every `Apache.Calcite.Tests` and `Apache.Calcite.Adapter.AdoNet.Tests` job failed, on all five platforms and both target frameworks, and not one of them ran a test. Every `Apache.Calcite.Data.Tests` job passed.

```
Testhost process for source(s) '.../Apache.Calcite.Tests.dll' exited with error:
  An assembly specified in the application dependencies manifest (testhost.deps.json)
  was not found:
    package: 'Newtonsoft.Json', version: '13.0.3'
    path: 'lib/net6.0/Newtonsoft.Json.dll'
Test Run Aborted.
```

## Why

`MSTest.Sdk` 3.10.4 -> 4.3.3, in 01e863a. 3.10.4 referenced `Microsoft.NET.Test.Sdk` from its **runner** profile, `Sdk/Runner/ClassicEngine.targets` — the path taken when `UseVSTest` is false, which is the default — so a project on the MSTest runner still carried the VSTest testhost into its output. 4.3.3 has that reference only in `Sdk/VSTest/VSTest.targets`, imported when `UseVSTest` is true. The workflow runs `dotnet test <dll>`, which is vstest.console, so the testhost is what starts the run, and it is no longer in the output.

`Apache.Calcite.Data.Tests` is green because it is a plain `Microsoft.NET.Sdk` project that declares `Microsoft.NET.Test.Sdk` itself.

## The change

`Microsoft.NET.Test.Sdk` 18.8.1 declared in the two `MSTest.Sdk` projects — what 3.10.4 did implicitly:

- `MSTest.TestAdapter` 4.3.3 still depends on `Microsoft.Testing.Extensions.VSTestBridge` 2.3.3, so VSTest still discovers the tests.
- `MSTest.TestAdapter.targets` still sets `GenerateProgramFile=false` under `EnableMSTestRunner`, so `Microsoft.NET.Test.Sdk`'s `AutoGeneratedProgram` does not collide with the runner's generated entry point.
- The version matches the 18.8.1 `Apache.Calcite.Data.Tests` already pins.

Running the built executable directly on Microsoft.Testing.Platform is unchanged.