### PR TITLE
Port CalciteConnectionImpl's constructor, and name a type system in .NET

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSchemaTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSchemaTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using org.apache.calcite.jdbc;
 using org.apache.calcite.rel.type;
@@ -125,7 +125,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [TestMethod]
         public void ATableKnowsItsDataSource()
         {
-            Assert.IsNotNull(((AdoTable)Table("EMPS")).DataSource);
+            Assert.IsNotNull(((AdoTable)Table("EMPS")).Schema.DataSource);
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.rel.type;
+using System.Data;
 using System.Data.Common;
 using System.Threading;
 
@@ -70,7 +73,7 @@ namespace Apache.Calcite.Adapter.AdoNet
             {
                 foreach (var table in _schema.DataSource.Metadata.GetTables(_schema.DatabaseName, _schema.SchemaName))
                     if (table.Name == name)
-                        return new AdoTable(_schema.DataSource, _schema.Convention, table.DatabaseName, table.SchemaName, table.Name, Schema.TableType.TABLE);
+                        return new AdoTable(_schema, table.DatabaseName, table.SchemaName, table.Name, Schema.TableType.TABLE);
 
                 return null;
             }
@@ -274,6 +277,143 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// Gets the schema refered to by this <see cref="AdoSchema"/>.
         /// </summary>
         public string? SchemaName => _schemaName;
+
+        /// <summary>
+        /// Gets the <see cref="RelProtoDataType"/> of a table, acquiring the column metadata first. This
+        /// is <c>JdbcSchema.getRelDataType</c>'s three-argument overload, which opens a connection to
+        /// reach <c>DatabaseMetaData</c>; the data source already carries ours.
+        /// </summary>
+        /// <param name="databaseName"></param>
+        /// <param name="schemaName"></param>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        /// <exception cref="AdoCalciteException"></exception>
+        internal RelProtoDataType GetRelDataType(string? databaseName, string? schemaName, string tableName)
+        {
+            return GetRelDataType(_dataSource.Metadata, databaseName, schemaName, tableName);
+        }
+
+        /// <summary>
+        /// Derives the <see cref="RelProtoDataType"/> of a table from column metadata.
+        /// </summary>
+        /// <param name="databaseName"></param>
+        /// <param name="schemaName"></param>
+        /// <param name="tableName"></param>
+        /// <returns></returns>
+        internal RelProtoDataType GetRelDataType(AdoDatabaseMetadata metaData, string? databaseName, string? schemaName, string tableName)
+        {
+            // This is JdbcSchema.getRelDataType's body, and upstream's comment on the line below is:
+            // "Temporary type factory, just for the duration of this method. Allowable because we're
+            // creating a proto-type, not a type; before being used, the proto-type will be copied into a
+            // real type factory." RelDataTypeImpl.proto is typeFactory -> typeFactory.copyType(t), so
+            // that holds.
+            //
+            // The one place this cannot follow upstream is where the column metadata comes from. JDBC
+            // reads DatabaseMetaData.getColumns off a connection the schema opens, and ADO.NET has no
+            // DatabaseMetaData -- GetSchema("Columns") differs per provider, and ODBC and OleDb cannot
+            // reliably say what they are -- so this adapter owns that SPI as AdoDatabaseMetadata. It
+            // takes the place of DatabaseMetaData in the parameter list, and the overload above acquires
+            // it where upstream opens a connection.
+            //
+            // Ours, not upstream's: copying is not re-deriving. createSqlType clamped precision and
+            // scale against DEFAULT's limits here, and copyType carries the clamped type across rather
+            // than deriving it again, so a connection's own type system does not widen a column read
+            // from an ADO source. Reasoned from those two members; no test covers it.
+            var typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+            var types = typeFactory.builder();
+
+            // derive a type for each field
+            foreach (var field in metaData.GetFields(databaseName, schemaName, tableName))
+            {
+                if (field.Name is null)
+                    throw new AdoCalciteException("Null value encountered for field name.");
+
+                types.add(field.Name, SqlType(typeFactory, field.DbType, field.Precision ?? -1, field.Scale ?? -1, field.Size ?? -1)).nullable(field.Nullable);
+            }
+
+            return RelDataTypeImpl.proto(types.build());
+        }
+
+        /// <summary>
+        /// Transforms a <see cref="DbType"/> and its various additional information into a <see cref="RelDataType"/>. This is <c>JdbcSchema.sqlType</c>.
+        /// </summary>
+        /// <param name="typeFactory"></param>
+        /// <param name="dbType"></param>
+        /// <param name="precision"></param>
+        /// <param name="scale"></param>
+        /// <param name="size"></param>
+        /// <returns></returns>
+        /// <exception cref="AdoCalciteException"></exception>
+        static RelDataType SqlType(RelDataTypeFactory typeFactory, DbType dbType, int precision, int scale, int size)
+        {
+            switch (dbType)
+            {
+                case DbType.AnsiString:
+                    return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
+                case DbType.Binary:
+                    return typeFactory.createSqlType(SqlTypeName.VARBINARY, size);
+                // DbType.Byte is the unsigned 0..255 one and TINYINT is signed, so the top half of its range
+                // comes back negative: SQL Server's tinyint 200 read as a TINYINT is -56. UTINYINT is the
+                // type that holds it, as USMALLINT holds a UInt16 below — and as ParameterBinder already
+                // says on the way in, binding a DbType.Byte as a joou UByte
+                case DbType.Byte:
+                    return typeFactory.createSqlType(SqlTypeName.UTINYINT);
+                case DbType.Boolean:
+                    return typeFactory.createSqlType(SqlTypeName.BOOLEAN);
+                // the scale money carries in every provider that has a distinct type for it
+                case DbType.Currency:
+                    return typeFactory.createSqlType(SqlTypeName.DECIMAL, 19, 4);
+                case DbType.Date:
+                    return typeFactory.createSqlType(SqlTypeName.DATE);
+                case DbType.DateTime:
+                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+                case DbType.Decimal:
+                    return typeFactory.createSqlType(SqlTypeName.DECIMAL, precision, scale);
+                case DbType.Double:
+                    return typeFactory.createSqlType(SqlTypeName.DOUBLE);
+                case DbType.Guid:
+                    return typeFactory.createSqlType(SqlTypeName.CHAR, 36);
+                case DbType.Int16:
+                    return typeFactory.createSqlType(SqlTypeName.SMALLINT);
+                case DbType.Int32:
+                    return typeFactory.createSqlType(SqlTypeName.INTEGER);
+                case DbType.Int64:
+                    return typeFactory.createSqlType(SqlTypeName.BIGINT);
+                // OTHER is the escape hatch the reader already understands: a column of unknown type is
+                // passed through rather than making the whole table unreadable
+                case DbType.Object:
+                    return typeFactory.createSqlType(SqlTypeName.OTHER);
+                case DbType.SByte:
+                    return typeFactory.createSqlType(SqlTypeName.TINYINT);
+                // REAL is four bytes in Calcite, as it is in SQL; DOUBLE is eight
+                case DbType.Single:
+                    return typeFactory.createSqlType(SqlTypeName.REAL);
+                case DbType.String:
+                    return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
+                case DbType.Time:
+                    return typeFactory.createSqlType(SqlTypeName.TIME);
+                case DbType.UInt16:
+                    return typeFactory.createSqlType(SqlTypeName.USMALLINT);
+                case DbType.UInt32:
+                    return typeFactory.createSqlType(SqlTypeName.UINTEGER);
+                case DbType.UInt64:
+                    return typeFactory.createSqlType(SqlTypeName.UBIGINT);
+                case DbType.VarNumeric:
+                    return typeFactory.createSqlType(SqlTypeName.DECIMAL, precision, scale);
+                case DbType.AnsiStringFixedLength:
+                    return typeFactory.createSqlType(SqlTypeName.CHAR, size);
+                case DbType.StringFixedLength:
+                    return typeFactory.createSqlType(SqlTypeName.CHAR, size);
+                case DbType.Xml:
+                    return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
+                case DbType.DateTime2:
+                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+                case DbType.DateTimeOffset:
+                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP_TZ);
+            }
+
+            throw new AdoCalciteException($"Unsupported database type: {dbType}.");
+        }
 
         /// <inheritdoc />
         public override Lookup tables()

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -68,24 +68,11 @@ namespace Apache.Calcite.Adapter.AdoNet
         }
 
         /// <summary>
-        /// Gets the schema holding this table, which is <c>JdbcTable.jdbcSchema</c>.
+        /// Gets the schema holding this table, which is <c>JdbcTable.jdbcSchema</c>. The data source, the
+        /// convention and the dialect are read through it, <c>JdbcTable</c> carrying no accessor of its
+        /// own for any of the three.
         /// </summary>
         public AdoSchema Schema => _schema;
