### PR TITLE
Cast to a type SQL Server knows, not to Calcite's UUID

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
@@ -280,6 +280,33 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
+        /// Correlating across a cast to <c>UUID</c>, which puts the type name into the generated SQL as
+        /// well as a <c>java.util.UUID</c> into the parameter.
+        /// </summary>
+        /// <remarks>
+        /// The cast is what makes the value a UUID rather than text — a <c>uniqueidentifier</c> reaches
+        /// Calcite as a <c>CHAR(36)</c>, so a schema wanting GUID semantics has to state them, which is
+        /// what a view over a document store does — and stating them is what puts a type name T-SQL has
+        /// never heard of into the statement: "Type UUID is not a defined system type". A parameter bound
+        /// into a statement the server refuses to parse is not yet a working comparison, which is why this
+        /// is here beside the conversion tests rather than covered by them.
+        /// </remarks>
+        /// <param name="provider"></param>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void CorrelatingAcrossAUuidCastRunsOnTheServer(string provider)
+        {
+            CollectionAssert.AreEqual(
+                new[] { "1" },
+                CorrelatedRows(provider, """
+                    SELECT T.ID FROM ADO.TYPES T
+                    WHERE EXISTS (SELECT 1 FROM ADO.TYPES T2 WHERE CAST(T2.C_GUID AS UUID) = CAST(T.C_GUID AS UUID))
+                    """));
+        }
+
+        /// <summary>
         /// A limitation of the driver rather than of the adapter, pinned so that it is a stated fact rather
         /// than a surprise: <c>System.Data.OleDb</c> cannot marshal a <see cref="DateTimeOffset"/> to a
         /// Variant at all, so a zoned timestamp cannot be a parameter through OLE DB. It fails on the

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
@@ -190,15 +190,36 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             /// rather than of Calcite — Postgres writes <c>double precision</c> through it — and it unparses
             /// the alias alone, which is what puts the <c>(MAX)</c> where a precision would otherwise go.
             /// </para>
+            /// <para>
+            /// <c>UUID</c> is the other name Calcite writes that T-SQL has never heard: the server answers
+            /// "Type UUID is not a defined system type" and the statement never runs. <c>uniqueidentifier</c>
+            /// is what SQL Server calls the same sixteen bytes. A schema reaches this by stating GUID
+            /// semantics for a key its source spells as text — which is what a view over a document store
+            /// does — and then every comparison against that key is a cast.
+            /// </para>
             /// </remarks>
             public override SqlNode getCastSpec(RelDataType type)
             {
-                if (UnboundedTypeName(type) is string typeAlias)
-                    return new SqlDataTypeSpec(
-                        new SqlAlienSystemTypeNameSpec(typeAlias, type.getSqlTypeName(), SqlParserPos.ZERO),
-                        SqlParserPos.ZERO);
+                if (UnboundedTypeName(type) is string unbounded)
+                    return AlienSpec(unbounded, type);
+
+                if (type.getSqlTypeName()?.name() == nameof(SqlTypeName.UUID))
+                    return AlienSpec("UNIQUEIDENTIFIER", type);
 
                 return base.getCastSpec(type);
+            }
+
+            /// <summary>
+            /// Writes a cast to a type named as SQL Server names it rather than as Calcite does.
+            /// </summary>
+            /// <param name="typeAlias"></param>
+            /// <param name="type"></param>
+            /// <returns></returns>
+            static SqlDataTypeSpec AlienSpec(string typeAlias, RelDataType type)
+            {
+                return new SqlDataTypeSpec(
+                    new SqlAlienSystemTypeNameSpec(typeAlias, type.getSqlTypeName(), SqlParserPos.ZERO),
+                    SqlParserPos.ZERO);
             }
 
             /// <summary>


### PR DESCRIPTION
Fixes #72. Rebuilt on current `main` — this was opened before #71 landed and originally carried a fix for #68 as well; that half is now upstream and better named, so all that remains here is the cast spec.

## The bug

`AdoSqlDialects.Mssql.getCastSpec` writes Calcite's `UUID` into the generated T-SQL, and SQL Server answers "Type UUID is not a defined system type" before it reads a row. It renders `uniqueidentifier` now — the name SQL Server gives the same sixteen bytes — through the same `SqlAlienSystemTypeNameSpec` the override already uses to correct an unbounded `VARCHAR` to `varchar(max)`.

A schema reaches this by stating GUID semantics for a key its source spells as text: `uniqueidentifier` arrives from `INFORMATION_SCHEMA` as a `CHAR(36)`, and a view over a document store has only strings to start from. Once the column is `UUID`, every comparison against it carries a cast.

## Why #71 did not cover it

They are sequential halves of one symptom. #71 fixed the parameter arriving as a `java.util.UUID`; this is the type name in the statement it gets bound into. #71's test binds through `prepareStatement` with a plain `?`, which carries no cast — so it passes without this, and a value bound into a statement the server refuses to parse is still not a working comparison.

## Verified

`CorrelatingAcrossAUuidCastRunsOnTheServer` correlates across the cast rather than over a column, and passes on **SqlClient, ODBC and OLE DB**. With the dialect change reverted it fails on all three, each reporting `Type UUID is not a defined system type` — so it pins this specific fix rather than the conversion #71 already covers.

Full adapter suite green: 367 tests.

Confirmed end-to-end outside the repo too, against a federation over real SQL Server and Cosmos, where a GUID key comparison now returns its row.