### PR TITLE
Group a modulo the way the call was written

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSqlDialectsTests.cs
@@ -88,6 +88,36 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
+        /// A column reference, for building a call the parser will not produce.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        static SqlNode Column(string name)
+        {
+            return new SqlIdentifier(name, SqlParserPos.ZERO);
+        }
+
+        /// <summary>
+        /// A call to an operator over the operands given.
+        /// </summary>
+        /// <param name="op"></param>
+        /// <param name="operands"></param>
+        /// <returns></returns>
+        static SqlNode Call(SqlOperator op, params SqlNode[] operands)
+        {
+            return op.createCall(SqlParserPos.ZERO, operands);
+        }
+
+        /// <summary>
+        /// <c>MOD(A, B)</c>, which is the call every modulo test is written around.
+        /// </summary>
+        /// <returns></returns>
+        static SqlNode Modulo()
+        {
+            return Call(SqlStdOperatorTable.MOD, Column("A"), Column("B"));
+        }
+
+        /// <summary>
         /// Builds types the way a connection does, from the default type system.
         /// </summary>
         static readonly RelDataTypeFactory Types = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
@@ -466,26 +496,6 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             StringAssert.Contains(Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), sql), expected);
         }
 
-        /// <summary>
-        /// <c>MOD</c> in particular, which is the interception this one is modelled on: CALCITE-6726 swapped
-        /// <c>PERCENT_REMAINDER</c> in through <c>SqlSyntax.BINARY</c>, and nothing pinned it.
-        /// </summary>
-        /// <remarks>
-        /// Built rather than parsed. An unqualified function name is a <c>SqlUnresolvedFunction</c> until
-        /// the validator has run, and <c>MssqlSqlDialect</c> switches on <c>SqlKind.MOD</c>, which an
-        /// unresolved call does not carry — so parse-then-unparse writes <c>MOD([ID], 2)</c> and says
-        /// nothing about the interception either way.
-        /// </remarks>
-        [TestMethod]
-        public void TheInterceptionThisOneIsModelledOnStillHappens()
-        {
-            var call = SqlStdOperatorTable.MOD.createCall(
-                SqlParserPos.ZERO,
-                new SqlIdentifier("ID", SqlParserPos.ZERO),
-                SqlLiteral.createExactNumeric("2", SqlParserPos.ZERO));
-
-            Assert.AreEqual("[ID] % 2", Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), call));
-        }
 
         #endregion
 
@@ -556,6 +566,181 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             Assert.AreEqual(
                 "SELECT [A] || [B] * 2 FROM [CAT]",
                 Unparse(MssqlSqlDialect.DEFAULT, "SELECT (A || B) * 2 FROM CAT"));