-
-        /// <summary>
-        /// Gets the ADO data source.
-        /// </summary>
-        public AdoDataSource DataSource => _schema.DataSource;
-
-        /// <summary>
-        /// Gets the ADO convention.
-        /// </summary>
-        public AdoConvention Convention => _schema.Convention;
-
-        /// <summary>
-        /// Gets the SQL dialect.
-        /// </summary>
-        public SqlDialect Dialect => _schema.Convention.Dialect;
 
         /// <inheritdoc />
         public override Schema.TableType getJdbcTableType() => _tableType;

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -128,12 +128,21 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         RelProtoDataType GetRowProtoDataType(string? databaseName, string? schemaName, string tableName)
         {
-            // Temporary type factory, just for the duration of this method. Allowable because we are
+            // This is JdbcSchema.getRelDataType's body, and upstream's comment on the line below is:
+            // "Temporary type factory, just for the duration of this method. Allowable because we're
             // creating a proto-type, not a type; before being used, the proto-type will be copied into a
-            // real type factory, RelDataTypeImpl.proto answering typeFactory -> typeFactory.copyType(t).
-            // Note that copying is not re-deriving: precision and scale were clamped against DEFAULT's
-            // limits here, so a connection's own type system does not widen a column read from an ADO
-            // source. That is JdbcSchema.getRelDataType's behaviour and this is a port of it.
+            // real type factory." RelDataTypeImpl.proto is typeFactory -> typeFactory.copyType(t), so
+            // that holds.
+            //
+            // It lives on the table rather than on the schema because AdoTable holds an AdoDataSource
+            // where JdbcTable holds its JdbcSchema and delegates through supplyProto. The memoized
+            // supplier is upstream's; only the body's home moved, and there is no AdoSchema member to
+            // delegate to.
+            //
+            // Ours, not upstream's: copying is not re-deriving. createSqlType clamped precision and
+            // scale against DEFAULT's limits here, and copyType carries the clamped type across rather
+            // than deriving it again, so a connection's own type system does not widen a column read
+            // from an ADO source. Reasoned from those two members; no test covers it.
             var typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
             var types = typeFactory.builder();
 

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Threading;
 
@@ -128,6 +128,12 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <returns></returns>
         RelProtoDataType GetRowProtoDataType(string? databaseName, string? schemaName, string tableName)
         {
+            // Temporary type factory, just for the duration of this method. Allowable because we are
+            // creating a proto-type, not a type; before being used, the proto-type will be copied into a
+            // real type factory, RelDataTypeImpl.proto answering typeFactory -> typeFactory.copyType(t).
+            // Note that copying is not re-deriving: precision and scale were clamped against DEFAULT's
+            // limits here, so a connection's own type system does not widen a column read from an ADO
+            // source. That is JdbcSchema.getRelDataType's behaviour and this is a port of it.
             var typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
             var types = typeFactory.builder();
 

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -134,10 +134,15 @@ namespace Apache.Calcite.Adapter.AdoNet
             // real type factory." RelDataTypeImpl.proto is typeFactory -> typeFactory.copyType(t), so
             // that holds.
             //
-            // It lives on the table rather than on the schema because AdoTable holds an AdoDataSource
-            // where JdbcTable holds its JdbcSchema and delegates through supplyProto. The memoized
-            // supplier is upstream's; only the body's home moved, and there is no AdoSchema member to
-            // delegate to.
+            // It lives on the table rather than on the schema, where upstream keeps it and reaches it
+            // through JdbcTable.supplyProto. JdbcSchema owns the method because JDBC's column metadata
+            // is DatabaseMetaData.getColumns off a connection the schema opens, and the schema is the
+            // only place with the means. ADO.NET has no DatabaseMetaData -- GetSchema("Columns") differs
+            // per provider and ODBC and OleDb cannot reliably say what they are -- so this adapter owns
+            // the SPI instead, AdoDatabaseMetadata.GetFields on the data source. Once the metadata hangs
+            // there, a schema-side method would take the table name and use nothing of its own, and
+            // AdoSchema and AdoTable hold the same four fields as it is. The memoized supplier is
+            // upstream's; only the body's home follows the metadata.
             //
             // Ours, not upstream's: copying is not re-deriving. createSqlType clamped precision and
             // scale against DEFAULT's limits here, and copyType carries the clamped type across rather

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTable.cs
@@ -38,8 +38,7 @@ namespace Apache.Calcite.Adapter.AdoNet
 
         readonly java.util.function.Supplier protoRowTypeSupplier;
 
-        readonly AdoDataSource _dataSource;
-        readonly AdoConvention _convention;
+        readonly AdoSchema _schema;
         readonly string? _databaseName;
         readonly string? _schemaName;
         readonly string _tableName;
@@ -50,20 +49,18 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
-        /// <param name="dataSource"></param>
-        /// <param name="convention"></param>
+        /// <param name="schema"></param>
         /// <param name="databaseName"></param>
         /// <param name="schemaName"></param>
         /// <param name="tableName"></param>
         /// <param name="tableType"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        internal AdoTable(AdoDataSource dataSource, AdoConvention convention, string? databaseName, string? schemaName, string tableName, Schema.TableType tableType) :
+        internal AdoTable(AdoSchema schema, string? databaseName, string? schemaName, string tableName, Schema.TableType tableType) :
             base((Class)typeof(object[]))
         {
-            protoRowTypeSupplier = Suppliers.memoize(new FuncSupplier<RelProtoDataType>(GetRowProtoDataType));
+            protoRowTypeSupplier = Suppliers.memoize(new FuncSupplier<RelProtoDataType>(SupplyProto));
 
-            _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
-            _convention = convention ?? throw new ArgumentNullException(nameof(convention));
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
             _databaseName = databaseName;
             _schemaName = schemaName;
             _tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
@@ -71,19 +68,24 @@ namespace Apache.Calcite.Adapter.AdoNet
         }
 
         /// <summary>
+        /// Gets the schema holding this table, which is <c>JdbcTable.jdbcSchema</c>.
+        /// </summary>
+        public AdoSchema Schema => _schema;
+
+        /// <summary>
         /// Gets the ADO data source.
         /// </summary>
-        public AdoDataSource DataSource => _dataSource;
+        public AdoDataSource DataSource => _schema.DataSource;
 
         /// <summary>
         /// Gets the ADO convention.
         /// </summary>
-        public AdoConvention Convention => _convention;
+        public AdoConvention Convention => _schema.Convention;
 
         /// <summary>
         /// Gets the SQL dialect.
         /// </summary>
-        public SqlDialect Dialect => _convention.Dialect;
+        public SqlDialect Dialect => _schema.Convention.Dialect;
 
         /// <inheritdoc />
         public override Schema.TableType getJdbcTableType() => _tableType;
@@ -110,138 +112,14 @@ namespace Apache.Calcite.Adapter.AdoNet
         }
 
         /// <summary>
-        /// Gets the <see cref="RelProtoDataType"/> for the row type of this table.
+        /// Supplies the <see cref="RelProtoDataType"/> the memoized supplier holds, which is
+        /// <c>JdbcTable.supplyProto</c> — the schema derives it, the table asks.
         /// </summary>
         /// <returns></returns>
         /// <exception cref="AdoCalciteException"></exception>
-        RelProtoDataType GetRowProtoDataType()
+        RelProtoDataType SupplyProto()
         {
-            return GetRowProtoDataType(_databaseName, _schemaName, _tableName);
-        }
-
-        /// <summary>
-        /// Gets the <see cref="RelProtoDataType"/> for a given table.
-        /// </summary>
-        /// <param name="databaseName"></param>
-        /// <param name="schemaName"></param>
-        /// <param name="tableName"></param>
-        /// <returns></returns>
-        RelProtoDataType GetRowProtoDataType(string? databaseName, string? schemaName, string tableName)
-        {
-            // This is JdbcSchema.getRelDataType's body, and upstream's comment on the line below is:
-            // "Temporary type factory, just for the duration of this method. Allowable because we're
-            // creating a proto-type, not a type; before being used, the proto-type will be copied into a
-            // real type factory." RelDataTypeImpl.proto is typeFactory -> typeFactory.copyType(t), so
-            // that holds.
-            //
-            // It lives on the table rather than on the schema, where upstream keeps it and reaches it
-            // through JdbcTable.supplyProto. JdbcSchema owns the method because JDBC's column metadata
-            // is DatabaseMetaData.getColumns off a connection the schema opens, and the schema is the
-            // only place with the means. ADO.NET has no DatabaseMetaData -- GetSchema("Columns") differs
-            // per provider and ODBC and OleDb cannot reliably say what they are -- so this adapter owns
-            // the SPI instead, AdoDatabaseMetadata.GetFields on the data source. Once the metadata hangs
-            // there, a schema-side method would take the table name and use nothing of its own, and
-            // AdoSchema and AdoTable hold the same four fields as it is. The memoized supplier is
-            // upstream's; only the body's home follows the metadata.
-            //
-            // Ours, not upstream's: copying is not re-deriving. createSqlType clamped precision and
-            // scale against DEFAULT's limits here, and copyType carries the clamped type across rather
-            // than deriving it again, so a connection's own type system does not widen a column read
-            // from an ADO source. Reasoned from those two members; no test covers it.
-            var typeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-            var types = typeFactory.builder();
-
-            // derive a type for each field
-            foreach (var field in _dataSource.Metadata.GetFields(databaseName, schemaName, tableName))
-            {
-                if (field.Name is null)
-                    throw new AdoCalciteException("Null value encountered for field name.");
-
-                types.add(field.Name, GetSqlType(typeFactory, field.DbType, field.Precision ?? -1, field.Scale ?? -1, field.Size ?? -1)).nullable(field.Nullable);
-            }
-
-            return RelDataTypeImpl.proto(types.build());
-        }
-
-        /// <summary>
-        /// Transforms a <see cref="DbType"/> and its various additional information into a <see cref="RelDataType"/>.
-        /// </summary>
-        /// <param name="typeFactory"></param>
-        /// <param name="dbType"></param>
-        /// <param name="precision"></param>
-        /// <param name="scale"></param>
-        /// <param name="size"></param>
-        /// <returns></returns>
-        /// <exception cref="AdoCalciteException"></exception>
-        RelDataType GetSqlType(RelDataTypeFactory typeFactory, DbType dbType, int precision, int scale, int size)
-        {
-            switch (dbType)
-            {
-                case DbType.AnsiString:
-                    return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
-                case DbType.Binary:
-                    return typeFactory.createSqlType(SqlTypeName.VARBINARY, size);
-                // DbType.Byte is the unsigned 0..255 one and TINYINT is signed, so the top half of its range
-                // comes back negative: SQL Server's tinyint 200 read as a TINYINT is -56. UTINYINT is the
-                // type that holds it, as USMALLINT holds a UInt16 below — and as ParameterBinder already
-                // says on the way in, binding a DbType.Byte as a joou UByte
-                case DbType.Byte:
-                    return typeFactory.createSqlType(SqlTypeName.UTINYINT);
-                case DbType.Boolean:
-                    return typeFactory.createSqlType(SqlTypeName.BOOLEAN);
-                // the scale money carries in every provider that has a distinct type for it
-                case DbType.Currency:
-                    return typeFactory.createSqlType(SqlTypeName.DECIMAL, 19, 4);
-                case DbType.Date:
-                    return typeFactory.createSqlType(SqlTypeName.DATE);
-                case DbType.DateTime:
-                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
-                case DbType.Decimal:
-                    return typeFactory.createSqlType(SqlTypeName.DECIMAL, precision, scale);
-                case DbType.Double:
-                    return typeFactory.createSqlType(SqlTypeName.DOUBLE);
-                case DbType.Guid:
-                    return typeFactory.createSqlType(SqlTypeName.CHAR, 36);
-                case DbType.Int16:
-                    return typeFactory.createSqlType(SqlTypeName.SMALLINT);
-                case DbType.Int32:
-                    return typeFactory.createSqlType(SqlTypeName.INTEGER);
-                case DbType.Int64:
-                    return typeFactory.createSqlType(SqlTypeName.BIGINT);
-                // OTHER is the escape hatch the reader already understands: a column of unknown type is
-                // passed through rather than making the whole table unreadable
-                case DbType.Object:
-                    return typeFactory.createSqlType(SqlTypeName.OTHER);
-                case DbType.SByte:
-                    return typeFactory.createSqlType(SqlTypeName.TINYINT);
-                // REAL is four bytes in Calcite, as it is in SQL; DOUBLE is eight
-                case DbType.Single:
-                    return typeFactory.createSqlType(SqlTypeName.REAL);
-                case DbType.String:
-                    return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
-                case DbType.Time:
-                    return typeFactory.createSqlType(SqlTypeName.TIME);
-                case DbType.UInt16:
-                    return typeFactory.createSqlType(SqlTypeName.USMALLINT);
-                case DbType.UInt32:
-                    return typeFactory.createSqlType(SqlTypeName.UINTEGER);
-                case DbType.UInt64:
-                    return typeFactory.createSqlType(SqlTypeName.UBIGINT);
-                case DbType.VarNumeric:
-                    return typeFactory.createSqlType(SqlTypeName.DECIMAL, precision, scale);
-                case DbType.AnsiStringFixedLength:
-                    return typeFactory.createSqlType(SqlTypeName.CHAR, size);
-                case DbType.StringFixedLength:
-                    return typeFactory.createSqlType(SqlTypeName.CHAR, size);
-                case DbType.Xml:
-                    return typeFactory.createSqlType(SqlTypeName.VARCHAR, size);
-                case DbType.DateTime2:
-                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
-                case DbType.DateTimeOffset:
-                    return typeFactory.createSqlType(SqlTypeName.TIMESTAMP_TZ);
-            }
-
-            throw new AdoCalciteException($"Unsupported database type: {dbType}.");
+            return _schema.GetRelDataType(_databaseName, _schemaName, _tableName);
         }
 
         /// <summary>
@@ -251,7 +129,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         internal SqlString GenerateSqlString()
         {
             var node = new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, SqlNodeList.SINGLETON_STAR, FullyQualifiedTableName, null, null, null, null, null, null, null, null, null);
-            var config = SqlPrettyWriter.config().withAlwaysUseParentheses(true).withDialect(_convention.Dialect);
+            var config = SqlPrettyWriter.config().withAlwaysUseParentheses(true).withDialect(_schema.Convention.Dialect);
             var writer = new SqlPrettyWriter(config);
             node.unparse(writer, 0, 0);
             return writer.toSqlString();
@@ -303,7 +181,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             var typeFactory = root.getTypeFactory();
             var sql = GenerateSql();
-            return AdoEnumerable.CreateReader(_dataSource, sql.getSql(), AdoUtils.CreateObjectArrayRowBuilderFactory(getRowType(typeFactory).getFieldList()));
+            return AdoEnumerable.CreateReader(_schema.DataSource, sql.getSql(), AdoUtils.CreateObjectArrayRowBuilderFactory(getRowType(typeFactory).getFieldList()));
         }
 
         /// <summary>
@@ -314,7 +192,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             var selectList = SqlNodeList.SINGLETON_STAR;
             var node = new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, selectList, FullyQualifiedTableName, null, null, null, null, null, null, null, null, null);
-            var config = SqlPrettyWriter.config().withAlwaysUseParentheses(true).withDialect(_convention.Dialect);
+            var config = SqlPrettyWriter.config().withAlwaysUseParentheses(true).withDialect(_schema.Convention.Dialect);
             var writer = new SqlPrettyWriter(config);
             node.unparse(writer, 0, 0);
             return writer.toSqlString();
