### PR TITLE
Convert a CHAR column's value in GetChar

### DIFF
--- a/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
@@ -176,6 +176,45 @@ namespace Apache.Calcite.Data.Tests
             Assert.Equal(typeof(string), r.GetFieldType(1));
         }
 
+        [Fact]
+        public void GetChar_should_convert_single_character_char_column()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES CAST('a' AS CHAR(1))";
+            using var r = cmd.ExecuteReader();
+            Assert.True(r.Read());
+
+            Assert.Equal('a', r.GetChar(0));
+        }
+
+        [Fact]
+        public void GetChar_should_refuse_char_column_longer_than_one()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES CAST('ab' AS CHAR(2))";
+            using var r = cmd.ExecuteReader();
+            Assert.True(r.Read());
+
+            Assert.Throws<InvalidCastException>(() => r.GetChar(0));
+        }
+
+        [Fact]
+        public void GetChar_should_refuse_varchar_column_of_length_one()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "VALUES CAST('a' AS VARCHAR(1))";
+            using var r = cmd.ExecuteReader();
+            Assert.True(r.Read());
+
+            Assert.Throws<InvalidCastException>(() => r.GetChar(0));
+        }
+
     }
 
 }

--- a/src/Apache.Calcite.Data/Internal/CalciteResultValue.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResultValue.cs
@@ -240,7 +240,10 @@ namespace Apache.Calcite.Data.Internal
         }
 
         /// <summary>
-        /// Implements the GetChar operation.
+        /// Implements the GetChar operation. A <c>CHAR</c> column means a character: Calcite's
+        /// runtime representation of the character family is a string, so the value converts
+        /// when the SQL type is <c>CHAR</c> and the string holds exactly one character. Any
+        /// other SQL type or length is not a character and does not convert.
         /// </summary>
         /// <returns></returns>
         public char GetChar()
@@ -248,6 +251,7 @@ namespace Apache.Calcite.Data.Internal
             return _value switch
             {
                 java.lang.Character c => c.charValue(),
+                string s when _sqlType == SqlTypeName.CHAR && s.Length == 1 => s[0],
                 _ => throw new InvalidCastException($"Cannot convert value of type '{_value?.GetType().Name}' with value '{_value}' (SQL type: {_sqlType}) to 'Char'"),
             };
         }


### PR DESCRIPTION
`GetChar` accepted only `java.lang.Character`, which Calcite never produces — the character family's runtime representation is a string — so every `CHAR(1)` read failed with `InvalidCastException`.

The accessor now follows the SQL type's meaning: a `CHAR` column whose string holds exactly one character converts to that character. Everything else still refuses — a longer `CHAR`, and `VARCHAR` even at length one, since `VARCHAR` means string. This keeps the reader's contract as *the .NET type the SQL type most appropriately means*, rather than a loose runtime-type widening.

Three new tests in `CalciteDataReaderTests` pin the contract: `CHAR(1)` converts, `CHAR(2)` refuses, `VARCHAR(1)` refuses. Full `Data.Tests` green (330).