+        }
+
+        #endregion
+
+        #region Modulo
+
+        /// <summary>
+        /// <c>MssqlSqlDialect</c> already writes a modulo as the operator T-SQL has, which CALCITE-6726
+        /// added and nothing pinned. This is the answer that is kept.
+        /// </summary>
+        /// <remarks>
+        /// Built rather than parsed throughout this region. An unqualified function name is a
+        /// <c>SqlUnresolvedFunction</c> until the validator has run, and the interception switches on
+        /// <c>SqlKind.MOD</c>, which an unresolved call does not carry — so parse-then-unparse writes
+        /// <c>MOD([A], [B])</c> and says nothing about the interception either way.
+        /// </remarks>
+        [TestMethod]
+        public void ModuloIsWrittenAsThePercentOperator()
+        {
+            Assert.AreEqual("[A] % [B]", Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), Modulo()));
+        }
+
+        /// <summary>
+        /// What is corrected is where the parentheses go. <c>MOD</c> is a function and carries a function's
+        /// precedence of 100; <c>PERCENT_REMAINDER</c> is 60. So as the right operand of an operator that
+        /// binds at 60, the substitution loses the grouping the call had, and the operands being numeric
+        /// there is no shape of the expression a validated plan cannot reach.
+        /// </summary>
+        [TestMethod]
+        [DataRow(nameof(SqlStdOperatorTable.DIVIDE), "[N] / ([A] % [B])")]
+        [DataRow(nameof(SqlStdOperatorTable.MULTIPLY), "[N] * ([A] % [B])")]
+        [DataRow(nameof(SqlStdOperatorTable.MOD), "[N] % ([A] % [B])")]
+        public void AModuloAsARightOperandKeepsItsGrouping(string operatorName, string expected)
+        {
+            var call = Call(OperatorNamed(operatorName), Column("N"), Modulo());
+
+            Assert.AreEqual(expected, Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), call));
+        }
+
+        /// <summary>
+        /// And the answers this corrects, so that the tests say what they are for. Each is grouped by the
+        /// server from the left: over 12, 7 and 4 they answer 1, 0 and 1 where the expressions mean 4, 36
+        /// and 0 — measured on the server, not derived from the precedence table.
+        /// </summary>
+        [TestMethod]
+        [DataRow(nameof(SqlStdOperatorTable.DIVIDE), "[N] / [A] % [B]")]
+        [DataRow(nameof(SqlStdOperatorTable.MULTIPLY), "[N] * [A] % [B]")]
+        [DataRow(nameof(SqlStdOperatorTable.MOD), "[N] % [A] % [B]")]
+        public void CalcitesOwnAnswerLosesTheGrouping(string operatorName, string expected)
+        {
+            var call = Call(OperatorNamed(operatorName), Column("N"), Modulo());
+
+            Assert.AreEqual(expected, Unparse(MssqlSqlDialect.DEFAULT, call));
+        }
+
+        /// <summary>
+        /// Everywhere else the rendering already meant what the call meant, and is left as it stands. As a
+        /// left operand left associativity gives the nesting for nothing; <c>%</c> binds tighter than
+        /// <c>-</c>; and SQL Server's <c>%</c> takes the sign of its dividend, so <c>(-a) % b</c> and
+        /// <c>-(a % b)</c> agree.
+        /// </summary>
+        [TestMethod]
+        [DataRow(nameof(SqlStdOperatorTable.MULTIPLY), "[A] % [B] * [N]")]
+        [DataRow(nameof(SqlStdOperatorTable.DIVIDE), "[A] % [B] / [N]")]
+        [DataRow(nameof(SqlStdOperatorTable.MINUS), "[A] % [B] - [N]")]
+        [DataRow(nameof(SqlStdOperatorTable.EQUALS), "[A] % [B] = [N]")]
+        public void AModuloAsALeftOperandIsUnchanged(string operatorName, string expected)
+        {
+            var call = Call(OperatorNamed(operatorName), Modulo(), Column("N"));
+            var dialect = AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382");
+
+            Assert.AreEqual(expected, Unparse(dialect, call));
+            Assert.AreEqual(expected, Unparse(MssqlSqlDialect.DEFAULT, call), "Calcite already writes this one");
+        }
+
+        /// <summary>
+        /// The right-operand context that was already right, for the same reason: a looser operator needs
+        /// no parentheses around a tighter one, and <c>%</c> binds tighter than <c>-</c>.
+        /// </summary>
+        [TestMethod]
+        public void AModuloUnderALooserOperatorIsUnchanged()
+        {
+            var dialect = AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382");
+            var minus = Call(SqlStdOperatorTable.MINUS, Column("N"), Modulo());
+
+            Assert.AreEqual("[N] - [A] % [B]", Unparse(dialect, minus));
+            Assert.AreEqual(Unparse(MssqlSqlDialect.DEFAULT, minus), Unparse(dialect, minus));
+        }
+
+        /// <summary>
+        /// A prefix operator hands its operand a left precedence of 80, which outranks
+        /// <c>PERCENT_REMAINDER</c>'s 60, so the parentheses go on where Calcite writes none. This is the
+        /// one place the correction writes a parenthesis Calcite would not have.
+        /// </summary>
+        /// <remarks>
+        /// Both compute the same thing here, and Calcite is not wrong — but only because SQL Server's
+        /// <c>%</c> takes the sign of its dividend, so <c>(-a) % b</c> and <c>-(a % b)</c> agree, measured
+        /// at -3 over 7 and 4. The rule the override applies does not know that and does not need to: it
+        /// writes the grouping the call had, and a parenthesis that was not needed costs nothing.
+        /// </remarks>
+        [TestMethod]
+        public void AModuloUnderAPrefixOperatorIsParenthesised()
+        {
+            var negated = Call(SqlStdOperatorTable.UNARY_MINUS, Modulo());
+
+            Assert.AreEqual("- ([A] % [B])", Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), negated));
+            Assert.AreEqual("- [A] % [B]", Unparse(MssqlSqlDialect.DEFAULT, negated), "the answer this does not need to correct");
+        }
+
+        /// <summary>
+        /// A postfix operator, which is what a sort key's null ordering is written with.
+        /// </summary>
+        [TestMethod]
+        public void AModuloUnderAPostfixOperatorIsUnchanged()
+        {
+            var call = Call(SqlStdOperatorTable.IS_NULL, Modulo());
+
+            Assert.AreEqual("[A] % [B] IS NULL", Unparse(AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382"), call));
+        }
+
+        /// <summary>
+        /// <c>SqlKind.MOD</c> is carried by two operators, and the other one is <c>PERCENT_REMAINDER</c>
+        /// itself — what a query written with <c>%</c> produces, under a conformance level that allows one.
+        /// The interception then substitutes an operator for itself, and the rule is applied to the same
+        /// precedences <c>SqlCall.unparse</c> has just applied it to, so it answers the same and no
+        /// parenthesis is written twice.
+        /// </summary>
+        [TestMethod]
+        public void ThePercentOperatorItselfIsUnchanged()
+        {
+            var dialect = AdoSqlDialects.For("Microsoft SQL Server", "15.00.4382");
+            var percent = Call(SqlStdOperatorTable.PERCENT_REMAINDER, Column("A"), Column("B"));
+
+            foreach (var call in new[]
+            {
+                percent,
+                Call(SqlStdOperatorTable.DIVIDE, Column("N"), percent),
+                Call(SqlStdOperatorTable.MULTIPLY, percent, Column("N")),
+                Call(SqlStdOperatorTable.UNARY_MINUS, percent),
+            })
+            {
+                Assert.AreEqual(Unparse(MssqlSqlDialect.DEFAULT, call), Unparse(dialect, call));
+            }
+        }
+
+        /// <summary>
+        /// The correction is SQL Server's alone. Another product writes the function, and writes it whole,
+        /// so there is no substitution to lose a grouping over.
+        /// </summary>
+        [TestMethod]
+        [DataRow("PostgreSQL")]
+        [DataRow("Oracle")]
+        public void AnotherProductKeepsTheFunction(string productName)
+        {
+            var call = Call(SqlStdOperatorTable.DIVIDE, Column("N"), Modulo());
+
+            Assert.IsFalse(Unparse(AdoSqlDialects.For(productName, "1.0"), call).Contains('%'));
+        }
+
+        /// <summary>
+        /// Resolves one of the operators the rows above name.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        static SqlOperator OperatorNamed(string name)
+        {
+            return name switch
+            {
+                nameof(SqlStdOperatorTable.DIVIDE) => SqlStdOperatorTable.DIVIDE,
+                nameof(SqlStdOperatorTable.MULTIPLY) => SqlStdOperatorTable.MULTIPLY,
+                nameof(SqlStdOperatorTable.MINUS) => SqlStdOperatorTable.MINUS,
+                nameof(SqlStdOperatorTable.EQUALS) => SqlStdOperatorTable.EQUALS,
+                nameof(SqlStdOperatorTable.MOD) => SqlStdOperatorTable.MOD,
+                _ => throw new AssertFailedException($"no operator {name}"),
+            };
         }
 
         #endregion

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/GeneratedSql.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/GeneratedSql.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Collects the statements the adapter generates, which the converters announce on
+    /// <c>Hook.QUERY_PLAN</c> as they build each one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What a test asserts about the rows is that the answer is right; what it asserts about these is that
+    /// the server is what answered. The two are separate claims, and a query the adapter declined to push
+    /// down would satisfy the first while saying nothing about the dialect.
+    /// </para>
+    /// <para>
+    /// IKVM does not project a Java default method onto a CLR class that implements the interface, so
+    /// <c>andThen</c> has to be written even though a hook handler is never composed with another.
+    /// </para>
+    /// </remarks>
+    sealed class GeneratedSql : java.util.function.Consumer
+    {
+
+        /// <summary>
+        /// Two handlers as one, which is what <c>Consumer.andThen</c> answers in Java.
+        /// </summary>
+        /// <param name="first"></param>
+        /// <param name="then"></param>
+        sealed class Composed(java.util.function.Consumer first, java.util.function.Consumer then) : java.util.function.Consumer
+        {
+
+            /// <inheritdoc />
+            public void accept(object value)
+            {
+                first.accept(value);
+                then.accept(value);
+            }
+
+            /// <inheritdoc />
+            public java.util.function.Consumer andThen(java.util.function.Consumer after)
+            {
+                return new Composed(this, after);
+            }
+
+        }
+
+        readonly List<string> _statements = [];
+
+        /// <summary>
+        /// Gets the statements generated so far.
+        /// </summary>
+        public IReadOnlyList<string> Statements => _statements;
+
+        /// <inheritdoc />
+        public void accept(object value)
+        {
+            _statements.Add(value?.ToString() ?? "");
+        }
+
+        /// <inheritdoc />
+        public java.util.function.Consumer andThen(java.util.function.Consumer after)
+        {
+            return new Composed(this, after);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerConcatenationTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerConcatenationTests.cs
@@ -85,61 +85,6 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// Collects the statements the adapter generates, which <c>AdoToEnumerableConverter</c> announces on
-        /// <c>Hook.QUERY_PLAN</c> as it builds each one.
-        /// </summary>
-        /// <remarks>
-        /// IKVM does not project a Java default method onto a CLR class that implements the interface, so
-        /// <c>andThen</c> has to be written even though a hook handler is never composed with another.
-        /// </remarks>
-        sealed class GeneratedSql : java.util.function.Consumer
-        {
-
-            /// <summary>
-            /// Two handlers as one, which is what <c>Consumer.andThen</c> answers in Java.
-            /// </summary>
-            /// <param name="first"></param>
-            /// <param name="then"></param>
-            sealed class Composed(java.util.function.Consumer first, java.util.function.Consumer then) : java.util.function.Consumer
-            {
-
-                /// <inheritdoc />
-                public void accept(object value)
-                {
-                    first.accept(value);
-                    then.accept(value);
-                }
-
-                /// <inheritdoc />
-                public java.util.function.Consumer andThen(java.util.function.Consumer after)
-                {
-                    return new Composed(this, after);
-                }
-
-            }
-
-            readonly List<string> _statements = [];
-
-            /// <summary>
-            /// Gets the statements generated so far.
-            /// </summary>
-            public IReadOnlyList<string> Statements => _statements;
-
-            /// <inheritdoc />
-            public void accept(object value)
-            {
-                _statements.Add(value?.ToString() ?? "");
-            }
-
-            /// <inheritdoc />
-            public java.util.function.Consumer andThen(java.util.function.Consumer after)
-            {
-                return new Composed(this, after);
-            }
-
-        }
-
-        /// <summary>
         /// What a query answered, and what was sent to the server to answer it.
         /// </summary>
         /// <param name="Rows"></param>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerModuloTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerModuloTests.cs
@@ -1,0 +1,208 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+using org.apache.calcite.runtime;
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// Covers a modulo against a real SQL Server, where the grouping of the expression that reached it is
+    /// the thing in question.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>MssqlSqlDialect</c> writes <c>MOD(a, b)</c> as <c>a % b</c>, which is right, and hands
+    /// <c>SqlSyntax.BINARY</c> an operator of a different precedence from the call's — a function's 100
+    /// against <c>PERCENT_REMAINDER</c>'s 60 — while <c>SqlCall.unparse</c> has already chosen the
+    /// parentheses from the call's own. So a modulo standing as the right operand of an operator binding at
+    /// 60 lost its grouping: <c>n / MOD(a, b)</c> went down as <c>n / a % b</c>, which the server reads as
+    /// <c>(n / a) % b</c>.
+    /// </para>
+    /// <para>
+    /// Unlike the concatenation half of the same correction, this one is reachable from a validated plan —
+    /// the operands are numeric, so <c>*</c>, <c>/</c> and <c>%</c> all take one. It is also silent: the
+    /// statement parses and runs and answers a number, so nothing failed and the number was wrong.
+    /// </para>
+    /// <para>
+    /// SqlClient alone. That all three drivers reach one dialect is a claim
+    /// <see cref="SqlServerConcatenationTests"/> makes and holds, and repeating the matrix here would test
+    /// the drivers again rather than the rendering.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class SqlServerModuloTests
+    {
+
+        static SqlServerModuloTests()
+        {
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(AdoSchemaFactory).Assembly);
+            ikvm.runtime.Startup.addBootClassPathAssembly(typeof(CalciteJdbc41Factory).Assembly);
+            java.lang.Class.forName("org.apache.calcite.jdbc.Driver");
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            if (SqlServerFixture.IsAvailable == false)
+                Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+        }
+
+        /// <summary>
+        /// What a query answered, and what was sent to the server to answer it.
+        /// </summary>
+        /// <param name="Rows"></param>
+        /// <param name="Statements"></param>
+        readonly record struct Answer(List<string> Rows, IReadOnlyList<string> Statements);
+
+        /// <summary>
+        /// Runs a query against the fixture's database.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static Answer Run(string sql)
+        {
+            var properties = new java.util.Properties();
+            properties.setProperty("lex", "JAVA");
+            properties.setProperty("caseSensitive", "false");
+
+            var generated = new GeneratedSql();
+            var handle = Hook.QUERY_PLAN.addThread(generated);
+
+            try
+            {
+                using var connection = java.sql.DriverManager.getConnection("jdbc:calcite:", properties);
+                var root = ((CalciteConnection)connection).getRootSchema();
+                root.add("ADO", AdoSchema.Create(root, "ADO", SqlServerFixture.Shared.DataSource, null, "dbo"));
+
+                using var statement = connection.createStatement();
+                var results = statement.executeQuery(sql);
+
+                var rows = new List<string>();
+                while (results.next())
+                    rows.Add(results.getObject(1)?.ToString() ?? "NULL");
+
+                return new Answer(rows, generated.Statements);
+            }
+            finally
+            {
+                handle.close();
+            }
+        }
+
+        /// <summary>
+        /// Runs a query over <c>DEPTS</c> ordered by its key, so that the answers line up with 10, 20 and 30
+        /// whatever order the server would otherwise have returned them in.
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        static Answer OverDepartments(string expression)
+        {
+            return Run($"SELECT {expression} FROM ADO.DEPTS ORDER BY DEPTNO");
+        }
+
+        #region The grouping
+
+        /// <summary>
+        /// A modulo as the right operand of a division, which is where the rendering lost the grouping.
+        /// Over 10, 20 and 30 the moduli are 3, 6 and 2, so the expression means 20, 10 and 30; grouped from
+        /// the left it is <c>(60 / DEPTNO) % 7</c>, which is 6, 3 and 2.
+        /// </summary>
+        [TestMethod]
+        public void AModuloUnderADivisionIsGrouped()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "20", "10", "30" },
+                OverDepartments("60 / MOD(DEPTNO, 7)").Rows);
+        }
+
+        /// <summary>
+        /// The same under a multiplication: the expression means 18, 36 and 12, and grouped from the left
+        /// <c>(6 * DEPTNO) % 7</c> is 4, 1 and 5.
+        /// </summary>
+        [TestMethod]
+        public void AModuloUnderAMultiplicationIsGrouped()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "18", "36", "12" },
+                OverDepartments("6 * MOD(DEPTNO, 7)").Rows);
+        }
+
+        /// <summary>
+        /// And under another modulo, which is the case that reads worst as SQL: the expression means 2, 2
+        /// and 0, and <c>(20 % DEPTNO) % 7</c> is 0, 0 and 6.
+        /// </summary>
+        [TestMethod]
+        public void AModuloUnderAModuloIsGrouped()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "2", "2", "0" },
+                OverDepartments("MOD(20, MOD(DEPTNO, 7))").Rows);
+        }
+
+        #endregion
+
+        #region What was already right
+
+        /// <summary>
+        /// As a left operand the rendering already meant what the call meant, left associativity giving the
+        /// nesting for nothing. Kept here so that the correction is known to be to the one case.
+        /// </summary>
+        [TestMethod]
+        public void AModuloAsALeftOperandIsUnaffected()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "9", "18", "6" },
+                OverDepartments("MOD(DEPTNO, 7) * 3").Rows);
+        }
+
+        /// <summary>
+        /// And under an operator that binds looser than <c>%</c> does.
+        /// </summary>
+        [TestMethod]
+        public void AModuloUnderASubtractionIsUnaffected()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "97", "94", "98" },
+                OverDepartments("100 - MOD(DEPTNO, 7)").Rows);
+        }
+
+        /// <summary>
+        /// The plain rendering, which is Calcite's and is kept: <c>%</c> is the operator T-SQL has, and
+        /// <c>MOD</c> is not a function it knows.
+        /// </summary>
+        [TestMethod]
+        public void APlainModuloStillRuns()
+        {
+            CollectionAssert.AreEqual(
+                new[] { "3", "6", "2" },
+                OverDepartments("MOD(DEPTNO, 7)").Rows);
+        }
+
+        #endregion
+
+        #region What went to the server
+
+        /// <summary>
+        /// The claim that the numbers above were answered by the server rather than by Calcite: the
+        /// statement carries the operator, and carries it parenthesised.
+        /// </summary>
+        [TestMethod]
+        public void TheGroupingIsPushedDown()
+        {
+            var answer = OverDepartments("60 / MOD(DEPTNO, 7)");
+            var generated = string.Join("\n", answer.Statements);
+
+            Assert.AreNotEqual(0, answer.Statements.Count, "nothing was pushed down at all");
+            Assert.IsTrue(answer.Statements.Any(s => s.Contains('%')), $"nothing computed a modulo on the server: {generated}");
+            Assert.IsTrue(answer.Statements.Any(s => s.Contains("([DEPTNO] % 7)")), $"the grouping did not go down: {generated}");
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Metadata/AdoSqlDialects.cs
@@ -127,7 +127,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         }
 
         /// <summary>
