### PR TITLE
Create the release from the build, and publish to nuget.org on a tag or on request

### DIFF
--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -190,12 +190,10 @@ jobs:
     - test
     runs-on: ubuntu-latest
     env:
-      # One switch for the GitHub release and the nuget.org push together, so a build cannot reach one
-      # and not the other. main carries it by default: only a push from the run that built the package
-      # puts the same assembly on both feeds, and a later run cannot, because GitHub Packages already
-      # holds the version and skips it as a duplicate. The workflow_dispatch input forces the same pair
-      # from any ref, for a branch that does not publish on its own or to retry a run that failed here.
-      PUBLISH: ${{ github.ref_type == 'tag' || github.ref == 'refs/heads/main' || inputs.publish == true }}
+      # One switch for the GitHub release and the nuget.org push together, so neither happens without the
+      # other. Nothing reaches nuget.org implicitly: either a tag drives the build, or the run was asked
+      # for it by hand. The GitHub Packages push below is not gated by this and still runs on every build.
+      PUBLISH: ${{ github.ref_type == 'tag' || inputs.publish == true }}
     steps:
     - name: Checkout Source
       uses: actions/checkout@v7
@@ -242,14 +240,16 @@ jobs:
       env:
         GITHUB_REPOS: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # Same run, same artifact, both feeds. Gating this on a tag while the GitHub push above runs on
-    # every build is what let one version name two different assemblies: GitVersion labels main `pre.N`,
-    # which is the shape a release tag also takes, so the tag build re-derives a version GitHub Packages
-    # already holds from an earlier main build and skips it as a duplicate -- leaving nuget.org with the
-    # tag build and GitHub Packages with the main build under `2.0.0-pre.9`. A consumer restoring from
-    # both feeds can then get Apache.Calcite.Data compiled against a Signature that the
-    # Apache.Calcite.Extensions beside it does not carry. Publishing from the run that already built the
-    # package removes the second build, so there is nothing left to disagree.
+    # --skip-duplicate so a version nuget.org already carries is a no-op here rather than a failure.
+    #
+    # Be aware that this run has rebuilt the package. GitVersion labels main `pre.N`, the same shape a
+    # release tag takes, so the version this pushes is one GitHub Packages already received from the
+    # build that produced it, and skipped as a duplicate when this run pushed above. The two feeds then
+    # carry different assemblies under one version -- which is how `2.0.0-pre.9` came to be a build from
+    # August on GitHub Packages and a September one on nuget.org, and how a consumer restoring from both
+    # gets Apache.Calcite.Data compiled against a Signature the Apache.Calcite.Extensions beside it does
+    # not carry. Publishing the artifact the original run built, rather than a rebuild of it, is what
+    # would close that.
     - name: Push NuGet
       if: env.PUBLISH == 'true'
       shell: pwsh

--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -222,8 +222,16 @@ jobs:
       env:
         GITHUB_REPOS: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Same run, same artifact, both feeds. Gating this on a tag while the GitHub push above runs on
+    # every build is what let one version name two different assemblies: GitVersion labels main `pre.N`,
+    # which is the shape a release tag also takes, so the tag build re-derives a version GitHub Packages
+    # already holds from an earlier main build and skips it as a duplicate -- leaving nuget.org with the
+    # tag build and GitHub Packages with the main build under `2.0.0-pre.9`. A consumer restoring from
+    # both feeds can then get Apache.Calcite.Data compiled against a Signature that the
+    # Apache.Calcite.Extensions beside it does not carry. Publishing from the run that already built the
+    # package removes the second build, so there is nothing left to disagree.
     - name: Push NuGet
