### PR TITLE
Write an unbounded string as varchar(max) for SQL Server

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -152,6 +152,18 @@ surface whether or not the operation succeeds.
   true and `SqlImplementor.visitRoot` only runs `AggregateProjectConstantToDummyJoinRule` when the dialect
   has asked for it. Postgres, Redshift and Informix each override it. `AdoSqlDialects.Mssql` says it here;
   the fix belongs in Calcite.
+- **Upstream, and worth reporting**: `SqlDialect.getCastSpec` writes an unbounded `VARCHAR` as the bare
+  keyword, and a bare `varchar` in T-SQL is not unbounded — it is one character in a declaration and thirty
+  in a `CAST`. So `CAST(<uniqueidentifier> AS VARCHAR)` is "Insufficient result space to convert
+  uniqueidentifier value to char" and the same cast over a long `nvarchar` returns its first thirty
+  characters with no error at all — both measured. `MssqlSqlDialect` does not override `getCastSpec`, and
+  CALCITE-6565 made bare `CHAR` the intended rendering for SQL Server, which has the same defect.
+  `AdoSqlDialects.Mssql` writes `VARCHAR(MAX)` / `VARBINARY(MAX)` for the unbounded case here; the fix
+  belongs in Calcite. Found while there and not fixed: SQL Server's `varchar` tops out at 8000 and
+  `MSSQL_TYPE_SYSTEM` inherits `getMaxPrecision` of 65536, so a stated length between the two is written
+  out as it stands and the server refuses it — measured, `CAST('a' AS varchar(20000))` is "The size (20000)
+  given to the type 'varchar' exceeds the maximum allowed for any data type (8000)". The clamp is not one
+  number: `nvarchar` stops at 4000, and nothing in the dialect distinguishes the two today.
 
 ## Translate a CLR expression tree into a linq4j one
 

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
@@ -2,10 +2,12 @@ using Apache.Calcite.Adapter.AdoNet.Metadata;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using org.apache.calcite.rel.type;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql.dialect;
 using org.apache.calcite.sql.parser;
 using org.apache.calcite.sql.pretty;
+using org.apache.calcite.sql.type;
 
 namespace Apache.Calcite.Adapter.AdoNet.Tests
 {
@@ -37,6 +39,31 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
             return writer.toSqlString().getSql();
         }
+
+        /// <summary>
+        /// Returns what a dialect writes for the target type of a cast.
+        /// </summary>
+        /// <param name="dialect"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        static string CastSpec(SqlDialect dialect, RelDataType type)
+        {
+            var writer = new SqlPrettyWriter(SqlPrettyWriter.config().withDialect(dialect));
+            dialect.getCastSpec(type).unparse(writer, 0, 0);
+
+            return writer.toSqlString().getSql().Trim();
+        }
+
+        /// <summary>
+        /// Builds types the way a connection does, from the default type system.
+        /// </summary>
+        static readonly RelDataTypeFactory Types = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+        /// <summary>
+        /// Builds types from the type system <see cref="MssqlSqlDialect"/> carries, which is the one that
+        /// leaves a <c>CHAR</c> with no precision.
+        /// </summary>
+        static readonly RelDataTypeFactory MssqlTypes = new SqlTypeFactoryImpl(MssqlSqlDialect.MSSQL_TYPE_SYSTEM);
 
         #region Product
 
