### PR TITLE
Report the column label from GetName

### DIFF
--- a/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
@@ -176,6 +176,19 @@ namespace Apache.Calcite.Data.Tests
             Assert.Equal(typeof(string), r.GetFieldType(1));
         }
 
+        [Fact]
+        public void GetName_should_return_alias_label()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT \"x\", \"x\" AS \"Foo\" FROM (VALUES (1)) AS t(\"x\")";
+            using var r = cmd.ExecuteReader();
+
+            Assert.Equal("x", r.GetName(0));
+            Assert.Equal("Foo", r.GetName(1));
+        }
+
     }
 
 }

--- a/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 
 
 using Xunit;
@@ -10,7 +11,25 @@ namespace Apache.Calcite.Data.Tests
     public class CalciteDataReaderTests
     {
 
+        static CalciteDataReaderTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.server.ServerDdlExecutor).Assembly);
+        }
+
         const string MultiRowQuery = "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(x, y)";
+
+        /// <summary>
+        /// A column origin needs a real table, and DDL is how this suite gets one; see
+        /// <see cref="CalciteDdlTests"/>. Everything else here queries <c>VALUES</c>, which is nothing's
+        /// origin: Calcite gives such a column the alias as its <c>columnName</c> as well as its label,
+        /// so the two agree and a name test over a derived table cannot tell them apart.
+        /// </summary>
+        static readonly string ServerDdlConnectionString = new CalciteConnectionStringBuilder
+        {
+            Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
+            ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            Schema = "adhoc",
+        };
 
         [Fact]
         public void Should_enumerate_all_rows()
@@ -179,14 +198,29 @@ namespace Apache.Calcite.Data.Tests
         [Fact]
         public void GetName_should_return_alias_label()
         {
-            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            using var c = new CalciteConnection(ServerDdlConnectionString);
             c.Open();
+
+            using (var ddl = c.CreateCommand())
+            {
+                ddl.CommandText = "CREATE TABLE IF NOT EXISTS \"labeltest\" (\"PostalCode\" INTEGER NOT NULL, \"City\" VARCHAR(64))";
+                ddl.ExecuteNonQuery();
+            }
+
             using var cmd = c.CreateCommand();
-            cmd.CommandText = "SELECT \"x\", \"x\" AS \"Foo\" FROM (VALUES (1)) AS t(\"x\")";
+            cmd.CommandText = "SELECT \"PostalCode\", \"PostalCode\" AS \"Foo\", \"City\" FROM \"labeltest\"";
             using var r = cmd.ExecuteReader();
 
-            Assert.Equal("x", r.GetName(0));
+            // both projections have PostalCode as their origin column, so the origin name reports the
+            // first two as one name; the label is what tells them apart, and a consumer keying the
+            // schema by name — EF Core's FromSqlQueryingEnumerable.BuildIndexMap — throws on the duplicate
+            Assert.Equal("PostalCode", r.GetName(0));
             Assert.Equal("Foo", r.GetName(1));
+            Assert.Equal("City", r.GetName(2));
+
+            // GetOrdinal and GetSchemaTable read the same accessor
+            Assert.Equal(1, r.GetOrdinal("Foo"));
+            Assert.Equal("Foo", r.GetSchemaTable().Rows[1][SchemaTableColumn.ColumnName]);
         }
 
     }

--- a/src/Apache.Calcite.Data/Internal/CalciteResultColumns.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResultColumns.cs
@@ -111,13 +111,17 @@ namespace Apache.Calcite.Data.Internal
         }
 
         /// <summary>
-        /// Gets the name of the column.
+        /// Gets the name of the column: the label — what an <c>AS</c> alias names the result
+        /// column — falling back to the underlying column name when no label is present. Two
+        /// projections of the same column under different aliases are distinct result columns,
+        /// and the origin name would report them as duplicates.
         /// </summary>
         /// <param name="index"></param>
         /// <returns></returns>
         public string GetName(int index)
         {
-            return GetColumn(index).columnName;
+            var column = GetColumn(index);
+            return string.IsNullOrEmpty(column.label) ? column.columnName : column.label;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Data/Internal/CalciteResultColumns.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteResultColumns.cs
@@ -111,17 +111,20 @@ namespace Apache.Calcite.Data.Internal
         }
 
         /// <summary>
-        /// Gets the name of the column: the label — what an <c>AS</c> alias names the result
-        /// column — falling back to the underlying column name when no label is present. Two
-        /// projections of the same column under different aliases are distinct result columns,
-        /// and the origin name would report them as duplicates.
+        /// Gets the name of the column: the label — what an <c>AS</c> alias names the result column.
         /// </summary>
+        /// <remarks>
+        /// This is JDBC's <c>getColumnLabel</c> and it is what ADO.NET's <c>GetName</c> means. The
+        /// origin <c>columnName</c> is the wrong answer: two projections of one table column under
+        /// different aliases share it, so the result schema reports a duplicate name and a consumer
+        /// keying by it fails. The label is always set — the metadata is built one column per field
+        /// of the validated row type, and the label is that field's name.
+        /// </remarks>
         /// <param name="index"></param>
         /// <returns></returns>
         public string GetName(int index)
         {
-            var column = GetColumn(index);
-            return string.IsNullOrEmpty(column.label) ? column.columnName : column.label;
+            return GetColumn(index).label;
         }
 
         /// <summary>


### PR DESCRIPTION
`CalciteDataReader.GetName` returned Avatica's `columnName` — the origin column — rather than the `label`. Two projections of the same column under different aliases therefore reported duplicate names, and consumers building name-keyed maps over the result schema fail: EF Core's `FromSqlQueryingEnumerable.BuildIndexMap` throws on exactly this shape for `SELECT "PostalCode", "PostalCode" AS "Foo", ...`.

The label is JDBC's `getColumnLabel` analog — what an `AS` alias names the result column — and is what ADO.NET's `GetName` means, so it is returned outright. There is nothing to fall back to: the metadata is built one column per field of the validated row type and the label is that field's name, so it is always set, and `columnName` is the origin this exists to stop reporting. `GetOrdinal` and `GetSchemaTable` flow through the same accessor and pick up the fix.

One test pins the alias case, and it needs a real table. Over a derived table Calcite gives a column the alias as its `columnName` as well as its `label`, so the two agree there and an assertion over one holds under either accessor — the first version of this test could not fail, measured against the accessor it was meant to pin. The test now creates a table through the server DDL parser, as `CalciteDdlTests` does, and reads `SELECT "PostalCode", "PostalCode" AS "Foo", "City"`: both projections carry `PostalCode` as their origin, and only the label tells them apart. It fails with `PostalCode` for the aliased column against the accessor this replaces. `GetOrdinal` and `GetSchemaTable` are asserted alongside it.

Full `Data.Tests` green (328) on net8.0 and net10.0.
