### PR TITLE
Update to IKVM 8.16.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,11 +315,25 @@ outrank an outer variable of its name, it makes it unreachable, and Calcite reli
 `row_` the input row and `row_` the `MemoryFactory.Memory` around it. Neither ran for want of that scope,
 and it was described in this file before it was in the code.
 
-**A user-defined function written in .NET runs in this convention and in no plan Janino compiles.** IKVM
-names a CLR class `cli.Namespace.Type`; `EnumerableConvention` writes that name into generated Java source
-and Janino does not resolve a `cli.` name, so the plan fails to compile — for a grouped aggregate and a
-windowed one alike. A tree holds the method rather than its name. So a UDF is the one thing the
-differential tests cannot use Calcite as the oracle for.
+**"Janino cannot name a CLR class" was an IKVM regression, not a fact about Janino, and it is fixed.** The
+claim stood in seven places here: IKVM names a CLR class `cli.Namespace.Type`, `EnumerableConvention` writes
+that name into generated Java source, and Janino answered "Cannot determine simple type name cli", so a .NET
+UDF, table function or metadata handler had no plan under Calcite's own engine. What actually happened is
+narrower. `IKVM.Maven.Sdk` stamps every `MavenReference` assembly with
+`CustomAssemblyClassLoaderAttribute(AppDomainAssemblyClassLoader)`, and Janino compiles against
+`calcite-core`'s own loader — that loader walks every loaded assembly and answers `cli.` names.
+`CustomAssemblyClassLoaderAttribute` was made **`internal`** in 8.14.0 by the IKVM.Reflection-into-CoreLib
+move, and `RuntimeAssemblyClassLoader.GetCustomClassLoader` reads it with
+`Assembly.GetCustomAttributes(type, false)`, which the CLR skips when the attribute type is not visible
+outside its own assembly. The stamp was in the metadata and unreadable, so calcite-core fell back to a
+per-assembly loader that sees nobody else's types. **8.16.0 makes it public again** (ikvm `e0a12705b3`,
+ikvm#723); it was public at 8.13.0, and this repo has only ever been on 8.14.0 and 8.15.0 — the whole of the
+broken window. Measured at one commit either side: at 8.15 `revise` throws and the UDF queries fail to
+compile; at 8.16 the handler compiles and `MY_SUM` and `NUMBERS` give the same rows in both conventions, so
+those three tests are differential like the rest. A tree still holds the method rather than its name, so
+this convention never cared — but the *capability* argument is gone, and what is left of
+`ClrRelMetadataProvider`'s reason is the compile it saves. Note the loader only sees assemblies already
+loaded in the AppDomain, and setting `MavenClassLoader` empty turns it off.
 
 ## Traps
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dotnet add package Apache.Calcite.Adapter.AdoNet
 
 With it, the prepare pipeline that takes a statement from SQL text to such a plan, and the interop helpers both need — including `CalciteConnectionProperties`, a strongly-typed wrapper over Calcite's `java.util.Properties`, so you can configure the engine with compile-time-safe .NET properties instead of raw string keys.
 
-Because the plan holds a method rather than its name, a user-defined function written in .NET runs in this convention — Janino cannot resolve the `cli.`-prefixed class name IKVM gives a CLR type, so such a query has no plan under `EnumerableConvention`.
+The plan holds a method rather than its name, so a user-defined function written in .NET runs in this convention without a class name ever being written out. Calcite's own engine runs one too, as long as IKVM can read the class-loader stamp `IKVM.Maven.Sdk` puts on `calcite-core`: IKVM 8.14.0 and 8.15.0 could not, so Janino could not resolve the `cli.`-prefixed name IKVM gives a CLR type and such a query had no plan under `EnumerableConvention` at all. IKVM 8.16.0 fixes that, so the difference between the two engines is the compile rather than the capability.
 
 Targets .NET 8, and is verified on .NET 8 and .NET 10.
 