@@ -170,6 +197,122 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         {
             Assert.IsFalse(AdoSqlDialects.For("PostgreSQL", "16.0").supportsGroupByLiteral(), "Postgres says so itself");
             Assert.IsTrue(AdoSqlDialects.For("MySQL", "8.0").supportsGroupByLiteral(), "MySQL can");
+        }
+
+        #endregion
+
+        #region Unbounded strings
+
+        /// <summary>
+        /// A Calcite <c>VARCHAR</c> with no precision is unbounded, and the bare keyword SQL Server reads it
+        /// as is thirty characters in a cast — so <c>CAST(&lt;uniqueidentifier&gt; AS VARCHAR)</c> is
+        /// "Insufficient result space to convert uniqueidentifier value to char" and the same cast over a
+        /// long string returns its first thirty characters with no error at all.
+        /// </summary>
+        [TestMethod]
+        public void AnUnboundedVarcharBecomesVarcharMax()
+        {
+            Assert.AreEqual("VARCHAR(MAX)", CastSpec(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), Types.createSqlType(SqlTypeName.VARCHAR)));
+        }
+
+        /// <summary>
+        /// And the answer this corrects, so that the test says what it is for: Calcite writes the keyword
+        /// alone, which is a different type on the server.
+        /// </summary>
+        [TestMethod]
+        public void CalcitesOwnAnswerIsTheBareKeyword()
+        {
+            Assert.AreEqual("VARCHAR", CastSpec(MssqlSqlDialect.DEFAULT, Types.createSqlType(SqlTypeName.VARCHAR)));
+        }
+
+        /// <summary>
+        /// The correction is to the unbounded case alone: a stated length is what the caller asked for and
+        /// is written as it stands.
+        /// </summary>
+        [TestMethod]
+        [DataRow(nameof(SqlTypeName.VARCHAR), 36, "VARCHAR(36)")]
+        [DataRow(nameof(SqlTypeName.CHAR), 36, "CHAR(36)")]
+        [DataRow(nameof(SqlTypeName.VARBINARY), 16, "VARBINARY(16)")]
+        [DataRow(nameof(SqlTypeName.BINARY), 4, "BINARY(4)")]
+        public void AStatedLengthIsLeftAlone(string typeName, int precision, string expected)
+        {
+            var type = Types.createSqlType(SqlTypeName.valueOf(typeName), precision);
+            Assert.AreEqual(expected, CastSpec(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), type));
+        }
+
+        /// <summary>
+        /// <c>varbinary</c> carries the same rule over bytes, and <c>VARBINARY</c>'s default precision is
+        /// unspecified for the same reason <c>VARCHAR</c>'s is.
+        /// </summary>
+        [TestMethod]
+        public void AnUnboundedVarbinaryBecomesVarbinaryMax()
+        {
+            Assert.AreEqual("VARBINARY(MAX)", CastSpec(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), Types.createSqlType(SqlTypeName.VARBINARY)));
+        }
+
+        /// <summary>
+        /// A <c>CHAR</c> reaches the same rendering where the type system leaves its precision unspecified —
+        /// CALCITE-6565 made the bare keyword the intended answer for SQL Server, and the server reads it as
+        /// thirty. There is no <c>char(max)</c> in T-SQL, and a fixed length with no length has nothing to
+        /// pad to.
+        /// </summary>
+        [TestMethod]
+        public void AnUnboundedCharBecomesVarcharMax()
+        {
+            var type = MssqlTypes.createSqlType(SqlTypeName.CHAR);
+            Assert.AreEqual("CHAR", CastSpec(MssqlSqlDialect.DEFAULT, type), "the answer being corrected");
+            Assert.AreEqual("VARCHAR(MAX)", CastSpec(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), type));
+        }
+
+        /// <summary>
+        /// Under the default type system a <c>CHAR</c> has a precision of one, so nothing changes for it.
+        /// </summary>
+        [TestMethod]
+        public void ACharOfTheDefaultTypeSystemKeepsItsOne()
+        {
+            Assert.AreEqual("CHAR(1)", CastSpec(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), Types.createSqlType(SqlTypeName.CHAR)));
+        }
+
+        /// <summary>
+        /// Nothing else is touched.
+        /// </summary>
+        [TestMethod]
+        public void AnotherTypeKeepsCalcitesAnswer()
+        {
+            var dialect = AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382");
+
+            Assert.AreEqual("INTEGER", CastSpec(dialect, Types.createSqlType(SqlTypeName.INTEGER)));
+            Assert.AreEqual("DECIMAL(12, 3)", CastSpec(dialect, Types.createSqlType(SqlTypeName.DECIMAL, 12, 3)));
+        }
+
+        /// <summary>
+        /// And the correction is SQL Server's alone. The bare keyword is a different default per product:
+        /// SQLite ignores a length entirely, and Postgres reads a bare <c>varchar</c> as unbounded, which is
+        /// what Calcite means. The claim is that no length was written, rather than that the whole spec is
+        /// the keyword: SQLite says it supports a character set, so Calcite names one after it.
+        /// </summary>
+        [TestMethod]
+        [DataRow("SQLite")]
+        [DataRow("PostgreSQL")]
+        public void AnotherProductKeepsTheBareKeyword(string productName)
+        {
+            var spec = CastSpec(AdoSqlDialects.For(productName, "1.0"), Types.createSqlType(SqlTypeName.VARCHAR));
+
+            StringAssert.StartsWith(spec, "VARCHAR");
+            Assert.IsFalse(spec.Contains('('), $"a length was written where the bare keyword is right: {spec}");
+        }
+
+        /// <summary>
+        /// A driver that only says what is behind it reaches the same corrected dialect, which is what
+        /// carries the fix to ODBC and OLE DB over SQL Server.
+        /// </summary>
+        [TestMethod]
+        [DataRow("Microsoft SQL Server")]
+        [DataRow("microsoft sql server")]
+        [DataRow("Microsoft SQL Server Enterprise Edition")]
+        public void AnyNameThatSelectsSqlServerGetsTheCorrection(string productName)
+        {
+            Assert.AreEqual("VARCHAR(MAX)", CastSpec(AdoSqlDialects.For(productName, "10.50.1600"), Types.createSqlType(SqlTypeName.VARCHAR)));
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
@@ -373,6 +373,57 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
 
         #endregion
 
+        #region Unbounded strings
+
+        /// <summary>
+        /// The cast from the report, against the column that makes the server say so out loud. A Calcite
+        /// <c>VARCHAR</c> with no precision is unbounded and Calcite writes it as the bare keyword, which
+        /// T-SQL reads as thirty characters in a cast; a <c>uniqueidentifier</c> is thirty-six, so the
+        /// server answers "Insufficient result space to convert uniqueidentifier value to char" rather than
+        /// truncating. The same rendering over a long string truncates instead and says nothing.
+        /// </summary>
+        /// <remarks>
+        /// Upper case, where <see cref="AUniqueIdentifierComesBackAsItsText"/> reading the same column is
+        /// lower — that is the server's own conversion rather than the reader's <c>Guid.ToString</c>, and so
+        /// is the evidence the cast was pushed down rather than computed here.
+        /// </remarks>
+        [TestMethod]
+        public void AnUnboundedCastKeepsTheWholeValue()
+        {
+            Assert.AreEqual(
+                "3F2504E0-4F89-11D3-9A0C-0305E82C3301",
+                Scalar("SELECT CAST(C_GUID AS VARCHAR) FROM ADO.TYPES WHERE ID = 1"));
+        }
+
+        /// <summary>
+        /// And in a predicate, which is the shape a caller has no way to influence: Entity Framework writes
+        /// an unbounded cast around the parameter, and comparing that against a column of a stated length
+        /// makes Calcite's coercion widen the column back to unbounded, so stating a length in a view does
+        /// not save you. The statement that reaches the server is the one the report quotes,
+        /// <c>WHERE CAST([C_GUID] AS VARCHAR) = CAST(@P0 AS VARCHAR)</c> — read back from
+        /// <c>sys.dm_exec_sql_text</c>.
+        /// </summary>
+        /// <remarks>
+        /// A cast on both sides is what makes this a cast on the wire at all:
+        /// <c>SqlImplementor.stripCastFromString</c> drops a character cast from a comparison where only one
+        /// side carries one, so the same query against a literal is sent as a bare <c>[C_GUID] = '…'</c> and
+        /// says nothing about the rendering. A parameter is how the other cast is come by without one being
+        /// written for its own sake.
+        /// </remarks>
+        [TestMethod]
+        public void AnUnboundedCastAroundAParameterMatches()
+        {
+            using var statement = _connection.prepareStatement("SELECT ID FROM ADO.TYPES WHERE CAST(C_GUID AS VARCHAR) = CAST(? AS VARCHAR)");
+            statement.setString(1, "3f2504e0-4f89-11d3-9a0c-0305e82c3301");
+
+            var results = statement.executeQuery();
+            Assert.IsTrue(results.next(), "the row the parameter names");
+            Assert.AreEqual(1, results.getInt(1));
+            Assert.IsFalse(results.next(), "and only that one");
+        }
+
+        #endregion
+
     }
 
 }

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
@@ -2,8 +2,11 @@ using System;
 using System.Data;
 using System.Data.Common;
 
