### PR TITLE
Build a row of more than six fields over IComparable

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/JavaRowFormatExtensions.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/JavaRowFormatExtensions.cs
@@ -341,11 +341,14 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     return Expression.Call(null, FlatListOf[expressions.Count - 2], arguments);
                 }
 
+                // Calcite writes newArrayInit(Comparable.class, ...), and IKVM erases a java.lang.Comparable
+                // to IComparable in every signature it compiles, copyOf's parameter included. The two differ
+                // in what they accept: a string has IComparable and has java.lang.Comparable only as a ghost.
                 var elements = new Expression[expressions.Count];
                 for (int i = 0; i < elements.Length; i++)
-                    elements[i] = ClrEnumUtils.Convert(expressions[i], typeof(java.lang.Comparable));
+                    elements[i] = ClrEnumUtils.Convert(expressions[i], typeof(IComparable));
 
-                return Expression.Call(null, FlatListCopyOf, Expression.NewArrayInit(typeof(java.lang.Comparable), elements));
+                return Expression.Call(null, FlatListCopyOf, Expression.NewArrayInit(typeof(IComparable), elements));
             }
 
         }

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -515,6 +515,13 @@ namespace Apache.Calcite.Tests
         public Task ShouldAgreeOnACube() =>
             Same("SELECT REGION, LABEL, COUNT(*) FROM SALES GROUP BY CUBE(REGION, LABEL) ORDER BY 1, 2");
 
+        // Eight key fields, which is the arity that builds the key through FlatLists.copyOf over an array of
+        // Comparable. See ClrEnumerableDifferentialTests.ShouldAgreeOnARollupOverEveryColumn.
+
+        [TestMethod]
+        public Task ShouldAgreeOnARollupOverEveryColumn() =>
+            Same("SELECT ID, REGION, AMOUNT, LABEL, COUNT(*) FROM SALES GROUP BY ROLLUP(ID, REGION, AMOUNT, LABEL) ORDER BY 1, 2, 3, 4, 5");
+
         [TestMethod]
         public Task ShouldAgreeOnAnAntiJoin() =>
             Same("SELECT ID FROM SALES WHERE ID NOT IN (SELECT K FROM SORTED WHERE K IS NOT NULL)");

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -1089,6 +1089,15 @@ namespace Apache.Calcite.Tests
         public void ShouldAgreeOnGroupingSetsOwnOrder() =>
             Same("SELECT \"REGION\", COUNT(*) FROM \"SALES\" GROUP BY GROUPING SETS ((\"REGION\"), ())");
 
+        // A grouping set over four columns keys on eight fields -- one per column and one indicator per column
+        // -- and a row of more than six is the only one FlatLists.copyOf builds, over an array whose element
+        // type Calcite names as Comparable. That is the arity at which a VARCHAR group column reaches the
+        // ghost interface, so no grouping set over three columns or fewer covers it.
+
+        [TestMethod]
+        public void ShouldAgreeOnARollupOverEveryColumn() =>
+            Same("SELECT \"ID\", \"REGION\", \"AMOUNT\", \"LABEL\", COUNT(*) FROM \"SALES\" GROUP BY ROLLUP(\"ID\", \"REGION\", \"AMOUNT\", \"LABEL\") ORDER BY 1, 2, 3, 4, 5");
+
         [TestMethod]
         public void ShouldAgreeOnTheGroupingFunction() =>
             Same("SELECT \"REGION\", GROUPING(\"REGION\"), COUNT(*) FROM \"SALES\" GROUP BY ROLLUP(\"REGION\") ORDER BY 1, 2");


### PR DESCRIPTION
A grouping set over four or more columns threw `InvalidCastException: Unable to cast object of type 'System.String' to type 'java.lang.Comparable'` in both conventions.

`JavaRowFormat.LIST.record` beyond six fields is `FlatLists.copyOf` over an array Calcite names as `Comparable` — and `java.lang.Comparable` is not the CLR type that names. IKVM declares it as an interface of its own, deriving from `IComparable` and implemented by the Java classes, but **erases it to `IComparable` in every signature it compiles**, `copyOf`'s parameter included:

```
java.util.List copyOf(System.IComparable[])                       // FlatLists.copyOf(Comparable...)
System.Int32   compare(System.IComparable, System.IComparable)    // Utilities.compare(Comparable, Comparable)
```

The two differ in what they accept: a string has `IComparable`, and has `java.lang.Comparable` only as a ghost. So the element conversion threw where Java's cast passes. Array covariance let the call itself stand — a `java.lang.Comparable[]` is assignable to the `IComparable[]` parameter — so nothing complained until a row ran.

Seven elements is reached by a grouping set over four columns, because the key carries one field **plus one indicator per column**. Both new tests roll up over all four of `SALES`; no grouping set over three columns or fewer covers this branch, which is why 730 tests did not.

Both threw the reported exception before the change and pass after. Full suite: 732 pass, none skipped.
