### PR TITLE
Reach a provider's metadata without asking it for a DbDataSource

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSchemaTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSchemaTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using org.apache.calcite.jdbc;
@@ -6,6 +7,7 @@ using org.apache.calcite.sql.type;
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 
 namespace Apache.Calcite.Adapter.AdoNet.Tests
@@ -219,6 +221,51 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         {
             var metadata = Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(_sqlite.DataSource);
             Assert.IsNotNull(metadata.Dialect);
+        }
+
+        #endregion
+
+        #region Provider factories
+
+        /// <summary>
+        /// Registers the SQLite factory under the invariant name a model would use, once for the process.
+        /// </summary>
+        static void RegisterSqliteFactory()
+        {
+            if (DbProviderFactories.TryGetFactory("Microsoft.Data.Sqlite", out _) == false)
+                DbProviderFactories.RegisterFactory("Microsoft.Data.Sqlite", SqliteFactory.Instance);
+        }
+
+        /// <summary>
+        /// A factory and a connection string are all a caller has for every provider this adapter carries
+        /// metadata for: none of them ships a <see cref="DbDataSource"/>, so none of them overrides
+        /// <see cref="DbProviderFactory.CreateDataSource"/>, whose base throws.
+        /// </summary>
+        [TestMethod]
+        public void AProviderFactoryAndConnectionStringBuildASchema()
+        {
+            var schema = AdoSchema.Create(_root, "FACTORY", SqliteFactory.Instance, _sqlite.DataSource.ConnectionString, null, null);
+
+            Assert.IsInstanceOfType<AdoTable>(schema.tables().get("EMPS"));
+        }
+
+        /// <summary>
+        /// The operand pair a JSON model names. It reached its metadata through
+        /// <see cref="DbProviderFactory.CreateDataSource"/>, so naming SQLite — or SQL Server, ODBC or
+        /// OLE DB — in a model threw rather than building a schema, and no test came through here.
+        /// </summary>
+        [TestMethod]
+        public void AnOperandOfProviderNameAndConnectionStringBuildsASchema()
+        {
+            RegisterSqliteFactory();
+
+            var operand = new java.util.HashMap();
+            operand.put("adoProviderName", "Microsoft.Data.Sqlite");
+            operand.put("adoConnectionString", _sqlite.DataSource.ConnectionString);
+
+            var schema = AdoSchema.Create(_root, "MODEL", operand);
+
+            Assert.IsInstanceOfType<AdoTable>(schema.tables().get("EMPS"));
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
@@ -109,12 +109,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         public static AdoSchema Create(SchemaPlus? parentSchema, string name, DbProviderFactory factory, string connectionString, string? databaseName, string? schemaName)
         {
-            ArgumentNullException.ThrowIfNull(factory);
-            ArgumentNullException.ThrowIfNull(connectionString);
-
-            var dataSource = new DbProviderFactoryDataSource(factory, connectionString);
-            var metadata = AdoDatabaseMetadataFactoryImpl.Instance.Create(dataSource);
-            return Create(parentSchema, name, new DbProviderAdoDataSource(factory, connectionString, metadata), databaseName, schemaName);
+            return Create(parentSchema, name, new DbProviderFactoryDataSource(factory, connectionString), databaseName, schemaName);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
@@ -92,6 +92,32 @@ namespace Apache.Calcite.Adapter.AdoNet
         }
 
         /// <summary>
+        /// Creates a new instance over a <see cref="DbProviderFactory"/> and a connection string.
+        /// </summary>
+        /// <remarks>
+        /// This is the route for a provider that ships no <see cref="DbDataSource"/>, which is every
+        /// provider this adapter carries metadata for: Microsoft.Data.Sqlite, Microsoft.Data.SqlClient,
+        /// System.Data.Odbc and System.Data.OleDb all inherit the throwing
+        /// <see cref="DbProviderFactory.CreateDataSource"/>, so there is no data source to ask them for.
+        /// </remarks>
+        /// <param name="parentSchema"></param>
+        /// <param name="name"></param>
+        /// <param name="factory"></param>
+        /// <param name="connectionString"></param>
+        /// <param name="databaseName"></param>
+        /// <param name="schemaName"></param>
+        /// <returns></returns>
+        public static AdoSchema Create(SchemaPlus? parentSchema, string name, DbProviderFactory factory, string connectionString, string? databaseName, string? schemaName)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+            ArgumentNullException.ThrowIfNull(connectionString);
+
+            var dataSource = new DbProviderFactoryDataSource(factory, connectionString);
+            var metadata = AdoDatabaseMetadataFactoryImpl.Instance.Create(dataSource);
+            return Create(parentSchema, name, new DbProviderAdoDataSource(factory, connectionString, metadata), databaseName, schemaName);
+        }
+
+        /// <summary>
         /// Creates a new instance.
         /// </summary>
         /// <param name="parentSchema"></param>