+using org.apache.calcite.rel.type;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql.dialect;
+using org.apache.calcite.sql.parser;
+using org.apache.calcite.sql.type;
 
 namespace Apache.Calcite.Adapter.AdoNet.Metadata
 {
@@ -123,7 +126,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         }
 
         /// <summary>
-        /// <see cref="MssqlSqlDialect"/>, and the one thing it does not say about SQL Server.
+        /// <see cref="MssqlSqlDialect"/>, and the two things it does not say about SQL Server.
         /// </summary>
         /// <param name="context"></param>
         /// <remarks>
@@ -141,6 +144,10 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// Calcite rather than a reproduction of it, which the adapter is entitled to make: it generates SQL
         /// for a server to run, and the server is the authority on what it accepts.
         /// </para>
+        /// <para>
+        /// The second is what an unbounded string casts to — see <see cref="Mssql.getCastSpec"/>, which is
+        /// the same kind of correction and made for the same reason.
+        /// </para>
         /// </remarks>
         sealed class Mssql(SqlDialect.Context context) : MssqlSqlDialect(context)
         {
@@ -149,6 +156,81 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             public override bool supportsGroupByLiteral()
             {
                 return false;
+            }
+
+            /// <inheritdoc />
+            /// <remarks>
+            /// <para>
+            /// A Calcite <c>VARCHAR</c> with no precision is unbounded, and <c>SqlDialect.getCastSpec</c>
+            /// writes it as the bare keyword, its precision being the type system's
+            /// <c>PRECISION_NOT_SPECIFIED</c>. A bare <c>varchar</c> in T-SQL is not unbounded: it is one
+            /// character in a declaration and <em>thirty</em> in a <c>CAST</c> or <c>CONVERT</c>. So the
+            /// cast that meant "no limit" silently becomes a thirty character one.
+            /// </para>
+            /// <para>
+            /// Where the conversion cannot fit it raises rather than truncates and reads as a type problem
+            /// in the caller's data — <c>CAST(&lt;uniqueidentifier&gt; AS VARCHAR)</c> is "Insufficient
+            /// result space to convert uniqueidentifier value to char", a GUID being thirty-six. Where it
+            /// fits it truncates: the same cast over a long <c>nvarchar</c> returns the first thirty
+            /// characters and raises nothing. And it is not contained to a query that writes the cast, since
+            /// comparing an unbounded string against a bounded column makes Calcite's coercion widen the
+            /// column back to unbounded, so a caller who stated a length in a view still gets it.
+            /// </para>
+            /// <para>
+            /// <c>varchar(max)</c> is SQL Server's own unbounded form and is what the type means.
+            /// <c>CHAR</c> goes to the same place rather than to a <c>char(max)</c>, there being no such
+            /// thing in T-SQL and nothing for a fixed length with no length to pad to; it is reachable
+            /// because a type system may leave <c>CHAR</c>'s precision unspecified, which
+            /// <c>MssqlSqlDialect.MSSQL_TYPE_SYSTEM</c> is itself one that does — CALCITE-6565 made bare
+            /// <c>CHAR</c> the intended rendering, and thirty is what the server reads it as.
+            /// <c>VARBINARY</c> and <c>BINARY</c> are the same rule over bytes.
+            /// </para>
+            /// <para>
+            /// <see cref="SqlAlienSystemTypeNameSpec"/> is how a dialect states a type name of the product
+            /// rather than of Calcite — Postgres writes <c>double precision</c> through it — and it unparses
+            /// the alias alone, which is what puts the <c>(MAX)</c> where a precision would otherwise go.
+            /// </para>
+            /// </remarks>
+            public override SqlNode getCastSpec(RelDataType type)
+            {
+                if (UnboundedTypeName(type) is string typeAlias)
+                    return new SqlDataTypeSpec(
+                        new SqlAlienSystemTypeNameSpec(typeAlias, type.getSqlTypeName(), SqlParserPos.ZERO),
+                        SqlParserPos.ZERO);
+
+                return base.getCastSpec(type);
+            }
+
+            /// <summary>
+            /// Returns the T-SQL type an unbounded <paramref name="type"/> has to be written as, or
+            /// <see langword="null"/> where Calcite's own answer stands.
+            /// </summary>
+            /// <param name="type"></param>
+            /// <returns></returns>
+            /// <remarks>
+            /// The <c>AbstractSqlType</c> test is <c>SqlDialect.getCastSpec</c>'s own: it is the branch that
+            /// reads a precision at all, and anything else goes to <c>SqlTypeUtil.convertTypeToSpec</c>
+            /// whole.
+            /// </remarks>
+            static string? UnboundedTypeName(RelDataType type)
+            {
+                if (type is not AbstractSqlType)
+                    return null;
+
+                if (type.getSqlTypeName() is not SqlTypeName typeName)
+                    return null;
+
+                var typeAlias = typeName.name() switch
+                {
+                    nameof(SqlTypeName.CHAR) or nameof(SqlTypeName.VARCHAR) => "VARCHAR(MAX)",
+                    nameof(SqlTypeName.BINARY) or nameof(SqlTypeName.VARBINARY) => "VARBINARY(MAX)",
+                    _ => null,
+                };
+
+                if (typeAlias is null)
+                    return null;
+
+                return type.getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED ? typeAlias : null;
             }
 
         }