@@ -323,10 +201,10 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <inheritdoc />
         public override object unwrap(Class aClass)
         {
-            if (aClass.isInstance(_dataSource))
-                return aClass.cast(_dataSource);
-            else if (aClass.isInstance(_convention.Dialect))
-                return aClass.cast(_convention.Dialect);
+            if (aClass.isInstance(_schema.DataSource))
+                return aClass.cast(_schema.DataSource);
+            else if (aClass.isInstance(_schema.Convention.Dialect))
+                return aClass.cast(_schema.Convention.Dialect);
             else
                 return base.unwrap(aClass);
         }

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTableQueryable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTableQueryable.cs
@@ -44,7 +44,7 @@ namespace Apache.Calcite.Adapter.AdoNet
             var typeFactory = ((CalciteConnection)queryProvider).getTypeFactory();
             var fields = _adoTable.getRowType(typeFactory).getFieldList();
             var sql = GenerateSql();
-            var enumerable = AdoEnumerable.CreateReader(_adoTable.DataSource, sql.getSql(), AdoUtils.CreateObjectArrayRowBuilderFactory(fields));
+            var enumerable = AdoEnumerable.CreateReader(_adoTable.Schema.DataSource, sql.getSql(), AdoUtils.CreateObjectArrayRowBuilderFactory(fields));
             return enumerable.enumerator();
         }
 
@@ -56,7 +56,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             var selectList = SqlNodeList.SINGLETON_STAR;
             var node = new SqlSelect(SqlParserPos.ZERO, SqlNodeList.EMPTY, selectList, _adoTable.FullyQualifiedTableName, null, null, null, null, null, null, null, null, null);
-            var config = SqlPrettyWriter.config().withAlwaysUseParentheses(true).withDialect(_adoTable.Dialect);
+            var config = SqlPrettyWriter.config().withAlwaysUseParentheses(true).withDialect(_adoTable.Schema.Convention.Dialect);
             var writer = new SqlPrettyWriter(config);
             node.unparse(writer, 0, 0);
             return writer.toSqlString();

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoTableScan.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoTableScan.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 using Apache.Calcite.Adapter.AdoNet.Rel;
 
@@ -30,7 +30,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="table"></param>
         /// <param name="adoTable"></param>
         internal AdoTableScan(RelOptCluster cluster, List hints, RelOptTable table, AdoTable adoTable) :
-            base(cluster, cluster.traitSetOf(adoTable.Convention), hints, table)
+            base(cluster, cluster.traitSetOf(adoTable.Schema.Convention), hints, table)
         {
             _adoTable = adoTable ?? throw new ArgumentNullException(nameof(adoTable));
         }

--- a/src/Apache.Calcite.Data.Tests/CalciteSessionConstructionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteSessionConstructionTests.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 using Apache.Calcite.Data.Internal;
 
@@ -20,9 +21,90 @@ namespace Apache.Calcite.Data.Tests
     public class TestTypeSystem : RelDataTypeSystemImpl
     {
 
+        /// <summary>
+        /// A public static field, which is upstream's only <c>#Member</c> form.
+        /// </summary>
+        public static readonly TestTypeSystem Handle = new TestTypeSystem();
+
         public override int getMaxPrecision(SqlTypeName typeName)
         {
             return typeName == SqlTypeName.DECIMAL ? 21 : base.getMaxPrecision(typeName);
+        }
+
+    }
+
+    /// <summary>
+    /// A type system that widens <c>SUM</c> over an exact integer to <c>BIGINT</c>. Calcite's default
+    /// <c>deriveSumType</c> answers the argument type, so <c>SUM</c> of an <c>INTEGER</c> column is an
+    /// <c>INTEGER</c>; this is the shape of type system that changes which Java class a row carries.
+    /// </summary>
+    public class WideSumTypeSystem : RelDataTypeSystemImpl
+    {
+
+        public override RelDataType deriveSumType(RelDataTypeFactory typeFactory, RelDataType argumentType)
+        {
+            return typeFactory.createTypeWithNullability(
+                typeFactory.createSqlType(SqlTypeName.BIGINT), argumentType.isNullable());
+        }
+
+    }
+
+    /// <summary>
+    /// A type system handed out by a public static field named <c>INSTANCE</c>, which the plugin machinery
+    /// reads in preference to the default constructor when no member is named.
+    /// </summary>
+    public class InstanceTypeSystem : RelDataTypeSystemImpl
+    {
+
+        /// <summary>
+        /// The instance.
+        /// </summary>
+        public static readonly InstanceTypeSystem INSTANCE = new InstanceTypeSystem();
+
+        public override int getMaxPrecision(SqlTypeName typeName)
+        {
+            return typeName == SqlTypeName.DECIMAL ? 22 : base.getMaxPrecision(typeName);
+        }
+
+    }
+
+    /// <summary>
+    /// A type system handed out by a public static parameterless method, which is the .NET form of the
+    /// <c>#Member</c> suffix and the one upstream's field-only lookup does not reach.
+    /// </summary>
+    public class MethodTypeSystem : RelDataTypeSystemImpl
+    {
+
+        /// <summary>
+        /// Answers the instance.
+        /// </summary>
+        public static MethodTypeSystem Create()
+        {
+            return new MethodTypeSystem();
+        }
+
+        public override int getMaxPrecision(SqlTypeName typeName)
+        {
+            return typeName == SqlTypeName.DECIMAL ? 23 : base.getMaxPrecision(typeName);
+        }
+
+    }
+
+    /// <summary>
+    /// A type system behind a <see cref="ThreadLocal{T}"/>, which is the CLR spelling of the holder
+    /// Avatica unwraps a <c>java.lang.ThreadLocal</c> for.
+    /// </summary>
+    public class ThreadLocalTypeSystem : RelDataTypeSystemImpl
+    {
+
+        /// <summary>
+        /// The instance for the calling thread.
+        /// </summary>
+        public static readonly ThreadLocal<ThreadLocalTypeSystem> Current = new(() => new ThreadLocalTypeSystem());
+
+        public override int getMaxPrecision(SqlTypeName typeName)
+        {
+            return typeName == SqlTypeName.DECIMAL ? 24 : base.getMaxPrecision(typeName);
         }
 
     }
@@ -51,6 +133,15 @@ namespace Apache.Calcite.Data.Tests
             return values;
         }
 
+        /// <summary>
+        /// A connection string naming a type system. The name is quoted because an assembly-qualified one
+        /// carries a comma, which the connection string would otherwise read as a separator.
+        /// </summary>
+        static string Cs(string typeSystem)
+        {
+            return TestModels.InlineEmptyModelConnectionString + ";TypeSystem=\"" + typeSystem + "\"";
+        }
+
         const string RaggedUnionSql =
             "SELECT * FROM (VALUES CAST('ab' AS CHAR(2))) UNION SELECT * FROM (VALUES CAST('abcde' AS CHAR(5)))";
 
@@ -74,10 +165,14 @@ namespace Apache.Calcite.Data.Tests
             Assert.Contains("abcde", values);
         }
 
+        /// <summary>
+        /// A type named by itself is constructed, which is the plain case and the only one a .NET user
+        /// writing their own type system needs.
+        /// </summary>
         [Fact]
-        public void TypeSystem_option_should_reach_the_type_factory()
+        public void TypeSystem_option_should_construct_a_type_named_by_itself()
         {
-            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";TypeSystem=\"" + typeof(TestTypeSystem).AssemblyQualifiedName + "\"");
+            using var c = new CalciteConnection(Cs(typeof(TestTypeSystem).AssemblyQualifiedName!));
             c.Open();
             var typeSystem = c.TypeFactory.getTypeSystem();
             Assert.IsType<TestTypeSystem>(typeSystem);
@@ -92,12 +187,182 @@ namespace Apache.Calcite.Data.Tests
             Assert.Same(RelDataTypeSystem.DEFAULT, c.TypeFactory.getTypeSystem());
         }
 