-        /// <see cref="MssqlSqlDialect"/>, and the three things it does not say about SQL Server.
+        /// <see cref="MssqlSqlDialect"/>, and the four things it does not say about SQL Server.
         /// </summary>
         /// <param name="context"></param>
         /// <remarks>
@@ -146,9 +146,10 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
         /// for a server to run, and the server is the authority on what it accepts.
         /// </para>
         /// <para>
-        /// The second is what an unbounded string casts to — see <see cref="Mssql.getCastSpec"/> — and the
-        /// third is that T-SQL has no concatenation operator — see <see cref="Mssql.unparseCall"/>. Both
-        /// are the same kind of correction and made for the same reason.
+        /// The second is what an unbounded string casts to — see <see cref="Mssql.getCastSpec"/>. The
+        /// third and fourth are both in <see cref="Mssql.unparseCall"/>: T-SQL has no concatenation
+        /// operator, and the modulo Calcite already writes for it is grouped wrongly. All three are the
+        /// same kind of correction and made for the same reason.
         /// </para>
         /// </remarks>
         sealed class Mssql(SqlDialect.Context context) : MssqlSqlDialect(context)
@@ -184,36 +185,61 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             /// <para>
             /// The swap is the shape CALCITE-6726 already put in this method for <c>MOD</c>:
             /// <see cref="SqlSyntax"/>'s <c>BINARY</c> unparses the call under another operator. What that