### PR DESCRIPTION
Fixes #58.

A Calcite `VARCHAR` with no precision is unbounded, and `SqlDialect.getCastSpec` writes it as the bare keyword. A bare `varchar` in T-SQL is not unbounded — one character in a declaration, thirty in a `CAST` — so the cast that meant "no limit" silently becomes a thirty character one.

Measured against LocalDB: `CAST(<uniqueidentifier> AS VARCHAR)` is `Insufficient result space to convert uniqueidentifier value to char`, a GUID being thirty-six; and `CAST(<40-character nvarchar> AS VARCHAR)` returns `LEN` 30 and raises nothing at all.

## The change

`AdoSqlDialects.Mssql` overrides `getCastSpec`. Where an `AbstractSqlType`'s precision is `PRECISION_NOT_SPECIFIED`:

| Calcite type | written as |
|---|---|
| `CHAR`, `VARCHAR` | `VARCHAR(MAX)` |
| `BINARY`, `VARBINARY` | `VARBINARY(MAX)` |

Everything else falls to `base.getCastSpec`. The route is `SqlAlienSystemTypeNameSpec`, which is how a dialect states a type name of the product rather than of Calcite — Postgres writes `double precision` through it — and which unparses the alias alone, so the `(MAX)` lands where a precision would.

`VARBINARY` is in because its default precision is unspecified for the same reason `VARCHAR`'s is, and a bare `varbinary` is thirty bytes. `CHAR` is in because `MSSQL_TYPE_SYSTEM` leaves `CHAR` unspecified itself, [CALCITE-6565](https://issues.apache.org/jira/browse/CALCITE-6565) having made the bare keyword the intended rendering; there is no `char(max)` to send it to, and a fixed length with no length has nothing to pad to.