--- a/global.json
+++ b/global.json
@@ -5,7 +5,7 @@
     },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets": "3.7.134",
-        "IKVM.Net.Sdk": "8.15.0",
+        "IKVM.Net.Sdk": "8.16.0",
         "MSTest.Sdk": "4.3.3"
     }
 }

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -16,8 +16,8 @@
              GenerateProgramFile=false under EnableMSTestRunner, so declaring the package restores what
              3.10.4 arranged, entry point included, and leaves the MSTest runner as it is. -->
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-        <PackageReference Include="IKVM" Version="8.15.0" />
-        <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
         <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
@@ -23,8 +23,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IKVM" Version="8.15.0" />
-        <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
+++ b/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IKVM" Version="8.15.0" />
-        <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
+++ b/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
@@ -22,8 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IKVM" Version="8.15.0" />
-        <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -385,9 +385,11 @@ providing a JDBC-style `unwrap`. This keeps the contract typed and discoverable 
 advanced consumers register schemas, tables, functions and views on `RootSchema`, build types with
 `TypeFactory`, and inspect resolved configuration through `Config`.
 
-A user-defined function written in .NET works here and in no plan Janino compiles: IKVM names a CLR
-class `cli.Namespace.Type`, which `EnumerableConvention` would write into generated Java source and
-Janino cannot resolve. This convention holds the method rather than its name.
+A user-defined function written in .NET works here without a class name being written out at all: IKVM
+names a CLR class `cli.Namespace.Type`, which `EnumerableConvention` writes into generated Java source,
+and this convention holds the method rather than its name. Janino resolves such a name through the
+class-loader stamp `IKVM.Maven.Sdk` puts on `calcite-core`, which IKVM 8.14.0 and 8.15.0 could not read —
+under those there was no plan for one under `EnumerableConvention` at all. IKVM 8.16.0 fixes it.
 
 The prepare and plan APIs are not exposed on the ADO.NET surface. A caller who wants them references
 `Apache.Calcite.Extensions` and uses `ClrPrepareImpl` directly.

--- a/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
+++ b/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
@@ -22,8 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="IKVM" Version="8.15.0" />
-        <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
         <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Apache.Calcite.Extensions/README.md
+++ b/src/Apache.Calcite.Extensions/README.md
@@ -23,7 +23,7 @@ Calcite normally executes a query by generating Java source and compiling it at 
 This package replaces that step. A query plan is compiled into a `System.Linq.Expressions` tree and turned into a delegate, so:
 
 - **No Java compiler runs when you prepare a statement.**
-- **A .NET method can be a SQL function.** Janino cannot resolve the `cli.`-prefixed name IKVM gives a CLR class, so a .NET user-defined function does not work under Calcite's own engine. It works here.
+- **A .NET method can be a SQL function, and no class name is written out.** Calcite's own engine reaches one only through the class-loader stamp `IKVM.Maven.Sdk` puts on `calcite-core`, which IKVM 8.14.0 and 8.15.0 could not read — under those a .NET user-defined function had no plan under `EnumerableConvention` at all, Janino refusing the `cli.`-prefixed name IKVM gives a CLR class. IKVM 8.16.0 fixes it; here it never mattered, because nothing writes a name.
 
 `ClrEnumerableConvention` mirrors Calcite's `EnumerableConvention` node for node and uses the same row types, and converter rules exist in both directions. A plan may hold nodes of both conventions: anything this convention has no rule for is planned by Calcite as usual, and rows cross between the two untouched.
 

--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataHandlerEmitter.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrMetadataHandlerEmitter.cs
@@ -26,8 +26,10 @@ namespace Apache.Calcite.Extensions.Rel.Metadata
     /// <para>So a metadata call is a virtual call into a method that tests the rel's class, calls the
     /// handler's own method directly, and reads and writes the query's table — the same instructions the
     /// generated Java compiles to, with no delegate, no argument array and no boxing that Java would not