-      if: github.ref_type == 'tag'
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
       shell: pwsh
       run: dotnet nuget push dist/nuget/*.nupkg --source $env:NUGET_REPOS --api-key $env:NUGET_TOKEN --skip-duplicate
       env:

--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -2,6 +2,11 @@ name: calcite-dotnet
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish this build to nuget.org, creating the GitHub release if one does not exist.
+        type: boolean
+        default: false
   push:
     branches:
     - main
@@ -184,6 +189,13 @@ jobs:
     needs:
     - test
     runs-on: ubuntu-latest
+    env:
+      # One switch for the GitHub release and the nuget.org push together, so a build cannot reach one
+      # and not the other. main carries it by default: only a push from the run that built the package
+      # puts the same assembly on both feeds, and a later run cannot, because GitHub Packages already
+      # holds the version and skips it as a duplicate. The workflow_dispatch input forces the same pair
+      # from any ref, for a branch that does not publish on its own or to retry a run that failed here.
+      PUBLISH: ${{ github.ref_type == 'tag' || github.ref == 'refs/heads/main' || inputs.publish == true }}
     steps:
     - name: Checkout Source
       uses: actions/checkout@v7
@@ -205,15 +217,23 @@ jobs:
       with:
         name: nuget
         path: dist/nuget
+    # `commit` is what lets this run from a branch: with no tag of this name yet the action creates one
+    # there, which is the tag that no longer has to be made by hand. Where the tag does already exist and
+    # carries a release -- an explicit tag build, or a re-run -- allowUpdates keeps that from failing and
+    # updates it in place instead, omitBodyDuringUpdate leaves notes written by hand alone, and
+    # replacesArtifacts refreshes the packages rather than colliding with the ones already attached.
     - name: Create Release
-      if: github.ref_type == 'tag'
+      if: env.PUBLISH == 'true'
       uses: ncipollo/release-action@v1
       with:
         tag: ${{ steps.GitVersion.outputs.semVer }}
+        commit: ${{ github.sha }}
         allowUpdates: true
         omitBodyDuringUpdate: true
+        replacesArtifacts: true
         artifacts: dist/nuget/*.nupkg,dist/nuget/*.snupkg
-        makeLatest: true
+        prerelease: ${{ contains(steps.GitVersion.outputs.semVer, '-') }}
+        makeLatest: ${{ !contains(steps.GitVersion.outputs.semVer, '-') }}
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Push NuGet (GitHub)
       if: github.event_name != 'pull_request'
@@ -231,7 +251,7 @@ jobs:
     # Apache.Calcite.Extensions beside it does not carry. Publishing from the run that already built the
     # package removes the second build, so there is nothing left to disagree.
     - name: Push NuGet
-      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+      if: env.PUBLISH == 'true'
       shell: pwsh
       run: dotnet nuget push dist/nuget/*.nupkg --source $env:NUGET_REPOS --api-key $env:NUGET_TOKEN --skip-duplicate
       env:


### PR DESCRIPTION
Getting a build to nuget.org meant creating a tag by hand, and those tags are made out
of order against a `main` that GitVersion is already numbering `pre.N`. This makes the
release something the workflow produces, and gives the push a switch that does not
depend on a tag existing first.

## The change

One `PUBLISH` switch, read by the GitHub release and the nuget.org push together, so
neither happens without the other:

```yaml
PUBLISH: ${{ github.ref_type == 'tag' || inputs.publish == true }}
```

- **Nothing reaches nuget.org implicitly.** A tag drives it, or a `workflow_dispatch`
  run is asked for it through the new `publish` input. `main` and `develop` builds still
  go only to GitHub Packages.
- **The release is created where none exists.** `commit` lets the step run from a branch:
  with no tag of that name yet, the action creates one at the built commit — so the tag
  is a product of the build rather than something to remember to make, and to keep in
  order.
- **A tag that already carries a release is updated, not failed.** `allowUpdates` updates
  in place, `omitBodyDuringUpdate` leaves hand-written notes alone, and `replacesArtifacts`
  refreshes the attached packages instead of colliding with the ones already there.
- **A prerelease is marked as one and does not take `latest`**, which it would have taken
  on every publish otherwise.

The GitHub Packages push is untouched and still runs on every non-pull-request build.
`--skip-duplicate` is unchanged on both, so re-running over a version a feed already holds
is a no-op rather than a failure.

## What this does not fix

The two feeds can still end up carrying different assemblies under one version, and the
comment on the push step now says so instead of claiming otherwise.

A run that reaches the nuget.org push has **rebuilt** the package. GitVersion labels `main`
`pre.N` — the same shape a release tag takes — so the version it pushes is one GitHub
Packages already received from the build that produced it, and skipped as a duplicate when
this run pushed there. Measured on the current packages:

| feed | `Apache.Calcite.Extensions 2.0.0-pre.9` published |
| --- | --- |
| GitHub Packages | ~Aug 9 |
| nuget.org | Sep 1, 12:45 UTC |

Two builds 23 days apart under one version string. `pre.7` and `pre.8` are split the same
way. A consumer restoring from both feeds — calcite-cosmos adds this organization's feed
beside nuget.org — can take `Apache.Calcite.Data` from one and `Apache.Calcite.Extensions`
from the other and get, at the first statement executed through the ADO.NET provider:

```
System.TypeLoadException: Could not load type 'Signature' from assembly
'Apache.Calcite.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null'
   at Apache.Calcite.Data.Internal.CalciteSession.ExecuteReaderCore(...)
```

Restoring from nuget.org alone the same consumer is green — 654 tests, 0 failed, against a
Cosmos emulator. That is what is red in ikvmnet/calcite-cosmos#56.

Closing it needs one of: publishing the artifact the original run built rather than a
rebuild of it (a `workflow_dispatch` that takes a run id and downloads its `nuget`
artifact), or giving every-build GitHub pushes a version a release can never claim. Neither
is in this change.

Separately, `2.0.0-pre.9` is already split and nuget.org cannot be overwritten — deleting
that version from GitHub Packages is what makes the two agree for anyone pinned to it, and
would unblock ikvmnet/calcite-cosmos#56 today.