+        /// <summary>
+        /// The point of the member form. Calcite ships its type systems as anonymous classes behind
+        /// public static fields, so they have no type to name and a type-only syntax cannot reach any of
+        /// them at all.
+        /// </summary>
+        [Fact]
+        public void TypeSystem_option_should_reach_a_type_system_calcite_ships()
+        {
+            using var c = new CalciteConnection(Cs("[org.apache.calcite.sql.dialect.MysqlSqlDialect, calcite.core]::MYSQL_TYPE_SYSTEM"));
+            c.Open();
+            Assert.Same(org.apache.calcite.sql.dialect.MysqlSqlDialect.MYSQL_TYPE_SYSTEM, c.TypeFactory.getTypeSystem());
+        }
+
+        /// <summary>
+        /// A Java <c>static final</c> is a CLR property under IKVM rather than a field, so the member
+        /// lookup has to try both.
+        /// </summary>
+        [Fact]
+        public void TypeSystem_option_should_read_a_member_that_ikvm_surfaces_as_a_property()
+        {
+            using var c = new CalciteConnection(Cs("[org.apache.calcite.rel.type.RelDataTypeSystem, calcite.core]::DEFAULT"));
+            c.Open();
+            Assert.Same(RelDataTypeSystem.DEFAULT, c.TypeFactory.getTypeSystem());
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_read_a_static_field_member()
+        {
+            using var c = new CalciteConnection(Cs("[" + typeof(TestTypeSystem).AssemblyQualifiedName + "]::Handle"));
+            c.Open();
+            Assert.Same(TestTypeSystem.Handle, c.TypeFactory.getTypeSystem());
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_read_a_static_method_member()
+        {
+            using var c = new CalciteConnection(Cs("[" + typeof(MethodTypeSystem).AssemblyQualifiedName + "]::Create"));
+            c.Open();
+            Assert.Equal(23, c.TypeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.DECIMAL));
+        }
+
+        /// <summary>
+        /// The thread-local holder Avatica unwraps, in its CLR spelling.
+        /// </summary>
+        [Fact]
+        public void TypeSystem_option_should_unwrap_a_thread_local_member()
+        {
+            using var c = new CalciteConnection(Cs("[" + typeof(ThreadLocalTypeSystem).AssemblyQualifiedName + "]::Current"));
+            c.Open();
+            Assert.Equal(24, c.TypeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.DECIMAL));
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_prefer_a_static_instance_member_to_the_constructor()
+        {
+            using var c = new CalciteConnection(Cs(typeof(InstanceTypeSystem).AssemblyQualifiedName!));
+            c.Open();
+            Assert.Same(InstanceTypeSystem.INSTANCE, c.TypeFactory.getTypeSystem());
+        }
+
+        /// <summary>
+        /// Calcite writes a plugin member with a <c>#</c>, and a connection string copied out of its
+        /// documentation should resolve rather than read as a missing type.
+        /// </summary>
+        [Fact]
+        public void TypeSystem_option_should_read_calcites_own_member_spelling()
+        {
+            using var c = new CalciteConnection(Cs("org.apache.calcite.rel.type.RelDataTypeSystem, calcite.core#DEFAULT"));
+            c.Open();
+            Assert.Same(RelDataTypeSystem.DEFAULT, c.TypeFactory.getTypeSystem());
+        }
+
+        /// <summary>
+        /// The name is resolved by <c>Type.GetType</c>, which searches the provider assembly and the core
+        /// library and nowhere else, so a name without its assembly does not resolve however well formed.
+        /// The message has to say so, this being the mistake a .NET user will actually make.
+        /// </summary>
+        [Fact]
+        public void TypeSystem_option_should_say_so_when_the_name_omits_its_assembly()
+        {
+            using var c = new CalciteConnection(Cs(typeof(TestTypeSystem).FullName!));
+            var e = Assert.Throws<CalciteException>(() => c.Open());
+            Assert.Contains("carries its assembly", e.InnerException?.Message);
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_fail_clearly_when_the_named_member_is_absent()
+        {
+            using var c = new CalciteConnection(Cs("[" + typeof(TestTypeSystem).AssemblyQualifiedName + "]::NoSuchMember"));
+            var e = Assert.Throws<CalciteException>(() => c.Open());
+            Assert.Contains("NoSuchMember", e.InnerException?.Message);
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_fail_clearly_when_the_bracket_is_not_closed()
+        {
+            using var c = new CalciteConnection(Cs("[" + typeof(TestTypeSystem).AssemblyQualifiedName + "::Handle"));
+            var e = Assert.Throws<CalciteException>(() => c.Open());
+            Assert.Contains("]::", e.InnerException?.Message);
+        }
+
         [Fact]
         public void TypeSystem_option_should_fail_clearly_when_unresolvable()
         {
-            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";TypeSystem=No.Such.Type");
+            using var c = new CalciteConnection(Cs("No.Such.Type"));
             var e = Assert.Throws<CalciteException>(() => c.Open());
             Assert.Contains("No.Such.Type", e.InnerException?.Message);
+        }
+
+        /// <summary>
+        /// A type that resolves but is not a type system is refused, rather than answered as one.
+        /// </summary>
+        [Fact]
+        public void TypeSystem_option_should_refuse_a_type_that_is_not_a_type_system()
+        {
+            using var c = new CalciteConnection(Cs(typeof(CalciteSessionConstructionTests).AssemblyQualifiedName!));
+            var e = Assert.Throws<CalciteException>(() => c.Open());
+            Assert.Contains("RelDataTypeSystem", e.InnerException?.Message);
+        }
+
+        /// <summary>
+        /// The invariant the conventions rest on: a row carries Java boxed values, and which Java class
+        /// it carries is <c>JavaTypeFactoryImpl.getJavaClass</c>, which reads the <c>SqlTypeName</c> and
+        /// the nullability and nothing else. A type system cannot introduce a class outside that closed
+        /// set, but it decides which member of it a query derives — so this is the half of the option
+        /// that reaches the runtime, and the reader has to follow it.
+        /// </summary>
+        [Fact]
+        public void A_derived_type_should_change_the_runtime_type_the_reader_answers()
+        {
+            const string Sql = "SELECT SUM(x) FROM (VALUES (1), (2)) AS t(x)";
+
+            using (var dflt = new CalciteConnection(TestModels.InlineEmptyModelConnectionString))
+            {
+                dflt.Open();
+                using var cmd = dflt.CreateCommand();
+                cmd.CommandText = Sql;
+                // Calcite's default deriveSumType answers the argument type, so this is an INTEGER
+                Assert.Equal(typeof(int), cmd.ExecuteScalar()!.GetType());
+            }
+
+            using (var wide = new CalciteConnection(Cs(typeof(WideSumTypeSystem).AssemblyQualifiedName!)))
+            {
+                wide.Open();
+                using var cmd = wide.CreateCommand();
+                cmd.CommandText = Sql;
+                Assert.Equal(typeof(long), cmd.ExecuteScalar()!.GetType());
+            }
+        }
+
+        /// <summary>
+        /// And the plan runs on the widened type rather than merely reporting it: the same query under
+        /// the same type system through the synchronous convention agrees, both conventions inside one
+        /// session sharing the session's type factory.
+        /// </summary>
+        [Fact]
+        public void A_derived_type_should_hold_across_both_conventions()
+        {
+            const string Sql = "SELECT SUM(x) FROM (VALUES (1), (2)) AS t(x)";
+            var typeSystem = Cs(typeof(WideSumTypeSystem).AssemblyQualifiedName!);
+
+            using var async = new CalciteConnection(typeSystem);
+            using var sync = new CalciteConnection(typeSystem + ";Synchronous=true");
+            async.Open();
+            sync.Open();
+
+            using var a = async.CreateCommand();
+            using var b = sync.CreateCommand();
+            a.CommandText = Sql;
+            b.CommandText = Sql;
+
+            var left = a.ExecuteScalar();
+            var right = b.ExecuteScalar();
+            Assert.Equal(typeof(long), left!.GetType());
+            Assert.Equal(left, right);
+            Assert.Equal(3L, left);
         }
 
         [Fact]

--- a/src/Apache.Calcite.Data.Tests/CalciteSessionConstructionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteSessionConstructionTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Data.Internal;
+
+using org.apache.calcite.jdbc;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql.type;
+
+using Xunit;
+
+namespace Apache.Calcite.Data.Tests
+{
+
+    /// <summary>
+    /// A type system with a distinctive <c>DECIMAL</c> precision, for proving the <c>TypeSystem</c>
+    /// connection string option reaches the session's type factory. Public with a public default
+    /// constructor, which is what the plugin machinery requires of a plain class name.
+    /// </summary>
+    public class TestTypeSystem : RelDataTypeSystemImpl
+    {
+
+        public override int getMaxPrecision(SqlTypeName typeName)
+        {
+            return typeName == SqlTypeName.DECIMAL ? 21 : base.getMaxPrecision(typeName);
+        }
+
+    }
+
+    /// <summary>
+    /// Holds the constructor region <c>CalciteSession</c> ports from <c>CalciteConnectionImpl</c>: the
+    /// <c>typeSystem</c> property, the conformance-driven ragged-union wrapper, the conformance-gated
+    /// <c>DUAL</c> view, and the root schema and type factory injection seam. None of it is visible to the
+    /// differential tests, because every convention inside one session shares the session's type factory
+    /// and so agrees with the divergence.
+    /// </summary>
+    public class CalciteSessionConstructionTests
+    {
+
+        /// <summary>
+        /// Reads all rows of the first column as strings.
+        /// </summary>
+        static List<string?> ReadStrings(CalciteConnection c, string sql)
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = sql;
+            using var reader = cmd.ExecuteReader();
+            var values = new List<string?>();
+            while (reader.Read())
+                values.Add(reader.IsDBNull(0) ? null : reader.GetString(0));
+            return values;
+        }
+
+        const string RaggedUnionSql =
+            "SELECT * FROM (VALUES CAST('ab' AS CHAR(2))) UNION SELECT * FROM (VALUES CAST('abcde' AS CHAR(5)))";
+
+        [Fact]
+        public void Ragged_union_should_derive_varying_under_pragmatic_conformance()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";Conformance=PRAGMATIC_2003");
+            c.Open();
+            var values = ReadStrings(c, RaggedUnionSql);
+            Assert.Contains("ab", values);
+            Assert.Contains("abcde", values);
+        }
+
+        [Fact]
+        public void Ragged_union_should_derive_padded_char_under_default_conformance()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            var values = ReadStrings(c, RaggedUnionSql);
+            Assert.Contains("ab   ", values);
+            Assert.Contains("abcde", values);
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_reach_the_type_factory()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";TypeSystem=\"" + typeof(TestTypeSystem).AssemblyQualifiedName + "\"");
+            c.Open();
+            var typeSystem = c.TypeFactory.getTypeSystem();
+            Assert.IsType<TestTypeSystem>(typeSystem);
+            Assert.Equal(21, typeSystem.getMaxPrecision(SqlTypeName.DECIMAL));
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_default_when_unset()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            Assert.Same(RelDataTypeSystem.DEFAULT, c.TypeFactory.getTypeSystem());
+        }
+
+        [Fact]
+        public void TypeSystem_option_should_fail_clearly_when_unresolvable()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";TypeSystem=No.Such.Type");
+            var e = Assert.Throws<CalciteException>(() => c.Open());
+            Assert.Contains("No.Such.Type", e.InnerException?.Message);
+        }
+
+        [Fact]
+        public void Dual_should_answer_non_simple_queries_under_oracle_conformance()
+        {
+            // deliberately not one of the SIMPLE_SQLS fast-path strings, so the catalog must hold DUAL
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";Conformance=ORACLE_12");
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT 2 FROM DUAL";
+            Assert.Equal(2, Convert.ToInt32(cmd.ExecuteScalar()));
+        }
+
+        [Fact]
+        public void Dual_should_not_exist_under_default_conformance()
+        {
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT 2 FROM DUAL";
+            Assert.Throws<CalciteException>(() => cmd.ExecuteScalar());
+        }
+
+        [Fact]
+        public void Injected_type_factory_should_bypass_type_system_and_ragged_union_wrapper()
+        {
+            var typeFactory = new JavaTypeFactoryImpl();
+            var session = new CalciteSession(
+                new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString + ";Conformance=PRAGMATIC_2003;TypeSystem=\"" + typeof(TestTypeSystem).AssemblyQualifiedName + "\""),
+                typeFactory: typeFactory);
+            Assert.Same(typeFactory, session.TypeFactory);
+            Assert.Same(RelDataTypeSystem.DEFAULT, session.TypeFactory.getTypeSystem());
+        }
+
+        [Fact]
+        public void Injected_root_schema_should_be_used_verbatim()
+        {
+            var root = CalciteSchema.createRootSchema(true);
+            root.plus().add("PRE", new org.apache.calcite.schema.impl.AbstractSchema());
+            var session = new CalciteSession(
+                new CalciteConnectionStringBuilder(),
+                rootSchema: root);
+            Assert.Same(root, session.RootSchema.unwrap((java.lang.Class)typeof(CalciteSchema)));
+            Assert.NotNull(session.RootSchema.getSubSchema("PRE"));
+        }
+
+        [Fact]
+        public void Model_should_apply_on_top_of_an_injected_root_schema()
+        {
+            var root = CalciteSchema.createRootSchema(true);
+            root.plus().add("PRE", new org.apache.calcite.schema.impl.AbstractSchema());
+            var session = new CalciteSession(
+                new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString),
+                rootSchema: root);
+            Assert.NotNull(session.RootSchema.getSubSchema("PRE"));
+            Assert.NotNull(session.RootSchema.getSubSchema("adhoc"));
+        }
+
+        [Fact]
+        public void Dual_should_be_added_to_an_injected_root_schema()
+        {
+            // DUAL is a view macro, so it registers as a nullary function rather than a plain table
+            var root = CalciteSchema.createRootSchema(true);
+            var session = new CalciteSession(
+                new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString + ";Conformance=ORACLE_12"),
+                rootSchema: root);
+            Assert.False(session.RootSchema.getFunctions("DUAL").isEmpty());
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -467,13 +467,21 @@ namespace Apache.Calcite.Data
         /// <c>INSTANCE</c> member, that instance is used in preference to the constructor. Note that
         /// these names contain a comma, so they have to be quoted in the connection string.</para>
         ///
-        /// <para>A type system decides two different things, and only one of them moves the type a query
-        /// answers. The limits — <c>getMaxPrecision</c> and its neighbours — change what is representable
-        /// and where a value overflows. The derivations — <c>deriveSumType</c>, <c>deriveAvgAggType</c>,
-        /// the decimal arithmetic types — change the derived <c>SqlTypeName</c>, and so the runtime type
-        /// a reader answers: Calcite's default <c>deriveSumType</c> answers the argument type, so
-        /// <c>SUM</c> of an <c>INTEGER</c> column reads back as an <see cref="int"/>, and a type system
-        /// that widens it to <c>BIGINT</c> makes the same query read back as a <see cref="long"/>.</para>
+        /// <para>A type system is <c>RelDataTypeSystem</c>, the policy object a
+        /// <c>RelDataTypeFactory</c> consults, and it decides more than its name suggests. The limits —
+        /// <c>getMaxPrecision</c> and its neighbours — change what is representable and where a value
+        /// overflows. The derivations — <c>deriveSumType</c>, <c>deriveAvgAggType</c>, the decimal
+        /// arithmetic types — change the derived <c>SqlTypeName</c>, and so the runtime type a reader
+        /// answers: Calcite's default <c>deriveSumType</c> answers the argument type, so <c>SUM</c> of an
+        /// <c>INTEGER</c> column reads back as an <see cref="int"/>, and a type system that widens it to
+        /// <c>BIGINT</c> makes the same query read back as a <see cref="long"/>.</para>
+        ///
+        /// <para>And <c>roundingMode</c> changes computed values rather than types at all.
+        /// <c>RexToLixTranslator</c> writes it into the tree it generates for a numeric cast, so it is
+        /// the type system that decides a cast to a narrower decimal truncates — <c>RoundingMode.DOWN</c>
+        /// by default — and it reaches both Clr conventions, the Rex machinery being shared. Note also
+        /// that <c>isSchemaCaseSensitive</c> does not decide how a schema is looked up, which is
+        /// <c>CalciteConnectionConfig.caseSensitive</c>; its readers uniquify struct field names.</para>
         /// </remarks>
         public string? TypeSystem
         {

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Data.Common;
 
 namespace Apache.Calcite.Data
@@ -446,8 +446,35 @@ namespace Apache.Calcite.Data
         }
 
         /// <summary>
