### PR TITLE
Implement WinAggContext.ignoreNulls on the window aggregate context

### DIFF
--- a/src/Apache.Calcite.Data.Tests/ClrEnumerablePrepareTests.cs
+++ b/src/Apache.Calcite.Data.Tests/ClrEnumerablePrepareTests.cs
@@ -68,6 +68,31 @@ namespace Apache.Calcite.Data.Tests
         }
 
         [Fact]
+        public void Window_aggregate_should_run_through_the_clr_convention()
+        {
+            // This project resolves calcite-core 1.43, and 1.43's WinAggContext has a member 1.42's does
+            // not. The class the convention hands to a window implementor is written against 1.42, so a
+            // member it does not carry is a type that will not load here at all, and every window query
+            // fails before it runs. Any window query is the guard.
+            using var c = Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = "SELECT x, SUM(x) OVER (ORDER BY x) FROM (VALUES (1), (2), (4)) AS t(x) ORDER BY x";
+
+            using var r = cmd.ExecuteReader();
+
+            Assert.True(r.Read());
+            Assert.Equal(1, r.GetInt32(0));
+            Assert.Equal(1, r.GetInt32(1));
+            Assert.True(r.Read());
+            Assert.Equal(2, r.GetInt32(0));
+            Assert.Equal(3, r.GetInt32(1));
+            Assert.True(r.Read());
+            Assert.Equal(4, r.GetInt32(0));
+            Assert.Equal(7, r.GetInt32(1));
+            Assert.False(r.Read());
+        }
+
+        [Fact]
         public void Scalar_of_one_column_should_be_the_value()
         {
             using var c = Open();

--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableWindow.cs
@@ -827,9 +827,10 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
         /// <param name="exclusion"></param>
         /// <remarks>
         /// The anonymous <c>WinAggContext</c> of <c>declareAndResetState</c>. A window has no grouping, so the
-        /// four members about one refuse, exactly as Calcite's does.
+        /// four members about one refuse, exactly as Calcite's does. It is not sealed only because
+        /// <c>ignoreNulls</c> has to be virtual — see that member.
         /// </remarks>
-        sealed class ClrWinAggContext(AggImpState agg, JavaTypeFactory typeFactory, RelDataType inputRowType, java.util.List constants, RexWindowExclusion exclusion) : WinAggContext
+        class ClrWinAggContext(AggImpState agg, JavaTypeFactory typeFactory, RelDataType inputRowType, java.util.List constants, RexWindowExclusion exclusion) : WinAggContext
         {
 
             /// <inheritdoc />
@@ -861,6 +862,24 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
             /// <inheritdoc />
             public RexWindowExclusion getExclude() => exclusion;
+
+            /// <summary>
+            /// Whether the window function ignores NULL values, that is, whether the call carries
+            /// IGNORE NULLS.
+            /// </summary>
+            /// <returns></returns>
+            /// <remarks>
+            /// <c>WinAggContext.ignoreNulls</c>, which CALCITE-7701 added in 1.43. This project compiles
+            /// against 1.42, where the interface has no such member, so the compiler cannot see this as an
+            /// implementation and emits it non-virtual — and a non-virtual method never fills an interface
+            /// slot, so under a 1.43 calcite-core the runtime refuses to load the class at all:
+            /// <c>Method 'ignoreNulls' in type 'ClrWinAggContext' does not have an implementation</c>.
+            /// Declaring it virtual, which costs the class its <c>sealed</c>, lets the runtime bind it to
+            /// the slot when it meets the newer interface, and costs nothing when it meets the older one.
+            /// IGNORE NULLS is still refused before any of this runs, so the answer is always false today;
+            /// it reads the call, as Calcite's does, for when that guard lifts.
+            /// </remarks>
+            public virtual bool ignoreNulls() => agg.call.ignoreNulls();
 
         }
 

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableWindow.cs
@@ -826,9 +826,10 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
         /// <param name="exclusion"></param>
         /// <remarks>
         /// The anonymous <c>WinAggContext</c> of <c>declareAndResetState</c>. A window has no grouping, so the
-        /// four members about one refuse, exactly as Calcite's does.
+        /// four members about one refuse, exactly as Calcite's does. It is not sealed only because
+        /// <c>ignoreNulls</c> has to be virtual — see that member.
         /// </remarks>
-        sealed class ClrWinAggContext(AggImpState agg, JavaTypeFactory typeFactory, RelDataType inputRowType, java.util.List constants, RexWindowExclusion exclusion) : WinAggContext
+        class ClrWinAggContext(AggImpState agg, JavaTypeFactory typeFactory, RelDataType inputRowType, java.util.List constants, RexWindowExclusion exclusion) : WinAggContext
         {
 
             /// <inheritdoc />
@@ -860,6 +861,24 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
             /// <inheritdoc />
             public RexWindowExclusion getExclude() => exclusion;
+
+            /// <summary>
+            /// Whether the window function ignores NULL values, that is, whether the call carries
+            /// IGNORE NULLS.
+            /// </summary>
+            /// <returns></returns>
+            /// <remarks>
+            /// <c>WinAggContext.ignoreNulls</c>, which CALCITE-7701 added in 1.43. This project compiles
+            /// against 1.42, where the interface has no such member, so the compiler cannot see this as an
+            /// implementation and emits it non-virtual — and a non-virtual method never fills an interface
+            /// slot, so under a 1.43 calcite-core the runtime refuses to load the class at all:
+            /// <c>Method 'ignoreNulls' in type 'ClrWinAggContext' does not have an implementation</c>.
+            /// Declaring it virtual, which costs the class its <c>sealed</c>, lets the runtime bind it to
+            /// the slot when it meets the newer interface, and costs nothing when it meets the older one.
+            /// IGNORE NULLS is still refused before any of this runs, so the answer is always false today;
+            /// it reads the call, as Calcite's does, for when that guard lifts.
+            /// </remarks>
+            public virtual bool ignoreNulls() => agg.call.ignoreNulls();
 
         }
 


### PR DESCRIPTION
Calcite 1.43 adds `ignoreNulls` to `WinAggContext` ([CALCITE-7701](https://issues.apache.org/jira/browse/CALCITE-7701), authored 9 Aug, landed on main 20 Aug, first in the `20260822` snapshot). It is a Java *default* method, but IKVM emits it abstract on the generated interface, so a C# implementor has to supply it or its type will not load at all.

Every window query fails under 1.43 before it runs, with the cause buried where "Unable to implement" hides it:

```
java.lang.IllegalStateException: Unable to implement ClrAsyncEnumerableSort(...)
  TypeLoadException: Method 'ignoreNulls' in type 'ClrWinAggContext' from
  assembly 'Apache.Calcite.Extensions' does not have an implementation
```

That is the fingerprint behind 1,660 of the 1,673 failures the calcite-efcore functional suite has been carrying since 22 Aug.

## Why the member is virtual, and the class no longer sealed

Nothing here moves to 1.43 — `Apache.Calcite.Extensions` still references released **1.42.0**, where the member does not exist. So the compiler cannot see this as an interface implementation and emits it non-virtual, and a non-virtual method never fills an interface slot. Measured, with a two-assembly repro: the sealed non-virtual form reproduces the exact `TypeLoadException` wording, the virtual form binds.

Declaring it virtual costs the class its `sealed` and nothing else. It is inert against 1.42. When 1.43 is released and the projects move to it, this becomes an ordinary `<inheritdoc />` implementation and the class can be sealed again.

IGNORE NULLS is still refused up front, so the answer is always false today; the member reads the call, as Calcite's own does, for when that guard lifts.

## The test

`Apache.Calcite.Data.Tests` is the project that resolves 1.43, and it had no window query at all — which is why nothing here caught this. One is added as the guard.

Note that its Maven resolution cache had been pinning it to a **13 Aug** snapshot, which predates the change; verifying against that showed a false pass. Re-resolved to `1.43.0-20260830.093627-212`, the new test fails with exactly the `TypeLoadException` above without the two members and passes with them. The failing path is the async convention, which is why both `ClrEnumerableWindow` and `ClrAsyncEnumerableWindow` are patched.

I also checked every interface under `core/src/main/java` and `linq4j` that gained a member between `calcite-1.42.0` and upstream main — `RelShuttle`, `SqlConformance`, `SqlValidator`, `FetchOffsetRoundingPolicy`, `ExtendedEnumerable`. No C# class here implements any of them, so this is the only break of its kind.

## Downstream

calcite-efcore picks this up only once a new `Apache.Calcite.Data` / `Apache.Calcite.Extensions` prerelease is published and its `2.0.0-pre.7` references are bumped.