-            /// shape does not carry across is precedence — <c>||</c> is 60 and <c>+</c> is 40 — and by the
-            /// time a dialect is asked, <c>SqlCall.unparse</c> has already decided the parentheses around
-            /// the call from the call's own operator. So the substitution alone writes a <c>+</c> inside
-            /// <c>||</c>'s parenthesisation, and where the two differ the grouping is the server's to get
-            /// wrong: <c>(a || b) * n</c> comes out as <c>a + b * n</c>.
+            /// shape does not carry across is precedence, and by the time a dialect is asked,
+            /// <c>SqlCall.unparse</c> has already decided the parentheses around the call from the call's
+            /// own operator. So the substitution alone writes the new operator inside the old one's
+            /// parenthesisation, and where the two differ the grouping is the server's to get wrong.
+            /// <see cref="UnparseAsBinary"/> is where that is put right, and both substitutions go through
+            /// it. For concatenation the gap is unreachable — <c>||</c> is 60 and <c>+</c> is 40, so
+            /// <c>(a || b) * n</c> would come out <c>a + b * n</c>, and a string is not a valid operand of
+            /// <c>*</c>.
             /// </para>
             /// <para>
-            /// So the rule is applied again here for the operator actually written. It is
-            /// <c>SqlCall.needsParentheses</c> over <c>PLUS</c> — the two clauses that read a precedence,
-            /// the third being the writer's own setting, which has already been consulted, and the fourth
-            /// a comparison, which neither operator is.
+            /// <c>MOD</c> is the same correction, and there the gap is not unreachable: it is a function
+            /// and carries a function's precedence of 100, <c>PERCENT_REMAINDER</c> is 60, and the operands
+            /// are numeric, so every context is a valid one. Measured on <c>MssqlSqlDialect.DEFAULT</c>,
+            /// with the call as the right operand:
             /// </para>
             /// <para>
