### PR TITLE
Name the package feeds in the repository

### DIFF
--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -43,9 +43,9 @@ jobs:
         versionSpec: 6.x
     - name: Execute GitVersion
       uses: gittools/actions/gitversion/execute@v4
-    - name: Add NuGet Source (GitHub)
+    - name: Authenticate NuGet Source (GitHub)
       shell: pwsh
-      run: dotnet nuget add source --username USERNAME --password $env:GITHUB_TOKEN --store-password-in-clear-text --name ${{ github.repository_owner }} $env:GITHUB_REPOS
+      run: dotnet nuget update source ${{ github.repository_owner }} --source $env:GITHUB_REPOS --username USERNAME --password $env:GITHUB_TOKEN --store-password-in-clear-text
       env:
         GITHUB_REPOS: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,9 +119,9 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
-    - name: Add NuGet Source (GitHub)
+    - name: Authenticate NuGet Source (GitHub)
       shell: pwsh
-      run: dotnet nuget add source --username USERNAME --password $env:GITHUB_TOKEN --store-password-in-clear-text --name ${{ github.repository_owner }} $env:GITHUB_REPOS
+      run: dotnet nuget update source ${{ github.repository_owner }} --source $env:GITHUB_REPOS --username USERNAME --password $env:GITHUB_TOKEN --store-password-in-clear-text
       env:
         GITHUB_REPOS: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -119,9 +119,13 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
-    - name: Authenticate NuGet Source (GitHub)
+    # This job never checks the repository out, so the nuget.config that names the feed is not on disk
+    # and there is no source here to authenticate: it has to be added outright. The build job, which
+    # does check out, updates the source its config already names instead — adding it there fails on the
+    # name being taken.
+    - name: Add NuGet Source (GitHub)
       shell: pwsh
-      run: dotnet nuget update source ${{ github.repository_owner }} --source $env:GITHUB_REPOS --username USERNAME --password $env:GITHUB_TOKEN --store-password-in-clear-text
+      run: dotnet nuget add source $env:GITHUB_REPOS --name ${{ github.repository_owner }} --username USERNAME --password $env:GITHUB_TOKEN --store-password-in-clear-text
       env:
         GITHUB_REPOS: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+    <!-- The organization's GitHub Packages feed carries the Apache.Calcite and IKVM prereleases this
+         repository builds against; nuget.org carries everything else and the tagged releases. The
+         workflow used to be the only place the feed was named, so a checkout could be built in CI and
+         not on a developer's machine, where restore failed on packages nuget.org has never held.
+
+         GitHub Packages requires authentication even to read, and has no NuGet credential provider of
+         its own, so the token is named rather than stored: NuGet expands %GITHUB_TOKEN% from the
+         environment at restore. Set it to a token with `read:packages` and nothing else is needed.
+         Nothing secret belongs in this file. -->
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="ikvmnet" value="https://nuget.pkg.github.com/ikvmnet/index.json" protocolVersion="3" />
+    </packageSources>
+
+    <packageSourceCredentials>
+        <ikvmnet>
+            <add key="Username" value="USERNAME" />
+            <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+        </ikvmnet>
+    </packageSourceCredentials>
+
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,24 +2,22 @@
 <configuration>
 
     <!-- The organization's GitHub Packages feed carries the Apache.Calcite and IKVM prereleases this
-         repository builds against; nuget.org carries everything else and the tagged releases. The
-         workflow used to be the only place the feed was named, so a checkout could be built in CI and
-         not on a developer's machine, where restore failed on packages nuget.org has never held.
+         repository builds against; nuget.org carries everything else. The workflow used to be the only
+         place the feed was named, so a checkout could be built in CI and not on a developer's machine,
+         where restore failed on packages nuget.org has never held.
 
-         GitHub Packages requires authentication even to read, and has no NuGet credential provider of
-         its own, so the token is named rather than stored: NuGet expands %GITHUB_TOKEN% from the
-         environment at restore. Set it to a token with `read:packages` and nothing else is needed.
-         Nothing secret belongs in this file. -->
+         Credentials are deliberately not here. GitHub Packages requires authentication even to read and
+         has no NuGet credential provider of its own, and NuGet does not expand environment variables in
+         packageSourceCredentials -- a %VAR% there is sent verbatim as the password and the feed answers
+         401. So the token is supplied out of band, once per machine:
+
+           dotnet nuget update source ikvmnet --username <you> \
+             --password <a token with read:packages> --store-password-in-clear-text
+
+         The workflow does the same thing with its own token before restoring. -->
     <packageSources>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
         <add key="ikvmnet" value="https://nuget.pkg.github.com/ikvmnet/index.json" protocolVersion="3" />
     </packageSources>
