### PR TITLE
Compare a synthetic record's reference fields

### DIFF
--- a/src/Apache.Calcite.Extensions/Runtime/SyntheticRecord.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/SyntheticRecord.cs
@@ -211,6 +211,10 @@ namespace Apache.Calcite.Extensions.Runtime
                 {
                     // a field the runtime cannot compare is skipped, exactly as Calcite skips one whose
                     // compare method does not exist: a record is not always used as a sorting key
+                    //
+                    // Calcite reads Types.RecordField.nullable() here and calls compareNullsLast for a
+                    // nullable field, which a CLR field does not carry and this does not follow. A null in a
+                    // reference field therefore throws where Calcite orders it last. Measured.
                     var compare = Compare(field.FieldType);
                     if (compare == null)
                         continue;
@@ -223,14 +227,6 @@ namespace Apache.Calcite.Extensions.Runtime
 
                 return Expression.Lambda<Func<object, object?, int>>(Expression.Block([self, that, c], body), left, right).Compile();
             }
-
-            /// <summary>
-            /// <c>Utilities.compare(Comparable, Comparable)</c>, reached by a method taking objects.
-            /// </summary>
-            static readonly MethodInfo ComparableCompare = typeof(Apache.Calcite.Extensions.Interop.JavaComparisons)
-                
-                .GetMethod(nameof(Apache.Calcite.Extensions.Interop.JavaComparisons.Compare), [typeof(object), typeof(object)])
-                ?? throw new InvalidOperationException("JavaComparisons has no Compare(object, object).");
 
             /// <summary>
             /// Brings a field to the type the comparison takes.
@@ -268,15 +264,17 @@ namespace Apache.Calcite.Extensions.Runtime
                     if (parameters[1].ParameterType == type)
                         return candidate;
 
-                    if (parameters[1].ParameterType == typeof(java.lang.Comparable) && type.IsValueType == false)
+                    // the general overload takes a java.lang.Comparable, and IComparable is the CLR type that
+                    // names: IKVM declares java.lang.Comparable as an interface of its own deriving from it,
+                    // but erases the parameter to IComparable in every signature it compiles
+                    // and the field has to be one, which is what Types.lookupMethod asks: Object is a
+                    // reference type and is not assignable to Comparable, so Calcite finds no overload for a
+                    // field of one and leaves it out of compareTo
+                    if (parameters[1].ParameterType == typeof(IComparable) && typeof(IComparable).IsAssignableFrom(type))
                         general = candidate;
                 }
 
-                // the general overload takes a java.lang.Comparable, which IKVM gives a string as a ghost
-                // interface: the CLR type system does not see it, so an Expression.Convert to it throws where
-                // Java's cast would have passed. The same call reached through a method taking an object does
-                // the conversion in compiled C#, where IKVM emits the check.
-                return general == null ? null : ComparableCompare;
+                return general;
             }
 
             /// <summary>

--- a/src/Apache.Calcite.Tests/SyntheticRecordTests.cs
+++ b/src/Apache.Calcite.Tests/SyntheticRecordTests.cs
@@ -1,0 +1,92 @@
+using System;
+
+using Apache.Calcite.Extensions.Linq4j.Tree;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// The four members Calcite writes into a generated record class, which are on <c>SyntheticRecord</c> here
+    /// instead.
+    /// </summary>
+    [TestClass]
+    public class SyntheticRecordTests
+    {
+
+        /// <summary>
+        /// Returns the CLR type of a synthetic record over the given Java field types.
+        /// </summary>
+        /// <param name="types"></param>
+        /// <returns></returns>
+        static Type Record(params java.lang.Class[] types)
+        {
+            var list = new java.util.ArrayList();
+            foreach (var type in types)
+                list.add(type);
+
+            return ClrTypes.Resolve((java.lang.reflect.Type)new JavaTypeFactoryImpl().createSyntheticType(list));
+        }
+
+        /// <summary>
+        /// <c>compareTo</c> returns on the first field that differs, and one of a reference type is among them:
+        /// Calcite's generated body compares it through <c>Utilities.compare(Comparable, Comparable)</c> and
+        /// leaves a field out only where no overload takes it at all.
+        /// </summary>
+        /// <remarks>
+        /// The ghost interface, from the other side. IKVM erases a <c>java.lang.Comparable</c> parameter to
+        /// <see cref="IComparable"/>, so the overload was looked for under a type no signature has, never
+        /// found, and every reference field dropped out of the comparison — a record of a string and an int
+        /// ordered on the int alone.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCompareAReferenceField()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, ["A", 1])!;
+            var b = Activator.CreateInstance(type, ["B", 1])!;
+
+            ((IComparable)a).CompareTo(b).Should().BeNegative();
+            ((IComparable)b).CompareTo(a).Should().BePositive();
+            ((IComparable)a).CompareTo(Activator.CreateInstance(type, ["A", 1])!).Should().Be(0);
+        }
+
+        /// <summary>
+        /// A field of a primitive type is compared through the overload that takes it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCompareAPrimitiveField()
+        {
+            var type = Record(java.lang.Integer.TYPE, java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, [1, 2])!;
+            var b = Activator.CreateInstance(type, [1, 3])!;
+
+            ((IComparable)a).CompareTo(b).Should().BeNegative();
+            ((IComparable)b).CompareTo(a).Should().BePositive();
+        }
+
+        /// <summary>
+        /// A field of a type no overload takes is left out of the comparison rather than failing it, because a
+        /// record is not always used as a sorting key.
+        /// </summary>
+        [TestMethod]
+        public void ShouldSkipAFieldNothingCompares()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.Object), java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, [new object(), 1])!;
+            var b = Activator.CreateInstance(type, [new object(), 1])!;
+
+            ((IComparable)a).CompareTo(b).Should().Be(0);
+        }
+
+    }
+
+}


### PR DESCRIPTION
The second site of the same mistake as #51, found by grepping for the constant.

`SyntheticRecord` builds the `compareTo` Calcite writes into a generated record class, choosing a `Utilities` overload per field. The general one takes a `java.lang.Comparable`, and **`IComparable` is the CLR type that names** — IKVM declares `java.lang.Comparable` as an interface of its own deriving from it, but erases the parameter to `IComparable` in every signature it compiles:

```
System.Int32 compare(System.IComparable, System.IComparable)   // Utilities.compare(Comparable, Comparable)
```

Looking for the interface matched nothing, so `general` was never set and **every field of a reference type dropped out of the comparison** — a record of a string and an int ordered on the int alone.

The guard on the field's own type was `IsValueType`, where what `Types.lookupMethod` asks is assignability. `Object` is a reference type and is not assignable to `Comparable`, so Calcite finds no overload for a field of one and leaves it out of `compareTo` — which is now what happens here, and is what `ShouldSkipAFieldNothingCompares` holds.

With the type corrected the `JavaComparisons.Compare(object, object)` detour has nothing left to work around, and `Utilities.compare` is called directly, as Calcite calls it.

### Not fixed here

Calcite reads `Types.RecordField.nullable()` and calls `compareNullsLast` for a nullable field. That flag is not on a CLR field and following it means carrying it through `SyntheticRecordEmitter`. So **a null in a reference field now throws where Calcite orders it last** — measured, and stated at the site. Before this change the field was skipped, so nothing threw and nothing was ordered.

Full suite: 744 pass, none skipped.