-            /// Calcite's <c>MOD</c> case has the same gap and does not close it — <c>MOD</c> is a function
-            /// and carries a function's precedence, <c>PERCENT_REMAINDER</c> is 60, and
-            /// <c>n / MOD(a, b)</c> is written <c>n / a % b</c>, measured, which the server groups as
-            /// <c>(n / a) % b</c>. That is a defect to raise upstream rather than one to reproduce: a
-            /// dialect exists to generate SQL a server will run, and a misgrouped expression is not that.
+            /// <c>n / MOD(a, b)</c> is written <c>n / a % b</c>, <c>n * MOD(a, b)</c> is written
+            /// <c>n * a % b</c>, and <c>MOD(n, MOD(a, b))</c> is written <c>n % a % b</c> — each grouped by
+            /// the server from the left, so over 12, 7 and 4 they answer 1, 0 and 1 where the expressions
+            /// mean 4, 36 and 0.
             /// </para>
             /// <para>
-            /// <c>SqlDialect.supportsFunction</c> is not the place for it and could not be: it lists
-            /// <c>CONCAT</c> in <c>BUILT_IN_OPERATORS_LIST</c>, and nothing in Calcite core at 1.42 calls
-            /// the method at all, so refusing the operator there would gate nothing.
+            /// Nothing else changes. As the left operand the rendering was already right, left
+            /// associativity giving what the nesting meant, and so was <c>n - MOD(a, b)</c>, <c>%</c>
+            /// binding tighter than <c>-</c>. The one place a parenthesis appears that Calcite would not
+            /// have written is under a prefix operator, which hands its operand a left precedence of 80:
+            /// <c>-MOD(a, b)</c> becomes <c>-(a % b)</c> where Calcite writes <c>-a % b</c>. Calcite is not
+            /// wrong there — SQL Server's <c>%</c> takes the sign of its dividend, so the two agree,
+            /// measured — but the rule does not know that and does not need to.
+            /// </para>
+            /// <para>
+            /// Calcite does not close either gap. That is a defect to raise upstream rather than one to
+            /// reproduce: a dialect exists to generate SQL a server will run, and a misgrouped expression
+            /// is not that.
+            /// </para>
+            /// <para>
+            /// <c>SqlDialect.supportsFunction</c> is not the place for the concatenation half and could not
+            /// be: it lists <c>CONCAT</c> in <c>BUILT_IN_OPERATORS_LIST</c>, and nothing in Calcite core at
+            /// 1.42 calls the method at all, so refusing the operator there would gate nothing.
             /// </para>
             /// </remarks>
             public override void unparseCall(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec)
             {
                 if (call.getOperator().equals(SqlStdOperatorTable.CONCAT))
                 {
-                    UnparseAsPlus(writer, call, leftPrec, rightPrec);
+                    UnparseAsBinary(writer, SqlStdOperatorTable.PLUS, call, leftPrec, rightPrec);
+                    return;
+                }
+
+                // the interception is Calcite's own and the operator is the one it chooses; what is taken
+                // over is where the parentheses go, which is why this is a case here rather than a call to
+                // base with something rearranged
+                if (call.getKind().name() == nameof(SqlKind.MOD))
+                {
+                    UnparseAsBinary(writer, SqlStdOperatorTable.PERCENT_REMAINDER, call, leftPrec, rightPrec);
                     return;
                 }
 
@@ -221,31 +247,32 @@ namespace Apache.Calcite.Adapter.AdoNet.Metadata
             }
 
             /// <summary>