This is a correction to Calcite rather than a reproduction of it, of the same kind as `supportsGroupByLiteral` directly above it in the same class and made for the same reason: the adapter generates SQL for a server to run, and the server is the authority on what it accepts. Recorded in `TODO.md` as worth reporting upstream.

## Tests

`SqlServerQueryTests` holds it end to end against LocalDB. Both new tests fail with the override disabled, the first with the reported error.

- The select-list cast is the report's own query.
- The predicate half needed a prepared statement. `SqlImplementor.stripCastFromString` drops a character cast from a comparison that carries one on a single side, so the literal form reaches the server as a bare `[C_GUID] = '…'` — read back from `sys.dm_exec_sql_text` — and says nothing about the rendering. A parameter puts a cast on both sides, which is the shape Entity Framework emits and the one the report quotes: `WHERE CAST([C_GUID] AS VARCHAR) = CAST(@P0 AS VARCHAR)`.

`AdoSqlDialectsTests` pins the rendering itself, with no database: the unbounded and the stated-length cases, that Calcite's own answer is the bare keyword, that SQLite and Postgres keep it — which is right for both — and that any product name resolving to SQL Server gets the correction, which is what carries it to ODBC and OLE DB.

362/362 in `Apache.Calcite.Adapter.AdoNet.Tests`; solution builds clean.

## Found while there, not fixed

`MSSQL_TYPE_SYSTEM` inherits a `getMaxPrecision` of 65536 and SQL Server's `varchar` stops at 8000, so a stated length between the two is written out as it stands and refused — `CAST('a' AS varchar(20000))` is `The size (20000) given to the type 'varchar' exceeds the maximum allowed for any data type (8000)`, measured. The clamp is not one number (`nvarchar` stops at 4000) and nothing in the dialect distinguishes the two today. Recorded in `TODO.md`.
