### PR TITLE
Write concatenation as + for SQL Server

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
@@ -1,10 +1,13 @@
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 
+using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using org.apache.calcite.rel.type;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql.dialect;
+using org.apache.calcite.sql.fun;
 using org.apache.calcite.sql.parser;
 using org.apache.calcite.sql.pretty;
 using org.apache.calcite.sql.type;
@@ -52,6 +55,36 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             dialect.getCastSpec(type).unparse(writer, 0, 0);
 
             return writer.toSqlString().getSql().Trim();
+        }
+
+        /// <summary>
+        /// Returns what a dialect writes for a statement, by parsing it and unparsing it again.
+        /// </summary>
+        /// <param name="dialect"></param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The route the adapter takes is a rel through <c>RelToSqlConverter</c>, and this is not that; it
+        /// is the same answer because both end at <c>SqlNode.unparse</c>, which is where an operator is
+        /// written. Measured on stock Calcite over the shapes in the report — projection, predicate, sort
+        /// key, aggregate argument — the two routes give the same string for this operator, so the shorter
+        /// one is what the assertions are made against and no schema is needed to make them.
+        /// </remarks>
+        static string Unparse(SqlDialect dialect, string sql)
+        {
+            return Unparse(dialect, SqlParser.create(sql).parseQuery());
+        }
+
+        /// <summary>
+        /// Returns what a dialect writes for a node already built, which is the way to reach an operator the
+        /// parser leaves unresolved.
+        /// </summary>
+        /// <param name="dialect"></param>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        static string Unparse(SqlDialect dialect, SqlNode node)
+        {
+            return Regex.Replace(node.toSqlString(dialect).getSql(), @"\s+", " ").Trim();
         }
 
         /// <summary>