-            /// Writes a concatenation as an addition, parenthesised as an addition would have been.
+            /// Writes a call under another operator, parenthesised as that operator would have been.
             /// </summary>
             /// <param name="writer"></param>
+            /// <param name="op"></param>
             /// <param name="call"></param>
             /// <param name="leftPrec"></param>
             /// <param name="rightPrec"></param>
             /// <remarks>
-            /// The two precedences the caller already spent on <c>||</c> are spent again on <c>+</c>, which
-            /// is <c>SqlCall.needsParentheses</c>'s test. Where the call was parenthesised on the way in,
-            /// both are zero and nothing more is written; where it was not, and <c>+</c> binds too loosely
-            /// for where it stands, the parentheses go on here.
+            /// The two precedences the caller already spent on the call's own operator are spent again on
+            /// the one being written, which is <c>SqlCall.needsParentheses</c>'s test — its two clauses that
+            /// read a precedence, the third being the writer's own setting, already consulted, and the
+            /// fourth a comparison, which none of these operators is. Where the call was parenthesised on
+            /// the way in, both are zero and nothing more is written; where it was not, and the new
+            /// operator binds too loosely for where it stands, the parentheses go on here.
             /// </remarks>
-            static void UnparseAsPlus(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec)
+            static void UnparseAsBinary(SqlWriter writer, SqlOperator op, SqlCall call, int leftPrec, int rightPrec)
             {
-                var plus = SqlStdOperatorTable.PLUS;
-
-                if (leftPrec > plus.getLeftPrec() || (plus.getRightPrec() <= rightPrec && rightPrec != 0))
+                if (leftPrec > op.getLeftPrec() || (op.getRightPrec() <= rightPrec && rightPrec != 0))
                 {
                     var frame = writer.startList("(", ")");
-                    SqlSyntax.BINARY.unparse(writer, plus, call, 0, 0);
+                    SqlSyntax.BINARY.unparse(writer, op, call, 0, 0);
                     writer.endList(frame);
                 }
                 else
                 {
-                    SqlSyntax.BINARY.unparse(writer, plus, call, leftPrec, rightPrec);
+                    SqlSyntax.BINARY.unparse(writer, op, call, leftPrec, rightPrec);
                 }
             }
 