@@ -219,7 +245,7 @@ namespace Apache.Calcite.Adapter.AdoNet
                     throw new AdoCalciteException("Required missing property 'adoConnectionString'.");
 
                 var dbFactory = DbProviderFactories.GetFactory(adoProviderName);
-                var dbDataSource = dbFactory.CreateDataSource(adoConnectionString);
+                var dbDataSource = new DbProviderFactoryDataSource(dbFactory, adoConnectionString);
                 adoDataSource = new DbProviderAdoDataSource(dbFactory, adoConnectionString, adoDatabaseMetadata ?? adoDatabaseMetadataFactory.Create(dbDataSource));
                 if (adoDataSource is null)
                     throw new AdoCalciteException("Failed to instantiate DbDataSource from adoProviderName and adoConnectionString.");

--- a/src/Apache.Calcite.Adapter.AdoNet/DbProviderFactoryDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/DbProviderFactoryDataSource.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Data.Common;
+
+namespace Apache.Calcite.Adapter.AdoNet
+{
+
+    /// <summary>
+    /// A <see cref="DbDataSource"/> over a <see cref="DbProviderFactory"/> and a connection string.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DbProviderFactory.CreateDataSource"/> is a throwing base implementation, and none of the
+    /// providers this adapter ships metadata for overrides it: Microsoft.Data.Sqlite, System.Data.Odbc and
+    /// System.Data.OleDb declare no <see cref="DbDataSource"/> at all, and Microsoft.Data.SqlClient offers
+    /// only <c>CreateDataSourceEnumerator</c>, which is unrelated. Asking a factory for one is therefore not
+    /// a way to reach a data source; opening the connection ourselves is. Metadata detection wants a
+    /// <see cref="DbDataSource"/> because that is what <see cref="Metadata.AdoDatabaseMetadataFactory"/>
+    /// takes, and this supplies one.
+    /// </remarks>
+    sealed class DbProviderFactoryDataSource : DbDataSource
+    {
+
+        readonly DbProviderFactory _factory;
+        readonly string _connectionString;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="factory">The provider factory used to create connections.</param>
+        /// <param name="connectionString">The connection string given to each new connection.</param>
+        /// <exception cref="ArgumentNullException">Any argument is <see langword="null"/>.</exception>
+        public DbProviderFactoryDataSource(DbProviderFactory factory, string connectionString)
+        {
+            _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+        }
+
+        /// <inheritdoc />
+        public override string ConnectionString => _connectionString;
+
+        /// <inheritdoc />
+        protected override DbConnection CreateDbConnection()
+        {
+            var cnn = _factory.CreateConnection() ?? throw new AdoCalciteException("Null result creating connection.");
+            cnn.ConnectionString = _connectionString;
+            return cnn;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -31,15 +31,13 @@ using Apache.Calcite.Adapter.AdoNet;
 using Apache.Calcite.Data;
 using Microsoft.Data.Sqlite;
 
-// 1. Any DbDataSource will do. The matching metadata provider is chosen for you.
-var dataSource = SqliteFactory.Instance.CreateDataSource("Data Source=sales.db");
-
-// 2. Open a Calcite connection and attach the schema.
+// 1. Open a Calcite connection.
 await using var conn = new CalciteConnection("Lex=JAVA;CaseSensitive=false");
 await conn.OpenAsync();
 
+// 2. Attach the database. A provider factory and a connection string are all it takes.
 var root = conn.RootSchema;
-root.add("ADO", AdoSchema.Create(root, "ADO", dataSource, null, null));
+root.add("ADO", AdoSchema.Create(root, "ADO", SqliteFactory.Instance, "Data Source=sales.db", null, null));
 
 // 3. Query it.
 await using var cmd = conn.CreateCommand();
@@ -51,7 +49,7 @@ while (await reader.ReadAsync())
     Console.WriteLine(reader.GetString(0));
 ```
 
-The last two arguments to `AdoSchema.Create` are the database and schema name to restrict discovery to; pass `null` for either to take the source's default. Overloads accept an `AdoDataSource`, an `AdoDatabaseMetadata`, or an `AdoDatabaseMetadataFactory` where you need to choose the metadata provider yourself.
+The last two arguments to `AdoSchema.Create` are the database and schema name to restrict discovery to; pass `null` for either to take the source's default. Overloads take a .NET 7+ `DbDataSource`, or an `AdoDataSource`, where you have one already — note that none of the providers below ships a `DbDataSource`, so the factory and connection string above is the usual way in.
 
 ## Quick start — JSON model
 
@@ -109,8 +107,8 @@ Federating across unrelated databases is the point of the adapter:
 
 ```csharp
 var root = conn.RootSchema;
-root.add("SQL",    AdoSchema.Create(root, "SQL",    sqlServerDataSource, null, null));
-root.add("SQLITE", AdoSchema.Create(root, "SQLITE", sqliteDataSource,    null, null));
+root.add("SQL",    AdoSchema.Create(root, "SQL",    SqlClientFactory.Instance, sqlServerConnectionString, null, null));
+root.add("SQLITE", AdoSchema.Create(root, "SQLITE", SqliteFactory.Instance,    sqliteConnectionString,    null, null));
 
 await using var cmd = conn.CreateCommand();
 cmd.CommandText = """
@@ -125,7 +123,7 @@ Each side is pushed to its own database as far as it can go, and the join runs i
 
 ## Provider support
 
-`AdoDatabaseMetadataFactoryImpl` — the default, used when you do not name one — inspects the connection the data source produces and selects a metadata provider:
+The adapter inspects the connection the data source produces and selects how to describe it. Nothing needs configuring for these:
 
 | Connection type | Discovery | Dialect |
 |---|---|---|

--- a/src/Apache.Calcite.Extensions/README.md
+++ b/src/Apache.Calcite.Extensions/README.md
@@ -99,8 +99,7 @@ Strongly-typed .NET properties over a Calcite `java.util.Properties` map. Instea
 
 ```csharp
 using Apache.Calcite.Extensions.Config;
-using java.util;
-using org.apache.calcite.avatica.util;
+using org.apache.calcite.config;
 
 var props = new CalciteConnectionProperties();
 


### PR DESCRIPTION
The adapter's README opens with a line that throws:

```csharp
var dataSource = SqliteFactory.Instance.CreateDataSource("Data Source=sales.db");
```

`DbProviderFactory.CreateDataSource` is a throwing base implementation, and none of the four providers this adapter carries metadata for overrides it. Microsoft.Data.Sqlite, System.Data.Odbc and System.Data.OleDb declare no `DbDataSource` at all; Microsoft.Data.SqlClient 7.0.2 offers only `CreateDataSourceEnumerator`, which is a different thing. This repository already knew — `SqliteFixture` hand-rolls the `DbDataSource` "Microsoft.Data.Sqlite does not ship" in order to test with one.

**The same call is in `AdoSchema` itself**, on the operand path a JSON model takes (`AdoSchema.cs:222`), so the documented `adoProviderName` / `adoConnectionString` pair threw for every provider the adapter supports. Nothing reached it: no test built a schema from an operand map or through `AdoSchemaFactory`, which is how a README example stayed broken.

## The change

The `DbDataSource` there is wanted only because `AdoDatabaseMetadataFactory.Create` takes one, and all it does with it is open a connection to see what is on the other end. `DbProviderFactoryDataSource` supplies one over the factory and the connection string the caller already has.

With that in place a factory and a connection string are enough to build a schema, so `AdoSchema.Create` takes them directly:

```csharp
root.add("ADO", AdoSchema.Create(root, "ADO", SqliteFactory.Instance, "Data Source=sales.db", null, null));
```

- `DbProviderFactoryDataSource` — internal; a `DbDataSource` over a factory and a connection string.
- `AdoSchema.Create(SchemaPlus?, string, DbProviderFactory, string, string?, string?)` — new public overload.
- The operand path builds the same wrapper instead of calling `CreateDataSource`.
- Two tests in `AdoSchemaTests`: the new overload, and the operand pair, both against SQLite.

## READMEs

- The adapter's code-driven and federated examples use the new overload; the JSON-model example is now true as written.
- Metadata-provider selection is no longer part of the quick start — the common case does not choose one.
- `Apache.Calcite.Extensions`' `CalciteConnectionProperties` example imported `org.apache.calcite.avatica.util` and `java.util`, so `Lex` and `NullCollation` did not resolve and the sample did not compile. They are in `org.apache.calcite.config`.

## Unproven

None of this has been compiled or run — the environment it was written in has no .NET SDK and no route to one — so this PR's own CI is the first check. The two new tests are the part most likely to need a correction.