### PR TITLE
Name the cause a Java wrapper keeps out of .NET's reach

### DIFF
--- a/src/Apache.Calcite.Data.Tests/CalciteExceptionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteExceptionTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Data.Common;
 
+using Apache.Calcite.Data.Internal;
+
 
 using Xunit;
 
@@ -29,6 +31,69 @@ namespace Apache.Calcite.Data.Tests
             var inner = new InvalidOperationException("inner");
             var e = new CalciteException("outer", inner);
             Assert.Same(inner, e.InnerException);
+        }
+
+
+        /// <summary>
+        /// The JDK's reflection wrappers keep their cause out of <see cref="Exception.InnerException"/>:
+        /// each calls <c>super((Throwable) null)</c> and overrides <c>getCause()</c> instead, so a .NET
+        /// report of one names nothing at all. This is the shape a CI failure of <c>CalciteDdlTests</c>
+        /// arrived in — "Failed to execute Calcite statement." over an
+        /// <c>UndeclaredThrowableException</c> with no message and no cause.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Cause_hiding_wrappers))]
+        public void Should_name_a_cause_dotnet_cannot_see(java.lang.Throwable wrapper)
+        {
+            Assert.Null(((Exception)wrapper).InnerException);
+
+            var message = JavaCauses.Amend("Failed to execute Calcite statement.", wrapper);
+
+            Assert.Contains("the real reason", message);
+            Assert.StartsWith("Failed to execute Calcite statement.", message);
+        }
+
+        public static TheoryData<java.lang.Throwable> Cause_hiding_wrappers() => new()
+        {
+            new java.lang.reflect.UndeclaredThrowableException(new java.lang.RuntimeException("the real reason")),
+            new java.lang.reflect.InvocationTargetException(new java.lang.RuntimeException("the real reason")),
+            new java.lang.ExceptionInInitializerError(new java.lang.RuntimeException("the real reason")),
+        };
+
+        /// <summary>
+        /// A cause .NET can already see is left alone; repeating it would double every report.
+        /// </summary>
+        [Fact]
+        public void Should_leave_a_visible_cause_alone()
+        {
+            var visible = new java.lang.RuntimeException("outer", new java.lang.RuntimeException("the real reason"));
+            Assert.NotNull(((Exception)visible).InnerException);
+
+            Assert.Equal("boom", JavaCauses.Amend("boom", visible));
+        }
+
+        /// <summary>
+        /// A wrapper reached through a cause .NET can see is still hidden from the report, so the walk
+        /// follows the visible chain rather than only looking at its head.
+        /// </summary>
+        [Fact]
+        public void Should_name_a_cause_hidden_beneath_a_visible_one()
+        {
+            var hidden = new java.lang.reflect.UndeclaredThrowableException(new java.lang.RuntimeException("the real reason"));
+            var outer = new java.lang.IllegalStateException("unable to implement", hidden);
+
+            Assert.Contains("the real reason", JavaCauses.Amend("boom", outer));
+        }
+
+        /// <summary>
+        /// Neither a plain CLR exception nor no exception at all is a Java throwable, and neither may
+        /// change the message.
+        /// </summary>
+        [Fact]
+        public void Should_leave_a_clr_exception_alone()
+        {
+            Assert.Equal("boom", JavaCauses.Amend("boom", new InvalidOperationException("clr only")));
+            Assert.Equal("boom", JavaCauses.Amend("boom", null));
         }
 
     }

--- a/src/Apache.Calcite.Data.Tests/CalciteExceptionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteExceptionTests.cs
@@ -37,9 +37,7 @@ namespace Apache.Calcite.Data.Tests
         /// <summary>
         /// The JDK's reflection wrappers keep their cause out of <see cref="Exception.InnerException"/>:
         /// each calls <c>super((Throwable) null)</c> and overrides <c>getCause()</c> instead, so a .NET
-        /// report of one names nothing at all. This is the shape a CI failure of <c>CalciteDdlTests</c>
-        /// arrived in — "Failed to execute Calcite statement." over an
-        /// <c>UndeclaredThrowableException</c> with no message and no cause.
+        /// report of one carries no message and no cause.
         /// </summary>
         [Theory]
         [MemberData(nameof(Cause_hiding_wrappers))]

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -184,7 +184,7 @@ namespace Apache.Calcite.Data.Internal
             }
             catch (Exception e) when (e is not CalciteException)
             {
-                throw new CalciteException("Failed to initialize Calcite.", e);
+                throw new CalciteException(JavaCauses.Amend("Failed to initialize Calcite.", e), e);
             }
         }
 
