### PR TITLE
Write a synthetic record's six members the way classDecl does

### DIFF
--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/ClrTypes.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/ClrTypes.cs
@@ -38,7 +38,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
             return type switch
             {
                 java.lang.Class c => FromClass(c),
-                org.apache.calcite.jdbc.JavaTypeFactoryImpl.SyntheticRecordType r => SyntheticRecordEmitter.Emit(r),
+                org.apache.calcite.jdbc.JavaTypeFactoryImpl.SyntheticRecordType r => SyntheticRecordEmitter.ClassDecl(r),
                 java.lang.reflect.ParameterizedType p => FromParameterizedType(p),
                 java.lang.reflect.GenericArrayType g => Resolve(g.getGenericComponentType()).MakeArrayType(),
                 _ => throw new NotSupportedException($"Cannot resolve a CLR type for '{type}' ({type.GetType()}).")
@@ -149,9 +149,16 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// <returns></returns>
         /// <exception cref="NotSupportedException"></exception>
         /// <remarks>
-        /// The same resolution as <see cref="Rebind"/>, where there is no method to start from. Calcite names
-        /// a class and a method and nothing more — <c>Expressions.call(Utilities.class, "compareNullsFirst",
-        /// args)</c> — and lets javac choose the overload from the argument expressions of the source it emits.
+        /// <c>Types.lookupMethod</c>, which is where <c>Expressions.call(Utilities.class, "compareNullsFirst",
+        /// args)</c> ends up: Calcite names a class and a method and nothing more, and the overload is bound
+        /// from the argument types — the one whose parameters are exactly these, else the first they are
+        /// assignable to, else a <c>NoSuchMethodException</c> the caller may catch.
+        ///
+        /// <para>Assignability is <c>Types.assignableFrom</c>: a subclass, or a widening between two
+        /// primitives, and <b>nothing else</b>. It is not <see cref="Accepts"/>, which also counts a box and
+        /// its primitive as fitting — that is right for <see cref="Rebind"/>, whose caller converts every
+        /// argument to its parameter, and wrong here, where the call is emitted as it stands. Under it a
+        /// <c>java.lang.Integer</c> binds <c>hash(int, Object)</c>, which is what Calcite binds.</para>
         /// </remarks>
         public static MethodInfo Resolve(Type declaring, string name, Type[] arguments)
         {
@@ -164,7 +171,7 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
                 return exact;
 
             foreach (var candidate in declaring.GetMethods(BindingFlags.Public | BindingFlags.Static))
-                if (candidate.Name == name && Accepts(candidate, arguments))
+                if (candidate.Name == name && AllAssignable(candidate, arguments))
                     return candidate;
 
             throw new NotSupportedException($"No overload of {name} on {declaring} accepts the given arguments.");
@@ -246,6 +253,40 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
                     return candidate;
 
             return method;
+        }
+
+        /// <summary>
+        /// Returns whether every argument is assignable to the parameter it would be passed as.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>Types.allAssignable</c> over <c>Types.assignableFrom</c>, which is a subclass or a widening
+        /// between two primitives and nothing further. Calcite's varargs arm has nothing to answer here: a
+        /// method IKVM compiled from a Java varargs one takes the array.
+        /// </remarks>
+        static bool AllAssignable(MethodInfo method, Type[] arguments)
+        {
+            var parameters = method.GetParameters();
+            if (parameters.Length != arguments.Length)
+                return false;
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i].ParameterType;
+                if (parameter.IsAssignableFrom(arguments[i]))
+                    continue;
+
+                var to = ClrPrimitive.Of(parameter);
+                var from = ClrPrimitive.Of(arguments[i]);
+                if (to != null && from != null && to.assignableFrom(from))
+                    continue;
+
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/SyntheticRecordEmitter.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/SyntheticRecordEmitter.cs
@@ -1,11 +1,12 @@
 using System;
-using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Reflection;
 using System.Reflection.Emit;
 
 using Apache.Calcite.Extensions.Runtime;
 
 using org.apache.calcite.jdbc;
+using org.apache.calcite.util;
 
 using J = org.apache.calcite.linq4j.tree;
 
@@ -18,27 +19,50 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
     /// <remarks>
     /// <c>JavaRowFormat.CUSTOM</c> asks the type factory for the class of a row, and for a struct of several
     /// fields the answer is a synthetic record: a type Calcite describes but has not got, because Janino
-    /// materialises it from the generated source. Nothing here changes what a row is; the record's fields and
-    /// their types are the factory's, and this only gives them somewhere to live.
+    /// materialises it from the generated source.
     ///
-    /// <para>Calcite writes equals, hashCode, compareTo and toString into the generated class. Those are on
-    /// <see cref="SyntheticRecord"/> instead, built from the fields once per type, so what is emitted is the
-    /// fields and the two constructors and nothing else.</para>
+    /// <para>Calcite never resolves one. <c>Types.toClass</c> throws on a <c>RecordType</c> — the class is
+    /// still text — and <c>Expressions.parameter</c> carries the type until Janino writes its name into the
+    /// same compilation unit as the class declaration. <see cref="System.Linq.Expressions.Expression"/> takes
+    /// a <see cref="Type"/>, so here the class has to be real before anything can name it, which is why
+    /// <see cref="ClassDecl"/> returns a finished type rather than a declaration and why all six members are
+    /// on it before it returns.</para>
     /// </remarks>
     static class SyntheticRecordEmitter
     {
 
         static readonly object sync = new();
-        static readonly Dictionary<JavaTypeFactoryImpl.SyntheticRecordType, Type> emitted = new(ReferenceEqualityComparer.Instance);
-        static ModuleBuilder? module;
         static int count;
 
         /// <summary>
-        /// Returns the CLR type for a synthetic record, emitting it the first time it is asked for.
+        /// The type emitted for each record type, held only for as long as the record type is.
+        /// </summary>
+        /// <remarks>
+        /// <b>Weakly, because this is the whole of the lifetime.</b> A <c>SyntheticRecordType</c> is reachable
+        /// from one place — <c>JavaTypeFactoryImpl.syntheticTypes</c>, an instance field — so it lives exactly
+        /// as long as the factory that made it, which is as long as the connection. Nothing reaches back the
+        /// other way: the record type holds its fields, its relational type and its name, and a field holds
+        /// the record type, and none of them holds the factory. So keying on the record type is what ties the
+        /// emitted type to the connection, and a strong map would untie it — the key alone would keep every
+        /// record type of every connection alive for the life of the process, and the emitted type with it.
+        ///
+        /// <para>The emitted type does not refer to the record type, which is what makes this safe to hold in
+        /// a table whose value must not reach its key.</para>
+        /// </remarks>
+        static readonly ConditionalWeakTable<JavaTypeFactoryImpl.SyntheticRecordType, Type> emitted = new();
+
+        /// <summary>
+        /// Returns the CLR type of a synthetic record, emitting it the first time it is asked for.
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        public static Type Emit(JavaTypeFactoryImpl.SyntheticRecordType type)
+        /// <remarks>
+        /// <c>EnumerableRelImplementor.classDecl</c>, which answers a class declaration for Janino to compile.
+        /// A declaration of the same shape twice is one class twice there, because the type factory hands out
+        /// one <c>SyntheticRecordType</c> per shape and the declaration is written once per compilation unit;
+        /// here the type is the thing itself, so it is emitted once per record type and kept.
+        /// </remarks>
+        public static Type ClassDecl(JavaTypeFactoryImpl.SyntheticRecordType type)
         {
             ArgumentNullException.ThrowIfNull(type);
 
@@ -47,65 +71,263 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
                 if (emitted.TryGetValue(type, out var existing))
                     return existing;
 
-                return emitted[type] = Build(type);
+                var clr = Emit(type);
+                emitted.Add(type, clr);
+                return clr;
             }
         }
 
         /// <summary>
-        /// Emits the type.
+        /// Emits the class and its six members.
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        static Type Build(JavaTypeFactoryImpl.SyntheticRecordType type)
+        /// <remarks>
+        /// The body of <c>classDecl</c>, section for section. What differs is at the leaves: a member is
+        /// emitted rather than added to a list of declarations, and a body is IL rather than a linq4j block,
+        /// so each statement Calcite writes as one call — <c>ifThen</c>, <c>return_</c>, <c>foldAnd</c> — is
+        /// several instructions here. The order, the locals and the per field loops are Calcite's.
+        /// </remarks>
+        static Type Emit(JavaTypeFactoryImpl.SyntheticRecordType type)
         {
-            module ??= AssemblyBuilder
-                .DefineDynamicAssembly(new AssemblyName("Apache.Calcite.Extensions.Records"), AssemblyBuilderAccess.RunAndCollect)
-                .DefineDynamicModule("Apache.Calcite.Extensions.Records");
+            // one collectable assembly per record type, so that the type goes when the record type does.
+            // RunAndCollect collects an assembly, not a type, so a shared one is released only when every
+            // type in it is unreachable -- and never at all while a static field holds the builder. Measured:
+            // an assembly of its own costs about 73us more to emit and about 32KB of loader allocator while
+            // the type is alive, and that 32KB comes back. A shared module returns nothing.
+            var name = $"{type.getName()}_{++count}";
+            var module = AssemblyBuilder
+                .DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.RunAndCollect)
+                .DefineDynamicModule(name);
 
             // the factory names a record after its shape, and two connections can each hold one of the same
-            // name describing the same shape, so the name is made unique rather than trusted
-            var builder = module.DefineType(
-                $"{type.getName()}_{++count}",
+            // name describing the same shape, so the name is made unique -- an assembly apiece means they
+            // cannot collide, but a stack trace naming one of two Record3_0s would say nothing
+            var classDeclaration = module.DefineType(
+                name,
                 TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
                 typeof(SyntheticRecord));
 
-            var recordFields = type.getRecordFields();
-            var fields = new FieldBuilder[recordFields.size()];
-            var types = new Type[recordFields.size()];
+            var recordFields = RecordFields(type);
+            var fields = new FieldBuilder[recordFields.Length];
+            var types = new Type[recordFields.Length];
 
-            for (int i = 0; i < fields.Length; i++)
+            // For each field:
+            //   public T0 f0;
+            //   ...
+            for (int i = 0; i < recordFields.Length; i++)
             {
-                var field = (J.Types.RecordField)recordFields.get(i);
-                types[i] = ClrTypes.Resolve(field.getType());
-                fields[i] = builder.DefineField(field.getName(), types[i], FieldAttributes.Public);
+                types[i] = ClrTypes.Resolve(recordFields[i].getType());
+                fields[i] = classDeclaration.DefineField(recordFields[i].getName(), types[i], FieldAttributes.Public);
             }
 
-            EmitConstructor(builder, [], fields);
+            // Constructor:
+            //   Foo(T0 f0, ...) { this.f0 = f0; ... }
 
-            // a record of no fields has the same two constructors, and emitting both leaves the type with two
-            // that cannot be told apart. A semi join whose right input projects nothing is one
+            // Here a constructor without parameter is used because the generated
+            // code could cause error if number of fields is too large.
+            ConstructorDecl(classDeclaration, [], fields);
+
+            // Calcite declares only that one, and its generated code assigns the fields. An expression tree
+            // has no statements to assign them in, so JavaRowFormat.CUSTOM.record calls a constructor and the
+            // one it calls is emitted for it. A record of no fields would have two that cannot be told apart;
+            // a semi join whose right input projects nothing is one.
             if (types.Length > 0)
-                EmitConstructor(builder, types, fields);
+                ConstructorDecl(classDeclaration, types, fields);
 
-            return builder.CreateType();
+            // equals method():
+            //   public boolean equals(Object o) {
+            //       if (this == o) return true;
+            //       if (!(o instanceof MyClass)) return false;
+            //       final MyClass that = (MyClass) o;
+            //       return this.f0 == that.f0
+            //         && equal(this.f1, that.f1)
+            //         ...
+            //   }
+            var blockBuilder2 = classDeclaration
+                .DefineMethod(nameof(Equals), Override, typeof(bool), [typeof(object)])
+                .GetILGenerator();
+            var thatParameter = blockBuilder2.DeclareLocal(classDeclaration);
+            var notSame = blockBuilder2.DefineLabel();
+            blockBuilder2.Emit(OpCodes.Ldarg_0);
+            blockBuilder2.Emit(OpCodes.Ldarg_1);
+            blockBuilder2.Emit(OpCodes.Bne_Un, notSame);
+            blockBuilder2.Emit(OpCodes.Ldc_I4_1);
+            blockBuilder2.Emit(OpCodes.Ret);
+            blockBuilder2.MarkLabel(notSame);
+            var isInstance = blockBuilder2.DefineLabel();
+            blockBuilder2.Emit(OpCodes.Ldarg_1);
+            blockBuilder2.Emit(OpCodes.Isinst, classDeclaration);
+            blockBuilder2.Emit(OpCodes.Brtrue, isInstance);
+            blockBuilder2.Emit(OpCodes.Ldc_I4_0);
+            blockBuilder2.Emit(OpCodes.Ret);
+            blockBuilder2.MarkLabel(isInstance);
+            blockBuilder2.Emit(OpCodes.Ldarg_1);
+            blockBuilder2.Emit(OpCodes.Castclass, classDeclaration);
+            blockBuilder2.Emit(OpCodes.Stloc, thatParameter);
+
+            // foldAnd, which short circuits: each condition falls through to the next and any false returns
+            var unequal = blockBuilder2.DefineLabel();
+            for (int i = 0; i < recordFields.Length; i++)
+            {
+                blockBuilder2.Emit(OpCodes.Ldarg_0);
+                blockBuilder2.Emit(OpCodes.Ldfld, fields[i]);
+                blockBuilder2.Emit(OpCodes.Ldloc, thatParameter);
+                blockBuilder2.Emit(OpCodes.Ldfld, fields[i]);
+
+                if (J.Primitive.@is(recordFields[i].getType()))
+                {
+                    blockBuilder2.Emit(OpCodes.Ceq);
+                }
+                else
+                {
+                    blockBuilder2.Emit(OpCodes.Call, ObjectsEqual);
+                }
+
+                blockBuilder2.Emit(OpCodes.Brfalse, unequal);
+            }
+
+            blockBuilder2.Emit(OpCodes.Ldc_I4_1);
+            blockBuilder2.Emit(OpCodes.Ret);
+            blockBuilder2.MarkLabel(unequal);
+            blockBuilder2.Emit(OpCodes.Ldc_I4_0);
+            blockBuilder2.Emit(OpCodes.Ret);
+
+            // hashCode method:
+            //   public int hashCode() {
+            //     int h = 0;
+            //     h = hash(h, f0);
+            //     ...
+            //     return h;
+            //   }
+            var blockBuilder3 = classDeclaration
+                .DefineMethod(nameof(GetHashCode), Override, typeof(int), [])
+                .GetILGenerator();
+            var hParameter = blockBuilder3.DeclareLocal(typeof(int));
+            blockBuilder3.Emit(OpCodes.Ldc_I4_0);
+            blockBuilder3.Emit(OpCodes.Stloc, hParameter);
+
+            for (int i = 0; i < recordFields.Length; i++)
+            {
+                blockBuilder3.Emit(OpCodes.Ldloc, hParameter);
+                blockBuilder3.Emit(OpCodes.Ldarg_0);
+                blockBuilder3.Emit(OpCodes.Ldfld, fields[i]);
+                blockBuilder3.Emit(OpCodes.Call, Call(BuiltInMethod.HASH.method, [typeof(int), types[i]]));
+                blockBuilder3.Emit(OpCodes.Stloc, hParameter);
+            }
+
+            blockBuilder3.Emit(OpCodes.Ldloc, hParameter);
+            blockBuilder3.Emit(OpCodes.Ret);
+
+            // compareTo method:
+            //   public int compareTo(MyClass that) {
+            //     int c;
+            //     c = compare(this.f0, that.f0);
+            //     if (c != 0) return c;
+            //     ...
+            //     return 0;
+            //   }
+            var blockBuilder4 = classDeclaration
+                .DefineMethod("compareTo", Override, typeof(int), [typeof(object)])
+                .GetILGenerator();
+            var cParameter = blockBuilder4.DeclareLocal(typeof(int));
+            var thatParameter4 = blockBuilder4.DeclareLocal(classDeclaration);
+            blockBuilder4.Emit(OpCodes.Ldarg_1);
+            blockBuilder4.Emit(OpCodes.Castclass, classDeclaration);
+            blockBuilder4.Emit(OpCodes.Stloc, thatParameter4);
+
+            for (int i = 0; i < recordFields.Length; i++)
+            {
+                MethodInfo compareCall;
+
+                try
+                {
+                    var method = (recordFields[i].nullable()
+                        ? BuiltInMethod.COMPARE_NULLS_LAST
+                        : BuiltInMethod.COMPARE).method;
+                    compareCall = Call(method, [types[i], types[i]]);
+                }
+                catch (NotSupportedException)
+                {
+                    // Just ignore the field in compareTo
+                    // "create synthetic record class" blindly creates compareTo for
+                    // all the fields, however not all the records will actually be used
+                    // as sorting keys (e.g. temporary state for aggregate calculation).
+                    // In those cases it is fine if we skip the problematic fields.
+                    continue;
+                }
+
+                var conditionalStatement = blockBuilder4.DefineLabel();
+                blockBuilder4.Emit(OpCodes.Ldarg_0);
+                blockBuilder4.Emit(OpCodes.Ldfld, fields[i]);
+                blockBuilder4.Emit(OpCodes.Ldloc, thatParameter4);
+                blockBuilder4.Emit(OpCodes.Ldfld, fields[i]);
+                blockBuilder4.Emit(OpCodes.Call, compareCall);
+                blockBuilder4.Emit(OpCodes.Stloc, cParameter);
+                blockBuilder4.Emit(OpCodes.Ldloc, cParameter);
+                blockBuilder4.Emit(OpCodes.Brfalse, conditionalStatement);
+                blockBuilder4.Emit(OpCodes.Ldloc, cParameter);
+                blockBuilder4.Emit(OpCodes.Ret);
+                blockBuilder4.MarkLabel(conditionalStatement);
+            }
+
+            blockBuilder4.Emit(OpCodes.Ldc_I4_0);
+            blockBuilder4.Emit(OpCodes.Ret);
+
+            // toString method:
+            //   public String toString() {
+            //     return "{f0=" + f0
+            //       + ", f1=" + f1
+            //       ...
+            //       + "}";
+            //   }
+            var blockBuilder5 = classDeclaration
+                .DefineMethod(nameof(ToString), Override, typeof(string), [])
+                .GetILGenerator();
+
+            if (recordFields.Length == 0)
+            {
+                blockBuilder5.Emit(OpCodes.Ldstr, "{}");
+            }
+            else
+            {
+                blockBuilder5.Emit(OpCodes.Ldstr, "{");
+
+                for (int i = 0; i < recordFields.Length; i++)
+                {
+                    blockBuilder5.Emit(OpCodes.Ldstr, (i == 0 ? "" : ", ") + recordFields[i].getName() + "=");
+                    blockBuilder5.Emit(OpCodes.Call, Concat);
+                    blockBuilder5.Emit(OpCodes.Ldarg_0);
+                    blockBuilder5.Emit(OpCodes.Ldfld, fields[i]);
+
+                    if (types[i].IsValueType)
+                        blockBuilder5.Emit(OpCodes.Box, types[i]);
+
+                    blockBuilder5.Emit(OpCodes.Call, ValueOf);
+                    blockBuilder5.Emit(OpCodes.Call, Concat);
+                }
+
+                blockBuilder5.Emit(OpCodes.Ldstr, "}");
+                blockBuilder5.Emit(OpCodes.Call, Concat);
+            }
+
+            blockBuilder5.Emit(OpCodes.Ret);
+
+            return classDeclaration.CreateType();
         }
 
         /// <summary>
         /// Emits a constructor assigning each of its parameters to the field of the same position.
         /// </summary>
-        /// <param name="builder"></param>
+        /// <param name="classDeclaration"></param>
         /// <param name="parameters"></param>
         /// <param name="fields"></param>
         /// <remarks>
-        /// Both are emitted because Calcite builds a record both ways. <c>JavaRowFormat.CUSTOM.record</c>
-        /// writes <c>new Foo(a, b)</c>, while <c>EnumerableAggregate</c> writes <c>new Foo()</c> and assigns
-        /// each field, which it changed to under CALCITE-1097 because Janino fails on a constructor with too
-        /// many parameters. Calcite's own generated class kept only the second, so the first would not have
-        /// compiled against it.
+        /// <c>Expressions.constructorDecl</c>, whose body Calcite leaves empty.
         /// </remarks>
-        static void EmitConstructor(TypeBuilder builder, Type[] parameters, FieldBuilder[] fields)
+        static void ConstructorDecl(TypeBuilder classDeclaration, Type[] parameters, FieldBuilder[] fields)
         {
-            var constructor = builder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, parameters);
+            var constructor = classDeclaration.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, parameters);
             var il = constructor.GetILGenerator();
 
             il.Emit(OpCodes.Ldarg_0);