-
-    <packageSourceCredentials>
-        <ikvmnet>
-            <add key="Username" value="USERNAME" />
-            <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
-        </ikvmnet>
-    </packageSourceCredentials>
 
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
-    <!-- The organization's GitHub Packages feed carries the Apache.Calcite and IKVM prereleases this
-         repository builds against; nuget.org carries everything else. The workflow used to be the only
+    <!-- The organization's GitHub Packages feed carries the IKVM packages this repository builds
+         against that nuget.org does not hold; nuget.org carries everything else. The workflow used to be the only
          place the feed was named, so a checkout could be built in CI and not on a developer's machine,
          where restore failed on packages nuget.org has never held.
 
          Credentials are deliberately not here. GitHub Packages requires authentication even to read and
          has no NuGet credential provider of its own, and NuGet does not expand environment variables in
-         packageSourceCredentials -- a %VAR% there is sent verbatim as the password and the feed answers
-         401. So the token is supplied out of band, once per machine:
+         packageSourceCredentials: a %VAR% written there is sent verbatim as the password and the feed
+         answers 401. So the token is supplied out of band, once per machine, by running
 
-           dotnet nuget update source ikvmnet --username <you> \
-             --password <a token with read:packages> --store-password-in-clear-text
+           dotnet nuget update source ikvmnet
 
-         The workflow does the same thing with its own token before restoring. -->
+         with your GitHub user name, a token carrying read:packages as the password, and the switch that
+         stores it in clear text (the encrypted store is Windows only). That writes the credentials to
+         the user level NuGet.Config and never to this file. The build job does the same with its own
+         token before restoring. -->
     <packageSources>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
         <add key="ikvmnet" value="https://nuget.pkg.github.com/ikvmnet/index.json" protocolVersion="3" />


### PR DESCRIPTION
The organization's GitHub Packages feed carries the `IKVM` packages this repository builds
against that nuget.org does not hold, and the workflow was the only place it was named. A
checkout therefore built in CI and not on a developer's machine, where restore failed on
packages nuget.org has never held and nothing in the tree said why.

## The change

- **`nuget.config`** names both feeds, and holds no credentials.
- **The build job's `dotnet nuget add source` becomes `update source`.** That job checks
  the repository out, so the config already names the source there and `add` fails on the
  name being taken.
- **The test job keeps adding the source outright.** It downloads the build's output and
  never checks out, so the config is not on disk there and there is nothing to update.

## Credentials, and a correction

GitHub Packages requires authentication even to read and — checked, not assumed — has
**no NuGet credential provider of its own**: Microsoft's
[artifacts-credprovider](https://github.com/microsoft/artifacts-credprovider) is Azure
Artifacts only, and there is an open request for a GitHub Packages one
([community#128462](https://github.com/orgs/community/discussions/128462)).

The first revision of this branch put `%GITHUB_TOKEN%` in `packageSourceCredentials`, on
the belief that NuGet expands environment variables there. **It does not.** CI sent the
literal string as the password and the feed answered:

```
error NU1301: ... Response status code does not indicate success: 401 (Unauthorized).
warning: Your request could not be authenticated by the GitHub Packages service.
```

That block is gone. The token is supplied out of band instead, once per machine, with
`dotnet nuget update source ikvmnet` and a token carrying `read:packages` — measured to
write the credentials to the user level `NuGet.Config` and never to the file in the tree.
The comment above the sources says so. CI does the same thing with its own token.

## Verification

Measured here rather than reasoned about, since it is what decides whether each job runs:

| | source already named | source not named |
| --- | --- | --- |
| `dotnet nuget add source` | fails, name taken | succeeds |
| `dotnet nuget update source` | succeeds | fails on a null reference |

which is why the two jobs differ. `dotnet nuget list source` reads the new config and
reports both feeds — the check the first revision needed and did not get, since a literal
`--` inside an XML comment made the file unparseable and every restore failed on it before
reading a source.

**Not verified end to end here.** This environment holds no token for the feed, so a
restore that actually reaches it still cannot be run; CI is the check on that half.

Worth knowing: with the feed named, a restore from a network that cannot reach
`nuget.pkg.github.com` fails with `NU1301` rather than falling back to nuget.org. That is
already true of CI today, and unavoidable while the packages live only on that feed.

Same change in ikvmnet/calcite-cosmos#59 and ikvmnet/calcite-efcore#22.