@@ -245,7 +245,7 @@ namespace Apache.Calcite.Data.Internal
             }
             catch (Exception e) when (e is not CalciteException)
             {
-                throw new CalciteException("Failed to load Calcite model.", e);
+                throw new CalciteException(JavaCauses.Amend("Failed to load Calcite model.", e), e);
             }
         }
 
@@ -466,7 +466,7 @@ namespace Apache.Calcite.Data.Internal
             }
             catch (Exception e)
             {
-                throw new CalciteException("Failed to execute Calcite statement.", e);
+                throw new CalciteException(JavaCauses.Amend("Failed to execute Calcite statement.", e), e);
             }
             finally
             {
@@ -552,7 +552,7 @@ namespace Apache.Calcite.Data.Internal
             }
             catch (Exception e)
             {
-                throw new CalciteException("Failed to execute Calcite statement.", e);
+                throw new CalciteException(JavaCauses.Amend("Failed to execute Calcite statement.", e), e);
             }
             finally
             {

--- a/src/Apache.Calcite.Data/Internal/JavaCauses.cs
+++ b/src/Apache.Calcite.Data/Internal/JavaCauses.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Apache.Calcite.Data.Internal
+{
+
+    /// <summary>
+    /// Names the causes a Java exception keeps where a .NET report cannot reach them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Three of the JDK's own wrappers withhold their cause from the constructor that would record it.
+    /// <c>UndeclaredThrowableException</c>, <c>InvocationTargetException</c> and
+    /// <c>ExceptionInInitializerError</c> each call <c>super((Throwable) null)</c> — the comment upstream
+    /// reads "Disallow initCause" — keep the throwable in a field of their own, and override
+    /// <c>getCause()</c> to answer that field. IKVM carries a <c>Throwable</c>'s cause as
+    /// <see cref="Exception.InnerException"/>, which that constructor left null, and the override is a Java
+    /// method no .NET reporter consults. Measured: each of the three answers an empty
+    /// <see cref="Exception.Message"/> and a null <see cref="Exception.InnerException"/> while
+    /// <c>getCause()</c> holds the reason, and a plain <c>RuntimeException(message, cause)</c> answers both.
+    /// </para>
+    /// <para>
+    /// What that costs is the whole of a diagnosis. A CI run of <c>CalciteDdlTests</c> failed with
+    /// "Failed to execute Calcite statement." over a bare <c>java.lang.reflect.UndeclaredThrowableException</c>
+    /// — no message and no cause — raised where Calcite's <c>Resources</c> proxy builds
+    /// <c>sQLFeature_E101_03</c>. That handler declares four checked exceptions the resource interface does
+    /// not, so the proxy converts whichever one escaped into the wrapper; which of the four it was is the
+    /// entire answer, and it was not in the log.
+    /// </para>
+    /// <para>
+    /// The test for it is exact rather than a list of class names: a <c>Throwable</c> holding a cause that
+    /// its own <see cref="Exception.InnerException"/> does not. That is the same condition for any wrapper
+    /// written the same way, including ones added later.
+    /// </para>
+    /// </remarks>
+    static class JavaCauses
+    {
+
+        /// <summary>
+        /// The number of causes to follow before giving up, so that a chain built to refer back to itself
+        /// cannot spin. <c>Throwable.getCause</c> answers null for a throwable that is its own cause, which
+        /// rules out the one-step cycle and nothing longer.
+        /// </summary>
+        const int MaxDepth = 16;
+
+        /// <summary>
+        /// Returns <paramref name="message"/> followed by the causes <paramref name="exception"/> holds out
+        /// of .NET's reach, or <paramref name="message"/> unchanged where it holds none.
+        /// </summary>
+        /// <param name="message">The message describing what failed.</param>
+        /// <param name="exception">The exception about to be given as an inner exception, or null.</param>
+        /// <returns></returns>
+        public static string Amend(string message, Exception? exception)
+        {
+            StringBuilder? builder = null;
+
+            foreach (var cause in Hidden(exception))
+                (builder ??= new StringBuilder(message)).Append(" ---> ").Append(cause);
+
+            return builder?.ToString() ?? message;
+        }
+
+        /// <summary>
+        /// Walks the chain a .NET report will print, and at each link yields what hangs off a cause it
+        /// will not.
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        static IEnumerable<string> Hidden(Exception? exception)
+        {
+            for (var e = exception; e is not null; e = e.InnerException)
+            {
+                // a Throwable whose cause never reached Exception: it and everything under it sit off the
+                // InnerException chain, and so appear in no .NET report of this exception
+                if (e.InnerException is not null || e is not java.lang.Throwable throwable)
+                    continue;
+
+                // getCause answers an Exception rather than a Throwable, IKVM carrying the one as the
+                // other, so each link is asked again what it is before it is asked what caused it
+                var cause = throwable.getCause();
+                for (int n = 0; cause is not null && n < MaxDepth; n++)
+                {
+                    yield return Describe(cause);
+                    cause = cause is java.lang.Throwable inner ? inner.getCause() : cause.InnerException;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the class and message of <paramref name="exception"/>.
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>Throwable.toString</c> is the class and the message and nothing else, and IKVM answers the
+        /// same from <see cref="object.ToString"/> — measured. <see cref="Exception.ToString"/> is not: it
+        /// carries the stack trace, which has no place in a message, so a cause that reached here as a CLR
+        /// exception is written out rather than asked.
+        /// </remarks>
+        static string Describe(Exception exception)
+        {
+            return exception is java.lang.Throwable ? exception.ToString() : $"{exception.GetType().FullName}: {exception.Message}";
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/Internal/JavaCauses.cs
+++ b/src/Apache.Calcite.Data/Internal/JavaCauses.cs
@@ -10,28 +10,25 @@ namespace Apache.Calcite.Data.Internal
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Three of the JDK's own wrappers withhold their cause from the constructor that would record it.
+    /// Three of the JDK's wrappers withhold their cause from the constructor that records it.
     /// <c>UndeclaredThrowableException</c>, <c>InvocationTargetException</c> and
-    /// <c>ExceptionInInitializerError</c> each call <c>super((Throwable) null)</c> — the comment upstream
-    /// reads "Disallow initCause" — keep the throwable in a field of their own, and override
-    /// <c>getCause()</c> to answer that field. IKVM carries a <c>Throwable</c>'s cause as
-    /// <see cref="Exception.InnerException"/>, which that constructor left null, and the override is a Java
-    /// method no .NET reporter consults. Measured: each of the three answers an empty
+    /// <c>ExceptionInInitializerError</c> each call <c>super((Throwable) null)</c>, keep the throwable in a
+    /// field of their own, and override <c>getCause()</c> to answer it. IKVM carries a <c>Throwable</c>'s
+    /// cause as <see cref="Exception.InnerException"/>, which that constructor leaves null, and the override
+    /// is a Java method no .NET reporter consults. Measured: each of the three answers an empty
     /// <see cref="Exception.Message"/> and a null <see cref="Exception.InnerException"/> while
     /// <c>getCause()</c> holds the reason, and a plain <c>RuntimeException(message, cause)</c> answers both.
     /// </para>
     /// <para>
-    /// What that costs is the whole of a diagnosis. A CI run of <c>CalciteDdlTests</c> failed with
-    /// "Failed to execute Calcite statement." over a bare <c>java.lang.reflect.UndeclaredThrowableException</c>
-    /// — no message and no cause — raised where Calcite's <c>Resources</c> proxy builds
-    /// <c>sQLFeature_E101_03</c>. That handler declares four checked exceptions the resource interface does
-    /// not, so the proxy converts whichever one escaped into the wrapper; which of the four it was is the
-    /// entire answer, and it was not in the log.
+    /// So a report of one of those names nothing at all, and the reason is on the object the whole time.
+    /// Calcite reaches all three: its <c>Resources</c> proxy turns whichever of the four checked exceptions
+    /// its handler declares into an <c>UndeclaredThrowableException</c>, and which one it was is the
+    /// diagnosis.
     /// </para>
     /// <para>
-    /// The test for it is exact rather than a list of class names: a <c>Throwable</c> holding a cause that
-    /// its own <see cref="Exception.InnerException"/> does not. That is the same condition for any wrapper
-    /// written the same way, including ones added later.
+    /// The test is the condition rather than a list of class names — a <c>Throwable</c> holding a cause that
+    /// its own <see cref="Exception.InnerException"/> does not — so a wrapper written the same way is
+    /// covered without being named.
     /// </para>
     /// </remarks>
     static class JavaCauses
@@ -95,7 +92,7 @@ namespace Apache.Calcite.Data.Internal
         /// <remarks>
         /// <c>Throwable.toString</c> is the class and the message and nothing else, and IKVM answers the
         /// same from <see cref="object.ToString"/> — measured. <see cref="Exception.ToString"/> is not: it
-        /// carries the stack trace, which has no place in a message, so a cause that reached here as a CLR
+        /// carries the stack trace, which has no place in a message, so a cause that reaches here as a CLR
         /// exception is written out rather than asked.
         /// </remarks>
         static string Describe(Exception exception)


### PR DESCRIPTION
Chasing why `main` went red. The failure itself is unreproduced; what this fixes is that nobody could have told you why.

## What the log said

Run [33587663344](https://github.com/ikvmnet/calcite-dotnet/actions/runs/33587663344), `Test (Apache.Calcite.Data.Tests:net10.0:linux-x64)`, `CalciteDdlTests.Insert_then_update_string_decimal_int_then_select_should_reflect_updated_values`:

```
Apache.Calcite.Data.CalciteException : Failed to execute Calcite statement.
---- java.lang.reflect.UndeclaredThrowableException :
     at com.sun.proxy.$Proxy11.sQLFeature_E101_03()
     at SqlValidatorImpl.registerQuery(...)
```

No message, no cause. That is the whole report.

## Why it is empty

Three of the JDK's own wrappers withhold their cause from the constructor that would record it. `UndeclaredThrowableException`, `InvocationTargetException` and `ExceptionInInitializerError` each call `super((Throwable) null)` — upstream's comment reads *"Disallow initCause"* — keep the throwable in a field of their own, and override `getCause()` to answer it.

IKVM carries a `Throwable`'s cause as `Exception.InnerException`, which that constructor left null, and the override is a Java method no .NET reporter consults. Measured, all three:

| | `Message` | `InnerException` | `getCause()` |
|---|---|---|---|
| `UndeclaredThrowableException` | `''` | **null** | the real reason |
| `InvocationTargetException` | `''` | **null** | the real reason |
| `ExceptionInInitializerError` | `''` | **null** | the real reason |
| `RuntimeException(message, cause)` | `'outer'` | the real reason | the real reason |

So the reason is on the object and cannot be printed. `CalciteSession` wraps at four sites and each passed the throwable through as an inner exception, which is where the diagnosis went: Calcite's `Resources` proxy turns whichever of the four checked exceptions its handler declares into the wrapper, and which one it was is the entire answer.

## The change

`JavaCauses.Amend` appends what the report cannot reach to the message the four sites already build. `e` stays the inner exception, so its stack — including the `$Proxy11` frame, the only useful thing in that log — is untouched.

The test is the condition rather than a list of class names: **a `Throwable` holding a cause that its own `InnerException` does not.** A wrapper written the same way later is covered without being named, a cause .NET can already see is left alone rather than printed twice, and a plain CLR exception is not a `java.lang.Throwable` at all under IKVM — measured, `new InvalidOperationException(...) is java.lang.Throwable` is false — so it is skipped.

The walk follows the visible `InnerException` chain and, at each link, the chain hanging off a cause .NET cannot see, with a depth cap: `Throwable.getCause` answers null for a throwable that is its own cause, which rules out the one-step cycle and nothing longer.

## What this does not do

**It does not fix the failure above.** That is one occurrence, unreproduced in thirteen clean runs of `Apache.Calcite.Data.Tests` on net10.0 locally. It makes the next one name itself.

Two things ruled out along the way, both worth recording:

- **Not the moving snapshot.** `Apache.Calcite.Data.Tests` resolves `1.43.0-SNAPSHOT`, which Apache republishes about daily — build 130 on 2026-08-04 through 213 on 2026-09-01. That is a real reproducibility hazard and it bit locally: an incremental build left an Aug 31 `calcite.core.dll` beside a Sep 1 `calcite.linq4j.dll`, mixing an old `StrictAggImplementor` with a newer `ParameterExpression`, and three tests failed on `parameter name should be a valid java identifier: acc.f0$Res`. A clean rebuild cleared it. Not what CI hit — CI builds once and each leg downloads that output.
- **Not PR #75.** The one red check there was a `macos-15` runner that spent 45 minutes in `Set up job` and never ran a step. Re-run, green.

## Measured

`Apache.Calcite.Data.Tests` 323 on net8.0 and net10.0 (317 + the 6 added here), `Apache.Calcite.Tests` 824, `Apache.Calcite.Adapter.AdoNet.Tests` 367 — green, nothing skipped. All three reference `Apache.Calcite.Data`, so all three were run.