@@ -122,10 +344,68 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         }
 
         /// <summary>
+        /// Returns the record's fields as an array.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        static J.Types.RecordField[] RecordFields(JavaTypeFactoryImpl.SyntheticRecordType type)
+        {
+            var list = type.getRecordFields();
+            var fields = new J.Types.RecordField[list.size()];
+            for (int i = 0; i < fields.Length; i++)
+                fields[i] = (J.Types.RecordField)list.get(i);
+
+            return fields;
+        }
+
+        /// <summary>
+        /// Returns the overload of the named method that takes the given arguments.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException"></exception>
+        /// <remarks>
+        /// <c>Expressions.call(method.getDeclaringClass(), method.getName(), arguments)</c>, which is how
+        /// Calcite writes every call in these bodies: it names a class and a method and lets
+        /// <c>Types.lookupMethod</c> bind the overload from the argument types.
+        ///
+        /// <para><see cref="ClrTypes.Resolve(Type, string, Type[])"/> is that method. It binds on
+        /// assignability alone, which is <c>Types.assignableFrom</c> and is what a body of IL needs: nothing
+        /// converts an argument here, where a tree Calcite composes converts each one to its parameter.</para>
+        /// </remarks>
+        static MethodInfo Call(java.lang.reflect.Method method, Type[] arguments)
+        {
+            return ClrTypes.Resolve(ClrTypes.FromClass(method.getDeclaringClass()), method.getName(), arguments);
+        }
+
+        /// <summary>
+        /// What a member of the record overrides the base with.
+        /// </summary>
+        const MethodAttributes Override = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig;
+
+        /// <summary>
         /// The base constructor every emitted record chains to.
         /// </summary>
         static readonly ConstructorInfo SyntheticRecordConstructor = typeof(SyntheticRecord).GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, [])
             ?? throw new InvalidOperationException($"{nameof(SyntheticRecord)} has no no-arg constructor.");