-    /// do. What Janino cannot do is name a CLR class: the generated source spells out the handler and every
-    /// rel class, and IKVM's name for one of ours begins <c>cli.</c>, which it refuses.</para>
+    /// do, and without a Java compiler running. Nothing here writes a name either: the generated source
+    /// spells out the handler and every rel class, and IKVM's name for one of ours begins <c>cli.</c>,
+    /// which Janino resolves only where IKVM can read the class-loader stamp on <c>calcite-core</c> — not
+    /// under IKVM 8.14.0 or 8.15.0, and again from 8.16.0.</para>
     ///
     /// <para>Two things are not literal. The keys and lookup tables cannot be constants of an emitted method,
     /// so they are held in one array the constructor takes rather than in a field each. And the catch is

--- a/src/Apache.Calcite.Extensions/Rel/Metadata/ClrRelMetadataProvider.cs
+++ b/src/Apache.Calcite.Extensions/Rel/Metadata/ClrRelMetadataProvider.cs
@@ -20,11 +20,16 @@ namespace Apache.Calcite.Extensions.Rel.Metadata
     /// from the same <see cref="RelMetadataProvider"/>, the class a rel dispatches to is chosen by the same
     /// rule, and the results are cached in the query's own table under the same keys, cycles included.
     ///
-    /// <para>Two things move. A handler is built once per provider and handler interface, as Janino's is, but
-    /// building one no longer runs a Java compiler. And a handler written in .NET works: Calcite's generated
-    /// source names the handler class and each rel class in Java, and IKVM's name for a CLR class begins
-    /// <c>cli.</c>, which Janino refuses — "Cannot determine simple type name cli", measured. Nothing here
-    /// writes a name.</para>
+    /// <para>What moves is the compile. A handler is built once per provider and handler interface, as
+    /// Janino's is, but building one no longer runs a Java compiler.</para>
+    ///
+    /// <para>It used to be more than that. Calcite's generated source names the handler class and each rel
+    /// class in Java, and IKVM's name for a CLR class begins <c>cli.</c>. Janino resolves one through the
+    /// class loader <c>IKVM.Maven.Sdk</c> stamps onto <c>calcite-core</c>; IKVM 8.14.0 and 8.15.0 could not
+    /// read that stamp, so it answered "Cannot determine simple type name cli" and a handler written in .NET
+    /// could answer here and nowhere else. IKVM 8.16.0 reads it again and Janino compiles that handler too,
+    /// measured at one commit either side. Nothing here writes a name either way; what is left of the reason
+    /// is the compile.</para>
     ///
     /// <para>Reached through <see cref="RelOptCluster.setMetadataQuerySupplier"/>:
     /// <c>RelMetadataQueryBase.THREAD_PROVIDERS</c> is typed to Janino's provider and cannot hold this one,

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -18,8 +18,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="FastExpressionCompiler.LightExpression" Version="5.4.1" />
         <PackageReference Include="FluentAssertions" Version="8.10.0" />
-        <PackageReference Include="IKVM" Version="8.15.0" />
-        <PackageReference Include="IKVM.Java.Extensions" Version="8.15.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
         <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
             <PrivateAssets>all</PrivateAssets>
@@ -38,9 +38,11 @@
                 com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
             </Dependencies>
         </MavenReference>
-        <!-- Smalls.fibonacciTableWithLimit100 is a one-column table function written in Java, and the only
-             oracle ClrEnumerableRowFormatTests can have: Janino cannot name a CLR class, so a table function
-             of this project's own gives EnumerableConvention no plan to compare against. -->
+        <!-- Smalls.fibonacciTableWithLimit100 is a one-column table function written in Java, and was the
+             only oracle ClrEnumerableRowFormatTests could have: Janino could not name a CLR class under IKVM
+             8.14.0 or 8.15.0, so a table function of this project's own gave EnumerableConvention no plan to
+             compare against. IKVM 8.16.0 fixed that; this stays because it is what the tests are written
+             against. -->
         <MavenReference Include="org.apache.calcite:calcite-testkit" Version="1.42.0" />
         <MavenReference Include="org.apache.calcite:calcite-server" Version="1.42.0" />
     </ItemGroup>

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -388,10 +388,10 @@ namespace Apache.Calcite.Tests
 
             // A CUSTOM-format fixture, which every other table here is not. HrSchema's rows are instances of
             // a Java class, so a scan of it yields a synthetic record rather than an Object[] and