### PR DESCRIPTION
Re-opens #84 against `main`. It merged into `fix/mssql-concat-operator` — the branch it was stacked
on — eleven seconds after that branch merged into `main`, so the commit landed on a branch `main` had
already taken and never reached `main` itself. `git show main:.../AdoSqlDialects.cs | grep -c
SqlKind.MOD` answers 0. This is the same commit cherry-picked onto `main`; nothing about it changed.

The original body follows.

---

Found while fixing #66. `MssqlSqlDialect` writes `MOD(a, b)` as `a % b` — CALCITE-6726, and the right
operator, T-SQL having no `MOD` function. What it does not write is the grouping. `MOD` is a function
and carries a function's precedence of 100, `PERCENT_REMAINDER` is 60, and `SqlCall.unparse` has
already chosen the parentheses around the call from the call's *own* operator by the time the dialect
is asked. So a modulo standing as the right operand of an operator that binds at 60 loses its
grouping.

## Measured

On `MssqlSqlDialect.DEFAULT`, and again through `org.apache.calcite.adapter.jdbc.JdbcImplementor` —
the JDBC adapter's own SQL writer, on a JVM, with nothing of this project involved:

```
SELECT 60 / [DEPTNO] % 7 AS [$f0] FROM [DEPTS]
SELECT 6 * [DEPTNO] % 7 AS [$f0] FROM [DEPTS]
```