+
+        /// <summary>
+        /// Guava's <c>Objects.equal</c>, which the generated equals compares a reference field with.
+        /// </summary>
+        static readonly MethodInfo ObjectsEqual = ClrTypes.Resolve(BuiltInMethod.OBJECTS_EQUAL.method);
+
+        /// <summary>
+        /// Java's string concatenation, which is what <c>Expressions.add</c> over a string is.
+        /// </summary>
+        static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(string), typeof(string)])
+            ?? throw new InvalidOperationException("String has no Concat(string, string).");
+
+        /// <summary>
+        /// <c>String.valueOf</c>, whose own helper IKVM keeps internal; both render a null as "null".
+        /// </summary>
+        static readonly MethodInfo ValueOf = typeof(java.util.Objects).GetMethod("toString", [typeof(object)])
+            ?? throw new InvalidOperationException("java.util.Objects has no toString(Object).");
 
     }
 

--- a/src/Apache.Calcite.Extensions/Runtime/SyntheticRecord.cs
+++ b/src/Apache.Calcite.Extensions/Runtime/SyntheticRecord.cs
@@ -1,10 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reflection;
-
-using org.apache.calcite.runtime;
 
 namespace Apache.Calcite.Extensions.Runtime
 {
@@ -13,304 +7,52 @@ namespace Apache.Calcite.Extensions.Runtime
     /// Base of the record classes emitted for <c>JavaRowFormat.CUSTOM</c>.
     /// </summary>
     /// <remarks>
-    /// Calcite generates a class per row shape with equals, hashCode, compareTo and toString written out, and
-    /// hands it to Janino. An emitted type carries only its fields and its constructors; the four members are
-    /// here, built once per type from those fields and against the same <see cref="Utilities"/> methods
-    /// Calcite's generated bodies call.
+    /// Calcite's generated record declares <c>equals</c>, <c>hashCode</c>, <c>compareTo</c> and
+    /// <c>toString</c> itself, and implements <c>Serializable</c> and nothing else. So does the type
+    /// <c>SyntheticRecordEmitter.ClassDecl</c> emits: the four are on the record, not here.
+    ///
+    /// <para>What is here is the base a CLR type needs so that those four are reachable by the names the two
+    /// runtimes call them by. <c>equals</c> and <c>hashCode</c> are <see cref="Equals(object)"/> and
+    /// <see cref="GetHashCode"/>, which are what IKVM maps a Java call onto, and the record overrides those.
+    /// <c>compareTo</c> is <see cref="IComparable.CompareTo"/>, because <c>java.lang.Comparable</c> is a ghost
+    /// deriving from it and declares no method of its own — a value reaches it through
+    /// <c>Comparable.__Helper.compareTo</c>, which calls <see cref="IComparable.CompareTo"/>.</para>
     /// </remarks>
     public abstract class SyntheticRecord : java.lang.Comparable
     {
 
         /// <summary>
-        /// What each record type does for the four members, built the first time one is asked for.
+        /// Initializes a new instance.
         /// </summary>
-        static readonly ConcurrentDictionary<Type, Members> ByType = new();
-
-        /// <summary>
-        /// Returns the members of this instance's type.
-        /// </summary>
-        /// <returns></returns>
-        Members Of() => ByType.GetOrAdd(GetType(), Members.For);
-
-        /// <inheritdoc />
-        public bool equals(object? other) => Of().IsEqual(this, other);
-
-        /// <inheritdoc />
-        public override bool Equals(object? other) => Of().IsEqual(this, other);
-
-        /// <inheritdoc />
-        public int hashCode() => Of().HashOf(this);
-
-        /// <inheritdoc />
-        public override int GetHashCode() => Of().HashOf(this);
-
-        /// <inheritdoc />
-        public override string ToString() => Of().PrintOf(this);
-
-        /// <inheritdoc />
-        public int compareTo(object? other) => Of().CompareOf(this, other);
-
-        /// <inheritdoc />
-        public int CompareTo(object? other) => Of().CompareOf(this, other);
-
-        /// <summary>
-        /// The four members of one record type.
-        /// </summary>
-        /// <param name="isEqual"></param>
-        /// <param name="hash"></param>
-        /// <param name="compare"></param>
-        /// <param name="print"></param>
-        sealed class Members(Func<object, object?, bool> isEqual, Func<object, int> hash, Func<object, object?, int> compare, Func<object, string> print)
+        protected SyntheticRecord()
         {
 
-            /// <summary>Compares two records field by field.</summary>
-            public Func<object, object?, bool> IsEqual { get; } = isEqual;
-
-            /// <summary>Accumulates a hash over the fields.</summary>
-            public Func<object, int> HashOf { get; } = hash;
-
-            /// <summary>Orders two records field by field.</summary>
-            public Func<object, object?, int> CompareOf { get; } = compare;
-
-            /// <summary>Renders a record.</summary>
-            public Func<object, string> PrintOf { get; } = print;
-
-            /// <summary>
-            /// <c>Utilities.hash(int, Object)</c> and its primitive overloads, which is what Calcite's
-            /// generated hashCode accumulates with.
-            /// </summary>
-            static readonly MethodInfo[] Hashes = typeof(Utilities).GetMethods(BindingFlags.Public | BindingFlags.Static);
-
-            /// <summary>
-            /// Builds the members of a record type from its fields.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <returns></returns>
-            public static Members For(Type type)
-            {
-                var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
-
-                return new Members(BuildEquals(type, fields), BuildHash(type, fields), BuildCompare(type, fields), BuildPrint(type, fields));
-            }
-
-            /// <summary>
-            /// Builds <c>equals</c>, which compares every field.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <param name="fields"></param>
-            /// <returns></returns>
-            static Func<object, object?, bool> BuildEquals(Type type, FieldInfo[] fields)
-            {
-                var left = Expression.Parameter(typeof(object), "o0");
-                var right = Expression.Parameter(typeof(object), "o1");
-                var that = Expression.Variable(type, "that");
-
-                Expression body = Expression.Constant(true);
-                foreach (var field in fields)
-                {
-                    var comparison = field.FieldType.IsValueType
-                        ? (Expression)Expression.Equal(Expression.Field(Expression.Convert(left, type), field), Expression.Field(that, field))
-                        : Expression.Call(ObjectsEqual, Expression.Convert(Expression.Field(Expression.Convert(left, type), field), typeof(object)), Expression.Convert(Expression.Field(that, field), typeof(object)));
-
-                    body = Expression.AndAlso(body, comparison);
-                }
-
-                var test = Expression.Condition(
-                    Expression.ReferenceEqual(left, right),
-                    Expression.Constant(true),
-                    Expression.Condition(
-                        Expression.TypeIs(right, type),
-                        Expression.Block([that], Expression.Assign(that, Expression.Convert(right, type)), body),
-                        Expression.Constant(false)));
-
-                return Expression.Lambda<Func<object, object?, bool>>(test, left, right).Compile();
-            }
-
-            /// <summary>
-            /// <c>Objects.equal</c>, which Calcite's generated equals uses for a reference field.
-            /// </summary>
-            static readonly MethodInfo ObjectsEqual = typeof(com.google.common.@base.Objects).GetMethod("equal", [typeof(object), typeof(object)])
-                ?? throw new InvalidOperationException("Guava's Objects has no equal(Object, Object).");
-
-            /// <summary>
-            /// Builds <c>hashCode</c>, accumulating one field at a time.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <param name="fields"></param>
-            /// <returns></returns>
-            static Func<object, int> BuildHash(Type type, FieldInfo[] fields)
-            {
-                var value = Expression.Parameter(typeof(object), "o");
-                var self = Expression.Variable(type, "self");
-                var h = Expression.Variable(typeof(int), "h");
-
-                var body = new List<Expression>
-                {
-                    Expression.Assign(self, Expression.Convert(value, type)),
-                    Expression.Assign(h, Expression.Constant(0)),
-                };
-
-                foreach (var field in fields)
-                    body.Add(Expression.Assign(h, Expression.Call(Hash(field.FieldType), h, Expression.Field(self, field))));
-
-                body.Add(h);
-
-                return Expression.Lambda<Func<object, int>>(Expression.Block([self, h], body), value).Compile();
-            }
-
-            /// <summary>
-            /// Returns the <c>Utilities.hash</c> overload that takes a value of the given type.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <returns></returns>
-            static MethodInfo Hash(Type type)
-            {
-                MethodInfo? general = null;
-
-                foreach (var candidate in Hashes)
-                {
-                    if (candidate.Name != "hash")
-                        continue;
-
-                    var parameters = candidate.GetParameters();
-                    if (parameters.Length != 2 || parameters[0].ParameterType != typeof(int))
-                        continue;
-
-                    if (parameters[1].ParameterType == type)
-                        return candidate;
-
-                    if (parameters[1].ParameterType == typeof(object))
-                        general = candidate;
-                }
-
-                return general ?? throw new NotSupportedException($"Utilities has no hash for '{type}'.");
-            }
-
-            /// <summary>
-            /// Builds <c>compareTo</c>, which returns on the first field that differs.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <param name="fields"></param>
-            /// <returns></returns>
-            static Func<object, object?, int> BuildCompare(Type type, FieldInfo[] fields)
-            {
-                var left = Expression.Parameter(typeof(object), "o0");
-                var right = Expression.Parameter(typeof(object), "o1");
-                var self = Expression.Variable(type, "self");
-                var that = Expression.Variable(type, "that");
-                var c = Expression.Variable(typeof(int), "c");
-                var end = Expression.Label(typeof(int), "return");
-
-                var body = new List<Expression>
-                {
-                    Expression.Assign(self, Expression.Convert(left, type)),
-                    Expression.Assign(that, Expression.Convert(right, type)),
-                };
-
-                foreach (var field in fields)
-                {
-                    // a field the runtime cannot compare is skipped, exactly as Calcite skips one whose
-                    // compare method does not exist: a record is not always used as a sorting key
-                    var compare = Compare(field.FieldType);
-                    if (compare == null)
-                        continue;
-
-                    body.Add(Expression.Assign(c, Expression.Call(compare, Convert(Expression.Field(self, field), compare, 0), Convert(Expression.Field(that, field), compare, 1))));
-                    body.Add(Expression.IfThen(Expression.NotEqual(c, Expression.Constant(0)), Expression.Return(end, c)));
-                }
-
-                body.Add(Expression.Label(end, Expression.Constant(0)));
-
-                return Expression.Lambda<Func<object, object?, int>>(Expression.Block([self, that, c], body), left, right).Compile();
-            }
-
-            /// <summary>
-            /// <c>Utilities.compare(Comparable, Comparable)</c>, reached by a method taking objects.
-            /// </summary>
-            static readonly MethodInfo ComparableCompare = typeof(Apache.Calcite.Extensions.Interop.JavaComparisons)
-                
-                .GetMethod(nameof(Apache.Calcite.Extensions.Interop.JavaComparisons.Compare), [typeof(object), typeof(object)])
-                ?? throw new InvalidOperationException("JavaComparisons has no Compare(object, object).");
-
-            /// <summary>
-            /// Brings a field to the type the comparison takes.
-            /// </summary>
-            /// <param name="field"></param>
-            /// <param name="method"></param>
-            /// <param name="index"></param>
-            /// <returns></returns>
-            static Expression Convert(Expression field, MethodInfo method, int index)
-            {
-                var parameter = method.GetParameters()[index].ParameterType;
-
-                return field.Type == parameter ? field : Expression.Convert(field, parameter);
-            }
-
-            /// <summary>
-            /// Returns the <c>Utilities.compare</c> overload that takes a value of the given type, or null when
-            /// there is none.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <returns></returns>
-            static MethodInfo? Compare(Type type)
-            {
-                MethodInfo? general = null;
-
-                foreach (var candidate in Hashes)
-                {
-                    if (candidate.Name != "compare")
-                        continue;
-
-                    var parameters = candidate.GetParameters();
-                    if (parameters.Length != 2 || parameters[0].ParameterType != parameters[1].ParameterType)
-                        continue;
-
-                    if (parameters[1].ParameterType == type)
-                        return candidate;
-
-                    if (parameters[1].ParameterType == typeof(java.lang.Comparable) && type.IsValueType == false)
-                        general = candidate;
-                }
-
-                // the general overload takes a java.lang.Comparable, which IKVM gives a string as a ghost
-                // interface: the CLR type system does not see it, so an Expression.Convert to it throws where
-                // Java's cast would have passed. The same call reached through a method taking an object does
-                // the conversion in compiled C#, where IKVM emits the check.
-                return general == null ? null : ComparableCompare;
-            }
-
-            /// <summary>
-            /// Builds <c>toString</c>.
-            /// </summary>
-            /// <param name="type"></param>
-            /// <param name="fields"></param>
-            /// <returns></returns>
-            static Func<object, string> BuildPrint(Type type, FieldInfo[] fields)
-            {
-                var value = Expression.Parameter(typeof(object), "o");
-                var self = Expression.Variable(type, "self");
-
-                Expression text = Expression.Constant(fields.Length == 0 ? "{}" : "{");
-                for (int i = 0; i < fields.Length; i++)
-                {
-                    text = Expression.Call(Concat, text, Expression.Constant((i == 0 ? "" : ", ") + fields[i].Name + "="));
-                    text = Expression.Call(Concat, text, Expression.Call(ValueOf, Expression.Convert(Expression.Field(self, fields[i]), typeof(object))));
-                }
-
-                if (fields.Length > 0)
-                    text = Expression.Call(Concat, text, Expression.Constant("}"));
-
-                return Expression.Lambda<Func<object, string>>(
-                    Expression.Block([self], Expression.Assign(self, Expression.Convert(value, type)), text), value).Compile();
-            }
-
-            static readonly MethodInfo Concat = typeof(string).GetMethod(nameof(string.Concat), [typeof(string), typeof(string)])
-                ?? throw new InvalidOperationException("String has no Concat(string, string).");
-            // Objects.toString rather than String.valueOf, whose helper IKVM keeps internal; both render a null as "null"
-            static readonly MethodInfo ValueOf = typeof(java.util.Objects).GetMethod("toString", [typeof(object)])
-                ?? throw new InvalidOperationException("java.util.Objects has no toString(Object).");
-
         }
+
+        /// <inheritdoc cref="Equals(object)" />
+        public bool equals(object? other) => Equals(other);
+
+        /// <inheritdoc />
+        public abstract override bool Equals(object? other);
+
+        /// <inheritdoc cref="GetHashCode" />
+        public int hashCode() => GetHashCode();
+
+        /// <inheritdoc />
+        public abstract override int GetHashCode();
+
+        /// <inheritdoc />
+        public abstract override string ToString();
+
+        /// <summary>
+        /// Orders this record against another, field by field.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public abstract int compareTo(object? other);
+
+        /// <inheritdoc />
+        public int CompareTo(object? other) => compareTo(other);
 
     }
 

--- a/src/Apache.Calcite.Tests/SyntheticRecordTests.cs
+++ b/src/Apache.Calcite.Tests/SyntheticRecordTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Runtime.CompilerServices;
+
+using Apache.Calcite.Extensions.Linq4j.Tree;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// The six members <c>EnumerableRelImplementor.classDecl</c> writes into a generated record class.
+    /// </summary>
+    [TestClass]
+    public class SyntheticRecordTests
+    {
+
+        /// <summary>
+        /// Returns the CLR type of a synthetic record over the given Java field types.
+        /// </summary>
+        /// <param name="types"></param>
+        /// <returns></returns>
+        static Type Record(params java.lang.Class[] types)
+        {
+            var list = new java.util.ArrayList();
+            foreach (var type in types)
+                list.add(type);
+
+            return ClrTypes.Resolve((java.lang.reflect.Type)new JavaTypeFactoryImpl().createSyntheticType(list));
+        }
+
+        /// <summary>
+        /// A record of one field per type, with the two constructors and nothing that is not a field.
+        /// </summary>
+        [TestMethod]
+        public void ShouldEmitAFieldPerRecordField()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            type.GetFields().Should().HaveCount(2);
+            type.GetField("f0")!.FieldType.Should().Be(typeof(string));
+            type.GetField("f1")!.FieldType.Should().Be(typeof(int));
+            type.GetConstructor([]).Should().NotBeNull();
+            type.GetConstructor([typeof(string), typeof(int)]).Should().NotBeNull();
+        }
+
+        /// <summary>
+        /// <c>equals</c> compares every field, a primitive with <c>==</c> and a reference through Guava's
+        /// <c>Objects.equal</c>, and <c>hashCode</c> accumulates <c>Utilities.hash</c> over them.
+        /// </summary>
+        [TestMethod]
+        public void ShouldEqualAndHashByEveryField()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, ["A", 1])!;
+
+            a.Equals(a).Should().BeTrue();
+            a.Equals(Activator.CreateInstance(type, ["A", 1])).Should().BeTrue();
+            a.Equals(Activator.CreateInstance(type, ["B", 1])).Should().BeFalse();
+            a.Equals(Activator.CreateInstance(type, ["A", 2])).Should().BeFalse();
+            a.Equals(null).Should().BeFalse();
+            a.Equals("A").Should().BeFalse();
+
+            a.GetHashCode().Should().Be(Activator.CreateInstance(type, ["A", 1])!.GetHashCode());
+        }
+
+        /// <summary>
+        /// A null in a reference field is equal to another null and not to a value.
+        /// </summary>
+        [TestMethod]
+        public void ShouldEqualOnANullReferenceField()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            var n = Activator.CreateInstance(type, [null, 1])!;
+
+            n.Equals(Activator.CreateInstance(type, [null, 1])).Should().BeTrue();
+            n.Equals(Activator.CreateInstance(type, ["A", 1])).Should().BeFalse();
+            n.GetHashCode().Should().Be(Activator.CreateInstance(type, [null, 1])!.GetHashCode());
+        }
+
+        /// <summary>
+        /// <c>compareTo</c> returns on the first field that differs, and one of a reference type is among
+        /// them: Calcite's body compares it through <c>Utilities.compare</c> and leaves a field out only
+        /// where no overload takes it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCompareAReferenceField()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, ["A", 1])!;
+            var b = Activator.CreateInstance(type, ["B", 1])!;
+
+            ((IComparable)a).CompareTo(b).Should().BeNegative();
+            ((IComparable)b).CompareTo(a).Should().BePositive();
+            ((IComparable)a).CompareTo(Activator.CreateInstance(type, ["A", 1])!).Should().Be(0);
+        }
+
+        /// <summary>
+        /// A field the record type declares nullable is compared with <c>Utilities.compareNullsLast</c>, which
+        /// orders a null after everything rather than throwing on it. Every reference field of a record built
+        /// from a list of types is nullable, because <c>createSyntheticType</c> asks <c>!Primitive.is</c>.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCompareANullReferenceFieldLast()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, ["A", 1])!;
+            var n = Activator.CreateInstance(type, [null, 1])!;
+
+            ((IComparable)a).CompareTo(n).Should().BeNegative();
+            ((IComparable)n).CompareTo(a).Should().BePositive();
+            ((IComparable)n).CompareTo(Activator.CreateInstance(type, [null, 1])!).Should().Be(0);
+        }
+
+        /// <summary>
+        /// A primitive field is not nullable and is compared with the overload that takes it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCompareAPrimitiveField()
+        {
+            var type = Record(java.lang.Integer.TYPE, java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, [1, 2])!;
+            var b = Activator.CreateInstance(type, [1, 3])!;
+
+            ((IComparable)a).CompareTo(b).Should().BeNegative();
+            ((IComparable)b).CompareTo(a).Should().BePositive();
+            ((IComparable)a).CompareTo(Activator.CreateInstance(type, [1, 2])!).Should().Be(0);
+        }
+
+        /// <summary>
+        /// A field of a type no overload of <c>compare</c> takes is left out rather than failing the
+        /// comparison, because a record is not always used as a sorting key.
+        /// </summary>
+        [TestMethod]
+        public void ShouldSkipAFieldNothingCompares()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.Object), java.lang.Integer.TYPE);
+
+            var a = Activator.CreateInstance(type, [new object(), 1])!;
+            var b = Activator.CreateInstance(type, [new object(), 2])!;
+
+            ((IComparable)a).CompareTo(b).Should().BeNegative();
+            ((IComparable)a).CompareTo(Activator.CreateInstance(type, [new object(), 1])!).Should().Be(0);
+        }
+
+        /// <summary>
+        /// <c>toString</c> renders every field, and a null the way Java's string concatenation does.
+        /// </summary>
+        [TestMethod]
+        public void ShouldPrintEveryField()
+        {
+            var type = Record((java.lang.Class)typeof(java.lang.String), java.lang.Integer.TYPE);
+
+            Activator.CreateInstance(type, ["A", 1])!.ToString().Should().Be("{f0=A, f1=1}");
+            Activator.CreateInstance(type, [null, 1])!.ToString().Should().Be("{f0=null, f1=1}");
+        }
+
+        /// <summary>
+        /// The emitted type is collected when the type factory that described it is, which is when the
+        /// connection closes.
+        /// </summary>
+        /// <remarks>
+        /// The record type is reachable only from <c>JavaTypeFactoryImpl.syntheticTypes</c>, so this holds
+        /// exactly as long as the emitter keys on it weakly and gives it an assembly of its own —
+        /// <c>RunAndCollect</c> collects an assembly rather than a type, so a type in a module shared with a
+        /// live one is never released, and a strongly keyed map roots the record type itself.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCollectWithTheTypeFactory()
+        {
+            var (type, factory) = Emitted();
+
+            for (int i = 0; i < 5; i++)
+            {
+                GC.Collect(2, GCCollectionMode.Forced, true, true);
+                GC.WaitForPendingFinalizers();
+            }
+
+            factory.IsAlive.Should().BeFalse();
+            type.IsAlive.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Emits a record from a factory of its own, and keeps neither.
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static (WeakReference Type, WeakReference Factory) Emitted()
+        {
+            var factory = new JavaTypeFactoryImpl();
+            var list = new java.util.ArrayList();
+            list.add((java.lang.Class)typeof(java.lang.String));
+            list.add(java.lang.Integer.TYPE);
+
+            var clr = ClrTypes.Resolve((java.lang.reflect.Type)factory.createSyntheticType(list));
+            Activator.CreateInstance(clr, ["A", 1]);
+
+            return (new WeakReference(clr), new WeakReference(factory));
+        }
+
+    }
+
+}