-            // PhysType.record, fieldReference and the join selector all take the other branch. It has to be
-            // Java rather than one of this project's own classes for the same reason MY_SUM does: Janino
-            // cannot name a CLR class, so a CLR-backed table would leave EnumerableConvention with no plan to
-            // compare against.
+            // PhysType.record, fieldReference and the join selector all take the other branch. It is Calcite's
+            // own schema rather than one of this project's classes because Janino could not name a CLR class
+            // under IKVM 8.14.0 or 8.15.0, which left EnumerableConvention with no plan to compare against.
+            // 8.16.0 fixed that, so it is no longer a constraint on the fixture.
             rootSchema.add("HR", new org.apache.calcite.adapter.java.ReflectiveSchema(new org.apache.calcite.test.schemata.hr.HrSchema()));
 
             // the hierarchy CALCITE-4054 is about, which is a recursive query whose step is a correlate over
@@ -1564,24 +1564,34 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public void ShouldAgreeOnLagWithAnOffsetAndDefault() => Same("SELECT \"ID\", LAG(\"AMOUNT\", 2, -1) OVER (ORDER BY \"ID\") FROM \"SALES\" ORDER BY \"ID\"");
 
-        // The two below are the only ones asserted by hand, because Calcite cannot answer them. A user-defined
-        // function written in C# is a class IKVM names cli.Apache.Calcite.Tests.SumAggregate;
-        // EnumerableConvention writes that name into generated Java source, and Janino does not resolve a
-        // cli. name, so its plan fails to compile. This convention holds the method itself rather than its
-        // name, so it runs — which makes these the one place a hand-written expectation is the only check
-        // available, and the values are SQL's rather than anything either convention produced.
+        // The two below were the only ones asserted by hand, because Calcite could not answer them. A
+        // user-defined function written in C# is a class IKVM names cli.Apache.Calcite.Tests.SumAggregate;
+        // EnumerableConvention writes that name into generated Java source, and Janino resolves it through
+        // the class-loader stamp IKVM.Maven.Sdk puts on calcite-core — which IKVM 8.14.0 and 8.15.0 could
+        // not read, so the plan failed to compile. This convention holds the method itself rather than its
+        // name, so it ran either way. 8.16.0 reads the stamp again and Calcite runs the same query, measured
+        // at one commit either side, so these are differential like the rest. The hand-written rows stay as
+        // a second oracle, being SQL's answer rather than either convention's.
 
         // running sum over ORDER BY ID, which the default RANGE frame makes a prefix, with the null skipped
         [TestMethod]
-        public void ShouldRunAUserDefinedWindowAggregate() =>
-            Gives("SELECT \"ID\", MY_SUM(\"AMOUNT\") OVER (ORDER BY \"ID\") FROM \"SALES\" ORDER BY \"ID\"",
-                "1|10", "2|30", "3|50", "4|80", "5|80", "6|85");
+        public void ShouldRunAUserDefinedWindowAggregate()
+        {
+            const string sql = "SELECT \"ID\", MY_SUM(\"AMOUNT\") OVER (ORDER BY \"ID\") FROM \"SALES\" ORDER BY \"ID\"";
+
+            Same(sql);
+            Gives(sql, "1|10", "2|30", "3|50", "4|80", "5|80", "6|85");
+        }
 
         // EAST is 10 + 20 + 20 and WEST is 30 + 5, the null contributing nothing
         [TestMethod]
