### PR TITLE
Carry a TINYINT's sign out to the provider

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoParameterValueTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoParameterValueTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.sql.type;
+
+using System;
+using System.Data.Common;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers the value a correlation variable becomes on its way into a provider's parameter.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A value leaves the plan in Calcite's representation, which is a boxed Java type, and no ADO.NET
+    /// provider knows what one of those is; <c>AdoEnumerable.ToProviderValue</c> unwraps each to the .NET
+    /// value it stands for. <see cref="GenericProviderCorrelationTests"/> proves the comparisons those
+    /// values take part in answer correctly against a real server, which is the stronger claim. This reads
+    /// the bound value itself, which is where a representation that a comparison happens not to notice
+    /// shows up — and it needs no server.
+    /// </para>
+    /// <para>
+    /// The enricher is reached the way the generated code reaches it: a correlation variable is a parameter
+    /// numbered from <see cref="AdoCorrelationDataContext.Offset"/>, so the context resolves it from its
+    /// own array and never consults the context it wraps.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class AdoParameterValueTests
+    {
+
+        sealed class Source : DbDataSource
+        {
+
+            public override string ConnectionString => "Data Source=:memory:";
+
+            protected override DbConnection CreateDbConnection() => new SqliteConnection(ConnectionString);
+
+        }
+
+        /// <summary>
+        /// Returns the value the given plan value is bound as, under the given SQL type.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="typeName"></param>
+        /// <returns></returns>
+        static object? Bound(object? value, SqlTypeName typeName)
+        {
+            var source = new Source();
+            var dataSource = new DbDataSourceAdoDataSource(source, Metadata.AdoDatabaseMetadataFactoryImpl.Instance.Create(source));
+
+            var indexes = new java.util.ArrayList();
+            indexes.add(java.lang.Integer.valueOf(AdoCorrelationDataContext.Offset));
+
+            var typeNames = new java.util.ArrayList();
+            typeNames.add(typeName.name());
+
+            using var command = new SqliteCommand();
+            AdoEnumerable.CreateEnricher(dataSource, indexes, typeNames, new AdoCorrelationDataContext(null!, [value!])).Enrich(command);
+
+            return command.Parameters[0].Value;
+        }
+
+        /// <summary>
+        /// The case the sign is lost in: Java's <c>byte</c> is signed and IKVM's is not, so
+        /// <c>byteValue()</c> answers the two's complement bits as an unsigned CLR <see cref="byte"/> and
+        /// -56 would reach the provider as 200.
+        /// </summary>
+        [TestMethod]
+        public void ANegativeTinyIntKeepsItsSign()
+        {
+            Assert.AreEqual((short)-56, Bound(java.lang.Byte.valueOf(unchecked((byte)-56)), SqlTypeName.TINYINT));
+        }
+
+        /// <summary>
+        /// A <c>TINYINT</c> is bound as a <see cref="short"/> rather than as the <see cref="sbyte"/> its
+        /// range would suggest: SqlClient refuses that type outright — "The parameter data type of SByte is
+        /// invalid" — which is the same wall the unsigned types run into, and a <see cref="short"/> holds
+        /// the whole of a signed byte's range exactly.
+        /// </summary>
+        [TestMethod]
+        public void ATinyIntIsBoundAsAShort()
+        {
+            Assert.IsInstanceOfType<short>(Bound(java.lang.Byte.valueOf((byte)7), SqlTypeName.TINYINT));
+        }
+
+        /// <summary>
+        /// The unsigned tinyint every real backend actually reports, which travels as a joou value and is
+        /// the arm a signed one must not be confused with: 200 is 200 and not -56.
+        /// </summary>
+        [TestMethod]
+        public void AUTinyIntStaysUnsigned()
+        {
+            Assert.AreEqual((byte)200, Bound(org.joou.UByte.valueOf(200), SqlTypeName.UTINYINT));
+        }
+
+        [TestMethod]
+        public void ANegativeSmallIntKeepsItsSign()
+        {
+            Assert.AreEqual((short)-300, Bound(java.lang.Short.valueOf((short)-300), SqlTypeName.SMALLINT));
+        }
+
+        [TestMethod]
+        public void ANegativeIntegerKeepsItsSign()
+        {
+            Assert.AreEqual(-70000, Bound(java.lang.Integer.valueOf(-70000), SqlTypeName.INTEGER));
+        }
+
+        [TestMethod]
+        public void ANegativeBigIntKeepsItsSign()
+        {
+            Assert.AreEqual(-9000000000L, Bound(java.lang.Long.valueOf(-9000000000L), SqlTypeName.BIGINT));
+        }
+
+        /// <summary>
+        /// A null is bound rather than skipped, which is what a driver matching parameters by position
+        /// requires.
+        /// </summary>
+        [TestMethod]
+        public void ANullIsBoundAsDbNull()
+        {
+            Assert.AreEqual(DBNull.Value, Bound(null, SqlTypeName.TINYINT));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
@@ -280,6 +280,40 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
+        /// Correlating on a signed <c>TINYINT</c>, which carries its sign to the provider.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The outer row is a <c>VALUES</c> because no SQL Server column can be one: the server's own
+        /// <c>tinyint</c> is unsigned, maps to <c>UTINYINT</c>, and is covered above as
+        /// <c>C_TINYINT</c>. Calcite's <c>TINYINT</c> is signed and holds its value in a
+        /// <c>java.lang.Byte</c>, whose <c>byteValue()</c> under IKVM answers an unsigned CLR
+        /// <see cref="byte"/> — so -56 binds as 200 unless the sign is carried out of it.
+        /// </para>
+        /// <para>
+        /// The comparison runs on the server against <c>ID</c>, whose two values are 1 and 2: -56 is below
+        /// both and 200 is above both, so the answer is one row where the sign survived the binding and
+        /// none where it did not. <c>C_TINYINT</c> cannot be the other side of it — comparing a
+        /// <c>TINYINT</c> against a <c>UTINYINT</c> casts to an unsigned type, which the MSSQL dialect
+        /// writes as a bare <c>UNSIGNED</c> that T-SQL will not parse.
+        /// </para>
+        /// </remarks>
+        /// <param name="provider"></param>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void CorrelatingOnASignedTinyIntKeepsItsSign(string provider)
+        {
+            CollectionAssert.AreEqual(
+                new[] { "-56" },
+                CorrelatedRows(provider, """
+                    SELECT V.X FROM (VALUES (CAST(-56 AS TINYINT))) AS V(X)
+                    WHERE EXISTS (SELECT 1 FROM ADO.TYPES T WHERE V.X < T.ID)
+                    """));
+        }
+
+        /// <summary>
         /// Correlating across a cast to <c>UUID</c>, which puts the type name into the generated SQL as
         /// well as a <c>java.util.UUID</c> into the parameter.
         /// </summary>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GenericProviderCorrelationTests.cs
@@ -293,9 +293,11 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         /// <para>
         /// The comparison runs on the server against <c>ID</c>, whose two values are 1 and 2: -56 is below
         /// both and 200 is above both, so the answer is one row where the sign survived the binding and
-        /// none where it did not. <c>C_TINYINT</c> cannot be the other side of it — comparing a
+        /// none where it did not. <c>C_TINYINT</c> cannot be the other side of it: ordering a
         /// <c>TINYINT</c> against a <c>UTINYINT</c> casts to an unsigned type, which the MSSQL dialect
-        /// writes as a bare <c>UNSIGNED</c> that T-SQL will not parse.
+        /// writes as a bare <c>UNSIGNED</c> that T-SQL will not parse — measured on this <c>&lt;</c>. The
+        /// equality form is written differently and does parse, so the limit is on the comparison and not
+        /// on the pair of types.
         /// </para>
         /// </remarks>
         /// <param name="provider"></param>

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
@@ -247,10 +247,21 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="value"></param>
         /// <returns></returns>
         /// <remarks>
+        /// <para>
         /// A parameter value comes out of the plan in Calcite's representation, which is a boxed Java
         /// type. No ADO.NET provider knows what a <see cref="java.lang.Long"/> is, so it is unwrapped to
-        /// the .NET value it stands for. This is the inverse of what <see cref="AdoReaderUtil"/> does on
-        /// the way in.
+        /// the .NET value it stands for, roughly inverting what <see cref="AdoReaderUtil"/> does on the
+        /// way in. Roughly, because the type chosen is the narrowest one every provider will bind and not
+        /// the narrowest one that holds the value: an <c>sbyte</c>, a <c>ushort</c>, a <c>uint</c> and a
+        /// <c>ulong</c> are none of them bindable, so each widens.
+        /// </para>
+        /// <para>
+        /// This settles what the value is and nothing about what it is bound as.
+        /// <see cref="SetParameter"/> sets no <see cref="System.Data.DbType"/>, so the provider infers one
+        /// from the CLR type, and a cast the dialect wrote around the marker names Calcite's type rather
+        /// than the provider's — a <c>TINYINT</c> being signed in Calcite and unsigned on SQL Server.
+        /// Neither is decidable from a value.
+        /// </para>
         /// </remarks>
         static object? ToProviderValue(object? value)
         {

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoEnumerable.cs
@@ -258,7 +258,12 @@ namespace Apache.Calcite.Adapter.AdoNet
             {
                 null => null,
                 java.lang.Boolean b => b.booleanValue(),
-                java.lang.Byte b => b.byteValue(),
+                // Java's byte is signed and IKVM's byte is not, so byteValue() answers a CLR byte
+                // holding the two's complement bits, and a TINYINT of -56 would bind as 200.
+                // shortValue() sign-extends instead, and short is the narrowest CLR type every
+                // provider binds: SqlClient refuses an sbyte outright, "The parameter data type of
+                // SByte is invalid", the same wall the unsigned types below run into
+                java.lang.Byte b => b.shortValue(),
                 java.lang.Short s => s.shortValue(),
                 java.lang.Integer i => i.intValue(),
                 java.lang.Long l => l.longValue(),


### PR DESCRIPTION
`AdoEnumerable.ToProviderValue` unwrapped a `java.lang.Byte` with `byteValue()`. Java's `byte` is signed and IKVM's is not, so that answers a CLR `byte` holding the two's complement bits — a Calcite `TINYINT` of -56 was bound to the provider as **200**.

An `sbyte` cannot be the answer on the way out. Measured against LocalDB:

```
sqlclient SByte => ArgumentException: The parameter data type of SByte is invalid.
sqlclient Int16 => -56
sqlclient Byte  => 200
```

So the value is sign-extended to a `short` — the same widening the unsigned `joou` arms beside it already do for the types no provider binds, and a `short` holds the whole of a signed byte's range exactly. The other arms are unchanged and correct; `AdoParameterValueTests` pins the neighbouring ones.

### Reaching it

`AdoSchema` maps `DbType.SByte` to `TINYINT`, but no SQL Server column is one — the server's own `tinyint` is unsigned and maps to `UTINYINT`. On a real backend the arm is reached through a cast, so the correlation test states the type with a `VALUES` row:

```sql
SELECT V.X FROM (VALUES (CAST(-56 AS TINYINT))) AS V(X)
WHERE EXISTS (SELECT 1 FROM ADO.TYPES T WHERE V.X < T.ID)
```

which generates, against SQL Server:

```sql
WHERE CAST(@P0 AS INTEGER) < [ID]      -- @P0 = -56 (Int16), DbType=Int16
```

`ID` is 1 and 2, so -56 is below both and 200 is above both: the comparison runs on the server and answers one row where the sign survived the binding and none where it did not. Without the fix it fails on all three drivers — SqlClient, ODBC and OLE DB.

### What this does not fix

`ToProviderValue` settles the value and nothing about the type it is bound as, and two things downstream of it are decided elsewhere. Both are pre-existing and untouched here; the second is a defect worth its own change.

- `SetParameter` sets no `DbType`. The provider infers one from the CLR type, which is why every arm has to pick a widely bindable type in the first place. A null binds as `DbType=String` — SqlClient's default for `DBNull` — and reaches a `smallint` column only because the server coerces it.

- **Calcite's `TINYINT` is signed and SQL Server's `tinyint` is unsigned, and the dialect writes the same token for both.** Where the plan puts a cast around the marker the statement is wrong however the value is bound:

  ```sql
  -- SELECT V.X FROM (VALUES (-56)) AS V(X)
  -- WHERE EXISTS (SELECT 1 FROM ADO.TYPES T WHERE T.C_SMALLINT = CAST(V.X AS TINYINT))
  WHERE [C_SMALLINT] = CAST(CAST(@P0 AS TINYINT) AS SMALLINT)   -- @P0 = -56 (Int32)
  ```
  ```
  SqlException: Arithmetic overflow error for data type tinyint, value = -56.
  ```

  The value bound is correct and the server still refuses it. The fix is a `getCastSpec` override on the `Mssql` dialect in `AdoSqlDialects`, beside the one already there for an unbounded `VARCHAR`, writing a Calcite `TINYINT` as `smallint`.

### Tests

- `GenericProviderCorrelationTests.CorrelatingOnASignedTinyIntKeepsItsSign`, over all three drivers.
- `AdoParameterValueTests`, new — reads `DbParameter.Value` straight off the enricher, no server needed.

Both verified against the old arm first: 5 of 10 fail, including all three drivers. `Apache.Calcite.Adapter.AdoNet.Tests`: 377 passed, 0 failed, 0 skipped.