### PR DESCRIPTION
Supersedes #52 and #53, both of which patched `SyntheticRecord.Members` — code this deletes.

## The shape

`EnumerableRelImplementor.classDecl` writes six things into one class declaration, from one loop over `getRecordFields()`:

| `classDecl` | before | now |
|---|---|---|
| a field per record field | `Build` | `Emit` |
| the constructor | `Build` | `Emit` |
| `equals` | `Members.BuildEquals` | `Emit` |
| `hashCode` | `Members.BuildHash` | `Emit` |
| `compareTo` | `Members.BuildCompare` | `Emit` |
| `toString` | `Members.BuildPrint` | `Emit` |

`ClassDecl` is the entry point and memoises; `Emit` is `classDecl`'s body section for section, with its comment blocks and its locals — `classDeclaration`, `blockBuilder2`…`blockBuilder5`, `thatParameter`, `cParameter`, `hParameter`.

Calcite never resolves a `SyntheticRecordType`: `Types.toClass` throws on a `RecordType` because the class is still text, and `Expressions.parameter` carries the type until Janino writes its name into the same compilation unit as the declaration. `Expression.Parameter` takes a `System.Type`, so the class has to be real before anything names it — which is why `ClassDecl` returns a finished type and why all six are on it before it returns.

## The bug that came out of the split