@@ -313,6 +346,216 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         public void AnyNameThatSelectsSqlServerGetsTheCorrection(string productName)
         {
             Assert.AreEqual("VARCHAR(MAX)", CastSpec(AdoSqlDialects.For(productName, "10.50.1600"), Types.createSqlType(SqlTypeName.VARCHAR)));
+        }
+
+        #endregion
+
+        #region Concatenation
+
+        /// <summary>
+        /// T-SQL has no <c>||</c>, and every statement that concatenates reached the server carrying one.
+        /// The four shapes are the ones measured in the report, and the fifth is two literals, which are
+        /// not folded away — so there is no spelling of the expression that avoids the operator.
+        /// </summary>
+        [TestMethod]
+        [DataRow("SELECT A || B FROM CAT WHERE ID = 1", "a projection")]
+        [DataRow("SELECT ID FROM CAT WHERE A || B = 'aabb'", "a predicate")]
+        [DataRow("SELECT ID FROM CAT ORDER BY A || B", "a sort key")]
+        [DataRow("SELECT MAX(A || B) FROM CAT", "an aggregate argument")]
+        [DataRow("SELECT A || B FROM CAT GROUP BY A || B", "a group key")]
+        [DataRow("SELECT 'x' || 'y' FROM CAT WHERE ID = 1", "two literals")]
+        public void ConcatenationIsWrittenAsPlus(string sql, string shape)
+        {
+            var written = Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), sql);
+
+            Assert.IsFalse(written.Contains("||"), $"{shape} still carries the operator the server refuses: {written}");
+            StringAssert.Contains(written, "+", $"{shape}: {written}");
+        }
+
+        /// <summary>
+        /// And the answer this corrects, so that the test says what it is for. <c>MssqlSqlDialect</c>
+        /// intercepts <c>SUBSTRING</c>, <c>CEIL</c>, <c>FLOOR</c>, <c>MOD</c> and <c>SAFE_CAST</c> and not
+        /// this, so the operator goes down as it stands and the server answers "Incorrect syntax near '|'".
+        /// </summary>
+        [TestMethod]
+        public void CalcitesOwnAnswerIsTheOperatorTheServerRefuses()
+        {
+            Assert.AreEqual(
+                "SELECT [A] || [B] FROM [CAT] WHERE [ID] = 1",
+                Unparse(MssqlSqlDialect.DEFAULT, "SELECT A || B FROM CAT WHERE ID = 1"));
+        }
+
+        /// <summary>
+        /// The whole statement, rather than the operator alone, for each shape — a substitution that writes
+        /// the right operator into the wrong place is still wrong.
+        /// </summary>
+        [TestMethod]
+        [DataRow(
+            "SELECT A || B FROM CAT WHERE ID = 1",
+            "SELECT [A] + [B] FROM [CAT] WHERE [ID] = 1")]
+        [DataRow(
+            "SELECT ID FROM CAT WHERE A || B = 'aabb'",
+            "SELECT [ID] FROM [CAT] WHERE [A] + [B] = 'aabb'")]
+        [DataRow(
+            "SELECT MAX(A || B) FROM CAT",
+            "SELECT MAX([A] + [B]) FROM [CAT]")]
+        [DataRow(
+            "SELECT A || B FROM CAT GROUP BY A || B",
+            "SELECT [A] + [B] FROM [CAT] GROUP BY [A] + [B]")]
+        public void TheStatementIsWrittenWhole(string sql, string expected)
+        {
+            Assert.AreEqual(expected, Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), sql));
+        }
+
+        /// <summary>
+        /// <c>+</c> and not <c>CONCAT</c>, and the difference is answers rather than taste: <c>||</c> yields
+        /// null when either operand is null, <c>+</c> does the same under the default
+        /// <c>CONCAT_NULL_YIELDS_NULL</c>, and T-SQL's <c>CONCAT</c> reads a null operand as the empty
+        /// string. The function would turn a query that should return nothing into one that returns a row.
+        /// </summary>
+        [TestMethod]
+        public void TheFunctionIsNotWhatIsWritten()
+        {
+            var written = Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), "SELECT A || B FROM CAT");
+
+            Assert.IsFalse(written.Contains("CONCAT"), $"the function does not propagate null: {written}");
+        }
+
+        /// <summary>
+        /// The correction is SQL Server's alone: a product whose own operator is <c>||</c> keeps it.
+        /// </summary>
+        [TestMethod]
+        [DataRow("PostgreSQL")]
+        [DataRow("SQLite")]
+        [DataRow("Oracle")]
+        // the generic dialect an unknown product gets, which is where a driver that will not say what it
+        // fronts ends up
+        [DataRow("Some Database Nobody Has Heard Of")]
+        public void AnotherProductKeepsTheOperator(string productName)
+        {
+            StringAssert.Contains(Unparse(AdoSqlDialects.For(productName, "1.0"), "SELECT A || B FROM CAT"), "||");
+        }
+
+        /// <summary>
+        /// ODBC and OLE DB reach SQL Server through this same dialect, and a name is all either can offer,
+        /// so every name that selects SQL Server has to carry the correction with it.
+        /// </summary>
+        [TestMethod]
+        [DataRow("Microsoft SQL Server")]
+        [DataRow("microsoft sql server")]
+        [DataRow("Microsoft SQL Server Enterprise Edition")]
+        public void AnyNameThatSelectsSqlServerGetsTheOperator(string productName)
+        {
+            Assert.AreEqual(
+                "SELECT [A] + [B] FROM [CAT]",
+                Unparse(AdoSqlDialects.For(productName, "10.50.1600"), "SELECT A || B FROM CAT"));
+        }
+
+        /// <summary>
+        /// The override is a case ahead of <c>MssqlSqlDialect.unparseCall</c> rather than a replacement of
+        /// it, so what that method already intercepts still happens. <c>MOD</c> is the one this is modelled
+        /// on — CALCITE-6726 swapped an operator in the same way — and <c>CEIL</c> is a rewrite of a
+        /// different shape.
+        /// </summary>
+        [TestMethod]
+        [DataRow("SELECT CEIL(SALARY) FROM CAT", "CEILING")]
+        [DataRow("SELECT SUBSTRING(A FROM 1 FOR 2) FROM CAT", "SUBSTRING")]
+        [DataRow("SELECT CAST(A AS INTEGER) FROM CAT", "CAST")]
+        public void TheDialectsOwnInterceptionsStillHappen(string sql, string expected)
+        {
+            StringAssert.Contains(Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), sql), expected);
+        }
+
+        /// <summary>
+        /// <c>MOD</c> in particular, which is the interception this one is modelled on: CALCITE-6726 swapped
+        /// <c>PERCENT_REMAINDER</c> in through <c>SqlSyntax.BINARY</c>, and nothing pinned it.
+        /// </summary>
+        /// <remarks>
+        /// Built rather than parsed. An unqualified function name is a <c>SqlUnresolvedFunction</c> until
+        /// the validator has run, and <c>MssqlSqlDialect</c> switches on <c>SqlKind.MOD</c>, which an
+        /// unresolved call does not carry — so parse-then-unparse writes <c>MOD([ID], 2)</c> and says
+        /// nothing about the interception either way.
+        /// </remarks>
+        [TestMethod]
+        public void TheInterceptionThisOneIsModelledOnStillHappens()
+        {
+            var call = SqlStdOperatorTable.MOD.createCall(
+                SqlParserPos.ZERO,
+                new SqlIdentifier("ID", SqlParserPos.ZERO),
+                SqlLiteral.createExactNumeric("2", SqlParserPos.ZERO));
+
+            Assert.AreEqual("[ID] % 2", Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), call));
+        }
+
+        #endregion
+
+        #region Concatenation and precedence
+
+        /// <summary>
+        /// <c>SqlSyntax.BINARY.unparse</c> is handed <c>PLUS</c>, whose precedence is not the one the call
+        /// carries — <c>||</c> is 60 and <c>+</c> is 40 — and <c>SqlCall.unparse</c> has already decided the
+        /// parentheses around the call from the call's own operator by the time the dialect is asked. So a
+        /// nested expression is where a substitution of this shape goes wrong.
+        /// </summary>
+        /// <remarks>
+        /// Concatenation nests inside itself, inside a comparison, inside a postfix operator and inside a
+        /// call that writes its own parentheses; all four are here, and the last row is the one where the
+        /// two precedences differ.
+        /// </remarks>
+        [TestMethod]
+        // concatenation in concatenation, which associates the same either way
+        [DataRow(
+            "SELECT A || B || C FROM CAT",
+            "SELECT [A] + [B] + [C] FROM [CAT]")]
+        // the right operand is parenthesised under either operator, each being left associative, so the
+        // grouping the caller wrote survives the substitution
+        [DataRow(
+            "SELECT A || (B || C) FROM CAT",
+            "SELECT [A] + ([B] + [C]) FROM [CAT]")]
+        // against a comparison, which binds looser than either spelling
+        [DataRow(
+            "SELECT ID FROM CAT WHERE A || B = 'aabb'",
+            "SELECT [ID] FROM [CAT] WHERE [A] + [B] = 'aabb'")]
+        [DataRow(
+            "SELECT ID FROM CAT WHERE A || B > 'aa' AND ID > 1",
+            "SELECT [ID] FROM [CAT] WHERE [A] + [B] > 'aa' AND [ID] > 1")]
+        // a postfix operator, which is what a sort key's null ordering is written with
+        [DataRow(
+            "SELECT ID FROM CAT WHERE A || B IS NULL",
+            "SELECT [ID] FROM [CAT] WHERE [A] + [B] IS NULL")]
+        // arithmetic reaches a string only through a cast, and a cast writes its own parentheses
+        [DataRow(
+            "SELECT A || CAST(ID + 1 AS VARCHAR(4)) FROM CAT",
+            "SELECT [A] + CAST([ID] + 1 AS VARCHAR(4)) FROM [CAT]")]
+        [DataRow(
+            "SELECT CAST(A || B AS VARCHAR(4)) FROM CAT",
+            "SELECT CAST([A] + [B] AS VARCHAR(4)) FROM [CAT]")]
+        // and inside a function call, whose frame parenthesises whatever it holds
+        [DataRow(
+            "SELECT UPPER(A || B) FROM CAT",
+            "SELECT UPPER([A] + [B]) FROM [CAT]")]
+        // the one context that binds between the two precedences, and the reason the override applies
+        // PLUS's parenthesisation itself rather than inheriting the one computed for the operator it
+        // replaces: without that, this is [A] + [B] * 2
+        [DataRow(
+            "SELECT (A || B) * 2 FROM CAT",
+            "SELECT ([A] + [B]) * 2 FROM [CAT]")]
+        public void ANestedConcatenationKeepsItsGrouping(string sql, string expected)
+        {
+            Assert.AreEqual(expected, Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), sql));
+        }
+
+        /// <summary>
+        /// Calcite writes no parentheses there, and is right not to: <c>||</c> binds as tightly as <c>*</c>
+        /// does. It is the substitution that makes them necessary, which is why closing the gap is this
+        /// override's job and not something to leave to the shape of the expression.
+        /// </summary>
+        [TestMethod]
+        public void TheGroupingIsOnlyAtRiskBecauseOfTheSubstitution()
+        {
+            Assert.AreEqual(
+                "SELECT [A] || [B] * 2 FROM [CAT]",
+                Unparse(MssqlSqlDialect.DEFAULT, "SELECT (A || B) * 2 FROM CAT"));
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerConcatenationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerConcatenationTests.cs
@@ -1,0 +1,407 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+using org.apache.calcite.runtime;
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers string concatenation against a real SQL Server through each of the three drivers that reach
+    /// it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// T-SQL has no <c>||</c>. <c>SqlStdOperatorTable.CONCAT</c> unparses as one and
+    /// <c>MssqlSqlDialect.unparseCall</c> does not intercept it, so every statement that concatenated
+    /// reached the server carrying an operator it will not parse and answered "Incorrect syntax near '|'" —
+    /// in a select list, in a predicate, in a sort key and in an aggregate argument alike, and over two
+    /// literals, which are not folded away. <see cref="Metadata.AdoSqlDialects"/> writes <c>+</c> instead.
+    /// </para>
+    /// <para>
+    /// The rendering is pinned without a database in <see cref="AdoSqlDialectsTests"/>; what these add is
+    /// that the server accepts the statement and answers what the operator means. Those are separate
+    /// claims, and the second is the one that decides between <c>+</c> and <c>CONCAT</c>: both concatenate
+    /// and only <c>+</c> propagates null, so a rendering that passed a syntax check would still have been
+    /// wrong.
+    /// </para>
+    /// <para>
+    /// All three drivers reach one dialect, chosen from the product name, so a correction that only
+    /// SqlClient carried would be a correction in the wrong place. Running the same statements over each is
+    /// what says it is in the right one.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class SqlServerConcatenationTests
+    {
+
+        const string SqlClient = "sqlclient";
+        const string Odbc = "odbc";
+        const string OleDb = "oledb";
+
+        static SqlServerConcatenationTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
+            java.lang.Class.forName("org.apache.calcite.jdbc.Driver");
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            if (SqlServerFixture.IsAvailable == false)
+                Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+        }
+
+        /// <summary>
+        /// Returns the data source for a provider, skipping the test where it is not installed.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        static DbDataSource DataSourceFor(string provider)
+        {
+            switch (provider)
+            {
+                case SqlClient:
+                    return SqlServerFixture.Shared.DataSource;
+                case Odbc:
+                    if (SqlServerFixture.OdbcDriver is null)
+                        Assert.Inconclusive("No SQL Server ODBC driver is installed on this machine.");
+
+                    return SqlServerFixture.Shared.OdbcDataSource;
+                case OleDb:
+                    if (SqlServerFixture.OleDbProvider is null)
+                        Assert.Inconclusive("No SQL Server OLE DB provider is registered for this process architecture.");
+
+                    return SqlServerFixture.Shared.OleDbDataSource;
+                default:
+                    throw new ArgumentException($"unknown provider {provider}", nameof(provider));
+            }
+        }
+
+        /// <summary>
+        /// Collects the statements the adapter generates, which <c>AdoToEnumerableConverter</c> announces on
+        /// <c>Hook.QUERY_PLAN</c> as it builds each one.
+        /// </summary>
+        /// <remarks>
+        /// IKVM does not project a Java default method onto a CLR class that implements the interface, so
+        /// <c>andThen</c> has to be written even though a hook handler is never composed with another.
+        /// </remarks>
+        sealed class GeneratedSql : java.util.function.Consumer
+        {
+
+            /// <summary>
+            /// Two handlers as one, which is what <c>Consumer.andThen</c> answers in Java.
+            /// </summary>
+            /// <param name="first"></param>
+            /// <param name="then"></param>
+            sealed class Composed(java.util.function.Consumer first, java.util.function.Consumer then) : java.util.function.Consumer
+            {
+
+                /// <inheritdoc />
+                public void accept(object value)
+                {
+                    first.accept(value);
+                    then.accept(value);
+                }
+
+                /// <inheritdoc />
+                public java.util.function.Consumer andThen(java.util.function.Consumer after)
+                {
+                    return new Composed(this, after);
+                }
+
+            }
+
+            readonly List<string> _statements = [];
+
+            /// <summary>
+            /// Gets the statements generated so far.
+            /// </summary>
+            public IReadOnlyList<string> Statements => _statements;
+
+            /// <inheritdoc />
+            public void accept(object value)
+            {
+                _statements.Add(value?.ToString() ?? "");
+            }
+
+            /// <inheritdoc />
+            public java.util.function.Consumer andThen(java.util.function.Consumer after)
+            {
+                return new Composed(this, after);
+            }
+
+        }
+
+        /// <summary>
+        /// What a query answered, and what was sent to the server to answer it.
+        /// </summary>
+        /// <param name="Rows"></param>
+        /// <param name="Statements"></param>
+        readonly record struct Answer(List<string> Rows, IReadOnlyList<string> Statements);
+
+        /// <summary>
+        /// Runs a query against the fixture's database through a provider.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static Answer Run(string provider, string sql)
+        {
+            var dataSource = DataSourceFor(provider);
+
+            var properties = new java.util.Properties();
+            properties.setProperty("lex", "JAVA");
+            properties.setProperty("caseSensitive", "false");
+
+            var generated = new GeneratedSql();
+            var handle = Hook.QUERY_PLAN.addThread(generated);
+
+            try
+            {
+                using var connection = java.sql.DriverManager.getConnection("jdbc:calcite:", properties);
+                var root = ((CalciteConnection)connection).getRootSchema();
+                root.add("ADO", AdoSchema.Create(root, "ADO", dataSource, null, "dbo"));
+
+                using var statement = connection.createStatement();
+                var results = statement.executeQuery(sql);
+
+                var rows = new List<string>();
+                var columns = results.getMetaData().getColumnCount();
+
+                while (results.next())
+                {
+                    var values = new string[columns];
+                    for (int i = 0; i < columns; i++)
+                        values[i] = results.getObject(i + 1)?.ToString() ?? "NULL";
+
+                    rows.Add(string.Join("|", values));
+                }
+
+                return new Answer(rows, generated.Statements);
+            }
+            finally
+            {
+                handle.close();
+            }
+        }
+
+        /// <summary>
+        /// Runs a query and returns its rows.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static List<string> Rows(string provider, string sql)
+        {
+            return Run(provider, sql).Rows;
+        }
+
+        #region The shapes the operator reaches the server in
+
+        /// <summary>
+        /// A select list, which is the shape in the report.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void AProjectionConcatenates(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "aabb" },
+                Rows(provider, "SELECT A || B FROM ADO.CAT WHERE ID = 1"));
+        }
+
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void APredicateConcatenates(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "1" },
+                Rows(provider, "SELECT ID FROM ADO.CAT WHERE A || B = 'aabb'"));
+        }
+
+        /// <summary>
+        /// A sort key, ordered so that a sort which did nothing would answer differently. The null row is
+        /// left out: where a null sorts is a separate question from what the operator is written as, and
+        /// Calcite already answers it.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ASortKeyConcatenates(string provider)
+        {
+            CollectionAssert.AreEqual(
+                new[] { "3", "1" },
+                Rows(provider, "SELECT ID FROM ADO.CAT WHERE B IS NOT NULL ORDER BY A || B DESC"));
+        }
+
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void AnAggregateArgumentConcatenates(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "ddee" },
+                Rows(provider, "SELECT MAX(A || B) FROM ADO.CAT"));
+        }
+
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void AGroupKeyConcatenates(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "aabb|1", "ddee|1", "NULL|1" },
+                Rows(provider, "SELECT A || B, COUNT(*) FROM ADO.CAT GROUP BY A || B"));
+        }
+
+        /// <summary>
+        /// Two literals, which are not folded away — so there is no shape of the expression that avoids the
+        /// operator.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void TwoLiteralsConcatenate(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "xy" },
+                Rows(provider, "SELECT 'x' || 'y' FROM ADO.CAT WHERE ID = 1"));
+        }
+
+        #endregion
+
+        #region What the operator means
+
+        /// <summary>
+        /// The reason the rendering is <c>+</c> and not <c>CONCAT</c>. <c>||</c> yields null when either
+        /// operand is null and so does <c>+</c>, under the default <c>CONCAT_NULL_YIELDS_NULL</c>; T-SQL's
+        /// <c>CONCAT</c> reads a null operand as the empty string and would have answered <c>cc</c>.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ANullOperandMakesTheWholeExpressionNull(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "NULL" },
+                Rows(provider, "SELECT A || B FROM ADO.CAT WHERE ID = 2"));
+        }
+
+        /// <summary>
+        /// And the same claim where it decides whether a row is returned at all, which is the failure a
+        /// syntax check would not have caught: under <c>CONCAT</c> the row matches.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ANullOperandMatchesNothing(string provider)
+        {
+            Assert.AreEqual(0, Rows(provider, "SELECT ID FROM ADO.CAT WHERE A || B = 'cc'").Count);
+        }
+
+        #endregion
+
+        #region Precedence
+
+        /// <summary>
+        /// <c>SqlSyntax.BINARY.unparse</c> is handed an operator whose precedence is not the one the call
+        /// carries — <c>||</c> is 60 and <c>+</c> is 40 — so a nested expression is where a substitution of
+        /// this shape goes wrong. These are the nestings a validated plan produces, and the server is the
+        /// authority on whether the parentheses came out right.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ConcatenationNestsInConcatenation(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "aabbaa" },
+                Rows(provider, "SELECT A || B || A FROM ADO.CAT WHERE ID = 1"));
+        }
+
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ConcatenationNestsToTheRight(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "aabbaa" },
+                Rows(provider, "SELECT A || (B || A) FROM ADO.CAT WHERE ID = 1"));
+        }
+
+        /// <summary>
+        /// Arithmetic reaches a string only through a cast, which writes its own parentheses — and the cast
+        /// is the one thing on either side of the operator whose rendering this project already corrects.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ConcatenationAgainstArithmetic(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "aa2" },
+                Rows(provider, "SELECT A || CAST(ID + 1 AS VARCHAR(4)) FROM ADO.CAT WHERE ID = 1"));
+        }
+
+        /// <summary>
+        /// A comparison binds looser than either spelling, and a conjunction looser still.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void ConcatenationInsideAConjunction(string provider)
+        {
+            CollectionAssert.AreEquivalent(
+                new[] { "3" },
+                Rows(provider, "SELECT ID FROM ADO.CAT WHERE A || B > 'aabb' AND ID > 1"));
+        }
+
+        #endregion
+
+        #region What went to the server
+
+        /// <summary>
+        /// The rows are the claim that matters, and this is the claim that they were answered by the server
+        /// rather than by Calcite: the statement the adapter generated carries the operator T-SQL has, and
+        /// no longer the one it does not.
+        /// </summary>
+        [TestMethod]
+        [DataRow(SqlClient)]
+        [DataRow(Odbc)]
+        [DataRow(OleDb)]
+        public void TheOperatorIsPushedDownAsPlus(string provider)
+        {
+            var answer = Run(provider, "SELECT A || B FROM ADO.CAT WHERE ID = 1");
+            var generated = string.Join("\n", answer.Statements);
+
+            Assert.AreNotEqual(0, answer.Statements.Count, "nothing was pushed down at all");
+            Assert.IsFalse(generated.Contains("||"), $"the operator the server refuses was pushed down: {generated}");
+            Assert.IsTrue(answer.Statements.Any(s => s.Contains('+')), $"nothing concatenated on the server: {generated}");
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerFixture.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerFixture.cs
@@ -250,6 +250,17 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             Execute("CREATE TABLE dbo.DEPTS (DEPTNO INT NOT NULL PRIMARY KEY, DNAME NVARCHAR(64) NOT NULL)");
             Execute("INSERT INTO dbo.DEPTS (DEPTNO, DNAME) VALUES (10, 'Sales'), (20, 'Engineering'), (30, 'Empty')");
 
+            // two short strings and a null one, which is the table concatenation was measured over: the
+            // operator has to reach the server as something it will parse, and it has to keep the meaning
+            // it had, which is that a null operand makes the whole expression null
+            Execute("""
+                CREATE TABLE dbo.CAT (
+                    ID INT         NOT NULL PRIMARY KEY,
+                    A  VARCHAR(16) NULL,
+                    B  VARCHAR(16) NULL)
+                """);
+            Execute("INSERT INTO dbo.CAT (ID, A, B) VALUES (1, 'aa', 'bb'), (2, 'cc', NULL), (3, 'dd', 'ee')");
+
             // one column of every type the server's information schema names differently, so that a gap in
             // the type mapping shows up as a failing test rather than as a table nobody can read
             Execute("""

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using org.apache.calcite.rel.type;
 using org.apache.calcite.sql;
 using org.apache.calcite.sql.dialect;
+using org.apache.calcite.sql.fun;
 using org.apache.calcite.sql.parser;
 using org.apache.calcite.sql.type;
 
@@ -126,7 +127,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         }
 
         /// <summary>
-        /// <see cref="MssqlSqlDialect"/>, and the two things it does not say about SQL Server.
+        /// <see cref="MssqlSqlDialect"/>, and the three things it does not say about SQL Server.
         /// </summary>
         /// <param name="context"></param>
         /// <remarks>
@@ -145,8 +146,9 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// for a server to run, and the server is the authority on what it accepts.
         /// </para>
         /// <para>
-        /// The second is what an unbounded string casts to — see <see cref="Mssql.getCastSpec"/>, which is
-        /// the same kind of correction and made for the same reason.
+        /// The second is what an unbounded string casts to — see <see cref="Mssql.getCastSpec"/> — and the
+        /// third is that T-SQL has no concatenation operator — see <see cref="Mssql.unparseCall"/>. Both
+        /// are the same kind of correction and made for the same reason.
         /// </para>
         /// </remarks>
         sealed class Mssql(SqlDialect.Context context) : MssqlSqlDialect(context)
@@ -156,6 +158,95 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             public override bool supportsGroupByLiteral()
             {
                 return false;
+            }
+
+            /// <inheritdoc />
+            /// <remarks>
+            /// <para>
+            /// T-SQL has no <c>||</c>. <c>SqlStdOperatorTable.CONCAT</c> unparses as one, and
+            /// <see cref="MssqlSqlDialect"/> intercepts <c>SUBSTRING</c>, <c>CEIL</c>, <c>FLOOR</c>,
+            /// <c>MOD</c> and <c>SAFE_CAST</c> without intercepting it — so every statement that
+            /// concatenates reaches the server as <c>[A] || [B]</c> and answers "Incorrect syntax near
+            /// '|'". It is not confined to a select list: the operator reaches a predicate, a sort key and
+            /// an aggregate argument the same way, and two literals are not folded away, so no spelling of
+            /// the expression avoids it.
+            /// </para>
+            /// <para>
+            /// <c>+</c> rather than <c>CONCAT</c>, and the difference is answers rather than taste. Both
+            /// concatenate, and only <c>+</c> means what the operator means: <c>||</c> yields null when
+            /// either operand is null, <c>+</c> does the same under the default
+            /// <c>CONCAT_NULL_YIELDS_NULL</c>, and T-SQL's <c>CONCAT</c> reads a null operand as the empty
+            /// string. Rendering the function would trade a loud failure for a row where there should have
+            /// been none. Calcite models that function correctly and separately, as
+            /// <c>SqlLibraryOperators.CONCAT_FUNCTION_WITH_NULL</c> under <c>fun=mssql</c>, which is why
+            /// enabling the library does not repair the operator either.
+            /// </para>
+            /// <para>
+            /// The swap is the shape CALCITE-6726 already put in this method for <c>MOD</c>:
+            /// <see cref="SqlSyntax"/>'s <c>BINARY</c> unparses the call under another operator. What that
+            /// shape does not carry across is precedence — <c>||</c> is 60 and <c>+</c> is 40 — and by the
+            /// time a dialect is asked, <c>SqlCall.unparse</c> has already decided the parentheses around
+            /// the call from the call's own operator. So the substitution alone writes a <c>+</c> inside
+            /// <c>||</c>'s parenthesisation, and where the two differ the grouping is the server's to get
+            /// wrong: <c>(a || b) * n</c> comes out as <c>a + b * n</c>.
+            /// </para>
+            /// <para>
+            /// So the rule is applied again here for the operator actually written. It is
+            /// <c>SqlCall.needsParentheses</c> over <c>PLUS</c> — the two clauses that read a precedence,
+            /// the third being the writer's own setting, which has already been consulted, and the fourth
+            /// a comparison, which neither operator is.
+            /// </para>
+            /// <para>
+            /// Calcite's <c>MOD</c> case has the same gap and does not close it — <c>MOD</c> is a function
+            /// and carries a function's precedence, <c>PERCENT_REMAINDER</c> is 60, and
+            /// <c>n / MOD(a, b)</c> is written <c>n / a % b</c>, measured, which the server groups as
+            /// <c>(n / a) % b</c>. That is a defect to raise upstream rather than one to reproduce: a
+            /// dialect exists to generate SQL a server will run, and a misgrouped expression is not that.
+            /// </para>
+            /// <para>
+            /// <c>SqlDialect.supportsFunction</c> is not the place for it and could not be: it lists
+            /// <c>CONCAT</c> in <c>BUILT_IN_OPERATORS_LIST</c>, and nothing in Calcite core at 1.42 calls
+            /// the method at all, so refusing the operator there would gate nothing.
+            /// </para>
+            /// </remarks>
+            public override void unparseCall(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec)
+            {
+                if (call.getOperator().equals(SqlStdOperatorTable.CONCAT))
+                {
+                    UnparseAsPlus(writer, call, leftPrec, rightPrec);
+                    return;
+                }
+
+                base.unparseCall(writer, call, leftPrec, rightPrec);
+            }
+
+            /// <summary>
+            /// Writes a concatenation as an addition, parenthesised as an addition would have been.
+            /// </summary>
+            /// <param name="writer"></param>
+            /// <param name="call"></param>
+            /// <param name="leftPrec"></param>
+            /// <param name="rightPrec"></param>
+            /// <remarks>
+            /// The two precedences the caller already spent on <c>||</c> are spent again on <c>+</c>, which
+            /// is <c>SqlCall.needsParentheses</c>'s test. Where the call was parenthesised on the way in,
+            /// both are zero and nothing more is written; where it was not, and <c>+</c> binds too loosely
+            /// for where it stands, the parentheses go on here.
+            /// </remarks>
+            static void UnparseAsPlus(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec)
+            {
+                var plus = SqlStdOperatorTable.PLUS;
+
+                if (leftPrec > plus.getLeftPrec() || (plus.getRightPrec() <= rightPrec && rightPrec != 0))
+                {
+                    var frame = writer.startList("(", ")");
+                    SqlSyntax.BINARY.unparse(writer, plus, call, 0, 0);
+                    writer.endList(frame);
+                }
+                else
+                {
+                    SqlSyntax.BINARY.unparse(writer, plus, call, leftPrec, rightPrec);
+                }
             }
 
             /// <inheritdoc />


### PR DESCRIPTION
Fixes #66.

T-SQL has no `||`. `SqlStdOperatorTable.CONCAT` unparses as one and `MssqlSqlDialect.unparseCall`
does not intercept it, so every statement the adapter pushed down that concatenated reached the
server carrying an operator it will not parse. `AdoSqlDialects.Mssql` writes `+` instead, beside
the two corrections already there.

## `+` rather than `CONCAT`

Both concatenate and only `+` means what the operator means. Measured on the LocalDB the tests run
against — `SELECT 'a' + NULL` is null, `SELECT CONCAT('a', NULL)` is `a`, and
`CONCAT_NULL_YIELDS_NULL` is on. Rendering the function would have traded a loud failure for a row
that should not have been returned, so the null case is asserted twice: once as a value, and once
as a row a predicate must not match.

## The substitution alone is not enough

`SqlSyntax.BINARY.unparse` writes the call under another operator but does not carry that
operator's precedence, and `SqlCall.unparse` has already chosen the parentheses around the call
from the call's *own* operator by the time a dialect is asked. `||` is 60 and `+` is 40, so the
substitution alone writes a `+` inside `||`'s parenthesisation: `(a || b) * n` comes out as
`a + b * n`.

So the override applies `PLUS`'s own rule — `SqlCall.needsParentheses`' two precedence clauses, the
third being a writer setting already consulted and the fourth a comparison, which neither operator
is. `SELECT (A || B) * 2` now renders `SELECT ([A] + [B]) * 2`, and a grouping the caller wrote is
preserved rather than flattened.

## Coverage

`AdoSqlDialectsTests` pins the rendering with no database: the four shapes from the report plus two
literals, the whole statement for each, the nestings a validated plan produces, that another
product keeps `||`, that every name selecting SQL Server carries the correction, and that the
dialect's own interceptions still run.

`SqlServerConcatenationTests` runs the same statements against LocalDB through SqlClient, ODBC and
OLE DB — 13 methods × 3 drivers. All three reach one dialect chosen from the product name, so a
correction only SqlClient carried would be in the wrong place. One of them reads `Hook.QUERY_PLAN`
and asserts the statement that actually went to the server, which is the claim that the rows were
answered there rather than by Calcite.

Verified both ways. With `AdoSqlDialects.cs` reverted and the tests kept, the server tests fail
with `Incorrect syntax near '|'` on all three drivers and 22 of the 72 unparse assertions fail;
with the fix the full adapter suite passes.

## Two things found while measuring, neither fixed here

**Upstream has the same defect, and it is not ours.** `org.apache.calcite.adapter.jdbc.JdbcImplementor`
on a JVM — calcite-core 1.42.0, no IKVM, nothing of this project — emits the identical strings for
`MssqlSqlDialect`:

```
projection          SELECT [A] || [B] AS [$f0] FROM [CAT] WHERE [ID] = 1
predicate           SELECT [ID] FROM [CAT] WHERE [A] || [B] = 'aabb'
sort key            SELECT [ID] FROM (SELECT [ID], [A] || [B] AS [$f1] FROM [CAT]
                      ORDER BY CASE WHEN [A] || [B] IS NULL THEN 1 ELSE 0 END, 2) AS [t0]
aggregate argument  SELECT MAX([A] || [B]) AS [$f0] FROM [CAT]
group key           SELECT [A] || [B] AS [$f3] FROM [CAT] GROUP BY [A] || [B]
```

Byte-identical to the report's table. So Calcite's own JDBC adapter against the Microsoft JDBC
driver fails the same way; this fix is a correction to Calcite made where the adapter is entitled
to make one.

**`MOD`, the interception this one is modelled on, has the precedence gap and does not close it.**
`MOD` carries a function's precedence and `PERCENT_REMAINDER` is 60, so — measured on
`MssqlSqlDialect.DEFAULT` — `n / MOD(a, b)` is written `n / a % b`, which the server groups as
`(n / a) % b`. Unlike the concatenation case the operands are numeric, so it is reachable from a
validated plan. Left alone here, and worth raising upstream.

Neither of these changes anything else in this branch. #64's length error is still open: the
operator now renders, and `varchar(8000) + varchar(8000)` is still `varchar(8000)` on the server
where Calcite's type is `VARCHAR(16000)`.
