### PR TITLE
Read and write an unsigned long as its bits, both directions

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoParameterConversionTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoParameterConversionTests.cs
@@ -1,0 +1,120 @@
+using System;
+
+using Apache.Calcite.Adapter.AdoNet.Metadata;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// The conversions <c>AdoEnumerable.ToProviderValue</c> performs, reached through the enricher rather
+    /// than through a query.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="GenericProviderCorrelationTests.CorrelatingOnAColumnConvertsItsValueForTheProvider"/>
+    /// covers the branches a real backend can produce, which is the better test where one can: it binds
+    /// against a live server and a wrong conversion is a wrong answer rather than a wrong object.
+    /// </para>
+    /// <para>
+    /// Three of them it cannot reach. <c>UShort</c>, <c>UInteger</c> and <c>ULong</c> come from a column a
+    /// provider describes as unsigned, and neither SQL Server nor SQLite has one wider than a
+    /// <c>tinyint</c> — so those branches had no test at all, and the widest of them was converting
+    /// through text until this class was written. The enricher is public and takes the context it reads
+    /// from, so a value can be handed to it directly.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class AdoParameterConversionTests
+    {
+
+        SqliteFixture _sqlite = null!;
+        AdoDataSource _dataSource = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _sqlite = new SqliteFixture();
+            _dataSource = new DbDataSourceAdoDataSource(_sqlite.DataSource, new SqliteDatabaseMetadata(_sqlite.DataSource));
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _sqlite?.Dispose();
+        }
+
+        /// <summary>
+        /// Returns what a provider would be handed for <paramref name="value"/>.
+        /// </summary>
+        /// <remarks>
+        /// The index is <see cref="AdoCorrelationDataContext.Offset"/>, which the context answers from its
+        /// own array without consulting the one it wraps — so there is no outer statement to arrange, and
+        /// the value goes in exactly where a correlation variable or a dynamic parameter would.
+        /// </remarks>
+        object? Bound(object value)
+        {
+            var indexes = new java.util.ArrayList();
+            indexes.add(java.lang.Integer.valueOf(AdoCorrelationDataContext.Offset));
+
+            var enricher = AdoEnumerable.CreateEnricher(_dataSource, indexes, new java.util.ArrayList(),
+                new AdoCorrelationDataContext(null!, [value]));
+
+            using var connection = _dataSource.OpenConnection();
+            using var command = connection.CreateCommand();
+            enricher.Enrich(command);
+
+            return command.Parameters[0].Value;
+        }
+
+        /// <summary>
+        /// The whole of a <c>ulong</c>, whose top half is outside a <see cref="long"/> and so has to be a
+        /// <see cref="decimal"/>. A joou <c>ULong</c> holds the bits of a signed long read unsigned, so the
+        /// value is that reinterpretation; it was read out of the type's text and parsed back before, which
+        /// is the same instinct the <c>BigDecimal</c> branch was wrong for.
+        /// </summary>
+        [TestMethod]
+        [DataRow("0")]
+        [DataRow("1")]
+        [DataRow("9223372036854775807")]  // long.MaxValue, the last value whose bits are not negative
+        [DataRow("9223372036854775808")]  // and the first that is
+        [DataRow("18446744073709551615")] // ulong.MaxValue
+        public void AULongIsBoundAsItsUnsignedValue(string literal)
+        {
+            Bound(org.joou.ULong.valueOf(literal)).Should().Be(decimal.Parse(literal, System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        [DataRow("0")]
+        [DataRow("65535")] // ushort.MaxValue, which is why the CLR type is an int
+        public void AUShortIsBoundAsAnInt(string literal)
+        {
+            Bound(org.joou.UShort.valueOf(literal)).Should().Be(int.Parse(literal));
+        }
+
+        [TestMethod]
+        [DataRow("0")]
+        [DataRow("4294967295")] // uint.MaxValue, which is why the CLR type is a long
+        public void AUIntegerIsBoundAsALong(string literal)
+        {
+            Bound(org.joou.UInteger.valueOf(literal)).Should().Be(long.Parse(literal));
+        }
+
+        /// <summary>
+        /// The branch a real backend does reach, here for the contrast: a <c>tinyint</c> is the one
+        /// unsigned type SQL Server describes, and its range fits the CLR type exactly.
+        /// </summary>
+        [TestMethod]
+        [DataRow("0")]
+        [DataRow("255")]
+        public void AUByteIsBoundAsAByte(string literal)
+        {
+            Bound(org.joou.UByte.valueOf(literal)).Should().Be(byte.Parse(literal));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
@@ -279,11 +279,13 @@ namespace Apache.Calcite.Adapter.AdoNet
                 // the unsigned types travel as joou values, and no provider knows those either. Each is
                 // unwrapped to the narrowest CLR type every provider binds: SqlClient takes a byte but none
                 // of ushort, uint or ulong, so the wider three go to the signed type that holds their range
-                // exactly — and ULong to decimal, ulong's top half being outside long
+                // exactly — and ULong to decimal, ulong's top half being outside long. A joou value holds
+                // the signed type's bits read unsigned, so every one of these is a reinterpretation and
+                // none of them has to be written out and read back
                 org.joou.UByte ub => (byte)ub.shortValue(),
                 org.joou.UShort us => us.intValue(),
                 org.joou.UInteger ui => ui.longValue(),
-                org.joou.ULong ul => decimal.Parse(ul.toString(), System.Globalization.CultureInfo.InvariantCulture),
+                org.joou.ULong ul => (decimal)unchecked((ulong)ul.longValue()),
                 _ => value,
             };
         }

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
@@ -231,12 +231,15 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="index"></param>
         /// <returns></returns>
         /// <remarks>
-        /// Through the decimal string, because the whole of the range is the point: <c>valueOf(long)</c>
-        /// refuses anything above <see cref="long.MaxValue"/>, which is half of what the type holds.
+        /// The bits, read unsigned. This went through the decimal string on the grounds that
+        /// <c>valueOf(long)</c> refuses anything above <see cref="long.MaxValue"/> and so could not carry
+        /// half of what the type holds; that is not what it does. Measured: <c>valueOf(-1L)</c> is
+        /// 18446744073709551615, the overload taking the argument's bits rather than its value, which is
+        /// the whole range and the same representation joou stores.
         /// </remarks>
         public static object? GetULong(DbDataReader reader, int index)
         {
-            return GetValueAs<ulong>(reader, index) is ulong value ? org.joou.ULong.valueOf(value.ToString(CultureInfo.InvariantCulture)) : null;
+            return GetValueAs<ulong>(reader, index) is ulong value ? org.joou.ULong.valueOf(unchecked((long)value)) : null;
         }
 
         /// <summary>


### PR DESCRIPTION
Follow-up to #71, which merged before this commit reached the branch. One commit, over the same boundary.

Both ends of the joou `ULong` went through a decimal string. Neither had to.

**Out of the plan**, `AdoEnumerable.ToProviderValue` parsed `ULong.toString()`. A joou value holds the signed type's bits read unsigned, so the whole of the range is a reinterpretation: `unchecked((ulong)ul.longValue())`, widened to a `decimal` because `ulong`'s top half is outside `long`.

**Into the plan**, `AdoReaderUtil.GetULong` wrote the `ulong` out and had `ULong` parse it back, and said why: `valueOf(long)` "refuses anything above `long.MaxValue`, which is half of what the type holds". It does not. Measured: `ULong.valueOf(-1L)` is `18446744073709551615` — that overload takes the argument's bits, not its value, which is exactly the representation joou stores. The remark now says so, and the conversion is `valueOf(unchecked((long)value))`.

## Coverage

`AnUnsignedValueKeepsTheWholeOfItsRange` already held the reader at `18446744073709551615`. The parameter side had nothing at all: `UShort`, `UInteger` and `ULong` come from a column a provider describes as unsigned, and neither SQL Server nor SQLite has one wider than a `tinyint`, so those three branches were unreachable from every query in the suite — which is how the widest of them stayed on text through #71.

`AdoParameterConversionTests` reaches them through `CreateEnricher`, which is public and takes the context it reads from, so a value goes in where a correlation variable or a dynamic parameter would and comes back out of a real `DbParameter`. All four unsigned types are pinned at both ends of their range, including `long.MaxValue + 1` and `ulong.MaxValue` — the two a signed widening gets wrong.

## Measured

Suites: `Apache.Calcite.Adapter.AdoNet.Tests` 375, `Apache.Calcite.Data.Tests` 317 — green, nothing skipped. `Apache.Calcite.Tests` is untouched by this change and was 811 green at the parent commit.