The four members were built later, from the CLR type, in the one row where `Types.RecordField.nullable()` is out of reach. So `compareTo` always named `compare` and never `compareNullsLast`:

```
RecordField f0 type=class java.lang.String nullable=True
the name Calcite would pick           = compareNullsLast
Utilities.compareNullsLast(null, "A") = 1
Utilities.compare(null, "A")          = System.NullReferenceException
```

A null in a reference field threw where Calcite orders it last. Held by `ShouldCompareANullReferenceFieldLast`.

Deleting `Members` also removes a `ConcurrentDictionary` lookup that ran on every `equals`, `hashCode` and `compareTo` — per row, inside hash joins and aggregates. Calcite pays nothing there.

## Lifetime

The emitted type now lives exactly as long as the factory that described it. A `SyntheticRecordType` is reachable only from `JavaTypeFactoryImpl.syntheticTypes`, an instance field, and nothing reaches back the other way — so a `ConditionalWeakTable` keyed on it *is* the lifetime, where the old static `Dictionary` rooted every record type of every connection for the life of the process.

`RunAndCollect` collects an assembly rather than a type, so one shared module released nothing while any type in it was live, and a static field holding the builder meant it was never collected at all. Measured over a thousand types:

| | emit | managed, alive | after dropping every reference | working set |
|---|---|---|---|---|
| one shared module | 128 µs/type | 2.2 KB/type | 2.2 KB/type still held | 105 MB, flat |
| an assembly per type | 201 µs/type | 0.3 KB/type | ~0 | 142 → 110 MB |

73 µs per record shape, once, against ~32 KB per live shape that comes back. `ShouldCollectWithTheTypeFactory` holds it — drop the factory, and after five blocking gen-2 collections both it and the emitted type are dead. **It is the only GC-timing-dependent test in the suite**; it passed on every run here, but it is the one to look at first if the suite ever goes red for no reason.

## `ClrTypes.Resolve(declaring, name, arguments)`

Now binds on `Types.assignableFrom` — a subclass, or a widening between two primitives — rather than on `Accepts`, which also counts a box and its primitive as fitting. That is right for `Rebind`, whose caller converts every argument to its parameter, and wrong for a call emitted as it stands: under it a `java.lang.Integer` field binds `hash(int, int)` and wants an unboxing nothing emits. Under `assignableFrom` it binds `hash(int, Object)`, which is what Calcite binds. `Accepts` is untouched and still `Rebind`'s.

## Verification

`SyntheticRecordTests`, 9 cases over the six members. Full suite 752, none skipped.

One thing to look at: `equals` now decides `==` versus `Objects.equal` on `Primitive.is(field.getType())`, the Java type, where it asked `FieldInfo.FieldType.IsValueType` before. I have found no case where they disagree; `Primitive.is` is simply what Calcite asks.
