### PR TITLE
Aggregate MIN, MAX, SUM and AVG over an ANY column

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregate.cs
@@ -91,7 +91,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(new AggImpState(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
 
             // the accumulator's state, and the block that sets it to its starting value
             var initExpressions = new java.util.ArrayList();
@@ -153,7 +153,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                results.add(agg.implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregate.cs
@@ -91,7 +91,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(new ClrAggImpState(i, (AggregateCall)getAggCallList().get(i), false));
 
             // the accumulator's state, and the block that sets it to its starting value
             var initExpressions = new java.util.ArrayList();
@@ -152,8 +152,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                var agg = (ClrAggImpState)aggs.get(i);
+                results.add(agg.Implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateBase.cs
@@ -69,7 +69,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         protected static bool HasOrderedCall(java.util.List aggs)
         {
             for (int i = 0; i < aggs.size(); i++)
-                if (((AggImpState)aggs.get(i)).call.collation.equals(RelCollations.EMPTY) == false)
+                if (((ClrAggImpState)aggs.get(i)).call.collation.equals(RelCollations.EMPTY) == false)
                     return true;
 
             return false;
@@ -142,10 +142,10 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
                 agg.context = new ClrAggContext(agg, typeFactory, inputRowType, groupSet, groupSets);
 
-                var state = agg.Implementor().getStateType(agg.context);
+                var state = agg.Implementor.getStateType(agg.context);
                 if (state.isEmpty())
                 {
                     agg.state = com.google.common.collect.ImmutableList.of();
@@ -165,7 +165,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
                 agg.state = decls;
                 initExpressions.addAll(decls);
-                agg.Implementor().implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
+                agg.Implementor.implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
             }
 
             return aggStateTypes;
@@ -192,7 +192,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             for (int i = 0, stateOffset = 0; i < aggs.size(); i++)
             {
                 var builder = new J.BlockBuilder();
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
                 var stateSize = agg.state.size();
                 var accumulator = new java.util.ArrayList(stateSize);
@@ -202,7 +202,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 agg.state = accumulator;
                 stateOffset += stateSize;
 
-                agg.Implementor().implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
+                agg.Implementor.implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
                 builder.add(J.Expressions.return_(null, acc_));
 
                 adders.add(
@@ -271,7 +271,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
                 var adder = (Expression)adders.get(i);
 
                 if (agg.call.collation.equals(RelCollations.EMPTY))

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableAggregateBase.cs
@@ -145,7 +145,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 var agg = (AggImpState)aggs.get(i);
                 agg.context = new ClrAggContext(agg, typeFactory, inputRowType, groupSet, groupSets);
 
-                var state = agg.implementor.getStateType(agg.context);
+                var state = agg.Implementor().getStateType(agg.context);
                 if (state.isEmpty())
                 {
                     agg.state = com.google.common.collect.ImmutableList.of();
@@ -165,7 +165,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
                 agg.state = decls;
                 initExpressions.addAll(decls);
-                agg.implementor.implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
+                agg.Implementor().implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
             }
 
             return aggStateTypes;
@@ -202,7 +202,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 agg.state = accumulator;
                 stateOffset += stateSize;
 
-                agg.implementor.implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
+                agg.Implementor().implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
                 builder.add(J.Expressions.return_(null, acc_));
 
                 adders.add(

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
@@ -126,7 +126,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(new AggImpState(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
 
             var initExpressions = new java.util.ArrayList();
             var initBlock = new J.BlockBuilder();
@@ -167,7 +167,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                results.add(agg.implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableSortedAggregate.cs
@@ -126,7 +126,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(new ClrAggImpState(i, (AggregateCall)getAggCallList().get(i), false));
 
             var initExpressions = new java.util.ArrayList();
             var initBlock = new J.BlockBuilder();
@@ -166,8 +166,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                var agg = (ClrAggImpState)aggs.get(i);
+                results.add(agg.Implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
@@ -184,7 +184,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 if (call.ignoreNulls())
                     throw new java.lang.UnsupportedOperationException("IGNORE NULLS not supported");
 
-                aggs.add(new AggImpState(aggIdx, call, true));
+                aggs.add(ClrAnyAggImplementors.State(aggIdx, call, true));
             }
 
             // the output of this group is its input plus one field per aggregate
@@ -291,7 +291,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                agg.implementor.implementReset(agg.context,
+                agg.Implementor().implementReset(agg.context,
                     new WinAggResetContextImpl(resetBuilder, agg.state, loop.Index, loop.Start, loop.End, loop.HasRows, loop.FrameRowCount, loop.PartitionRowCount));
             }
 
@@ -299,7 +299,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                agg.implementor.implementAdd(agg.context,
+                agg.Implementor().implementAdd(agg.context,
                     new ClrWinAggAddContext(addBuilder, agg.state, frame, loop.Position, RexArguments(agg, result.PhysType.RelRowType, constants)));
             }
 
@@ -492,7 +492,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 agg.context = new ClrWinAggContext(agg, typeFactory, result.PhysType.RelRowType, constants, exclusion);
 
                 var aggName = ClrAsyncEnumerableAggregateBase.AggName(agg);
-                var state = agg.implementor.getStateType(agg.context);
+                var state = agg.Implementor().getStateType(agg.context);
 
                 var decls = new java.util.ArrayList(state.size());
                 for (int j = 0; j < state.size(); j++)
@@ -522,7 +522,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 stateTypes.add(aggHolderType);
                 initExpressions.add(aggRes);
 
-                agg.implementor.implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
+                agg.Implementor().implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
             }
         }
 
@@ -548,13 +548,13 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             {
                 var agg = (AggImpState)aggs.get(i);
 
-                var needCache = agg.implementor is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
+                var needCache = agg.Implementor() is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
                 if (needCache ^ cachedBlock)
                     continue;
 
                 nonEmpty = true;
 
-                var res = agg.implementor.implementResult(agg.context,
+                var res = agg.Implementor().implementResult(agg.context,
                     new ClrWinAggResultContext(builder, agg.state, frame, RexArguments(agg, inputRowType, constants)));
 
                 // several count(a) and count(b) might share the result

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
@@ -184,7 +184,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 if (call.ignoreNulls())
                     throw new java.lang.UnsupportedOperationException("IGNORE NULLS not supported");
 
-                aggs.add(ClrAnyAggImplementors.State(aggIdx, call, true));
+                aggs.add(new ClrAggImpState(aggIdx, call, true));
             }
 
             // the output of this group is its input plus one field per aggregate
@@ -192,7 +192,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             typeBuilder.addAll(inputPhysType.RelRowType.getFieldList());
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
                 // [CALCITE-4326] NullPointerException possible in EnumerableWindow when agg.call.name is null
                 typeBuilder.add(agg.call.name ?? throw new java.lang.NullPointerException($"agg.call.name for {agg.call}"), agg.call.type);
@@ -242,7 +242,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             // out of a lambda rather than something mutated where it was declared
             for (int i = 0, slot = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
                 var state = new java.util.ArrayList(agg.state.size());
                 for (int j = 0; j < agg.state.size(); j++)
@@ -290,16 +290,16 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             var resetBuilder = new J.BlockBuilder();
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                agg.Implementor().implementReset(agg.context,
+                var agg = (ClrAggImpState)aggs.get(i);
+                agg.Implementor.implementReset(agg.context,
                     new WinAggResetContextImpl(resetBuilder, agg.state, loop.Index, loop.Start, loop.End, loop.HasRows, loop.FrameRowCount, loop.PartitionRowCount));
             }
 
             var addBuilder = new J.BlockBuilder();
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                agg.Implementor().implementAdd(agg.context,
+                var agg = (ClrAggImpState)aggs.get(i);
+                agg.Implementor.implementAdd(agg.context,
                     new ClrWinAggAddContext(addBuilder, agg.state, frame, loop.Position, RexArguments(agg, result.PhysType.RelRowType, constants)));
             }
 
@@ -488,11 +488,11 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         {
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
                 agg.context = new ClrWinAggContext(agg, typeFactory, result.PhysType.RelRowType, constants, exclusion);
 
                 var aggName = ClrAsyncEnumerableAggregateBase.AggName(agg);
-                var state = agg.Implementor().getStateType(agg.context);
+                var state = agg.Implementor.getStateType(agg.context);
 
                 var decls = new java.util.ArrayList(state.size());
                 for (int j = 0; j < state.size(); j++)
@@ -522,7 +522,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 stateTypes.add(aggHolderType);
                 initExpressions.add(aggRes);
 
-                agg.Implementor().implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
+                agg.Implementor.implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
             }
         }
 
@@ -546,15 +546,15 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
-                var needCache = agg.Implementor() is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
+                var needCache = agg.Implementor is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
                 if (needCache ^ cachedBlock)
                     continue;
 
                 nonEmpty = true;
 
-                var res = agg.Implementor().implementResult(agg.context,
+                var res = agg.Implementor.implementResult(agg.context,
                     new ClrWinAggResultContext(builder, agg.state, frame, RexArguments(agg, inputRowType, constants)));
 
                 // several count(a) and count(b) might share the result

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAggImpState.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAggImpState.cs
@@ -1,0 +1,72 @@
+using org.apache.calcite.adapter.enumerable;
+using org.apache.calcite.rel.core;
+
+namespace Apache.Calcite.Extensions.Adapter.Enumerable
+{
+
+    /// <summary>
+    /// The state of one aggregate call while a node of either CLR convention is being implemented.
+    /// </summary>
+    /// <remarks>
+    /// <c>AggImpState</c> with a second implementor beside the one it already has, which is not a shape anyone
+    /// would choose. Every value in <c>AggImpState.implementor</c> is the right one but for a call of type
+    /// ANY, which needs <see cref="ClrAnyAggImplementors"/>'s.
+    ///
+    /// <para><b>1.42 leaves nothing to extend.</b> <c>RexImpTable</c>'s constructor is private, its
+    /// <c>Builder</c> is a private static class, <c>INSTANCE</c> is the only instance there will ever be, and
+    /// <c>AggImpState</c>'s only constructor calls <c>RexImpTable.INSTANCE.get(...)</c> by name. So a table of
+    /// our own could neither be built nor consulted. The one seam left is which object a node reads the
+    /// implementor back out of, and this is that.</para>
+    ///
+    /// <para><b>And the base field cannot simply be corrected.</b> It is <c>final</c> in Java, and IKVM emits
+    /// a Java <c>public final</c> field as a get-only property — so it is read only from C# even here, in a
+    /// subclass. Measured rather than assumed: assigning it is CS0200. Hence a second field, and hence every
+    /// node reading <see cref="Implementor"/> rather than <c>implementor</c>. The base field is left visible
+    /// rather than hidden, so that what <c>RexImpTable</c> answered can be read next to what is being used
+    /// instead; for every call but an ANY one the two are the same object.</para>
+    ///
+    /// <para><b>1.43 adds the extension point, and this class is what to delete when we take it.</b>
+    /// <c>RexImplementorTable</c> is a public interface with <c>get(SqlAggFunction, boolean)</c>, and
+    /// <c>AggImpState</c> gains an <c>(int, AggregateCall, boolean, RexImplementorTable)</c> constructor —
+    /// with the three argument one deprecated in its favour. Present at <c>main</c>, absent at both
+    /// <c>calcite-1.41.0</c> and <c>calcite-1.42.0</c>, checked with <c>git cat-file -e</c>. Then the right
+    /// shape is a <c>RexImplementorTable</c> that delegates to <c>RexImpTable.INSTANCE</c> and answers
+    /// <see cref="ClrAnyAggImplementors"/> for an ANY call, handed to that constructor — at which point this
+    /// type goes away and every site reads <c>agg.implementor</c> again.</para>
+    ///
+    /// <para>Calcite never sees one of these: nothing upstream builds this project's nodes or reads their
+    /// state, so every <c>AggImpState</c> in either convention is one of these and the cast at each read
+    /// site is total.</para>
+    /// </remarks>
+    sealed class ClrAggImpState : AggImpState
+    {
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="aggIdx"></param>
+        /// <param name="call"></param>
+        /// <param name="windowContext"></param>
+        public ClrAggImpState(int aggIdx, AggregateCall call, bool windowContext) :
+            base(aggIdx, call, windowContext)
+        {
+            // one substitution serves a window as well, because a window context falls through to the regular
+            // implementor for any function without one of its own, and none of the ANY functions has one
+            Implementor = ClrAnyAggImplementors.For(call) ?? implementor;
+        }
+
+        /// <summary>
+        /// Gets the implementor this call is to be written with.
+        /// </summary>
+        /// <remarks>
+        /// Settled once rather than worked out per read, which is the other half of why this is a field and
+        /// not a method. <c>StrictAggImplementor</c> keeps state across the phases it is called in: it works
+        /// out its state size and whether it has to track an empty set in <c>getStateType</c>, and reads both
+        /// back in <c>implementAdd</c> and <c>implementResult</c>. An implementor built afresh at each phase
+        /// would answer from a state that had never been sized.
+        /// </remarks>
+        public AggImplementor Implementor { get; }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAnyAggImplementors.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAnyAggImplementors.cs
@@ -1,0 +1,257 @@
+using System;
+
+using org.apache.calcite.adapter.enumerable;
+using org.apache.calcite.rel.core;
+using org.apache.calcite.runtime;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.type;
+
+using J = org.apache.calcite.linq4j.tree;
+
+namespace Apache.Calcite.Extensions.Adapter.Enumerable
+{
+
+    /// <summary>
+    /// The aggregate implementors this project adds for a column of type ANY, and the state that carries one
+    /// in place of the implementor <c>RexImpTable</c> would have answered.
+    /// </summary>
+    /// <remarks>
+    /// Not a port. Calcite cannot aggregate over ANY either, and the two ways it fails are both measured in
+    /// <c>ClrEnumerableDifferentialTests</c>: <c>MinMaxImplementor</c> names <c>SqlFunctions.lesser</c> and
+    /// asks <c>Types.lookupMethod</c> to resolve it against the accumulator's static type, which for ANY is
+    /// <c>Object</c> and has no overload; <c>SumImplementor</c> writes a binary <c>+</c>, which Janino refuses
+    /// over two <c>Object</c>s. Both fail before a row is read, so <c>EnumerableConvention</c> forms a plan for
+    /// MIN, MAX, SUM and AVG over an ANY column and then cannot implement it. There is nothing upstream to
+    /// reproduce, which is why these are an addition rather than a defect, and why the differential tests
+    /// cannot use Calcite as the oracle for them.
+    ///
+    /// <para>What the addition reaches for is Calcite's own, though. A value of type ANY carries its type at
+    /// run time and nowhere else, so the operation has to be chosen per value, and <c>SqlFunctions</c> already
+    /// does that for the scalar case: <c>RexImpTable.BinaryImplementor</c> answers <c>ltAny</c>,
+    /// <c>plusAny</c>, <c>divideAny</c> and the rest whenever an operand is ANY. These implementors call that
+    /// same runtime from the accumulator, so a minimum over ANY orders its values the way <c>&lt;</c> over ANY
+    /// orders them and a sum adds them the way <c>+</c> over ANY adds them — mixed numeric types included,
+    /// which is the case a schema of ANY columns is usually there for. It also fixes the answer's type:
+    /// <c>plusAny</c> converts both operands to <c>java.math.BigDecimal</c>, so SUM and AVG over ANY are
+    /// BigDecimal however the column's values were boxed.</para>
+    ///
+    /// <para>AVG needs no implementor of its own. <c>RexImpTable</c> has none for it in any type — a program
+    /// runs <c>AGGREGATE_REDUCE_FUNCTIONS</c> first and the call becomes <c>$SUM0</c> over <c>COUNT</c> — so
+    /// once <c>$SUM0</c> accumulates, the division left behind is a <c>RexCall</c> and
+    /// <c>BinaryImplementor</c>'s ANY path already answers it.</para>
+    /// </remarks>
+    static class ClrAnyAggImplementors
+    {
+
+        /// <summary>
+        /// Returns the state of one aggregate call, holding the implementor that call is to be written with.
+        /// </summary>
+        /// <param name="aggIdx"></param>
+        /// <param name="call"></param>
+        /// <param name="windowContext"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>new AggImpState(...)</c> for every node of both conventions. It exists because
+        /// <c>AggImpState.implementor</c> is final and is filled from <c>RexImpTable.INSTANCE</c> by the
+        /// constructor, so an implementor of ours cannot be put there: the substitution travels beside the
+        /// state rather than in it, and <see cref="Implementor"/> is where every site reads it.
+        /// </remarks>
+        public static AggImpState State(int aggIdx, AggregateCall call, bool windowContext)
+        {
+            return new ClrAggImpState(aggIdx, call, windowContext);
+        }
+
+        /// <summary>
+        /// Returns the implementor an aggregate call is to be written with.
+        /// </summary>
+        /// <param name="agg"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>agg.implementor</c> everywhere except where the call's type is ANY, and one instance per call
+        /// rather than one per read: <c>StrictAggImplementor</c> works out its state size and whether it has
+        /// to track an empty set in <c>getStateType</c> and reads both back in <c>implementAdd</c> and
+        /// <c>implementResult</c>, so an implementor built afresh at each phase would answer from a state that
+        /// had never been sized.
+        /// </remarks>
+        public static AggImplementor Implementor(this AggImpState agg)
+        {
+            return agg is ClrAggImpState state ? state.Implementor : agg.implementor;
+        }
+
+        /// <summary>
+        /// Returns the implementor to write a call of type ANY with, or null where there is none.
+        /// </summary>
+        /// <param name="call"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The call's own type rather than its argument's, because that is what breaks Calcite's implementors:
+        /// <c>StrictAggImplementor.getNotNullState</c> takes the accumulator's type from
+        /// <c>info.returnType()</c>, and an ANY return type is what makes it <c>Object</c>. MIN, MAX and SUM
+        /// all return the type they read, so for these three the two are the same type anyway.
+        ///
+        /// <para>COUNT is not here and needs nothing: it never looks at the value.</para>
+        /// </remarks>
+        static AggImplementor? For(AggregateCall call)
+        {
+            if (call.getType().getSqlTypeName() != SqlTypeName.ANY)
+                return null;
+
+            // by name, because a Java enum's ordinals are not stable across versions
+            return call.getAggregation().getKind().name() switch
+            {
+                nameof(SqlKind.MIN) => new ClrAnyMinMaxImplementor(true),
+                nameof(SqlKind.MAX) => new ClrAnyMinMaxImplementor(false),
+                nameof(SqlKind.SUM) or nameof(SqlKind.SUM0) => new ClrAnySumImplementor(),
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// An <c>AggImpState</c> that carries the implementor its call is to be written with.
+        /// </summary>
+        /// <remarks>
+        /// Calcite never sees one of these: every <c>AggImpState</c> either convention builds is built here,
+        /// and the only code that reads the implementor back is this project's own aggregate, sorted aggregate
+        /// and window.
+        /// </remarks>
+        sealed class ClrAggImpState : AggImpState
+        {
+
+            /// <summary>
+            /// Initializes a new instance.
+            /// </summary>
+            /// <param name="aggIdx"></param>
+            /// <param name="call"></param>
+            /// <param name="windowContext"></param>
+            public ClrAggImpState(int aggIdx, AggregateCall call, bool windowContext) :
+                base(aggIdx, call, windowContext)
+            {
+                // one substitution serves a window as well, because a window context falls through to the
+                // regular implementor for any function without one of its own, and none of these three has one
+                Implementor = For(call) ?? implementor;
+            }
+
+            /// <inheritdoc cref="ClrAnyAggImplementors.Implementor" />
+            public AggImplementor Implementor { get; }
+
+        }
+
+        /// <summary>
+        /// Implements MIN and MAX over a value whose type is only known at run time.
+        /// </summary>
+        /// <remarks>
+        /// <c>RexImpTable.MinMaxImplementor</c> with its comparison changed. That one calls
+        /// <c>SqlFunctions.lesser</c>, which compares with <c>Comparable.compareTo</c> and so requires the two
+        /// values to be of one class — true of every column whose type Calcite can name, and not of an ANY
+        /// column, where <c>compareTo</c> on an <c>Integer</c> and a <c>Double</c> throws. So the comparison
+        /// here is <c>ltAny</c> and <c>gtAny</c>, which is what <c>BinaryImplementor</c> answers for a scalar
+        /// <c>&lt;</c> over ANY: same class compares directly, two numbers compare as BigDecimal, and anything
+        /// else is refused with Calcite's own message.
+        ///
+        /// <para>Those two take no null, where <c>lesser</c> does, so the empty accumulator is tested here
+        /// instead. It is only ever null when no row has been folded in yet:
+        /// <c>StrictAggImplementor.implementAdd</c> guards the whole block on the arguments being non-null, so
+        /// a null the column holds never reaches this. The reset is Calcite's own and needs no override —
+        /// <c>Primitive.of(Object)</c> is null, so the accumulator starts null.</para>
+        /// </remarks>
+        sealed class ClrAnyMinMaxImplementor(bool min) : StrictAggImplementor
+        {
+
+            /// <inheritdoc />
+            protected override void implementNotNullAdd(AggContext info, AggAddContext add)
+            {
+                var acc = (J.Expression)add.accumulator().get(0);
+
+                // named once, because it is read three times below and is an arbitrary expression rather than
+                // a field: MinMaxImplementor reads its argument once and needs no such declaration
+                var arg = add.currentBlock().append("arg", (J.Expression)add.arguments().get(0));
+
+                accAdvance(add, acc,
+                    J.Expressions.condition(
+                        J.Expressions.equal(acc, J.Expressions.constant(null)),
+                        arg,
+                        J.Expressions.condition(
+                            J.Expressions.call(min ? LtAny : GtAny, arg, acc),
+                            arg,
+                            acc)));
+            }
+
+        }
+
+        /// <summary>
+        /// Implements SUM and $SUM0 over a value whose type is only known at run time.
+        /// </summary>
+        /// <remarks>
+        /// <c>RexImpTable.SumImplementor</c>, whose <c>Expressions.add</c> becomes a call to
+        /// <c>SqlFunctions.plusAny</c> — the addition Calcite already performs for a scalar <c>+</c> whose
+        /// operand is ANY, which converts both sides to <c>java.math.BigDecimal</c> and refuses anything that
+        /// is not a number.
+        ///
+        /// <para>The reset is <c>SumImplementor</c>'s, copied: the accumulator starts at the <c>int</c>
+        /// constant zero, which the translator boxes the Java way on its way into an <c>Object</c> slot, so
+        /// <c>plusAny</c> is handed a <c>java.lang.Integer</c> rather than a CLR box it would refuse. An empty
+        /// set is still <c>StrictAggImplementor</c>'s business: SUM is nullable and answers null, $SUM0 is not
+        /// and answers the zero.</para>
+        /// </remarks>
+        sealed class ClrAnySumImplementor : StrictAggImplementor
+        {
+
+            /// <inheritdoc />
+            protected override void implementNotNullReset(AggContext info, AggResetContext reset)
+            {
+                reset.currentBlock().add(
+                    J.Expressions.statement(
+                        J.Expressions.assign((J.Expression)reset.accumulator().get(0), Zero)));
+            }
+
+            /// <inheritdoc />
+            protected override void implementNotNullAdd(AggContext info, AggAddContext add)
+            {
+                var acc = (J.Expression)add.accumulator().get(0);
+                var arg = (J.Expression)add.arguments().get(0);
+
+                accAdvance(add, acc, J.Expressions.call(PlusAny, acc, arg));
+            }
+
+            /// <summary>
+            /// <c>Expressions.constant(0)</c>, which is an <c>int</c> rather than a box.
+            /// </summary>
+            static readonly J.ConstantExpression Zero = J.Expressions.constant(java.lang.Integer.valueOf(0));
+
+        }
+
+        /// <summary>
+        /// <c>SqlFunctions.ltAny(Object, Object)</c>.
+        /// </summary>
+        static readonly java.lang.reflect.Method LtAny = AnyOfTwo("ltAny");
+
+        /// <summary>
+        /// <c>SqlFunctions.gtAny(Object, Object)</c>.
+        /// </summary>
+        static readonly java.lang.reflect.Method GtAny = AnyOfTwo("gtAny");
+
+        /// <summary>
+        /// <c>SqlFunctions.plusAny(Object, Object)</c>.
+        /// </summary>
+        static readonly java.lang.reflect.Method PlusAny = AnyOfTwo("plusAny");
+
+        /// <summary>
+        /// Returns the <c>SqlFunctions</c> method of a name taking two <c>Object</c>s.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Named as a method rather than written into the tree as a string. That is half of the fix for MIN
+        /// and MAX: <c>Expressions.call(Type, String, ...)</c> resolves the overload through
+        /// <c>Types.lookupMethod</c> against the arguments' static types, which is exactly the resolution that
+        /// fails when those types are <c>Object</c>.
+        /// </remarks>
+        static java.lang.reflect.Method AnyOfTwo(string name)
+        {
+            return ((java.lang.Class)typeof(SqlFunctions)).getMethod(name, [(java.lang.Class)typeof(java.lang.Object), (java.lang.Class)typeof(java.lang.Object)])
+                ?? throw new NotSupportedException($"Calcite's runtime has no SqlFunctions.{name}(Object, Object).");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAnyAggImplementors.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrAnyAggImplementors.cs
@@ -12,8 +12,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 {
 
     /// <summary>
-    /// The aggregate implementors this project adds for a column of type ANY, and the state that carries one
-    /// in place of the implementor <c>RexImpTable</c> would have answered.
+    /// The aggregate implementors this project adds for a column of type ANY.
     /// </summary>
     /// <remarks>
     /// Not a port. Calcite cannot aggregate over ANY either, and the two ways it fails are both measured in
@@ -23,7 +22,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
     /// over two <c>Object</c>s. Both fail before a row is read, so <c>EnumerableConvention</c> forms a plan for
     /// MIN, MAX, SUM and AVG over an ANY column and then cannot implement it. There is nothing upstream to
     /// reproduce, which is why these are an addition rather than a defect, and why the differential tests
-    /// cannot use Calcite as the oracle for them.
+    /// cannot use Calcite as the oracle for them. <see cref="ClrAggImpState"/> is what carries one to the
+    /// node that writes with it.
     ///
     /// <para>What the addition reaches for is Calcite's own, though. A value of type ANY carries its type at
     /// run time and nowhere else, so the operation has to be chosen per value, and <c>SqlFunctions</c> already
@@ -44,41 +44,6 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
     {
 
         /// <summary>
-        /// Returns the state of one aggregate call, holding the implementor that call is to be written with.
-        /// </summary>
-        /// <param name="aggIdx"></param>
-        /// <param name="call"></param>
-        /// <param name="windowContext"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// <c>new AggImpState(...)</c> for every node of both conventions. It exists because
-        /// <c>AggImpState.implementor</c> is final and is filled from <c>RexImpTable.INSTANCE</c> by the
-        /// constructor, so an implementor of ours cannot be put there: the substitution travels beside the
-        /// state rather than in it, and <see cref="Implementor"/> is where every site reads it.
-        /// </remarks>
-        public static AggImpState State(int aggIdx, AggregateCall call, bool windowContext)
-        {
-            return new ClrAggImpState(aggIdx, call, windowContext);
-        }
-
-        /// <summary>
-        /// Returns the implementor an aggregate call is to be written with.
-        /// </summary>
-        /// <param name="agg"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// <c>agg.implementor</c> everywhere except where the call's type is ANY, and one instance per call
-        /// rather than one per read: <c>StrictAggImplementor</c> works out its state size and whether it has
-        /// to track an empty set in <c>getStateType</c> and reads both back in <c>implementAdd</c> and
-        /// <c>implementResult</c>, so an implementor built afresh at each phase would answer from a state that
-        /// had never been sized.
-        /// </remarks>
-        public static AggImplementor Implementor(this AggImpState agg)
-        {
-            return agg is ClrAggImpState state ? state.Implementor : agg.implementor;
-        }
-
-        /// <summary>
         /// Returns the implementor to write a call of type ANY with, or null where there is none.
         /// </summary>
         /// <param name="call"></param>
@@ -89,9 +54,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <c>info.returnType()</c>, and an ANY return type is what makes it <c>Object</c>. MIN, MAX and SUM
         /// all return the type they read, so for these three the two are the same type anyway.
         ///
-        /// <para>COUNT is not here and needs nothing: it never looks at the value.</para>
+        /// <para>COUNT is not here and needs nothing: it never looks at the value. Nor are the aggregates
+        /// whose implementors already work over an <c>Object</c> — <c>COLLECT</c>, <c>MODE</c>,
+        /// <c>ARG_MIN</c>, <c>ARG_MAX</c>, <c>LISTAGG</c> and <c>JSON_ARRAYAGG</c> all run over ANY untouched,
+        /// in Calcite as well. What is left out and could be added is <c>BIT_AND</c> and <c>BIT_OR</c>, which
+        /// have no <c>Object</c> overload in <c>SqlFunctions</c> and no <c>*Any</c> counterpart to reach for
+        /// either.</para>
         /// </remarks>
-        static AggImplementor? For(AggregateCall call)
+        internal static AggImplementor? For(AggregateCall call)
         {
             if (call.getType().getSqlTypeName() != SqlTypeName.ANY)
                 return null;
@@ -101,39 +71,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             {
                 nameof(SqlKind.MIN) => new ClrAnyMinMaxImplementor(true),
                 nameof(SqlKind.MAX) => new ClrAnyMinMaxImplementor(false),
+
+                // ANY_VALUE is MinMaxImplementor upstream too, and takes its MAX branch: the implementor asks
+                // whether the kind is MIN and this is not it
+                nameof(SqlKind.ANY_VALUE) => new ClrAnyMinMaxImplementor(false),
+
                 nameof(SqlKind.SUM) or nameof(SqlKind.SUM0) => new ClrAnySumImplementor(),
                 _ => null,
             };
-        }
-
-        /// <summary>
-        /// An <c>AggImpState</c> that carries the implementor its call is to be written with.
-        /// </summary>
-        /// <remarks>
-        /// Calcite never sees one of these: every <c>AggImpState</c> either convention builds is built here,
-        /// and the only code that reads the implementor back is this project's own aggregate, sorted aggregate
-        /// and window.
-        /// </remarks>
-        sealed class ClrAggImpState : AggImpState
-        {
-
-            /// <summary>
-            /// Initializes a new instance.
-            /// </summary>
-            /// <param name="aggIdx"></param>
-            /// <param name="call"></param>
-            /// <param name="windowContext"></param>
-            public ClrAggImpState(int aggIdx, AggregateCall call, bool windowContext) :
-                base(aggIdx, call, windowContext)
-            {
-                // one substitution serves a window as well, because a window context falls through to the
-                // regular implementor for any function without one of its own, and none of these three has one
-                Implementor = For(call) ?? implementor;
-            }
-
-            /// <inheritdoc cref="ClrAnyAggImplementors.Implementor" />
-            public AggImplementor Implementor { get; }
-
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregate.cs
@@ -89,7 +89,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(new ClrAggImpState(i, (AggregateCall)getAggCallList().get(i), false));
 
             // the accumulator's state, and the block that sets it to its starting value
             var initExpressions = new java.util.ArrayList();
@@ -150,8 +150,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                var agg = (ClrAggImpState)aggs.get(i);
+                results.add(agg.Implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregate.cs
@@ -89,7 +89,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(new AggImpState(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
 
             // the accumulator's state, and the block that sets it to its starting value
             var initExpressions = new java.util.ArrayList();
@@ -151,7 +151,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                results.add(agg.implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateBase.cs
@@ -67,7 +67,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         protected static bool HasOrderedCall(java.util.List aggs)
         {
             for (int i = 0; i < aggs.size(); i++)
-                if (((AggImpState)aggs.get(i)).call.collation.equals(RelCollations.EMPTY) == false)
+                if (((ClrAggImpState)aggs.get(i)).call.collation.equals(RelCollations.EMPTY) == false)
                     return true;
 
             return false;
@@ -140,10 +140,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
                 agg.context = new ClrAggContext(agg, typeFactory, inputRowType, groupSet, groupSets);
 
-                var state = agg.Implementor().getStateType(agg.context);
+                var state = agg.Implementor.getStateType(agg.context);
                 if (state.isEmpty())
                 {
                     agg.state = com.google.common.collect.ImmutableList.of();
@@ -163,7 +163,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
                 agg.state = decls;
                 initExpressions.addAll(decls);
-                agg.Implementor().implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
+                agg.Implementor.implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
             }
 
             return aggStateTypes;
@@ -190,7 +190,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             for (int i = 0, stateOffset = 0; i < aggs.size(); i++)
             {
                 var builder = new J.BlockBuilder();
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
                 var stateSize = agg.state.size();
                 var accumulator = new java.util.ArrayList(stateSize);
@@ -200,7 +200,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 agg.state = accumulator;
                 stateOffset += stateSize;
 
-                agg.Implementor().implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
+                agg.Implementor.implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
                 builder.add(J.Expressions.return_(null, acc_));
 
                 adders.add(
@@ -269,7 +269,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
                 var adder = (Expression)adders.get(i);
 
                 if (agg.call.collation.equals(RelCollations.EMPTY))

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateBase.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableAggregateBase.cs
@@ -143,7 +143,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 var agg = (AggImpState)aggs.get(i);
                 agg.context = new ClrAggContext(agg, typeFactory, inputRowType, groupSet, groupSets);
 
-                var state = agg.implementor.getStateType(agg.context);
+                var state = agg.Implementor().getStateType(agg.context);
                 if (state.isEmpty())
                 {
                     agg.state = com.google.common.collect.ImmutableList.of();
@@ -163,7 +163,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
                 agg.state = decls;
                 initExpressions.addAll(decls);
-                agg.implementor.implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
+                agg.Implementor().implementReset(agg.context, new AggResultContextImpl(initBlock, agg.call, decls, null, null));
             }
 
             return aggStateTypes;
@@ -200,7 +200,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 agg.state = accumulator;
                 stateOffset += stateSize;
 
-                agg.implementor.implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
+                agg.Implementor().implementAdd(agg.context, new ClrAggAddContext(builder, accumulator, agg, inputPhysType, in_, typeFactory, implementor.Conformance));
                 builder.add(J.Expressions.return_(null, acc_));
 
                 adders.add(

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
@@ -124,7 +124,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(new AggImpState(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
 
             var initExpressions = new java.util.ArrayList();
             var initBlock = new J.BlockBuilder();
@@ -165,7 +165,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                results.add(agg.implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableSortedAggregate.cs
@@ -124,7 +124,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             var aggs = new java.util.ArrayList();
             for (int i = 0; i < getAggCallList().size(); i++)
-                aggs.add(ClrAnyAggImplementors.State(i, (AggregateCall)getAggCallList().get(i), false));
+                aggs.add(new ClrAggImpState(i, (AggregateCall)getAggCallList().get(i), false));
 
             var initExpressions = new java.util.ArrayList();
             var initBlock = new J.BlockBuilder();
@@ -164,8 +164,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                results.add(agg.Implementor().implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
+                var agg = (ClrAggImpState)aggs.get(i);
+                results.add(agg.Implementor.implementResult(agg.context, new AggResultContextImpl(resultBlock, agg.call, agg.state, key_, keyPhysType)));
             }
 
             resultBlock.add(J.Expressions.return_(null, outputCalcite.record(results)));

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
@@ -182,7 +182,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 if (call.ignoreNulls())
                     throw new java.lang.UnsupportedOperationException("IGNORE NULLS not supported");
 
-                aggs.add(ClrAnyAggImplementors.State(aggIdx, call, true));
+                aggs.add(new ClrAggImpState(aggIdx, call, true));
             }
 
             // the output of this group is its input plus one field per aggregate
@@ -190,7 +190,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             typeBuilder.addAll(inputPhysType.RelRowType.getFieldList());
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
                 // [CALCITE-4326] NullPointerException possible in EnumerableWindow when agg.call.name is null
                 typeBuilder.add(agg.call.name ?? throw new java.lang.NullPointerException($"agg.call.name for {agg.call}"), agg.call.type);
@@ -240,7 +240,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             // out of a lambda rather than something mutated where it was declared
             for (int i = 0, slot = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
                 var state = new java.util.ArrayList(agg.state.size());
                 for (int j = 0; j < agg.state.size(); j++)
@@ -288,16 +288,16 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             var resetBuilder = new J.BlockBuilder();
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                agg.Implementor().implementReset(agg.context,
+                var agg = (ClrAggImpState)aggs.get(i);
+                agg.Implementor.implementReset(agg.context,
                     new WinAggResetContextImpl(resetBuilder, agg.state, loop.Index, loop.Start, loop.End, loop.HasRows, loop.FrameRowCount, loop.PartitionRowCount));
             }
 
             var addBuilder = new J.BlockBuilder();
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
-                agg.Implementor().implementAdd(agg.context,
+                var agg = (ClrAggImpState)aggs.get(i);
+                agg.Implementor.implementAdd(agg.context,
                     new ClrWinAggAddContext(addBuilder, agg.state, frame, loop.Position, RexArguments(agg, result.PhysType.RelRowType, constants)));
             }
 
@@ -487,11 +487,11 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         {
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
                 agg.context = new ClrWinAggContext(agg, typeFactory, result.PhysType.RelRowType, constants, exclusion);
 
                 var aggName = ClrEnumerableAggregateBase.AggName(agg);
-                var state = agg.Implementor().getStateType(agg.context);
+                var state = agg.Implementor.getStateType(agg.context);
 
                 var decls = new java.util.ArrayList(state.size());
                 for (int j = 0; j < state.size(); j++)
@@ -521,7 +521,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 stateTypes.add(aggHolderType);
                 initExpressions.add(aggRes);
 
-                agg.Implementor().implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
+                agg.Implementor.implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
             }
         }
 
@@ -545,15 +545,15 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             for (int i = 0; i < aggs.size(); i++)
             {
-                var agg = (AggImpState)aggs.get(i);
+                var agg = (ClrAggImpState)aggs.get(i);
 
-                var needCache = agg.Implementor() is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
+                var needCache = agg.Implementor is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
                 if (needCache ^ cachedBlock)
                     continue;
 
                 nonEmpty = true;
 
-                var res = agg.Implementor().implementResult(agg.context,
+                var res = agg.Implementor.implementResult(agg.context,
                     new ClrWinAggResultContext(builder, agg.state, frame, RexArguments(agg, inputRowType, constants)));
 
                 // several count(a) and count(b) might share the result

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
@@ -182,7 +182,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 if (call.ignoreNulls())
                     throw new java.lang.UnsupportedOperationException("IGNORE NULLS not supported");
 
-                aggs.add(new AggImpState(aggIdx, call, true));
+                aggs.add(ClrAnyAggImplementors.State(aggIdx, call, true));
             }
 
             // the output of this group is its input plus one field per aggregate
@@ -289,7 +289,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                agg.implementor.implementReset(agg.context,
+                agg.Implementor().implementReset(agg.context,
                     new WinAggResetContextImpl(resetBuilder, agg.state, loop.Index, loop.Start, loop.End, loop.HasRows, loop.FrameRowCount, loop.PartitionRowCount));
             }
 
@@ -297,7 +297,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             for (int i = 0; i < aggs.size(); i++)
             {
                 var agg = (AggImpState)aggs.get(i);
-                agg.implementor.implementAdd(agg.context,
+                agg.Implementor().implementAdd(agg.context,
                     new ClrWinAggAddContext(addBuilder, agg.state, frame, loop.Position, RexArguments(agg, result.PhysType.RelRowType, constants)));
             }
 
@@ -491,7 +491,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 agg.context = new ClrWinAggContext(agg, typeFactory, result.PhysType.RelRowType, constants, exclusion);
 
                 var aggName = ClrEnumerableAggregateBase.AggName(agg);
-                var state = agg.implementor.getStateType(agg.context);
+                var state = agg.Implementor().getStateType(agg.context);
 
                 var decls = new java.util.ArrayList(state.size());
                 for (int j = 0; j < state.size(); j++)
@@ -521,7 +521,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 stateTypes.add(aggHolderType);
                 initExpressions.add(aggRes);
 
-                agg.implementor.implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
+                agg.Implementor().implementReset(agg.context, new WinAggResetContextImpl(initBlock, agg.state, null, null, null, null, null, null));
             }
         }
 
@@ -547,13 +547,13 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             {
                 var agg = (AggImpState)aggs.get(i);
 
-                var needCache = agg.implementor is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
+                var needCache = agg.Implementor() is not WinAggImplementor implementor || implementor.needCacheWhenFrameIntact();
                 if (needCache ^ cachedBlock)
                     continue;
 
                 nonEmpty = true;
 
-                var res = agg.implementor.implementResult(agg.context,
+                var res = agg.Implementor().implementResult(agg.context,
                     new ClrWinAggResultContext(builder, agg.state, frame, RexArguments(agg, inputRowType, constants)));
 
                 // several count(a) and count(b) might share the result

--- a/src/Apache.Calcite.Tests/AsyncTestSchema.cs
+++ b/src/Apache.Calcite.Tests/AsyncTestSchema.cs
@@ -79,6 +79,24 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// Values in a column of type ANY, whose Java class is <c>Object</c>.
+        /// </summary>
+        /// <remarks>
+        /// A provider type the ADO.NET adapter has no <c>SqlTypeName</c> for arrives as ANY, so an
+        /// aggregate over one of these has to accumulate a value whose type is only known at run time. The
+        /// same rows as <c>ClrEnumerableDifferentialTests.AnysTable</c>, which is what makes the
+        /// synchronous convention an oracle for this one.
+        /// </remarks>
+        public static readonly object?[][] Anys =
+        [
+            [java.lang.Integer.valueOf(1), "EAST", java.lang.Integer.valueOf(10), "b"],
+            [java.lang.Integer.valueOf(2), "EAST", java.lang.Double.valueOf(20.5), "a"],
+            [java.lang.Integer.valueOf(3), "WEST", java.lang.Integer.valueOf(30), "d"],
+            [java.lang.Integer.valueOf(4), "WEST", null, null],
+            [java.lang.Integer.valueOf(5), "WEST", java.lang.Integer.valueOf(5), "c"],
+        ];
+
+        /// <summary>
         /// Returns the WIDE row type.
         /// </summary>
         public static RelDataType WideRowType(RelDataTypeFactory typeFactory)
@@ -110,6 +128,19 @@ namespace Apache.Calcite.Tests
             return typeFactory.builder()
                 .add("K", typeFactory.createSqlType(SqlTypeName.INTEGER))
                 .add("V", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+                .build();
+        }
+
+        /// <summary>
+        /// Returns the ANYS row type.
+        /// </summary>
+        public static RelDataType AnysRowType(RelDataTypeFactory typeFactory)
+        {
+            return typeFactory.builder()
+                .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                .add("K", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+                .add("V", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
+                .add("S", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
                 .build();
         }
 

--- a/src/Apache.Calcite.Tests/ClrAnyAggregateTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAnyAggregateTests.cs
@@ -189,6 +189,7 @@ namespace Apache.Calcite.Tests
             "SELECT MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS",
             "SELECT K, MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS GROUP BY K",
             "SELECT MIN(S), MAX(S) FROM ANYS",
+            "SELECT ANY_VALUE(V), VAR_POP(V), MIN(V) FILTER (WHERE ID > 1) FROM ANYS",
             "SELECT ID, MIN(V) OVER (PARTITION BY K), SUM(V) OVER (ORDER BY ID) FROM ANYS",
         ];
 

--- a/src/Apache.Calcite.Tests/ClrAnyAggregateTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAnyAggregateTests.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite;
+using org.apache.calcite.linq4j;
+using org.apache.calcite.plan;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.tools;
+
+using Apache.Calcite.Extensions;
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Holds what an aggregate over a column of type ANY compiles to.
+    /// </summary>
+    /// <remarks>
+    /// The answers themselves are asserted by the two differential suites; this asks the other question about
+    /// the same plans, which is what they are made of. MIN, MAX and SUM over ANY are the one place in either
+    /// convention where this project writes a linq4j tree of its own rather than translating one Calcite
+    /// produced — <c>ClrAnyAggImplementors</c> implements <c>AggImplementor</c>, whose contexts hand out a
+    /// <c>BlockBuilder</c> and a list of linq4j expressions and admit nothing else — so the claim that it is
+    /// all translated away before anything runs is worth measuring rather than asserting.
+    ///
+    /// <para>A tree that reached the delegate untranslated would in fact throw at
+    /// <see cref="LambdaExpression.Compile"/> long before it ran, so this is belt and braces. What it really
+    /// guards is the day someone adds a node to those implementors that <c>LixToClrTranslator</c> happens to
+    /// carry across as a constant.</para>
+    /// </remarks>
+    [TestClass]
+    public class ClrAnyAggregateTests
+    {
+
+        /// <summary>
+        /// Initializes the static instance.
+        /// </summary>
+        static ClrAnyAggregateTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(org.apache.calcite.jdbc.CalciteJdbc41Factory).Assembly);
+        }
+
+        /// <summary>
+        /// A table of two ANY columns, one holding numbers of two classes and one holding strings.
+        /// </summary>
+        sealed class AnysTable : AbstractTable, ScannableTable
+        {
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .add("K", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+                    .add("V", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
+                    .add("S", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
+                    .build();
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root)
+            {
+                var list = new java.util.ArrayList();
+                foreach (var row in AsyncTestRows.Anys)
+                    list.add(row);
+
+                return Linq4j.asEnumerable(list);
+            }
+
+        }
+
+        /// <summary>
+        /// The context a plan is bound with.
+        /// </summary>
+        sealed class TestDataContext(SchemaPlus rootSchema, java.util.Map parameters) : DataContext
+        {
+
+            /// <inheritdoc />
+            public SchemaPlus getRootSchema() => rootSchema;
+
+            /// <inheritdoc />
+            public org.apache.calcite.adapter.java.JavaTypeFactory getTypeFactory() => new org.apache.calcite.jdbc.JavaTypeFactoryImpl();
+
+            /// <inheritdoc />
+            public QueryProvider getQueryProvider() => null!;
+
+            /// <inheritdoc />
+            public object get(string name) => parameters.get(name);
+
+        }
+
+        /// <summary>
+        /// Plans a statement into one of the two conventions and returns the tree and the rows it gives.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <param name="async">Whether to plan into the asynchronous convention.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>AGGREGATE_REDUCE_FUNCTIONS</c> for the same reason the differential suites register it: AVG has
+        /// no implementor in any convention, in any type, and is a <c>$SUM0</c> over a <c>COUNT</c> by the
+        /// time a planner sees it.
+        /// </remarks>
+        static async Task<(LambdaExpression Tree, List<string> Rows)> Plan(string sql, bool async)
+        {
+            var rootSchema = Frameworks.createRootSchema(true);
+            rootSchema.add("ANYS", new AnysTable());
+
+            var rules = new java.util.ArrayList();
+            foreach (var rule in async ? ClrAsyncEnumerableRules.Rules() : ClrEnumerableRules.Rules())
+                rules.add(rule);
+            rules.add(org.apache.calcite.rel.rules.CoreRules.AGGREGATE_REDUCE_FUNCTIONS);
+            rules.add(org.apache.calcite.rel.rules.CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW);
+
+            var calcRules = new java.util.ArrayList();
+            foreach (var rule in async ? ClrAsyncEnumerableRules.CalcRules() : ClrEnumerableRules.CalcRules())
+                calcRules.add(rule);
+            foreach (var rule in RelOptRules.CALC_RULES.toArray())
+                calcRules.add(rule);
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(rootSchema)
+                .programs(
+                    Programs.subQuery(org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE),
+                    new DefaultRulesProgram(rules),
+                    Programs.hep(calcRules, true, org.apache.calcite.rel.metadata.DefaultRelMetadataProvider.INSTANCE))
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+            var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+            var expanded = planner.transform(0, logical.getTraitSet(), logical);
+
+            var convention = async ? (Convention)ClrAsyncEnumerableConvention.Instance : ClrEnumerableConvention.Instance;
+            var chosen = planner.transform(1, expanded.getTraitSet().replace(convention).simplify(), expanded);
+            var physical = planner.transform(2, chosen.getTraitSet(), chosen);
+
+            var parameters = new java.util.HashMap();
+            var context = new TestDataContext(rootSchema, parameters);
+            var rows = new List<string>();
+
+            LambdaExpression tree;
+
+            if (async)
+            {
+                var implementor = new ClrAsyncEnumerableRelImplementor(physical.getCluster().getRexBuilder(), parameters);
+                tree = implementor.ImplementRoot((ClrAsyncEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+                var plan = (Func<DataContext, IAsyncEnumerable<object>>)tree.Compile();
+                await foreach (var row in plan(context))
+                    rows.Add(Render(row));
+            }
+            else
+            {
+                var implementor = new ClrEnumerableRelImplementor(physical.getCluster().getRexBuilder(), parameters);
+                tree = implementor.ImplementRoot((ClrEnumerableRel)physical, ClrEnumerablePrefer.Array);
+
+                var plan = (Func<DataContext, IEnumerable<object>>)tree.Compile();
+                foreach (var row in plan(context))
+                    rows.Add(Render(row));
+            }
+
+            return (tree, rows);
+        }
+
+        static string Render(object row)
+        {
+            if (row is object[] array)
+                return string.Join("|", array.Select(Render));
+
+            return row?.ToString() ?? "<null>";
+        }
+
+        /// <summary>
+        /// Every query that reaches one of the ANY implementors, aggregate and window alike.
+        /// </summary>
+        static readonly string[] Queries =
+        [
+            "SELECT MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS",
+            "SELECT K, MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS GROUP BY K",
+            "SELECT MIN(S), MAX(S) FROM ANYS",
+            "SELECT ID, MIN(V) OVER (PARTITION BY K), SUM(V) OVER (ORDER BY ID) FROM ANYS",
+        ];
+
+        [TestMethod]
+        public Task ShouldCompileASyncAnyAggregateToNoLinq4j() => ShouldCompileToNoLinq4j(false);
+
+        [TestMethod]
+        public Task ShouldCompileAnAsyncAnyAggregateToNoLinq4j() => ShouldCompileToNoLinq4j(true);
+
+        static async Task ShouldCompileToNoLinq4j(bool async)
+        {
+            foreach (var sql in Queries)
+            {
+                var (tree, rows) = await Plan(sql, async);
+
+                // the tree is only worth reading if it produced something: a plan that yielded nothing would
+                // satisfy the assertion below without having exercised an implementor at all
+                rows.Should().NotBeEmpty("'{0}' should give rows", sql);
+
+                var found = new Linq4jTrees();
+                found.Visit(tree);
+                found.Found.Should().BeEmpty("'{0}' should hold no linq4j tree node once it is compiled", sql);
+            }
+        }
+
+        /// <summary>
+        /// Collects every reference to a linq4j tree type in an expression tree.
+        /// </summary>
+        /// <remarks>
+        /// <c>org.apache.calcite.linq4j.tree</c> only, and not linq4j as a whole. A plan legitimately holds
+        /// linq4j's <em>runtime</em> — a <c>ScannableTable</c> answers an <c>Enumerable</c> and the scan reads
+        /// it — and what is being asked here is whether a tree Calcite's or ours <em>built</em> survived the
+        /// translation rather than being turned into <see cref="Expression"/>s.
+        /// </remarks>
+        sealed class Linq4jTrees : ExpressionVisitor
+        {
+
+            public readonly List<string> Found = [];
+
+            /// <inheritdoc />
+            public override Expression? Visit(Expression? node)
+            {
+                switch (node)
+                {
+                    case null:
+                        break;
+                    case ConstantExpression constant when constant.Value != null:
+                        Check(constant.Value.GetType(), node);
+                        Check(node.Type, node);
+                        break;
+                    case MethodCallExpression call:
+                        Check(call.Method.DeclaringType, node);
+                        Check(call.Method.ReturnType, node);
+                        foreach (var parameter in call.Method.GetParameters())
+                            Check(parameter.ParameterType, node);
+                        Check(node.Type, node);
+                        break;
+                    case MemberExpression member:
+                        Check(member.Member.DeclaringType, node);
+                        Check(node.Type, node);
+                        break;
+                    case NewExpression created when created.Constructor != null:
+                        Check(created.Constructor.DeclaringType, node);
+                        Check(node.Type, node);
+                        break;
+                    default:
+                        Check(node.Type, node);
+                        break;
+                }
+
+                return base.Visit(node);
+            }
+
+            void Check(Type? type, Expression node)
+            {
+                foreach (var each in Expand(type))
+                    if (each.FullName is string name && name.StartsWith("org.apache.calcite.linq4j.tree.", StringComparison.Ordinal))
+                        Found.Add($"{name} at {node.NodeType}");
+            }
+
+            /// <summary>
+            /// Yields a type and everything it is written in terms of, so that a linq4j node hiding as an
+            /// element or a type argument is seen.
+            /// </summary>
+            static IEnumerable<Type> Expand(Type? type)
+            {
+                if (type == null)
+                    yield break;
+
+                yield return type;
+
+                if (type.HasElementType)
+                    foreach (var each in Expand(type.GetElementType()))
+                        yield return each;
+
+                if (type.IsGenericType)
+                    foreach (var argument in type.GetGenericArguments())
+                        foreach (var each in Expand(argument))
+                            yield return each;
+            }
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -401,6 +401,15 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public Task ShouldAgreeOnARunningTotalOverAnAnyColumn() => SameThrough("ClrAsyncEnumerableWindow", "SELECT ID, SUM(V) OVER (ORDER BY ID) FROM ANYS ORDER BY ID");
 
+        [TestMethod]
+        public Task ShouldAgreeOnTakingAnyValueOfAnAnyColumn() => SameThrough("ClrAsyncEnumerableAggregate", "SELECT ANY_VALUE(V), ANY_VALUE(S) FROM ANYS");
+
+        [TestMethod]
+        public Task ShouldAgreeOnDeviatingOverAnAnyColumn() => Same("SELECT VAR_POP(V), VAR_SAMP(V) FROM ANYS");
+
+        [TestMethod]
+        public Task ShouldAgreeOnFilteringAnAggregateOverAnAnyColumn() => Same("SELECT MIN(V) FILTER (WHERE ID > 1), SUM(V) FILTER (WHERE K = 'EAST') FROM ANYS");
+
         // and the same column read every way that already worked
 
         [TestMethod]

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -54,12 +54,14 @@ namespace Apache.Calcite.Tests
                 rootSchema.add("SALES", new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false));
                 rootSchema.add("SORTED", new AsyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, true));
                 rootSchema.add("WIDE", new AsyncRowsTable(AsyncTestRows.Wide, AsyncTestRows.WideRowType, false));
+                rootSchema.add("ANYS", new AsyncRowsTable(AsyncTestRows.Anys, AsyncTestRows.AnysRowType, false));
             }
             else
             {
                 rootSchema.add("SALES", new SyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false));
                 rootSchema.add("SORTED", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, true));
                 rootSchema.add("WIDE", new SyncRowsTable(AsyncTestRows.Wide, AsyncTestRows.WideRowType, false));
+                rootSchema.add("ANYS", new SyncRowsTable(AsyncTestRows.Anys, AsyncTestRows.AnysRowType, false));
             }
 
             // a table function, which this convention has no node for: Calcite plans it and the converter
@@ -374,6 +376,44 @@ namespace Apache.Calcite.Tests
 
         [TestMethod]
         public Task ShouldAgreeOnAGrandTotal() => Same("SELECT SUM(AMOUNT), MIN(ID), MAX(ID) FROM SALES");
+
+        // MIN, MAX, SUM and AVG over a column of type ANY, whose Java class is Object. Neither convention
+        // gets these from Calcite — ClrAnyAggImplementors says why and ClrEnumerableDifferentialTests asserts
+        // the answers — so what is checked here is the thing this harness is for: that the asynchronous
+        // convention gives what the synchronous one gives, mixed numeric types, strings and an empty group
+        // included.
+
+        [TestMethod]
+        public Task ShouldAgreeOnAggregatingAnAnyColumn() => SameThrough("ClrAsyncEnumerableAggregate", "SELECT MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAGroupedAggregateOverAnAnyColumn() => SameThrough("ClrAsyncEnumerableAggregate", "SELECT K, MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS GROUP BY K ORDER BY K");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAggregatingAnAnyColumnOfStrings() => Same("SELECT MIN(S), MAX(S) FROM ANYS");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAggregatingAnEmptyAnyColumn() => Same("SELECT MIN(V), MAX(V), SUM(V), AVG(V) FROM ANYS WHERE K = 'NORTH'");
+
+        [TestMethod]
+        public Task ShouldAgreeOnWindowingAnAggregateOverAnAnyColumn() => SameThrough("ClrAsyncEnumerableWindow", "SELECT ID, MIN(V) OVER (PARTITION BY K), MAX(V) OVER (PARTITION BY K), SUM(V) OVER (PARTITION BY K) FROM ANYS ORDER BY ID");
+
+        [TestMethod]
+        public Task ShouldAgreeOnARunningTotalOverAnAnyColumn() => SameThrough("ClrAsyncEnumerableWindow", "SELECT ID, SUM(V) OVER (ORDER BY ID) FROM ANYS ORDER BY ID");
+
+        // and the same column read every way that already worked
+
+        [TestMethod]
+        public Task ShouldAgreeOnScanningAnAnyColumn() => Same("SELECT K, V, S FROM ANYS");
+
+        [TestMethod]
+        public Task ShouldAgreeOnCountingAnAnyColumn() => Same("SELECT K, COUNT(V), COUNT(*) FROM ANYS GROUP BY K ORDER BY K");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAggregatingACastAnyColumn() => Same("SELECT MIN(CAST(V AS INTEGER)), MAX(CAST(V AS INTEGER)), SUM(CAST(V AS INTEGER)), AVG(CAST(V AS INTEGER)) FROM ANYS");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAGroupedAggregateOverACastAnyColumn() => Same("SELECT K, MIN(CAST(V AS INTEGER)), SUM(CAST(V AS INTEGER)) FROM ANYS GROUP BY K ORDER BY K");
 
         [TestMethod]
         public Task ShouldAgreeOnDistinct() => Same("SELECT DISTINCT REGION FROM SALES");

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerablePlanCancellationTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerablePlanCancellationTests.cs
@@ -56,12 +56,41 @@ namespace Apache.Calcite.Tests
             return rows;
         }
 
+        /// <summary>
+        /// The same, in the shape of the ANYS table: an INTEGER key and two columns of type ANY.
+        /// </summary>
+        /// <remarks>
+        /// Every fourth row holds a <c>java.lang.Double</c> where the others hold an <c>Integer</c>, which is
+        /// the mixture <c>ClrAnyAggImplementors</c> reaches <c>SqlFunctions.ltAny</c> for. A fold that is only
+        /// ever handed one class would not exercise it.
+        /// </remarks>
+        static object[][] ManyAnys(int count)
+        {
+            var rows = new object[count][];
+            for (int i = 0; i < count; i++)
+                rows[i] = [
+                    java.lang.Integer.valueOf(i),
+                    "R" + (i % 4),
+                    i % 4 == 0 ? java.lang.Double.valueOf(i + 0.5) : java.lang.Integer.valueOf(i),
+                    "S" + (i % 7)];
+
+            return rows;
+        }
+
+        static (IAsyncEnumerable<object> Rows, AsyncRowsTable Leaf) PlanAny(string sql, int rowCount)
+        {
+            return Plan(sql, "ANYS", new AsyncRowsTable(ManyAnys(rowCount), AsyncTestRows.AnysRowType, false));
+        }
+
         static (IAsyncEnumerable<object> Rows, AsyncRowsTable Leaf) Plan(string sql, int rowCount)
         {
-            var leaf = new AsyncRowsTable(Many(rowCount), AsyncTestRows.SortedRowType, false);
+            return Plan(sql, "SORTED", new AsyncRowsTable(Many(rowCount), AsyncTestRows.SortedRowType, false));
+        }
 
+        static (IAsyncEnumerable<object> Rows, AsyncRowsTable Leaf) Plan(string sql, string name, AsyncRowsTable leaf)
+        {
             var rootSchema = Frameworks.createRootSchema(true);
-            rootSchema.add("SORTED", leaf);
+            rootSchema.add(name, leaf);
 
             var rules = new java.util.ArrayList();
             var calcRules = new java.util.ArrayList();
@@ -201,6 +230,74 @@ namespace Apache.Calcite.Tests
 
             cancelled.Should().BeTrue();
             leaf.Produced.Should().BeLessThan(10_000);
+        }
+
+        /// <summary>
+        /// The same, for an aggregate over a column of type ANY.
+        /// </summary>
+        /// <remarks>
+        /// The question this answers is whether the implementors <c>ClrAnyAggImplementors</c> substitutes for
+        /// MIN, MAX and SUM over ANY changed how the asynchronous convention reads its input. They cannot —
+        /// an implementor writes only the fold, which is a function of an accumulator and a row in either
+        /// convention and in Calcite's, and the draining belongs to the operator — but "cannot" is a claim
+        /// about code that was just changed, so it is measured: a fold that blocked, or that drained its
+        /// input before the token was consulted, would read all ten thousand rows and then succeed.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldCancelWhileAnAggregateOverAnAnyColumnIsStillFolding()
+        {
+            var (rows, leaf) = PlanAny("SELECT K, MIN(V), MAX(V), SUM(V), AVG(V), MIN(S) FROM ANYS GROUP BY K", 10_000);
+
+            using var cancellation = new CancellationTokenSource();
+
+            leaf.OnRow = n => { if (n == 50) cancellation.Cancel(); };
+
+            var cancelled = false;
+
+            try
+            {
+                await foreach (var row in rows.WithCancellation(cancellation.Token))
+                {
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+            }
+
+            cancelled.Should().BeTrue();
+            leaf.SawCancellableToken.Should().BeTrue("the leaf must receive the caller's token through the aggregate");
+            leaf.Produced.Should().BeLessThan(10_000);
+        }
+
+        /// <summary>
+        /// An aggregate over an ANY column suspends while it folds, rather than running to completion in one
+        /// synchronous step.
+        /// </summary>
+        /// <remarks>
+        /// Cancellation says the token is seen; this says the plan really gives the thread back. The leaf
+        /// awaits <c>Task.Yield</c> per row, so a fold that drained it without ever suspending would have to
+        /// have blocked on it — and the first <c>MoveNextAsync</c> would then complete already finished.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldFoldAnAnyColumnWithoutBlocking()
+        {
+            var (rows, leaf) = PlanAny("SELECT MIN(V), MAX(V), SUM(V) FROM ANYS", 5_000);
+
+            var enumerator = rows.GetAsyncEnumerator();
+
+            try
+            {
+                var moving = enumerator.MoveNextAsync();
+                moving.IsCompleted.Should().BeFalse("a fold over a leaf that suspends per row cannot finish synchronously");
+
+                (await moving).Should().BeTrue();
+                leaf.Produced.Should().Be(5_000, "the whole input should have been folded by the time the one row arrives");
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+            }
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -955,6 +955,52 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// ANY_VALUE over an ANY column.
+        /// </summary>
+        /// <remarks>
+        /// The same implementor as MAX, upstream and here: <c>RexImpTable</c> answers ANY_VALUE with
+        /// <c>MinMaxImplementor</c>, which asks whether the kind is MIN and takes the other branch when it is
+        /// not. So the value is the largest rather than an arbitrary one, and that is Calcite's choice being
+        /// followed rather than a decision made here.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldTakeAnyValueOfAnAnyColumn() => Gives("SELECT ANY_VALUE(\"V\"), ANY_VALUE(\"S\") FROM \"ANYS\"", "30|d");
+
+        /// <summary>
+        /// The deviations and the variances over an ANY column.
+        /// </summary>
+        /// <remarks>
+        /// None of these has an implementor in any convention, in any type. <c>AGGREGATE_REDUCE_FUNCTIONS</c>
+        /// rewrites each into sums of the value and of its square over a count, so they cost nothing beyond
+        /// SUM working — but that means they are only reachable while it does, and a test says so rather than
+        /// leaving it to be rediscovered.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldDeviateOverAnAnyColumn() => Gives("SELECT VAR_POP(\"V\"), VAR_SAMP(\"V\") FROM \"ANYS\"", "93.171875|124.2291666666667");
+
+        /// <summary>
+        /// An aggregate over an ANY column carrying a FILTER.
+        /// </summary>
+        /// <remarks>
+        /// The filter is <c>StrictAggImplementor</c>'s business rather than an implementor's — it folds into
+        /// the same condition the null check builds — so this works for the same reason the null does. Worth
+        /// a row of its own because Calcite cannot run it, and so the differential suite cannot say it.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldFilterAnAggregateOverAnAnyColumn() => Gives("SELECT MIN(\"V\") FILTER (WHERE \"ID\" > 1), SUM(\"V\") FILTER (WHERE \"K\" = 'EAST') FROM \"ANYS\"", "5|30.5");
+
+        /// <summary>
+        /// A DISTINCT aggregate over an ANY column.
+        /// </summary>
+        /// <remarks>
+        /// Both conventions refuse a distinct call outright, exactly as <c>EnumerableAggregate</c> does, and
+        /// <c>AGGREGATE_EXPAND_DISTINCT_AGGREGATES</c> is what takes the DISTINCT off before either sees it.
+        /// So this measures the rule reaching an ANY column rather than anything in the implementors.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAggregateDistinctlyOverAnAnyColumn() => Gives("SELECT COUNT(DISTINCT \"V\"), SUM(DISTINCT \"V\") FROM \"ANYS\"", "4|65.5");
+
+        /// <summary>
         /// Requires that these are still queries Calcite itself cannot run.
         /// </summary>
         /// <param name="sql"></param>
@@ -993,6 +1039,9 @@ namespace Apache.Calcite.Tests
             StillBeyondCalcite("SELECT MAX(\"V\") FROM \"ANYS\"");
             StillBeyondCalcite("SELECT SUM(\"V\") FROM \"ANYS\"");
             StillBeyondCalcite("SELECT AVG(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT ANY_VALUE(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT VAR_POP(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT MIN(\"V\") FILTER (WHERE \"ID\" > 1) FROM \"ANYS\"");
             StillBeyondCalcite("SELECT \"K\", MIN(\"V\"), SUM(\"V\") FROM \"ANYS\" GROUP BY \"K\"");
         }
 

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -190,6 +190,57 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// A table with a column of type ANY, whose Java class is <c>Object</c> and whose values therefore
+        /// carry no type the plan can read.
+        /// </summary>
+        /// <remarks>
+        /// Not a curiosity: a provider type the ADO.NET adapter has no <c>SqlTypeName</c> for arrives as
+        /// ANY, so this is the shape a column of an unmapped type has. Every other fixture here declares a
+        /// concrete type, so until now nothing asked an aggregate to accumulate over a value whose type is
+        /// only known at run time.
+        ///
+        /// <para>An ordinary INTEGER key in front, so that a window over this table has something to order
+        /// by that is not itself ANY. Three shapes after it, on purpose. <c>V</c> mixes a <c>java.lang.Integer</c> with a
+        /// <c>java.lang.Double</c>, which is the ordinary case for a document store and the one a comparison
+        /// through <c>Comparable.compareTo</c> throws on; <c>S</c> holds strings, which are orderable and not
+        /// addable; and both have a null, so that an aggregate has one to skip.</para>
+        /// </remarks>
+        sealed class AnysTable : AbstractTable, ScannableTable
+        {
+
+            static readonly object?[][] Rows =
+            [
+                [java.lang.Integer.valueOf(1), "EAST", java.lang.Integer.valueOf(10), "b"],
+                [java.lang.Integer.valueOf(2), "EAST", java.lang.Double.valueOf(20.5), "a"],
+                [java.lang.Integer.valueOf(3), "WEST", java.lang.Integer.valueOf(30), "d"],
+                [java.lang.Integer.valueOf(4), "WEST", null, null],
+                [java.lang.Integer.valueOf(5), "WEST", java.lang.Integer.valueOf(5), "c"],
+            ];
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .add("K", typeFactory.createSqlType(SqlTypeName.VARCHAR))
+                    .add("V", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
+                    .add("S", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
+                    .build();
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root)
+            {
+                var list = new java.util.ArrayList();
+                foreach (var row in Rows)
+                    list.add(row);
+
+                return Linq4j.asEnumerable(list);
+            }
+
+        }
+
+        /// <summary>
         /// A table of twelve distinct keys, which is the one row count at which a hash join's leftovers can
         /// come out in the wrong order.
         /// </summary>
@@ -332,6 +383,7 @@ namespace Apache.Calcite.Tests
             rootSchema.add("SORTED", new SortedTable());
             rootSchema.add("SCALARS", new ScalarsTable());
             rootSchema.add("WIDE", new WideTable());
+            rootSchema.add("ANYS", new AnysTable());
             rootSchema.add("FIB", org.apache.calcite.schema.impl.TableFunctionImpl.create(org.apache.calcite.util.Smalls.FIBONACCI_LIMIT_100_TABLE_METHOD));
 
             // A CUSTOM-format fixture, which every other table here is not. HrSchema's rows are instances of
@@ -802,6 +854,162 @@ namespace Apache.Calcite.Tests
         /// </summary>
         [TestMethod]
         public void ShouldAgreeOnAGroupBysOwnOrder() => Same("SELECT \"REGION\", COUNT(*) FROM \"SALES\" GROUP BY \"REGION\"");
+
+        // MIN, MAX, SUM and AVG over a column of type ANY, whose Java class is Object.
+        //
+        // Not Same: Calcite cannot run any of these, so there is no oracle to compare against and the answers
+        // are asserted by hand, exactly as they are for a .NET user-defined function. What Calcite does with
+        // them is held separately by ShouldStillBeBeyondCalcite below, which is the test that says when to
+        // come back here — the day Calcite implements these, these answers are what its own should be
+        // compared against.
+        //
+        // The values are BigDecimal wherever SqlFunctions.plusAny and divideAny have been through them, which
+        // is what Calcite's ANY arithmetic answers for a scalar + as well.
+
+        [TestMethod]
+        public void ShouldAggregateAnAnyColumn() => Gives("SELECT MIN(\"V\"), MAX(\"V\"), SUM(\"V\"), AVG(\"V\") FROM \"ANYS\"", "5|30|65.5|16.375");
+
+        [TestMethod]
+        public void ShouldGroupAnAggregateOverAnAnyColumn() => Gives("SELECT \"K\", MIN(\"V\"), MAX(\"V\"), SUM(\"V\"), AVG(\"V\") FROM \"ANYS\" GROUP BY \"K\" ORDER BY \"K\"", "EAST|10|20.5|30.5|15.25", "WEST|5|30|35|17.5");
+
+        /// <summary>
+        /// MIN and MAX over an ANY column holding two numeric classes.
+        /// </summary>
+        /// <remarks>
+        /// The case that decides the comparison. <c>SqlFunctions.lesser</c>, which
+        /// <c>RexImpTable.MinMaxImplementor</c> calls, compares through <c>Comparable.compareTo</c> and throws
+        /// on an <c>Integer</c> against a <c>Double</c>; <c>ltAny</c> compares the two as BigDecimal, which is
+        /// what a scalar <c>&lt;</c> over ANY already does. A schema of ANY columns is usually a document
+        /// store, where one path holding both is the ordinary case rather than the odd one.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAggregateAnAnyColumnOfMixedNumericTypes() => Gives("SELECT MIN(\"V\"), MAX(\"V\") FROM \"ANYS\" WHERE \"K\" = 'EAST'", "10|20.5");
+
+        /// <summary>
+        /// MIN and MAX over an ANY column holding strings.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="string"/> is what IKVM gives <c>java.lang.Comparable</c> to as a ghost, so a value of
+        /// one reaching a comparison is worth a test of its own. Nothing casts to <c>Comparable</c> here —
+        /// <c>ltAny</c> takes two <c>Object</c>s — which is the whole reason the ghost cannot bite.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAggregateAnAnyColumnOfStrings() => Gives("SELECT MIN(\"S\"), MAX(\"S\") FROM \"ANYS\"", "a|d");
+
+        /// <summary>
+        /// An aggregate over an ANY column of a group with no rows in it.
+        /// </summary>
+        /// <remarks>
+        /// <c>StrictAggImplementor</c> decides this and neither implementor here overrides it: SUM is nullable
+        /// and answers null over an empty set, and MIN and MAX do the same. The accumulator being null is also
+        /// what MIN reads as "no row yet", so the two meanings meet here.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAggregateAnEmptyAnyColumn() => Gives("SELECT MIN(\"V\"), MAX(\"V\"), SUM(\"V\"), AVG(\"V\") FROM \"ANYS\" WHERE \"K\" = 'NORTH'", "<null>|<null>|<null>|<null>");
+
+        /// <summary>
+        /// SUM over an ANY column holding something that cannot be added.
+        /// </summary>
+        /// <remarks>
+        /// Calcite's refusal, reached from the accumulator rather than from a scalar <c>+</c>:
+        /// <c>plusAny</c> throws for anything but two numbers, and this convention does not soften that. A
+        /// query that adds up a document path holding text should say so rather than answer.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRefuseToSumAnAnyColumnOfStrings()
+        {
+            var act = () => Run("SELECT SUM(\"S\") FROM \"ANYS\"", true);
+
+            act.Should().Throw<java.lang.RuntimeException>().WithMessage("*arithmetic*");
+        }
+
+        /// <summary>
+        /// MIN, MAX and SUM over an ANY column in a window.
+        /// </summary>
+        /// <remarks>
+        /// The same implementors, reached the other way. <c>RexImpTable</c> answers a window context with the
+        /// regular implementor for any function that has no window implementor of its own, and none of these
+        /// three has one, so <c>ClrEnumerableWindow</c> asks for and gets the ANY substitution — but it asks
+        /// through its own code rather than through the aggregate's, which is why this is worth running.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldWindowAnAggregateOverAnAnyColumn()
+        {
+            Gives("SELECT \"ID\", MIN(\"V\") OVER (PARTITION BY \"K\"), MAX(\"V\") OVER (PARTITION BY \"K\"), SUM(\"V\") OVER (PARTITION BY \"K\") FROM \"ANYS\" ORDER BY \"ID\"",
+                "1|10|20.5|30.5",
+                "2|10|20.5|30.5",
+                "3|5|30|35",
+                "4|5|30|35",
+                "5|5|30|35");
+        }
+
+        [TestMethod]
+        public void ShouldRunARunningTotalOverAnAnyColumn()
+        {
+            Gives("SELECT \"ID\", SUM(\"V\") OVER (ORDER BY \"ID\") FROM \"ANYS\" ORDER BY \"ID\"",
+                "1|10",
+                "2|30.5",
+                "3|60.5",
+                "4|60.5",
+                "5|65.5");
+        }
+
+        /// <summary>
+        /// Requires that these are still queries Calcite itself cannot run.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <remarks>
+        /// The other half of asserting an answer by hand. The four queries above have no oracle only for as
+        /// long as <c>EnumerableConvention</c> cannot implement them, and if that changes this goes red and
+        /// says so — which is the moment to compare the two conventions row by row rather than to discover
+        /// from a user that they disagree. It is not an assertion that Calcite ought to fail.
+        /// </remarks>
+        static void StillBeyondCalcite(string sql)
+        {
+            Failure(() => Run(sql, false)).Should().NotBeNull(
+                "Calcite still cannot implement '{0}'; now that it can, the answers this convention gives should be compared against its own", sql);
+        }
+
+        /// <summary>
+        /// Runs a query and returns what it threw, or null if it did not throw.
+        /// </summary>
+        static Exception? Failure(Func<List<string>> run)
+        {
+            try
+            {
+                run();
+                return null;
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+        }
+
+        [TestMethod]
+        public void ShouldStillBeBeyondCalcite()
+        {
+            StillBeyondCalcite("SELECT MIN(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT MAX(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT SUM(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT AVG(\"V\") FROM \"ANYS\"");
+            StillBeyondCalcite("SELECT \"K\", MIN(\"V\"), SUM(\"V\") FROM \"ANYS\" GROUP BY \"K\"");
+        }
+
+        // and the same column read every way that already worked, so that a change here is known to be about
+        // the aggregate rather than about the column, the fixture or the scan
+
+        [TestMethod]
+        public void ShouldAgreeOnScanningAnAnyColumn() => Same("SELECT \"K\", \"V\", \"S\" FROM \"ANYS\"");
+
+        [TestMethod]
+        public void ShouldAgreeOnCountingAnAnyColumn() => Same("SELECT \"K\", COUNT(\"V\"), COUNT(*) FROM \"ANYS\" GROUP BY \"K\" ORDER BY \"K\"");
+
+        [TestMethod]
+        public void ShouldAgreeOnAggregatingACastAnyColumn() => Same("SELECT MIN(CAST(\"V\" AS INTEGER)), MAX(CAST(\"V\" AS INTEGER)), SUM(CAST(\"V\" AS INTEGER)), AVG(CAST(\"V\" AS INTEGER)) FROM \"ANYS\"");
+
+        [TestMethod]
+        public void ShouldAgreeOnAGroupedAggregateOverACastAnyColumn() => Same("SELECT \"K\", MIN(CAST(\"V\" AS INTEGER)), SUM(CAST(\"V\" AS INTEGER)) FROM \"ANYS\" GROUP BY \"K\" ORDER BY \"K\"");
 
         [TestMethod]
         public void ShouldAgreeOnAGlobalAggregate() => Same("SELECT COUNT(*), SUM(\"AMOUNT\"), AVG(\"AMOUNT\") FROM \"SALES\"");


### PR DESCRIPTION
Closes half of #47 — the aggregate half. The correlate over an uncollect is untouched.

## What was wrong

`MIN`, `MAX`, `SUM` and `AVG` over a column of type ANY form a plan and then fail to implement, in `ClrEnumerableConvention` and `ClrAsyncEnumerableConvention` alike.

The issue records this as something Calcite's own convention handles: *"Calcite's own enumerable convention reaches `SqlFunctions` for exactly this and gets a runtime answer per value."* It does for scalar operators, and not for aggregates. `EnumerableConvention` fails on all four too, measured before anything here was written:

| | how it fails |
|---|---|
| `MIN`, `MAX` | `MinMaxImplementor` names `SqlFunctions.lesser` and asks `Types.lookupMethod` to resolve it against the accumulator's static type, which for ANY is `Object`. There is no such overload. |
| `SUM`, `AVG` | `SumImplementor` writes a binary `+`. Janino: `Binary numeric promotion not possible on types "java.lang.Object" and "java.lang.Object"`. |

So there is nothing upstream to port, and this is an addition rather than a defect.

## What it does

`ClrAnyAggImplementors` substitutes an `AggImplementor` for `MIN`, `MAX`, `SUM` and `$SUM0` whenever the call's type is ANY. What it substitutes is still Calcite's, reached from the accumulator instead of from a `RexCall`: a value of type ANY carries its type at run time and nowhere else, and `SqlFunctions` already chooses per value for the scalar case — `BinaryImplementor` answers `ltAny`, `plusAny` and `divideAny` whenever an operand is ANY.

So a minimum over ANY orders its values the way `<` over ANY orders them, and a sum adds them the way `+` over ANY adds them.

Two consequences worth knowing:

- **`SqlFunctions.lesser` would not have done.** It compares through `Comparable.compareTo`, which throws on an `Integer` against a `Double`. A schema of ANY columns is usually a document store, where one path holding both is the ordinary case. `ltAny` compares the two as `BigDecimal`.
- **`SUM` and `AVG` over ANY are `BigDecimal`**, because `plusAny` converts both operands. Summing something that is not a number is refused with Calcite's own `Invalid types for arithmetic`.

`AVG` needed no implementor. `RexImpTable` has none for it in any type — a program runs `AGGREGATE_REDUCE_FUNCTIONS` and the call is `$SUM0` over `COUNT` by the time a planner sees it — so once `$SUM0` accumulates, the division left behind is a `RexCall` that `BinaryImplementor`'s ANY path already answers.

`AggImpState.implementor` is final and filled from `RexImpTable.INSTANCE` by the constructor, so the substitution travels beside the state rather than in it: every node builds its state through `ClrAnyAggImplementors.State` and reads the implementor back through `Implementor()`. One instance per call, because `StrictAggImplementor` sizes its state in `getStateType` and reads that back in `implementAdd` and `implementResult`. The window is included and needed no separate work — a window context falls through to the regular implementor for any function without one of its own, and none of these three has one.

## Tests

- **Answers asserted by hand**, as they are for a .NET user-defined function, because Calcite is no oracle here. Global, grouped, windowed, running total, mixed `Integer`/`Double`, strings, an empty group, and the refusal to sum text.
- **`ShouldStillBeBeyondCalcite`** pins that `EnumerableConvention` still cannot run these. If that changes it goes red, which is when to compare the two row by row rather than let them drift.
- **The asynchronous side** compares against the synchronous one and names the node it went through (`SameThrough`), so a plan reached by some other route cannot pass.
- **`ClrAnyAggregateTests`** walks the compiled expression tree of four ANY plans in both conventions and requires no `org.apache.calcite.linq4j.tree` type to survive anywhere in it. These implementors are the one place in the project that writes a linq4j tree of its own — `AggImplementor`'s contexts hand out a `BlockBuilder` and admit nothing else — and it has to be translated away before anything runs. The visitor was checked against `org.apache.calcite.runtime.` to confirm it is not vacuously passing.
- **Two tests in `ClrAsyncEnumerablePlanCancellationTests`** hold that folding an ANY column still suspends and still sees the caller's token. An implementor writes only the fold and the draining belongs to the operator, so this cannot have regressed — but that is a claim about code this PR changes. One cancels at row 50 of 10,000; the other requires the first `MoveNextAsync()` to come back not completed.

723 tests in `Apache.Calcite.Tests` and 345 in `Apache.Calcite.Adapter.AdoNet.Tests`, all green, none skipped.