-        public void ShouldRunAUserDefinedAggregate() =>
-            Gives("SELECT \"REGION\", MY_SUM(\"AMOUNT\") FROM \"SALES\" GROUP BY \"REGION\" ORDER BY \"REGION\"",
-                "EAST|50", "WEST|35");
+        public void ShouldRunAUserDefinedAggregate()
+        {
+            const string sql = "SELECT \"REGION\", MY_SUM(\"AMOUNT\") FROM \"SALES\" GROUP BY \"REGION\" ORDER BY \"REGION\"";
+
+            Same(sql);
+            Gives(sql, "EAST|50", "WEST|35");
+        }
 
         // SORTED advertises a collation, so Calcite plans these with EnumerableMergeJoin where it plans the
         // same query over SALES with a hash join. This convention has no merge join yet, so what these
@@ -1831,11 +1841,18 @@ namespace Apache.Calcite.Tests
         // all EnumerableMatch generates: implementPattern handles a literal and a concatenation and throws on
         // anything else, so *, + and | never reach a plan in either convention.
 
-        // A table function is a class too, so the same thing holds as for MY_SUM: Janino cannot name a CLR
-        // class, so EnumerableConvention has no plan for these and there is nothing to compare against. The
-        // function yields one to n, which is what is asserted.
+        // A table function is a class too, so the same thing holds as for MY_SUM: Janino could not name a CLR
+        // class under IKVM 8.14.0 or 8.15.0, so EnumerableConvention had no plan for these and there was
+        // nothing to compare against. 8.16.0 names one, so this is differential like the rest; the function
+        // yields one to n, which the hand-written rows still assert.
         [TestMethod]
-        public void ShouldRunATableFunction() => Gives("SELECT * FROM TABLE(NUMBERS(3))", "1", "2", "3");
+        public void ShouldRunATableFunction()
+        {
+            const string sql = "SELECT * FROM TABLE(NUMBERS(3))";
+
+            Same(sql);
+            Gives(sql, "1", "2", "3");
+        }
 
         // A join over a one-column table function puts a sort on it, and that is EnumerableSort's defect:
         // it optimises the scan's ARRAY to SCALAR and hands the Object[] rows on unchanged. Refused rather

--- a/src/Apache.Calcite.Tests/ClrRelMetadataProviderTests.cs
+++ b/src/Apache.Calcite.Tests/ClrRelMetadataProviderTests.cs
@@ -244,13 +244,17 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
-        /// A metadata handler written in .NET answers here, and does not compile under Janino.
+        /// A metadata handler written in .NET answers here, and answers through Janino too.
         /// </summary>
         /// <remarks>
         /// The generated source names the handler class and the rel class the way Java names them, and IKVM's
-        /// name for a CLR class begins <c>cli.</c>. Janino answers "Cannot determine simple type name cli",
-        /// which is what stops a .NET user-defined function under <c>EnumerableConvention</c> as well. It is
-        /// the reason this provider exists; the compile it saves is the other one.
+        /// name for a CLR class begins <c>cli.</c>. Janino resolves one through the class loader
+        /// <c>IKVM.Maven.Sdk</c> stamps onto <c>calcite-core</c>, which walks every loaded assembly — no
+        /// <c>addBootClassPathAssembly</c> call is needed here. IKVM 8.14.0 and 8.15.0 could not read that
+        /// stamp, so Janino answered "Cannot determine simple type name cli" and this provider was the only
+        /// way such a handler could answer at all; 8.16.0 reads it again, measured at one commit either side.
+        /// What remains of the reason is the compile, which
+        /// <see cref="Should_prepare_without_compiling_a_handler"/> holds.
         /// </remarks>
         [TestMethod]
         public void Should_take_a_handler_written_in_dotnet()
@@ -267,9 +271,10 @@ namespace Apache.Calcite.Tests
             var mq = new RelMetadataQuery(ClrRelMetadataProvider.Of(chained));
             Assert.AreEqual(7d, mq.getRowCount(values).doubleValue(), 0.0001);
 
