### PR TITLE
Let the Maven SDK reach consumers, so a referenced package can load

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/Apache.Calcite.Adapter.AdoNet.Tests.csproj
@@ -19,10 +19,11 @@
         <PackageReference Include="IKVM" Version="8.16.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
         <PackageReference Include="FluentAssertions" Version="8.10.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
         <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />

--- a/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
+++ b/src/Apache.Calcite.Adapter.AdoNet/Apache.Calcite.Adapter.AdoNet.csproj
@@ -25,10 +25,12 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.16.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through,
+             which is what we want. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
         <PackageReference Include="System.Data.OleDb" Version="10.0.11" />
         <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
              declare the missing edge, optional like json-path's own bundled descriptor intends, so the

--- a/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
+++ b/src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj
@@ -15,10 +15,11 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.16.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
+++ b/src/Apache.Calcite.Data/Apache.Calcite.Data.csproj
@@ -24,10 +24,12 @@
     <ItemGroup>
         <PackageReference Include="IKVM" Version="8.16.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through,
+             which is what we want. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
         <!-- json-path's published POM declares no jackson dependency at all (json-path/JsonPath#1082);
              declare the missing edge, optional like json-path's own bundled descriptor intends, so its
              jackson providers compile against the real assembly and the version sorts ahead when the

--- a/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
+++ b/src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj
@@ -25,10 +25,12 @@
         <PackageReference Include="IKVM" Version="8.16.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through,
+             which is what we want. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
         <!-- calcite-linq4j is deliberately not named. It arrives transitively from calcite-core, at whatever
              version core resolves to. Pinning it here pins linq4j to 1.42 while a consumer that asks for
              1.43 — Apache.Calcite.Data.Tests does, for calcite-server — resolves core to 1.43, and 1.43's

--- a/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
+++ b/src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj
@@ -21,10 +21,11 @@
         <PackageReference Include="IKVM" Version="8.16.0" />
         <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
         <PackageReference Include="IKVM.Jdbc.Data" Version="1.0.13" />
-        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #69.

`IKVM.Maven.Sdk` was marked `PrivateAssets="all"` in every project. That package ships **only** `buildTransitive/` — there is no `build/` folder — which is the folder NuGet added so a package's build assets reach consumers through an intermediate package. Marking it private disables the one delivery mechanism it has.

So a project that references `Apache.Calcite.Data` restores, compiles, and then dies the first time anything touches Calcite:

```
System.IO.FileNotFoundException: Could not load file or assembly
'calcite.core, Version=1.42.0.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58'
```

The package carries no such assembly and causes none to be produced. The published nuspec shows why — the SDK is not even listed, because `PrivateAssets="all"` strips it:

```xml
<dependency id="Apache.Calcite.Extensions" version="2.0.0-pre.9" exclude="Build,Analyzers" />
<dependency id="IKVM" version="8.16.0" exclude="Build,Analyzers" />
<dependency id="IKVM.Java.Extensions" version="8.16.0" exclude="Build,Analyzers" />
```

The declaration contradicted itself as well: `IncludeAssets` named `buildtransitive`, which is the intent to flow, and `PrivateAssets="all"` overrode it. That pairing is the analyzer and source-generator idiom applied to a package that is neither — easy to copy in, and nothing about it fails at build time.

## The change

Drop the metadata entirely, leaving `<PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />`. The default `PrivateAssets` keeps `build` to ourselves and lets `buildTransitive` through, which is what was wanted. The packed nuspec then reads:

```xml
<dependency id="IKVM.Maven.Sdk" version="1.12.0" exclude="Build,Analyzers" />
```

Applied to the test projects too. The SDK is not a development-only dependency of anything here, and no project should be excluding it.

## Verified

A bare console project — a `nuget.config` pointing at a local feed, and one `PackageReference` to the locally packed `Apache.Calcite.Data`, nothing else:

```xml
<PackageReference Include="Apache.Calcite.Data" Version="1.0.0-dev" />
```

`calcite.core.dll` lands in its output, and it runs a query:

```
CONSUMER OK: 2
```

The same project against the published packages fails with the `FileNotFoundException` above. That is the acceptance test for this, and it is worth having somewhere permanent — a consumption smoke test over the packed output would catch a regression that no amount of building this repository can, since every project here declares the SDK itself.

Companion changes for the same declaration are going up against `calcite-cosmos` and `calcite-efcore`.