-        /// Gets or sets the type system class name.
+        /// Gets or sets the type system, named as a .NET type. Default is Calcite's own type system.
         /// </summary>
+        /// <remarks>
+        /// A type with a public parameterless constructor is named by itself,
+        /// <c>Namespace.Type, Assembly</c>. The name goes to <see cref="System.Type.GetType(string)"/>,
+        /// which searches the provider assembly and the core library and nowhere else, so a type from
+        /// anywhere else carries its assembly. A type system written in Java is named through its IKVM
+        /// projection the same way.
+        ///
+        /// <para>An existing instance held in a static member is named
+        /// <c>[Namespace.Type, Assembly]::Member</c>, as PowerShell and MSBuild property functions write
+        /// it. The member may be a field, a property or a parameterless method. This is how Calcite's own
+        /// type systems are reached, they being anonymous classes behind static fields and so having no
+        /// type to name:
+        /// <c>[org.apache.calcite.sql.dialect.PostgresqlSqlDialect, calcite.core]::POSTGRESQL_TYPE_SYSTEM</c>.
+        /// Calcite's own <c>Type#MEMBER</c> spelling is read too.</para>
+        ///
+        /// <para>Where no member is named but the type carries a static <c>Instance</c> or
+        /// <c>INSTANCE</c> member, that instance is used in preference to the constructor. Note that
+        /// these names contain a comma, so they have to be quoted in the connection string.</para>
+        ///
+        /// <para>A type system decides two different things, and only one of them moves the type a query
+        /// answers. The limits — <c>getMaxPrecision</c> and its neighbours — change what is representable
+        /// and where a value overflows. The derivations — <c>deriveSumType</c>, <c>deriveAvgAggType</c>,
+        /// the decimal arithmetic types — change the derived <c>SqlTypeName</c>, and so the runtime type
+        /// a reader answers: Calcite's default <c>deriveSumType</c> answers the argument type, so
+        /// <c>SUM</c> of an <c>INTEGER</c> column reads back as an <see cref="int"/>, and a type system
+        /// that widens it to <c>BIGINT</c> makes the same query read back as a <see cref="long"/>.</para>
+        /// </remarks>
         public string? TypeSystem
         {
             get => TryGetString(TypeSystemKey);

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -1,3 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Apache.Calcite.Extensions.Prepare;
+
 using com.google.common.collect;
 
 using java.util;
@@ -8,22 +16,11 @@ using org.apache.calcite.adapter.java;
 using org.apache.calcite.avatica;
 using org.apache.calcite.config;
 using org.apache.calcite.jdbc;
-using org.apache.calcite.linq4j;
 using org.apache.calcite.model;
 using org.apache.calcite.rel.type;
 using org.apache.calcite.runtime;
 using org.apache.calcite.schema;
 using org.apache.calcite.schema.impl;
-
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Apache.Calcite.Extensions.Prepare;
-using Apache.Calcite.Extensions.Adapter.Enumerable;
 
 namespace Apache.Calcite.Data.Internal
 {
@@ -99,19 +96,35 @@ namespace Apache.Calcite.Data.Internal
         /// </summary>
         /// <param name="options">The connection string options.</param>
         /// <param name="rootSchema">Root schema, or null.</param>
-        /// <param name="typeFactory">Type factory, or null.</param>
+        /// <param name="typeFactory">Type factory, or null. See the remarks for why this is the concrete type.</param>
         /// <param name="prepareFactory">Prepare factory, or null for <see cref="ClrPrepareImpl"/>.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="CalciteException"></exception>
         /// <remarks>
         /// The body is <c>CalciteConnectionImpl</c>'s constructor, statement for statement — the config, the
-        /// prepare factory, the type factory resolved from the <c>typeSystem</c> property under the
+        /// prepare factory, the type factory resolved from the <c>typeSystem</c> property (by
+        /// <see cref="ClrPlugin"/>, this provider naming a plugin in .NET rather than in Java) under the
         /// conformance's ragged-union wrapper, the root schema, and the conformance-gated <c>DUAL</c> view —
         /// followed by the model step the JDBC driver runs after construction, in that order, so a model can
         /// overwrite <c>DUAL</c> and never the reverse. The injection pair is upstream's too: an injected
         /// <paramref name="typeFactory"/> bypasses both the configured type system and the ragged-union
         /// wrapper, an injected <paramref name="rootSchema"/> is used verbatim, and <c>DUAL</c> is added to an
-        /// injected root all the same.
+        /// injected root all the same. Nothing in the provider passes either yet: they are the seam a
+        /// session needs to be built over a root schema and a type factory it does not own, which is what
+        /// sharing one session across several connections would require. Tests are the only callers today.
+        ///
+        /// <para>The one deviation is that <paramref name="typeFactory"/> is the concrete
+        /// <see cref="JavaTypeFactoryImpl"/> where upstream takes the <c>JavaTypeFactory</c> interface,
+        /// because both conventions require the implementation and not the interface. Every grouped
+        /// aggregate and every window builds its accumulator from <c>createSyntheticType</c> and then
+        /// matches the result against <c>JavaTypeFactoryImpl.SyntheticRecordType</c> — a nested class of
+        /// the implementation — which is Calcite's own coupling, <c>EnumerableAggregateBase</c> having the
+        /// same <c>instanceof</c>. What differs here is the consequence: Calcite writes the type's name
+        /// into Java source for Janino to resolve, while <c>ClrTypes.Resolve</c> has to answer a CLR type
+        /// and throws where it cannot. A foreign <c>getJavaClass</c> is out of reach for the same reason —
+        /// the Java classes a row may carry are the closed set that method names, and the conventions box
+        /// and unbox against exactly that set. Taking the interface here would advertise a freedom no
+        /// plan of either convention can honour.</para>
         ///
         /// <para>Every query is planned into one of the two Clr conventions and run as a compiled expression
         /// tree — which one is the connection's choice, the way Calcite's own connection can ask for the
@@ -121,17 +134,14 @@ namespace Apache.Calcite.Data.Internal
         /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
         /// converter carrying its rows.</para>
         /// </remarks>
-        public CalciteSession(
-            CalciteConnectionStringBuilder options,
-            CalciteSchema? rootSchema = null,
-            JavaTypeFactory? typeFactory = null,
-            Func<ClrPrepareImpl>? prepareFactory = null)
+        public CalciteSession(CalciteConnectionStringBuilder options, CalciteSchema? rootSchema = null, JavaTypeFactoryImpl? typeFactory = null, Func<ClrPrepareImpl>? prepareFactory = null)
         {
             ArgumentNullException.ThrowIfNull(options);
 
             try
             {
                 var cfg = new CalciteConnectionConfigImpl(BuildEngineProperties(options));
+
                 _prepareFactory = prepareFactory ?? (static () => new ClrPrepareImpl());
                 if (typeFactory != null)
                 {
@@ -139,14 +149,15 @@ namespace Apache.Calcite.Data.Internal
                 }
                 else
                 {
-                    RelDataTypeSystem typeSystem = TypeSystemPlugin(options.TypeSystem);
+                    var typeSystem = ClrPlugin.Resolve(options.TypeSystem, RelDataTypeSystem.DEFAULT);
                     if (cfg.conformance().shouldConvertRaggedUnionTypesToVarying())
-                    {
                         typeSystem = new RaggedUnionDelegatingTypeSystem(typeSystem);
-                    }
+
                     _typeFactory = new JavaTypeFactoryImpl(typeSystem);
                 }
+
                 _rootSchema = rootSchema != null ? rootSchema : CalciteSchema.createRootSchema(true);
+
                 // Add dual table metadata when isSupportedDualTable return true
                 if (cfg.conformance().isSupportedDualTable())
                 {
@@ -197,105 +208,6 @@ namespace Apache.Calcite.Data.Internal
                 return true;
             }
 
-        }
-
-        /// <summary>
-        /// Resolves the <c>TypeSystem</c> connection string option to a <see cref="RelDataTypeSystem"/>.
-        /// </summary>
-        /// <param name="className">The type system's type name, or <see langword="null"/>.</param>
-        /// <returns>The resolved type system, or <see cref="RelDataTypeSystem.DEFAULT"/> where none is named.</returns>
-        /// <remarks>
-        /// Upstream this is <c>cfg.typeSystem(RelDataTypeSystem.class, RelDataTypeSystem.DEFAULT)</c>, which
-        /// is <c>ConnectionConfigImpl.pluginConverter</c> — an unset property answers the default instance —
-        /// over <c>AvaticaUtils.instantiatePlugin</c>, mirrored here statement for statement: the
-        /// <c>#FIELD</c> static-member form, the <c>INSTANCE</c> field tried before the assignability check,
-        /// then the public default constructor. The deviation is the language the name is written in: this
-        /// provider's connection string names a CLR type, so <c>Class.forName</c> is
-        /// <see cref="Type.GetType(string)"/> — which reaches a Java-defined type system through its IKVM
-        /// projection's name all the same — and a static member is read field then property, because a Java
-        /// <c>static final</c> surfaces as a CLR property under IKVM.
-        /// </remarks>
-        static RelDataTypeSystem TypeSystemPlugin(string? className)
-        {
-            if (string.IsNullOrEmpty(className))
-                return RelDataTypeSystem.DEFAULT;
-
-            string? right = null;
-            string? left = null;
-            object? value = null;
-
-            // Given a static field, say "com.example.MyClass#FOO_INSTANCE", return
-            // the value of that static field.
-            if (className.Contains('#'))
-            {
-                int i = className.IndexOf('#');
-                left = className.Substring(0, i);
-                right = className.Substring(i + 1);
-                var clazz = Type.GetType(left) ?? throw new InvalidOperationException(
-                    $"Property '{className}' not valid as '{left}' was not found as a CLR type");
-                if (TryStaticMember(clazz, right, out var fieldValue) == false)
-                    throw new InvalidOperationException(
-                        $"Property '{className}' not valid as there is no '{right}' field in the class of '{left}'");
-                if (fieldValue is java.lang.ThreadLocal threadLocal)
-                    value = threadLocal.get();
-                else
-                    value = fieldValue;
-                return value as RelDataTypeSystem ?? throw new InvalidOperationException(
-                    $"Property '{className}' not valid as cannot convert {value?.GetType().FullName ?? "null"} to {typeof(RelDataTypeSystem).FullName}");
-            }
-            else
-            {
-                var clazz = Type.GetType(className) ?? throw new InvalidOperationException(
-                    $"Property '{className}' not valid as '{className}' was not found as a CLR type");
-                // We assume that if there is an INSTANCE field it is static and
-                // has the right type.
-                if (TryStaticMember(clazz, "INSTANCE", out value))
-                    return value as RelDataTypeSystem ?? throw new InvalidOperationException(
-                        $"Property '{className}' not valid as cannot convert {value?.GetType().FullName ?? "null"} to {typeof(RelDataTypeSystem).FullName}");
-                if (!typeof(RelDataTypeSystem).IsAssignableFrom(clazz))
-                    throw new InvalidOperationException(
-                        $"Property '{className}' not valid for plugin type {typeof(RelDataTypeSystem).FullName}");
-                var constructor = clazz.GetConstructor(Type.EmptyTypes) ?? throw new InvalidOperationException(
-                    $"Property '{className}' not valid as the default constructor is necessary, but not found in the class of '{className}'");
-
-                try
-                {
-                    return (RelDataTypeSystem)constructor.Invoke(null);
-                }
-                catch (TargetInvocationException e)
-                {
-                    throw new InvalidOperationException(
-                        $"Property '{className}' not valid. The exception info here : {e.InnerException?.Message ?? e.Message}", e);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Reads a public static member, trying field then property, because a Java <c>static final</c>
-        /// surfaces as a CLR property under IKVM.
-        /// </summary>
-        /// <param name="type">The type holding the member.</param>
-        /// <param name="name">The member name.</param>
-        /// <param name="value">The member's value, where found.</param>
-        /// <returns><see langword="true"/> where the member exists.</returns>
-        static bool TryStaticMember(Type type, string name, out object? value)
-        {
-            var field = type.GetField(name, BindingFlags.Public | BindingFlags.Static);
-            if (field is not null)
-            {
-                value = field.GetValue(null);
-                return true;
-            }
-
-            var property = type.GetProperty(name, BindingFlags.Public | BindingFlags.Static);
-            if (property is not null)
-            {
-                value = property.GetValue(null);
-                return true;
-            }
-
-            value = null;
-            return false;
         }
 
         /// <summary>
@@ -353,8 +265,8 @@ namespace Apache.Calcite.Data.Internal
                 if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                // a provider option, not an engine one: it names a CLR type, resolved by TypeSystemPlugin,
-                // and nothing in calcite-core reads the engine property but the constructor line this ports
+                // a provider option, not an engine one: it names a .NET type, resolved by ClrPlugin, and
+                // nothing in calcite-core reads the engine property but the constructor line this ports
                 if (string.Equals(key, CalciteConnectionStringBuilder.TypeSystemKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -1,3 +1,5 @@
+using com.google.common.collect;
+
 using java.util;
 using java.util.concurrent.atomic;
 
@@ -8,12 +10,15 @@ using org.apache.calcite.config;
 using org.apache.calcite.jdbc;
 using org.apache.calcite.linq4j;
 using org.apache.calcite.model;
+using org.apache.calcite.rel.type;
 using org.apache.calcite.runtime;
 using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
 
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -77,7 +82,6 @@ namespace Apache.Calcite.Data.Internal
             [CalciteConnectionStringBuilder.SchemaTypeKey] = CalciteConnectionProperty.SCHEMA_TYPE,
             [CalciteConnectionStringBuilder.SparkKey] = CalciteConnectionProperty.SPARK,
             [CalciteConnectionStringBuilder.TimeZoneKey] = CalciteConnectionProperty.TIME_ZONE,
-            [CalciteConnectionStringBuilder.TypeSystemKey] = CalciteConnectionProperty.TYPE_SYSTEM,
             [CalciteConnectionStringBuilder.TypeCoercionKey] = CalciteConnectionProperty.TYPE_COERCION,
         };
 
@@ -94,29 +98,72 @@ namespace Apache.Calcite.Data.Internal
         /// Initializes a new instance.
         /// </summary>
         /// <param name="options">The connection string options.</param>
+        /// <param name="rootSchema">Root schema, or null.</param>
+        /// <param name="typeFactory">Type factory, or null.</param>
+        /// <param name="prepareFactory">Prepare factory, or null for <see cref="ClrPrepareImpl"/>.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="CalciteException"></exception>
         /// <remarks>
-        /// Every query is planned into one of the two Clr conventions and run as a compiled expression tree —
-        /// which one is the connection's choice, the way Calcite's own connection can ask for the bindable
-        /// convention. The default is <c>ClrAsyncEnumerableConvention</c>;
+        /// The body is <c>CalciteConnectionImpl</c>'s constructor, statement for statement — the config, the
+        /// prepare factory, the type factory resolved from the <c>typeSystem</c> property under the
+        /// conformance's ragged-union wrapper, the root schema, and the conformance-gated <c>DUAL</c> view —
+        /// followed by the model step the JDBC driver runs after construction, in that order, so a model can
+        /// overwrite <c>DUAL</c> and never the reverse. The injection pair is upstream's too: an injected
+        /// <paramref name="typeFactory"/> bypasses both the configured type system and the ragged-union
+        /// wrapper, an injected <paramref name="rootSchema"/> is used verbatim, and <c>DUAL</c> is added to an
+        /// injected root all the same.
+        ///
+        /// <para>Every query is planned into one of the two Clr conventions and run as a compiled expression
+        /// tree — which one is the connection's choice, the way Calcite's own connection can ask for the
+        /// bindable convention. The default is <c>ClrAsyncEnumerableConvention</c>;
         /// <see cref="CalciteConnectionStringBuilder.Synchronous"/> asks for <c>ClrEnumerableConvention</c>
         /// instead. Either way Calcite's own rules stay on the planner, so a statement the chosen convention
         /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
-        /// converter carrying its rows.
+        /// converter carrying its rows.</para>
         /// </remarks>
-        public CalciteSession(CalciteConnectionStringBuilder options, Func<ClrPrepareImpl>? prepareFactory = null)
+        public CalciteSession(
+            CalciteConnectionStringBuilder options,
+            CalciteSchema? rootSchema = null,
+            JavaTypeFactory? typeFactory = null,
+            Func<ClrPrepareImpl>? prepareFactory = null)
         {
             ArgumentNullException.ThrowIfNull(options);
 
-            _prepareFactory = prepareFactory ?? (static () => new ClrPrepareImpl());
-
             try
             {
-                _rootSchema = BuildRootSchema(options, out var modelDefaultSchema);
+                var cfg = new CalciteConnectionConfigImpl(BuildEngineProperties(options));
+                _prepareFactory = prepareFactory ?? (static () => new ClrPrepareImpl());
+                if (typeFactory != null)
+                {
+                    _typeFactory = typeFactory;
+                }
+                else
+                {
+                    RelDataTypeSystem typeSystem = TypeSystemPlugin(options.TypeSystem);
+                    if (cfg.conformance().shouldConvertRaggedUnionTypesToVarying())
+                    {
+                        typeSystem = new RaggedUnionDelegatingTypeSystem(typeSystem);
+                    }
+                    _typeFactory = new JavaTypeFactoryImpl(typeSystem);
+                }
+                _rootSchema = rootSchema != null ? rootSchema : CalciteSchema.createRootSchema(true);
+                // Add dual table metadata when isSupportedDualTable return true
+                if (cfg.conformance().isSupportedDualTable())
+                {
+                    SchemaPlus schemaPlus = _rootSchema.plus();
+                    // Dual table contains one row with a value X
+                    schemaPlus.add(
+                        "DUAL", ViewTable.viewMacro(schemaPlus, "VALUES ('X')",
+                        ImmutableList.of(), null, java.lang.Boolean.valueOf(false)));
+                }
+                _config = cfg;
                 _rootSchemaPlus = _rootSchema.plus();
-                _config = new CalciteConnectionConfigImpl(BuildEngineProperties(options));
-                _typeFactory = new JavaTypeFactoryImpl();
+
+                // the driver's ModelHandler step, run after the constructor's work as upstream runs it
+                string? modelDefaultSchema = null;
+                if (string.IsNullOrEmpty(options.Model) == false)
+                    ApplyModel(_rootSchema, options.Model, out modelDefaultSchema);
+
                 _synchronous = options.Synchronous ?? false;
                 var defaultSchema = modelDefaultSchema ?? options.Schema;
                 _defaultSchemaPath = string.IsNullOrEmpty(defaultSchema) ? [] : [defaultSchema];
@@ -128,20 +175,127 @@ namespace Apache.Calcite.Data.Internal
         }
 
         /// <summary>
-        /// Builds the root schema based on the provided connection options, applying any specified model and determining the default schema path.
+        /// The anonymous <c>DelegatingTypeSystem</c> subclass of <c>CalciteConnectionImpl</c>'s constructor,
+        /// named because C# has no anonymous classes. One override, nothing else.
         /// </summary>
-        /// <param name="options"></param>
-        /// <param name="defaultSchema"></param>
-        /// <returns></returns>
-        CalciteSchema BuildRootSchema(CalciteConnectionStringBuilder options, out string? defaultSchema)
+        sealed class RaggedUnionDelegatingTypeSystem : DelegatingTypeSystem
         {
-            var rootSchema = CalciteSchema.createRootSchema(addMetadataSchema: true);
-            defaultSchema = null;
 
-            if (string.IsNullOrEmpty(options.Model) == false)
-                ApplyModel(rootSchema, options.Model, out defaultSchema);
+            /// <summary>
+            /// Initializes a new instance.
+            /// </summary>
+            /// <param name="typeSystem">The type system to delegate to.</param>
+            public RaggedUnionDelegatingTypeSystem(RelDataTypeSystem typeSystem) :
+                base(typeSystem)
+            {
 
-            return rootSchema;
+            }
+
+            /// <inheritdoc />
+            public override bool shouldConvertRaggedUnionTypesToVarying()
+            {
+                return true;
+            }
+
+        }
+
+        /// <summary>
+        /// Resolves the <c>TypeSystem</c> connection string option to a <see cref="RelDataTypeSystem"/>.
+        /// </summary>
+        /// <param name="className">The type system's type name, or <see langword="null"/>.</param>
+        /// <returns>The resolved type system, or <see cref="RelDataTypeSystem.DEFAULT"/> where none is named.</returns>
+        /// <remarks>
+        /// Upstream this is <c>cfg.typeSystem(RelDataTypeSystem.class, RelDataTypeSystem.DEFAULT)</c>, which
+        /// is <c>ConnectionConfigImpl.pluginConverter</c> — an unset property answers the default instance —
+        /// over <c>AvaticaUtils.instantiatePlugin</c>, mirrored here statement for statement: the
+        /// <c>#FIELD</c> static-member form, the <c>INSTANCE</c> field tried before the assignability check,
+        /// then the public default constructor. The deviation is the language the name is written in: this
+        /// provider's connection string names a CLR type, so <c>Class.forName</c> is
+        /// <see cref="Type.GetType(string)"/> — which reaches a Java-defined type system through its IKVM
+        /// projection's name all the same — and a static member is read field then property, because a Java
+        /// <c>static final</c> surfaces as a CLR property under IKVM.
+        /// </remarks>
+        static RelDataTypeSystem TypeSystemPlugin(string? className)
+        {
+            if (string.IsNullOrEmpty(className))
+                return RelDataTypeSystem.DEFAULT;
+
+            string? right = null;
+            string? left = null;
+            object? value = null;
+
+            // Given a static field, say "com.example.MyClass#FOO_INSTANCE", return
+            // the value of that static field.
+            if (className.Contains('#'))
+            {
+                int i = className.IndexOf('#');
+                left = className.Substring(0, i);
+                right = className.Substring(i + 1);
+                var clazz = Type.GetType(left) ?? throw new InvalidOperationException(
+                    $"Property '{className}' not valid as '{left}' was not found as a CLR type");
+                if (TryStaticMember(clazz, right, out var fieldValue) == false)
+                    throw new InvalidOperationException(
+                        $"Property '{className}' not valid as there is no '{right}' field in the class of '{left}'");
+                if (fieldValue is java.lang.ThreadLocal threadLocal)
+                    value = threadLocal.get();
+                else
+                    value = fieldValue;
+                return value as RelDataTypeSystem ?? throw new InvalidOperationException(
+                    $"Property '{className}' not valid as cannot convert {value?.GetType().FullName ?? "null"} to {typeof(RelDataTypeSystem).FullName}");
+            }
+            else
+            {
+                var clazz = Type.GetType(className) ?? throw new InvalidOperationException(
+                    $"Property '{className}' not valid as '{className}' was not found as a CLR type");
+                // We assume that if there is an INSTANCE field it is static and
+                // has the right type.
+                if (TryStaticMember(clazz, "INSTANCE", out value))
+                    return value as RelDataTypeSystem ?? throw new InvalidOperationException(
+                        $"Property '{className}' not valid as cannot convert {value?.GetType().FullName ?? "null"} to {typeof(RelDataTypeSystem).FullName}");
+                if (!typeof(RelDataTypeSystem).IsAssignableFrom(clazz))
+                    throw new InvalidOperationException(
+                        $"Property '{className}' not valid for plugin type {typeof(RelDataTypeSystem).FullName}");
+                var constructor = clazz.GetConstructor(Type.EmptyTypes) ?? throw new InvalidOperationException(
+                    $"Property '{className}' not valid as the default constructor is necessary, but not found in the class of '{className}'");
+
+                try
+                {
+                    return (RelDataTypeSystem)constructor.Invoke(null);
+                }
+                catch (TargetInvocationException e)
+                {
+                    throw new InvalidOperationException(
+                        $"Property '{className}' not valid. The exception info here : {e.InnerException?.Message ?? e.Message}", e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads a public static member, trying field then property, because a Java <c>static final</c>
+        /// surfaces as a CLR property under IKVM.
+        /// </summary>
+        /// <param name="type">The type holding the member.</param>
+        /// <param name="name">The member name.</param>
+        /// <param name="value">The member's value, where found.</param>
+        /// <returns><see langword="true"/> where the member exists.</returns>
+        static bool TryStaticMember(Type type, string name, out object? value)
+        {
+            var field = type.GetField(name, BindingFlags.Public | BindingFlags.Static);
+            if (field is not null)
+            {
+                value = field.GetValue(null);
+                return true;
+            }
+
+            var property = type.GetProperty(name, BindingFlags.Public | BindingFlags.Static);
+            if (property is not null)
+            {
+                value = property.GetValue(null);
+                return true;
+            }
+
+            value = null;
+            return false;
         }
 
         /// <summary>
@@ -197,6 +351,11 @@ namespace Apache.Calcite.Data.Internal
 
                 // a provider option, not an engine one: it chooses the convention the session plans into
                 if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // a provider option, not an engine one: it names a CLR type, resolved by TypeSystemPlugin,
+                // and nothing in calcite-core reads the engine property but the constructor line this ports
+                if (string.Equals(key, CalciteConnectionStringBuilder.TypeSystemKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 if (options.TryGetValue(key, out var v) && v is not null)

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -96,7 +96,7 @@ namespace Apache.Calcite.Data.Internal
         /// </summary>
         /// <param name="options">The connection string options.</param>
         /// <param name="rootSchema">Root schema, or null.</param>
-        /// <param name="typeFactory">Type factory, or null. See the remarks for why this is the concrete type.</param>
+        /// <param name="typeFactory">Type factory, or null. See the remarks for what the conventions require of one.</param>
         /// <param name="prepareFactory">Prepare factory, or null for <see cref="ClrPrepareImpl"/>.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="CalciteException"></exception>
@@ -113,18 +113,21 @@ namespace Apache.Calcite.Data.Internal
         /// session needs to be built over a root schema and a type factory it does not own, which is what
         /// sharing one session across several connections would require. Tests are the only callers today.
         ///
-        /// <para>The one deviation is that <paramref name="typeFactory"/> is the concrete
-        /// <see cref="JavaTypeFactoryImpl"/> where upstream takes the <c>JavaTypeFactory</c> interface,
-        /// because both conventions require the implementation and not the interface. Every grouped
+        /// <para>Both conventions require more of <paramref name="typeFactory"/> than its interface says,
+        /// and the requirement is stated rather than typed because no type expresses it. Every grouped
         /// aggregate and every window builds its accumulator from <c>createSyntheticType</c> and then
-        /// matches the result against <c>JavaTypeFactoryImpl.SyntheticRecordType</c> — a nested class of
-        /// the implementation — which is Calcite's own coupling, <c>EnumerableAggregateBase</c> having the
-        /// same <c>instanceof</c>. What differs here is the consequence: Calcite writes the type's name
-        /// into Java source for Janino to resolve, while <c>ClrTypes.Resolve</c> has to answer a CLR type
-        /// and throws where it cannot. A foreign <c>getJavaClass</c> is out of reach for the same reason —
-        /// the Java classes a row may carry are the closed set that method names, and the conventions box
-        /// and unbox against exactly that set. Taking the interface here would advertise a freedom no
-        /// plan of either convention can honour.</para>
+        /// matches the result against <c>JavaTypeFactoryImpl.SyntheticRecordType</c>, a nested class of
+        /// the implementation — Calcite's own coupling, <c>EnumerableAggregateBase</c> having the same
+        /// <c>instanceof</c> — and <c>ClrTypes.Resolve</c> has to answer a CLR type for whatever comes
+        /// back, throwing where it cannot. Calcite survives further, writing the type's name into Java
+        /// source for Janino to resolve. The same goes for <c>getJavaClass</c>, whose closed set of Java
+        /// classes is what the conventions box and unbox against.</para>
+        ///
+        /// <para>Naming <c>JavaTypeFactoryImpl</c> here would not enforce any of that — a subclass
+        /// overriding <c>createSyntheticType</c> satisfies the parameter and still breaks the plan —
+        /// while <c>_typeFactory</c>, <see cref="TypeFactory"/>, <c>PrepareContext</c> and everything in
+        /// <c>Apache.Calcite.Extensions</c> that consumes one are declared against the interface. A
+        /// narrower door onto a pipeline typed the other way buys nothing and reads as though it did.</para>
         ///
         /// <para>Every query is planned into one of the two Clr conventions and run as a compiled expression
         /// tree — which one is the connection's choice, the way Calcite's own connection can ask for the
@@ -134,7 +137,7 @@ namespace Apache.Calcite.Data.Internal
         /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
         /// converter carrying its rows.</para>
         /// </remarks>
-        public CalciteSession(CalciteConnectionStringBuilder options, CalciteSchema? rootSchema = null, JavaTypeFactoryImpl? typeFactory = null, Func<ClrPrepareImpl>? prepareFactory = null)
+        public CalciteSession(CalciteConnectionStringBuilder options, CalciteSchema? rootSchema = null, JavaTypeFactory? typeFactory = null, Func<ClrPrepareImpl>? prepareFactory = null)
         {
             ArgumentNullException.ThrowIfNull(options);
 

--- a/src/Apache.Calcite.Data/Internal/ClrPlugin.cs
+++ b/src/Apache.Calcite.Data/Internal/ClrPlugin.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+
+namespace Apache.Calcite.Data.Internal
+{
+
+    /// <summary>
+    /// Resolves a plugin named by a connection string option — a type system, a parser factory — to an
+    /// instance of it.
+    /// </summary>
+    /// <remarks>
+    /// This is <c>AvaticaUtils.instantiatePlugin</c>'s reach, expressed the way .NET writes such things.
+    /// Avatica reaches four things: a class with a public no-argument constructor, a class carrying a
+    /// public static <c>INSTANCE</c> field, a named static field of a class, and a thread-local holding
+    /// any of those. Each has a form here.
+    ///
+    /// <para>The type is an ordinary .NET type name, resolved by <see cref="Type.GetType(string)"/> —
+    /// which searches this assembly and the core library and nowhere else, so a type from anywhere else
+    /// carries its assembly, <c>Namespace.Type, Assembly</c>. That is how a Java-defined plugin is named
+    /// too, through its IKVM projection and the assembly holding it.</para>
+    ///
+    /// <para>A static member is named <c>[Namespace.Type, Assembly]::Member</c>. .NET has no expression
+    /// of its own for a type and one of its static members in a single string — <c>Type.GetType</c>'s
+    /// grammar covers types alone, and the XML documentation id (<c>F:</c>, <c>P:</c>, <c>M:</c>) is an
+    /// identifier for documentation tooling that nothing resolves — but it does have a convention, the
+    /// one PowerShell and MSBuild property functions both use: <c>[System.Math]::PI</c>. That is the
+    /// form taken here, because a .NET user has read it before. The brackets are what make it parse:
+    /// they hold an unmodified .NET type name, assembly and generic arguments and all, and the member
+    /// sits outside them where no part of it can be mistaken for a namespace.</para>
+    ///
+    /// <para>The member may be a field, a property or a parameterless method, tried in that order. A
+    /// field is Avatica's only form; a Java <c>static final</c> surfaces as a CLR property under IKVM, so
+    /// nothing Calcite ships is reachable without the second; and a .NET type is as likely to hand out
+    /// its instance from a method as from a field.</para>
+    ///
+    /// <para>Calcite's own <c>Namespace.Type#MEMBER</c> is read as well, and is not the convention. It
+    /// costs one branch, and it is what a connection string copied out of Calcite's documentation says;
+    /// refusing it would fail in a way that reads like the type is missing.</para>
+    /// </remarks>
+    static class ClrPlugin
+    {
+
+        /// <summary>
+        /// Resolves <paramref name="name"/> to an instance of <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The plugin's type.</typeparam>
+        /// <param name="name">The name from the connection string, or <see langword="null"/>.</param>
+        /// <param name="fallback">The instance to answer where nothing is named.</param>
+        /// <returns>The resolved plugin.</returns>
+        /// <exception cref="InvalidOperationException">Where the name does not resolve.</exception>
+        public static T Resolve<T>(string? name, T fallback)
+            where T : class
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return fallback;
+
+            var (typeName, memberName) = Split(name);
+            var type = Type.GetType(typeName) ?? throw new InvalidOperationException(
+                $"'{name}' does not name a .NET type: '{typeName}' was not found. A type outside " +
+                $"{typeof(ClrPlugin).Assembly.GetName().Name} carries its assembly, as in 'Namespace.Type, Assembly'.");
+
+            if (memberName is not null)
+            {
+                if (TryStaticMember(type, memberName, out var named) == false)
+                    throw new InvalidOperationException(
+                        $"'{name}' does not name a member: '{type.FullName}' has no public static field, " +
+                        $"property or parameterless method '{memberName}'.");
+
+                return Cast<T>(name, Unwrap(named));
+            }
+
+            // a type that hands out a singleton is named by the type alone, which is Avatica's convention
+            // and .NET's both; only the casing differs, so both spellings are read
+            if (TryStaticMember(type, "INSTANCE", out var instance) || TryStaticMember(type, "Instance", out instance))
+                return Cast<T>(name, Unwrap(instance));
+
+            if (typeof(T).IsAssignableFrom(type) == false)
+                throw new InvalidOperationException(
+                    $"'{name}' names '{type.FullName}', which is not a {typeof(T).FullName}.");
+
+            var constructor = type.GetConstructor(Type.EmptyTypes) ?? throw new InvalidOperationException(
+                $"'{name}' names '{type.FullName}', which has neither a public parameterless constructor " +
+                $"nor a static Instance member.");
+
+            try
+            {
+                return Cast<T>(name, constructor.Invoke(null));
+            }
+            catch (TargetInvocationException e)
+            {
+                throw new InvalidOperationException(
+                    $"'{name}' names '{type.FullName}', whose constructor threw: {e.InnerException?.Message ?? e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Splits a name into its type and, where one is named, its static member.
+        /// </summary>
+        /// <param name="name">The name from the connection string.</param>
+        /// <returns>The type name, and the member name or <see langword="null"/>.</returns>
+        /// <exception cref="InvalidOperationException">Where the bracketed form is not closed.</exception>
+        static (string TypeName, string? MemberName) Split(string name)
+        {
+            name = name.Trim();
+
+            // [Namespace.Type, Assembly]::Member. A leading '[' cannot begin a .NET type name — the
+            // brackets of an array or of a generic argument list always follow one — so it decides the
+            // form on its own. The close is sought from the end, a generic argument list holding ']' too.
+            if (name.StartsWith('['))
+            {
+                var i = name.LastIndexOf("]::", StringComparison.Ordinal);
+                if (i < 0)
+                    throw new InvalidOperationException(
+                        $"'{name}' opens with '[', so it is read as '[Namespace.Type, Assembly]::Member', " +
+                        $"but nothing closes it with ']::'.");
+
+                return (name.Substring(1, i - 1).Trim(), name.Substring(i + 3).Trim());
+            }
+
+            // Namespace.Type#MEMBER, Calcite's own syntax, read as written
+            var hash = name.IndexOf('#');
+            if (hash >= 0)
+                return (name.Substring(0, hash).Trim(), name.Substring(hash + 1).Trim());
+
+            return (name, null);
+        }
+
+        /// <summary>
+        /// Reads a public static member, trying field, then property, then parameterless method.
+        /// </summary>
+        /// <param name="type">The type holding the member.</param>
+        /// <param name="name">The member name.</param>
+        /// <param name="value">The member's value, where found.</param>
+        /// <returns><see langword="true"/> where the member exists.</returns>
+        static bool TryStaticMember(Type type, string name, out object? value)
+        {
+            var field = type.GetField(name, BindingFlags.Public | BindingFlags.Static);
+            if (field is not null)
+            {
+                value = field.GetValue(null);
+                return true;
+            }
+
+            var property = type.GetProperty(name, BindingFlags.Public | BindingFlags.Static);
+            if (property is not null)
+            {
+                value = property.GetValue(null);
+                return true;
+            }
+
+            var method = type.GetMethod(name, BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null);
+            if (method is not null && method.ReturnType != typeof(void))
+            {
+                value = method.Invoke(null, null);
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Unwraps a thread-local holder, which Avatica's plugin path reaches and which both runtimes
+        /// express.
+        /// </summary>
+        /// <param name="value">The member's value.</param>
+        /// <returns>The value held, where the value is a thread-local.</returns>
+        static object? Unwrap(object? value)
+        {
+            if (value is java.lang.ThreadLocal javaLocal)
+                return javaLocal.get();
+
+            var type = value?.GetType();
+            if (type is not null && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ThreadLocal<>))
+                return type.GetProperty("Value")?.GetValue(value);
+
+            return value;
+        }
+
+        /// <summary>
+        /// Casts a resolved value to the plugin's type.
+        /// </summary>
+        /// <typeparam name="T">The plugin's type.</typeparam>
+        /// <param name="name">The name from the connection string, for the message.</param>
+        /// <param name="value">The resolved value.</param>
+        /// <returns>The value.</returns>
+        /// <exception cref="InvalidOperationException">Where the value is of another type.</exception>
+        static T Cast<T>(string name, object? value)
+            where T : class
+        {
+            return value as T ?? throw new InvalidOperationException(
+                $"'{name}' resolved to {value?.GetType().FullName ?? "null"}, which is not a {typeof(T).FullName}.");
+        }
+
+    }
+
+}


### PR DESCRIPTION
Seven commits across three projects: `CalciteSession` gains upstream's constructor and a .NET spelling for the plugin name it reads, and the ADO.NET adapter moves a table's row-type derivation onto its schema, where `JdbcSchema` keeps it.

This branch started out named for connection pooling and carries none; it has been renamed to what it contains. Pooling was measured while reviewing it — numbers and a conclusion at the bottom.

## Port CalciteConnectionImpl's constructor into CalciteSession

The session used to build a root schema, apply a model and construct a bare `JavaTypeFactoryImpl`. It is now upstream's constructor in order — config, prepare factory, type factory under the conformance's ragged-union wrapper, root schema, conformance-gated `DUAL` — followed by the model step the JDBC driver runs afterwards, so a model can overwrite `DUAL` and never the reverse.

Three things change for a caller:

- **`TypeSystem` did nothing before.** It was passed to the engine as a property, and the one member of calcite-core that reads that property is the constructor line this ports. The type factory was built with no type system at all, so the option was documented and silent.
- **`DUAL` exists under Oracle conformance**, so `SELECT 2 FROM DUAL` answers.
- **Ragged-union conformance reaches the type factory**, so `PRAGMATIC_2003` derives VARCHAR over a ragged UNION where the default pads CHAR.

`rootSchema`, `typeFactory` and `prepareFactory` are injectable as upstream has them — the last being `Driver.withPrepareFactory` ported. **Nothing in the provider passes any of them yet**; tests are the only callers, and the doc comment says so rather than leaving it to be inferred. They are worth more than that, and the pooling section at the bottom says why.

## Name a type system plugin the way .NET names one

The resolution that came with the port was `AvaticaUtils.instantiatePlugin` transcribed: a Java class name and a `#FIELD` suffix. The reach is kept; the spelling is not.

```
Namespace.Type, Assembly                        construct it
[Namespace.Type, Assembly]::Member              read the static member
```

The type half is an ordinary .NET type name through `Type.GetType`, which searches the provider assembly and the core library and nowhere else — so anything from elsewhere carries its assembly, and that is how a Java-defined type system is named too, through its IKVM projection. The member half is `[Type]::Member`, which is how PowerShell and MSBuild property functions write one. .NET has no expression of its own for a type plus one of its static members in a single string: `Type.GetType`'s grammar covers types alone, and the XML documentation id (`F:`, `P:`, `M:`) is an identifier for doc tooling that nothing resolves. The brackets hold an unmodified type name, so no part of the member can be read as a namespace.

Everything `instantiatePlugin` reaches has a form:

| Avatica | here |
|---|---|
| public no-arg constructor | `Ns.Type, Asm` |
| static `INSTANCE` field | same, `INSTANCE` or `Instance` preferred to the constructor |
| `Class#FIELD` | `[Ns.Type, Asm]::Member` — field, property, or parameterless method |
| a `ThreadLocal` holding any of those | unwrapped, `java.lang.ThreadLocal` and `ThreadLocal<T>` both |

Field alone is not enough twice over: a Java `static final` surfaces as a CLR **property** under IKVM, and a .NET type is as likely to hand out a singleton from a method. Without the property form nothing Calcite ships is reachable at all — `MYSQL_TYPE_SYSTEM`, `POSTGRESQL_TYPE_SYSTEM` and the rest are anonymous classes behind static fields, so they have no type to name:

```
TypeSystem="[org.apache.calcite.sql.dialect.MysqlSqlDialect, calcite.core]::MYSQL_TYPE_SYSTEM"
```

Calcite's own `Type#MEMBER` is still read, and documented as tolerated rather than the convention — a string pasted from Calcite's docs otherwise fails as though the type were missing, which sends you looking in the wrong place.

This lives in `ClrPlugin` rather than on the session, because it is `instantiatePlugin`'s job and not the type system's. `parserFactory` is the obvious next caller: its three readers are all ours, and `SqlParser.Config.withParserFactory` already takes an instance.

### What a type system actually decides

Three kinds of thing, not one. The **limits** — `getMaxPrecision` and its neighbours — change what is representable and where a value overflows. The **derivations** — `deriveSumType`, `deriveAvgAggType`, the decimal arithmetic types — change the derived `SqlTypeName`, and so the runtime type a reader answers. And **`roundingMode`** changes computed values rather than types at all: `RexToLixTranslator` writes it into the tree it generates for a numeric cast, so the type system decides that a cast to a narrower decimal truncates, `RoundingMode.DOWN` being the default. It reaches both Clr conventions, the Rex machinery being shared.

Tests pin the derivation case rather than comments asserting it: `SUM` over an `INTEGER` column reads back as an `int` under Calcite's default `deriveSumType` and as a `long` under one that widens it, and both conventions agree, sharing the session's type factory.

Also documented at the site, because the name misleads: `isSchemaCaseSensitive` does not decide how a schema is looked up — that is `CalciteConnectionConfig.caseSensitive`. Its readers uniquify struct field names.

### What the conventions require of a type factory

More than the interface says. Every grouped aggregate and every window builds its accumulator from `createSyntheticType` and matches the result against `JavaTypeFactoryImpl.SyntheticRecordType`, a nested class of the implementation — Calcite's own coupling, `EnumerableAggregateBase.declareParentAccumulator` having the same `instanceof` — and `ClrTypes.Resolve` has to answer a CLR `Type` for whatever comes back, throwing where it cannot. Calcite survives further, writing the type's name into Java source for Janino to resolve.

The parameter briefly took `JavaTypeFactoryImpl` to say so. That was the wrong tool and is reverted: it enforced nothing, since a subclass overriding `createSyntheticType` satisfies the parameter and still breaks the plan, and it was the only narrow declaration in a pipeline typed the other way — `_typeFactory`, `TypeFactory`, `PrepareContext` and every consumer in `Apache.Calcite.Extensions` all name the interface. The constraint is stated in the doc comment instead, where it can be read.

A *type system* is safe by contrast. `JavaTypeFactoryImpl.getJavaClass` dispatches on `SqlTypeName` and nullability alone, so the Java classes a row may carry are a closed set a type system cannot add to; it only decides which member of that set a query derives, and — per above — how a cast rounds.

## The row type moves to AdoSchema

`AdoTable` derived its own proto row type. `JdbcSchema` owns that method upstream, and this adapter follows the JDBC design class for class until something makes it impossible, so it moves.

`AdoSchema` now carries `getRelDataType`'s two overloads — the three-argument one acquiring the column metadata, the four-argument one deriving from it — with `sqlType` a private static beside them. `AdoTable` holds its `AdoSchema` as `JdbcTable` holds `jdbcSchema`, and its memoized supplier delegates through `SupplyProto`.

`AdoTable.DataSource`, `.Convention` and `.Dialect` are **removed**: `JdbcTable` carries no accessor for any of the three, and callers go through the schema. `Schema` is the one member left, being `jdbcSchema`. The three call sites moved with it — `AdoTableQueryable` for the reader and the writer config, `AdoTableScan` for the trait set. `AdoSchema.DataSource` and `.Convention` stay internal, matching the package-private fields upstream.

One parameter is the forced deviation: JDBC acquires metadata as `DatabaseMetaData` off a connection the schema opens, ADO.NET has no equivalent (`TODO.md` item 0b), so `AdoDatabaseMetadata` stands in that position and the acquiring overload reads it off the data source.

## Tests

24 facts in `CalciteSessionConstructionTests`, a new file: the ragged-union pair, `DUAL` present and absent, all four plugin reaches, both member spellings, the `Instance` preference, four failure messages including an unclosed bracket and a name missing its assembly, the injection seams, and the two runtime-type facts above.

All three suites, nothing skipped, solution builds clean:

| suite | |
|---|---|
| `Apache.Calcite.Tests` | 743 passed |
| `Apache.Calcite.Data.Tests` | 355 passed |
| `Apache.Calcite.Adapter.AdoNet.Tests` | 345 passed |

The adapter suite is the one that covers the `AdoSchema` move, running against SQLite and SQL Server.

## Left open

- `ParserFactory` and `SchemaFactory` are still Java-named engine passthroughs, so the connection string is not yet uniform. `ClrPlugin` is what makes closing that cheap.
- `SchemaFactory` and `SchemaType` read as inert in this provider — the only reader in calcite-core is `Driver.connect`, which the provider never goes through. Not proven by test.
- `checkArgument(rootSchema.isRoot())` is not ported, so an injected sub-schema is accepted silently.
- A type factory whose `createSyntheticType` or `getJavaClass` departs from `JavaTypeFactoryImpl`'s breaks a plan in the ways described above. No type expresses the constraint and no cheap runtime guard exists; it is the exposure Calcite carries too.
- That a connection's own type system does not widen a column read from an ADO source — `createSqlType` having clamped against `DEFAULT` when the proto was built, and `copyType` carrying the clamp rather than re-deriving — is reasoned from those two members and is marked at the site as untested.

## On pooling, since that is what the branch was for

Measured in Release, warm process, 200 iterations after a discarded pass:

| | ms |
|---|---|
| process warm-up, first connection and query | 1396 (one-time; pooling cannot touch it) |
| `new CalciteSession`, 5 schemas and 3 views | 0.076 |
| close/open with the session already built | 0.0001 |
| one-view query | 8.8 |
| three-way join | 38.0 |

Sharing a session saves about 76 microseconds per connection. A view query is 116 times that and a three-way join 500 times. The cost is planning, and every execute replans — `CalciteCommand.Prepare()` is an empty override reading "Phase 1: no preparation cache", and `CalciteBatch` says the same.

**So pooling is not worth building for its own saving, and that is not the same as not worth building.** A plan carries `Signature.RootSchema`, "the schema the statement was planned against", and `InternalParameters`, which "must be the map the plan was built against". A plan cannot move between sessions, so a plan cache cannot hit unless what the plan is bound to is shared. The 76 microseconds is not the prize; being able to keep the 8.8 to 38 is.

Calcite provides the place to put such a cache — `Driver.withPrepareFactory`, documented for a custom prepare, its supplier free to return a shared instance — and this branch ports it as the `prepareFactory` parameter. Note then what the three injectables are: root schema, type factory, prepare. **That is exactly a plan's binding set**, the fourth term being the config, which is equal for two connections built from the same connection string. Connections sharing an injected schema, an injected type factory and one caching prepare get interchangeable plans without any connection being pooled.

Two things stand between that and working, and neither is in this PR: `CalciteSession.Dispose` sets a flag and releases nothing, so a shared session has no defined ownership; and a shared mutable `RootSchema` means one caller's `add` has to invalidate everyone's cached plans. Cheapest first step needing neither is filling in `DbCommand.Prepare`, where the plan is held by the command and dies with it.

Not measured: a model bringing an ADO sub-schema, where `CreateDialect` opens a real connection to read the server version. That cost is real, and it is `TODO.md` item 6 — adapter-side caching of the dialect and data source.