Against LocalDB over `DEPTNO` in 10, 20, 30:

| expression | means | written | server answers |
|---|---|---|---|
| `60 / MOD(d, 7)` | 20, 10, 30 | `60 / [d] % 7` | 6, 3, 2 |
| `6 * MOD(d, 7)` | 18, 36, 12 | `6 * [d] % 7` | 4, 1, 5 |
| `MOD(20, MOD(d, 7))` | 2, 2, 0 | `20 % [d] % 7` | 0, 0, 6 |

**Two things make this worse than the `||` half of the same defect.** The operands are numeric, so
`*`, `/` and `%` all take one and every context is reachable from a validated plan — where a string
is not a valid operand of `*`, which is why the concatenation gap could only be reached by
constructing a call by hand. And it is silent: the statement parses, runs, and answers a number. No
`Incorrect syntax`, just a wrong result.

## What is not affected

As a left operand the rendering already meant what the call meant, left associativity giving the
nesting for nothing — `MOD(d, 7) * 3` is `[d] % 7 * 3`, correct. So is `100 - MOD(d, 7)`, `%` binding
tighter than `-`. Both are pinned so the correction is known to be to the one case.

The one place this writes a parenthesis Calcite would not have is under a prefix operator, which
hands its operand a left precedence of 80: `-MOD(a, b)` becomes `-([a] % [b])` where Calcite writes
`-[a] % [b]`. Calcite is not wrong there — SQL Server's `%` takes the sign of its dividend, so
`(-a) % b` and `-(a % b)` agree, measured at -3 over 7 and 4 — but the rule does not know that and
does not need to, and a parenthesis that was not needed costs nothing.

## The change

`UnparseAsPlus` from #83 becomes `UnparseAsBinary`, and both substitutions go through it: it applies
`SqlCall.needsParentheses`' two precedence clauses to the operator actually being written rather than
to the one being replaced. The `MOD` case is a branch beside the `CONCAT` one, keyed on
`SqlKind.MOD` by name per the enum-ordinal rule. The operator stays Calcite's choice; only the
parentheses are taken over, which is why it is a case here rather than a call to `base` with
something rearranged.

Two operators carry `SqlKind.MOD`, and the other is `PERCENT_REMAINDER` itself — what a query written
with `%` produces under a conformance level that allows one. The interception then substitutes an
operator for itself, and the rule is applied to the same precedences `SqlCall.unparse` has just
applied it to, so it answers the same and writes no parenthesis twice. Pinned against Calcite's own
rendering rather than against a literal, the claim being that nothing changed.

## Coverage

`AdoSqlDialectsTests` gains a `Modulo` region: the plain rendering that is kept, the three
right-operand contexts, the answers being corrected on `MssqlSqlDialect.DEFAULT` so each test says
what it is for, the left-operand and looser-operator contexts asserted to match Calcite exactly, the
prefix case, and that another product keeps the function. Built rather than parsed throughout — an
unqualified function name is a `SqlUnresolvedFunction` until the validator runs, so the interception
switches on a kind a parsed call does not carry.

`SqlServerModuloTests` runs the arithmetic against LocalDB and asserts the numbers, plus that the
grouping is what went down. SqlClient alone: that all three drivers reach one dialect is a claim #83
makes and holds, and repeating the matrix here would test the drivers rather than the rendering.
`GeneratedSql`, the `Hook.QUERY_PLAN` handler, moves out of the concatenation tests into a file of
its own so both use it.

Verified both ways. With the `MOD` case reverted, 4 of the server tests fail on the numbers and 4
unparse assertions fail; with it the full adapter suite passes.

## Upstream

Calcite has this defect and it is not ours — the `JdbcImplementor` output above is upstream's, so the
JDBC adapter against the Microsoft JDBC driver returns the same wrong numbers. Worth raising against
CALCITE-6726, which introduced the interception. Not filed from here.