-            var refused = Assert.Throws<java.lang.RuntimeException>(
-                () => JaninoRelMetadataProvider.of(chained).revise(handlerClass));
-            StringAssert.Contains(refused.ToString(), "cli");
+            Assert.IsNotNull(JaninoRelMetadataProvider.of(chained).revise(handlerClass));
+
+            var janino = new RelMetadataQuery(JaninoRelMetadataProvider.of(chained));
+            Assert.AreEqual(7d, janino.getRowCount(values).doubleValue(), 0.0001);
         }
 
         /// <summary>


### PR DESCRIPTION
`IKVM`, `IKVM.Java.Extensions` and the `IKVM.Net.Sdk` msbuild-sdk go from 8.15.0 to 8.16.0. `IKVM.Maven.Sdk` 1.12.0, `IKVM.Jdbc.Data` 1.0.13 and `IKVM.Core.MSBuild` 0.1.108 are already the latest released, so they are unchanged.

## What the upgrade changes

8.16.0 makes `IKVM.Attributes.CustomAssemblyClassLoaderAttribute` public again. It had become `internal` in 8.14.0 with the move of IKVM.Reflection into CoreLib, and `RuntimeAssemblyClassLoader.GetCustomClassLoader` reads it through `Assembly.GetCustomAttributes(type, false)` — which the CLR skips when the attribute type is not visible outside its own assembly. `IKVM.Maven.Sdk` stamps every `MavenReference` assembly with that attribute to give it an `AppDomainAssemblyClassLoader`, so with the stamp present in metadata but unreadable, `calcite-core` fell back to a per-assembly loader that cannot see another assembly's `cli.` types.

That is the whole of **"Janino cannot name a CLR class"**, which this repository had recorded in seven places as a property of Janino. It held only for 8.14.0 and 8.15.0 — the two versions this repository has ever been on — and neither before nor after.

Measured at one commit, changing only the IKVM version:

| | 8.15.0 | 8.16.0 |
|---|---|---|
| `JaninoRelMetadataProvider.of(chained).revise(handlerClass)` | `CompileException: Cannot determine simple type name "cli"` | `GeneratedMetadata_RowCountHandler`, answers `7.0` |
| `MY_SUM` (a C# aggregate) under `EnumerableConvention` | Janino `CompileException` out of `EnumerableInterpretable.compileToBindable` | same rows as `ClrEnumerableConvention` |
| `JaninoRexCompiler.class.getClassLoader()` | `AssemblyClassLoader \| calcite.core` | `AppDomainAssemblyClassLoader`, parent `AssemblyClassLoader \| calcite.core` |

## Consequences in this tree

- `Should_take_a_handler_written_in_dotnet` asserted that Janino *refuses* a handler naming a `cli.` class. It now asserts that Janino takes one and gives the same answer as `ClrRelMetadataProvider`.
- `ShouldRunAUserDefinedAggregate`, `ShouldRunAUserDefinedWindowAggregate` and `ShouldRunATableFunction` were the only tests in `ClrEnumerableDifferentialTests` asserted by hand, because Calcite could not answer them. They are differential against Calcite now, and keep their hand-written rows as a second oracle.
- What is left of `ClrRelMetadataProvider`'s reason is the compile it saves, not one it made possible. The comments and documentation stating otherwise are corrected — `CLAUDE.md`, both READMEs, `DESIGN.md`, `ClrMetadataHandlerEmitter`, `ClrRelMetadataProvider` and the test project's `calcite-testkit` note.

Two edges worth knowing: the restored loader only sees assemblies already loaded into the AppDomain, and setting `MavenClassLoader` empty turns it off.

## Testing

1470 tests pass, none skipped: 752 `Apache.Calcite.Tests`, 362 `Apache.Calcite.Adapter.AdoNet.Tests`, 356 `Apache.Calcite.Data.Tests`.
