### PR TITLE
Add an optional geography package

### DIFF
--- a/.github/workflows/Apache.Calcite.yml
+++ b/.github/workflows/Apache.Calcite.yml
@@ -97,6 +97,7 @@ jobs:
         - Apache.Calcite.Tests
         - Apache.Calcite.Adapter.AdoNet.Tests
         - Apache.Calcite.Data.Tests
+        - Apache.Calcite.Geography.Tests
         sys:
         - win-x64
         - linux-x64

--- a/Apache.Calcite.slnx
+++ b/Apache.Calcite.slnx
@@ -20,6 +20,8 @@
     <Project Path="src/Apache.Calcite.Data.Tests/Apache.Calcite.Data.Tests.csproj" />
     <Project Path="src/Apache.Calcite.Data/Apache.Calcite.Data.csproj" />
     <Project Path="src/Apache.Calcite.Extensions/Apache.Calcite.Extensions.csproj" />
+    <Project Path="src/Apache.Calcite.Geography.Tests/Apache.Calcite.Geography.Tests.csproj" />
+    <Project Path="src/Apache.Calcite.Geography/Apache.Calcite.Geography.csproj" />
     <Project Path="src/Apache.Calcite.Tests/Apache.Calcite.Tests.csproj" />
   </Folder>
   <Folder Name="/src/dist/">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ instead of Janino, and the prepare pipeline that gets a statement to one.
 | `Apache.Calcite.Adapter.AdoNet` | pushes a plan down to an ADO.NET provider |
 | `Apache.Calcite.Data` | the `DbConnection` / `DbCommand` surface |
 | `Apache.Calcite.Extensions` | `ClrEnumerableConvention` and `ClrAsyncEnumerableConvention`, the prepare pipeline, and the IKVM interop helpers |
+| `Apache.Calcite.Geography` | optional; a `GEOGRAPHY` type distinct from Calcite's `GEOMETRY`, the `ST_GEOG_*` operator table, and a geodesic evaluator over Google's S2. Nothing else references it, and it references nothing else here |
 
 `TODO.md` has the outstanding work on the ADO.NET adapter, sized and reasoned, and the findings of the
 operator audit against linq4j — 45 methods read side by side, 17 of them divergent.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Targets .NET 8, and is verified on .NET 8 and .NET 10.
 dotnet add package Apache.Calcite.Extensions
 ```
 
+### [`Apache.Calcite.Geography`](https://www.nuget.org/packages/Apache.Calcite.Geography) · `src/Apache.Calcite.Geography`
+
+A `GEOGRAPHY` type and a set of `ST_GEOG_*` operators that read coordinates as WGS84 and answer in metres.
+
+Calcite has `GEOMETRY` and no `GEOGRAPHY`: its spatial library is planar JTS answering in the units of an unprojected coordinate system, while the stores that speak WGS84 — PostGIS `geography`, BigQuery, Snowflake, Elasticsearch, MongoDB — are geodesic. The two disagree about what identically-named functions mean, and the disagreement is not a scale factor. The type keeps them apart: Calcite's own `ST_*` refuse a geography at validation, and the crossing between the two readings has to be written down.
+
+Optional, and nothing else here depends on it. The geodesic engine is Google's S2.
+
+```sh
+dotnet add package Apache.Calcite.Geography
+```
+
 ## Test and distribution projects
 
 | Project | Purpose |
@@ -45,6 +57,7 @@ dotnet add package Apache.Calcite.Extensions
 | `Apache.Calcite.Tests` | Core engine integration tests, and the convention and prepare pipeline tests — including the differential suites that run the same SQL through `ClrEnumerableConvention` and `EnumerableConvention` and require the same rows |
 | `Apache.Calcite.Data.Tests` | Provider integration tests |
 | `Apache.Calcite.Adapter.AdoNet.Tests` | Adapter integration tests |
+| `Apache.Calcite.Geography.Tests` | Geography type, operator table and geodesic evaluator tests |
 | `dist-nuget` | Packages NuGet artifacts |
 | `dist-tests` | Packages test artifacts for CI |
 

--- a/src/Apache.Calcite.Geography.Tests/Apache.Calcite.Geography.Tests.csproj
+++ b/src/Apache.Calcite.Geography.Tests/Apache.Calcite.Geography.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="MSTest.Sdk/4.3.3">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <!-- MSTest.Sdk 4 references Microsoft.NET.Test.Sdk only under UseVSTest, so a build under 4 puts no
+             VSTest testhost in the output and CI's `dotnet test <dll>` aborts before a test runs.
+             MSTest.TestAdapter still carries the VSTest bridge and still sets GenerateProgramFile=false under
+             EnableMSTestRunner, so declaring the package restores what 3.10.4 arranged, entry point included,
+             and leaves the MSTest runner as it is. -->
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="FluentAssertions" Version="8.10.0" />
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Apache.Calcite.Geography\Apache.Calcite.Geography.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// Every <c>ST_GEOG_*</c> operation against the <c>ST_*</c> it mirrors, over shapes small enough and near
+    /// enough the equator that the sphere and the plane have to agree.
+    /// </summary>
+    /// <remarks>
+    /// Calcite's function is the specification with the plane swapped for the sphere — <c>ST_Within</c> is
+    /// <c>geom1.within(geom2)</c> and <c>ST_Distance</c> is <c>geom1.distance(geom2)</c>, so what these
+    /// operations mean is what JTS means by those words. A shape a few thousandths of a degree across at the
+    /// equator is a shape where the difference between a great-circle edge and a straight line in longitude
+    /// and latitude is far below any tolerance, so the two models must answer the same thing; where they do
+    /// not, this convention has a defect rather than a different reading.
+    ///
+    /// <para>The cases where the two genuinely disagree are the point of the package and are held separately,
+    /// in <see cref="GeographyFunctionTests"/>. Nothing here is near one.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyDifferentialTests
+    {
+
+        /// <summary>
+        /// Metres per degree of arc on the sphere S2 models the Earth as.
+        /// </summary>
+        const double Degree = 6371010.0 * Math.PI / 180;
+
+        /// <summary>
+        /// Shapes of every dimension, overlapping, touching, nested and disjoint.
+        /// </summary>
+        static readonly string[] shapes =
+        [
+            "POINT EMPTY",
+            "LINESTRING EMPTY",
+            "POLYGON EMPTY",
+            "POINT(0 0)",
+            "POINT(0.002 0.002)",
+            "POINT(0.004 0)",
+            "POINT(0.01 0.01)",
+            "MULTIPOINT((0.001 0.001), (0.002 0.002))",
+            "LINESTRING(0 0, 0.004 0)",
+            "LINESTRING(0 0, 0.004 0.004)",
+            "LINESTRING(0.001 -0.002, 0.001 0.002)",
+            "LINESTRING(0.001 0.001, 0.003 0.001, 0.003 0.003)",
+            "MULTILINESTRING((0 0, 0.004 0), (0 0.004, 0.004 0.004))",
+            "POLYGON((0 0, 0.004 0, 0.004 0.004, 0 0.004, 0 0))",
+            "POLYGON((0.001 0.001, 0.003 0.001, 0.003 0.003, 0.001 0.003, 0.001 0.001))",
+            "POLYGON((0.002 0.002, 0.006 0.002, 0.006 0.006, 0.002 0.006, 0.002 0.002))",
+            "POLYGON((0.01 0.01, 0.02 0.01, 0.02 0.02, 0.01 0.02, 0.01 0.01))",
+            "POLYGON((0 0, 0.006 0, 0.006 0.006, 0 0.006, 0 0), (0.002 0.002, 0.004 0.002, 0.004 0.004, 0.002 0.004, 0.002 0.002))",
+            "MULTIPOLYGON(((0 0, 0.002 0, 0.002 0.002, 0 0.002, 0 0)), ((0.004 0.004, 0.006 0.004, 0.006 0.006, 0.004 0.006, 0.004 0.004)))",
+        ];
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        /// <summary>
+        /// Runs a binary predicate over every ordered pair of shapes and reports every disagreement at once.
+        /// </summary>
+        /// <param name="geodesic"></param>
+        /// <param name="planar"></param>
+        static void Differ(Func<Geometry, Geometry, java.lang.Boolean?> geodesic, Func<Geometry, Geometry, bool> planar)
+        {
+            var differences = new List<string>();
+
+            foreach (var left in shapes)
+            {
+                foreach (var right in shapes)
+                {
+                    var a = Wkt(left);
+                    var b = Wkt(right);
+
+                    var ours = geodesic(a, b)!.booleanValue();
+                    var theirs = planar(a, b);
+
+                    if (ours != theirs)
+                        differences.Add($"{left} / {right}: ours {ours}, Calcite {theirs}");
+                }
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnWithin()
+        {
+            Differ(GeographyFunctions.Within, SpatialTypeFunctions.ST_Within);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnIntersects()
+        {
+            Differ(GeographyFunctions.Intersects, SpatialTypeFunctions.ST_Intersects);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnIsValid()
+        {
+            var differences = new List<string>();
+
+            foreach (var shape in shapes)
+            {
+                var geography = Wkt(shape);
+                var ours = GeographyFunctions.IsValid(geography)!.booleanValue();
+                var theirs = SpatialTypeFunctions.ST_IsValid(geography);
+
+                if (ours != theirs)
+                    differences.Add($"{shape}: ours {ours}, Calcite {theirs}");
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        /// <summary>
+        /// The distance in metres against the distance in degrees, which at this scale on the equator is the
+        /// same measurement in two units.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnDistance()
+        {
+            var differences = new List<string>();
+
+            foreach (var left in shapes)
+            {
+                foreach (var right in shapes)
+                {
+                    var a = Wkt(left);
+                    var b = Wkt(right);
+
+                    var ours = GeographyFunctions.Distance(a, b)!.doubleValue();
+                    var theirs = SpatialTypeFunctions.ST_Distance(a, b) * Degree;
+
+                    if (Math.Abs(ours - theirs) > Math.Max(1e-4 * theirs, 1e-6))
+                        differences.Add($"{left} / {right}: ours {ours}, Calcite {theirs}");
+                }
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        /// <summary>
+        /// <c>ST_DWithin</c> is <c>distance &lt;= d</c> and nothing else, so it is tested at a threshold that
+        /// falls between the pairs rather than on one.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeOnDWithin()
+        {
+            var differences = new List<string>();
+
+            foreach (var left in shapes)
+            {
+                foreach (var right in shapes)
+                {
+                    var a = Wkt(left);
+                    var b = Wkt(right);
+
+                    var threshold = 0.003;
+                    var ours = GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(threshold * Degree))!.booleanValue();
+                    var theirs = SpatialTypeFunctions.ST_DWithin(a, b, threshold);
+
+                    if (ours != theirs)
+                        differences.Add($"{left} / {right}: ours {ours}, Calcite {theirs}");
+                }
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
@@ -62,6 +62,34 @@ namespace Apache.Calcite.Geography.Tests
             "POLYGON((0.01 0.01, 0.02 0.01, 0.02 0.02, 0.01 0.02, 0.01 0.01))",
             "POLYGON((0 0, 0.006 0, 0.006 0.006, 0 0.006, 0 0), (0.002 0.002, 0.004 0.002, 0.004 0.004, 0.002 0.004, 0.002 0.002))",
             "MULTIPOLYGON(((0 0, 0.002 0, 0.002 0.002, 0 0.002, 0 0)), ((0.004 0.004, 0.006 0.004, 0.006 0.006, 0.004 0.006, 0.004 0.004)))",
+            // two lines meeting end to end, which is the container a line is covered by in two pieces
+            "MULTILINESTRING((0 0, 0.002 0), (0.002 0, 0.004 0))",
+            // a line half inside a polygon and half out of it
+            "LINESTRING(0.002 0.002, 0.008 0.002)",
+            // a square meeting another only at a corner
+            "POLYGON((0.004 0.004, 0.006 0.004, 0.006 0.006, 0.004 0.006, 0.004 0.004))",
+            // dimensions mixed in one geography
+            "GEOMETRYCOLLECTION(POINT(0.001 0.001), LINESTRING(0.002 0, 0.004 0))",
+            // negative coordinates, where a sign carried the wrong way would show
+            "POINT(-0.001 -0.001)",
+            "POLYGON((-0.002 -0.002, 0.002 -0.002, 0.002 0.002, -0.002 0.002, -0.002 -0.002))",
+        ];
+
+        /// <summary>
+        /// Shapes that are not valid, for the one operation that has something to say about them.
+        /// </summary>
+        /// <remarks>
+        /// They are kept out of the pairwise set deliberately: what a relation means over an invalid geometry
+        /// is not defined by either model, so a disagreement there would say nothing.
+        /// </remarks>
+        static readonly string[] degenerate =
+        [
+            // a line that goes nowhere
+            "LINESTRING(0 0, 0 0)",
+            // a bow tie, whose edges cross
+            "POLYGON((0 0, 0.004 0.004, 0.004 0, 0 0.004, 0 0))",
+            // a ring with a repeated vertex
+            "POLYGON((0 0, 0.004 0, 0.004 0, 0.004 0.004, 0 0.004, 0 0))",
         ];
 
         static Geometry Wkt(string wkt)
@@ -74,9 +102,22 @@ namespace Apache.Calcite.Geography.Tests
         /// </summary>
         /// <param name="geodesic"></param>
         /// <param name="planar"></param>
-        static void Differ(Func<Geometry, Geometry, java.lang.Boolean?> geodesic, Func<Geometry, Geometry, bool> planar)
+        /// <param name="refusals">How many of the pairs Calcite is expected to refuse to answer.</param>
+        /// <remarks>
+        /// A pair Calcite throws on has no answer to compare against and is skipped, but the number of them
+        /// is asserted rather than left open: a change that made Calcite refuse everything would otherwise
+        /// turn this suite green by emptying it. What is refused is a geometry collection reaching
+        /// <c>Geometry.relate</c>, which calls <c>checkNotGeometryCollection</c> — a multi-point, a
+        /// multi-line and a multi-polygon are not collections by that test, and <c>contains</c> does not
+        /// always reach <c>relate</c>, since it answers a rectangular container through
+        /// <c>RectangleContains</c> first. So it is particular pairs rather than particular shapes, and
+        /// <see cref="ShouldAnswerWithinOverACollectionWhereCalciteRefuses"/> pins what this convention says
+        /// about one of them.
+        /// </remarks>
+        static void Differ(Func<Geometry, Geometry, java.lang.Boolean?> geodesic, Func<Geometry, Geometry, bool> planar, int refusals)
         {
             var differences = new List<string>();
+            var refused = 0;
 
             foreach (var left in shapes)
             {
@@ -85,8 +126,19 @@ namespace Apache.Calcite.Geography.Tests
                     var a = Wkt(left);
                     var b = Wkt(right);
 
+                    bool theirs;
+
+                    try
+                    {
+                        theirs = planar(a, b);
+                    }
+                    catch (java.lang.IllegalArgumentException)
+                    {
+                        refused++;
+                        continue;
+                    }
+
                     var ours = geodesic(a, b)!.booleanValue();
-                    var theirs = planar(a, b);
 
                     if (ours != theirs)
                         differences.Add($"{left} / {right}: ours {ours}, Calcite {theirs}");
@@ -94,18 +146,52 @@ namespace Apache.Calcite.Geography.Tests
             }
 
             differences.Should().BeEmpty(string.Join("\n", differences));
+            refused.Should().Be(refusals);
         }
 
         [TestMethod]
         public void ShouldAgreeOnWithin()
         {
-            Differ(GeographyFunctions.Within, SpatialTypeFunctions.ST_Within);
+            Differ(GeographyFunctions.Within, SpatialTypeFunctions.ST_Within, refusals: 6);
         }
 
         [TestMethod]
         public void ShouldAgreeOnIntersects()
         {
-            Differ(GeographyFunctions.Intersects, SpatialTypeFunctions.ST_Intersects);
+            Differ(GeographyFunctions.Intersects, SpatialTypeFunctions.ST_Intersects, refusals: 0);
+        }
+
+        /// <summary>
+        /// A geometry collection is answered rather than refused.
+        /// </summary>
+        /// <remarks>
+        /// A deliberate divergence, and of the same kind as the one in <c>GeographyFunctions.DWithin</c>:
+        /// Calcite cannot answer this at all, and reproducing an inability buys nothing. The container is the
+        /// donut rather than a square because <c>Geometry.contains</c> answers a rectangular one through
+        /// <c>RectangleContains</c> without reaching the relate that refuses collections — the refusal is a
+        /// property of the pair and not of the collection.
+        ///
+        /// <para>The collection is a point inside the donut and a line lying along its southern edge, so
+        /// every part of it lies in the donut, and the interiors meet at the point even though the line only
+        /// touches the boundary. That is the answer JTS would give if its relate handled mixed
+        /// dimensions.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAnswerWithinOverACollectionWhereCalciteRefuses()
+        {
+            var collection = Wkt("GEOMETRYCOLLECTION(POINT(0.001 0.001), LINESTRING(0.002 0, 0.004 0))");
+            var donut = Wkt("POLYGON((0 0, 0.006 0, 0.006 0.006, 0 0.006, 0 0), (0.002 0.002, 0.004 0.002, 0.004 0.004, 0.002 0.004, 0.002 0.002))");
+
+            var refused = () => SpatialTypeFunctions.ST_Within(collection, donut);
+            refused.Should().Throw<java.lang.IllegalArgumentException>().WithMessage("*GeometryCollection*");
+
+            GeographyFunctions.Within(collection, donut)!.booleanValue().Should().BeTrue();
+
+            // the line alone touches only the boundary, so its interior never meets the interior of the
+            // donut and it is not within it — which Calcite can answer, and does answer the same way
+            var line = Wkt("LINESTRING(0.002 0, 0.004 0)");
+            GeographyFunctions.Within(line, donut)!.booleanValue().Should().BeFalse();
+            SpatialTypeFunctions.ST_Within(line, donut).Should().BeFalse();
         }
 
         [TestMethod]
@@ -113,7 +199,7 @@ namespace Apache.Calcite.Geography.Tests
         {
             var differences = new List<string>();
 
-            foreach (var shape in shapes)
+            foreach (var shape in System.Linq.Enumerable.Concat(shapes, degenerate))
             {
                 var geography = Wkt(shape);
                 var ours = GeographyFunctions.IsValid(geography)!.booleanValue();

--- a/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
@@ -123,6 +123,64 @@ namespace Apache.Calcite.Geography.Tests
         }
 
         /// <summary>
+        /// Every operator the table declares, run.
+        /// </summary>
+        /// <remarks>
+        /// Declaring an operator and running one are different things, and the gap between them is where a
+        /// body whose parameters cannot be reached from generated code hides — the <c>BigDecimal</c> that
+        /// stops Calcite's own <c>ST_DWITHIN</c> being called with <c>2.0</c> is exactly that shape of defect,
+        /// and it was found by running rather than by declaring. So each of the twelve declarations is called
+        /// here at least once, and the ones that answer a geography are wrapped in one that answers a value a
+        /// result set can carry.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRunEveryOperator()
+        {
+            var cases = new (string Sql, object Expected)[]
+            {
+                ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'))", true),
+                ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMWKT('POINT(0 0)'))", true),
+                ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMTEXT('POINT(0 0)', 4326))", true),
+                ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMWKT('POINT(0 0)', 4326))", true),
+                ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMGEOJSON('{\"type\":\"Point\",\"coordinates\":[0,0]}'))", true),
+                ("ST_GEOG_ISVALID(ST_GEOM_ASGEOG(ST_GEOMFROMTEXT('POINT(0 0)')))", true),
+                ("ST_ASTEXT(ST_GEOG_ASGEOM(ST_GEOG_GEOMFROMTEXT('POINT(0 0)')))", "POINT (0 0)"),
+                ("ST_GEOG_DISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(0 0)'))", 0.0),
+                ("ST_GEOG_DWITHIN(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'), 200000.0)", true),
+                ("ST_GEOG_WITHIN(ST_GEOG_GEOMFROMTEXT('POINT(1 1)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+                ("ST_GEOG_INTERSECTS(ST_GEOG_GEOMFROMTEXT('POINT(1 1)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+                ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+            };
+
+            var failures = new List<string>();
+
+            foreach (var (sql, expected) in cases)
+            {
+                try
+                {
+                    var rows = Run($"SELECT {sql}");
+                    var answer = rows[0][0];
+
+                    var same = expected switch
+                    {
+                        bool b => answer is java.lang.Boolean j && j.booleanValue() == b,
+                        double d => answer is java.lang.Number n && Math.Abs(n.doubleValue() - d) < 1e-6,
+                        _ => Equals(answer?.ToString(), expected.ToString()),
+                    };
+
+                    if (same == false)
+                        failures.Add($"{sql}: answered {answer}, wanted {expected}");
+                }
+                catch (Exception e)
+                {
+                    failures.Add($"{sql}: {e.Message}");
+                }
+            }
+
+            failures.Should().BeEmpty(string.Join("\n", failures));
+        }
+
+        /// <summary>
         /// A table of two rows, each holding a geography a degree apart on the equator.
         /// </summary>
         sealed class GeographyTable : AbstractTable, ScannableTable

--- a/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Geography.Rel.Type;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite;
+using org.apache.calcite.adapter.enumerable;
+using org.apache.calcite.jdbc;
+using org.apache.calcite.linq4j;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.tools;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// A geography through a whole statement — planned, code-generated, compiled and run.
+    /// </summary>
+    /// <remarks>
+    /// The design issue left this open: validation and code generation were measured and a full run was not.
+    /// It runs. The engine here is Calcite's own <c>EnumerableConvention</c>, so the block is Java source
+    /// compiled by Janino, which is the harder of the two cases — the body is a .NET method and Janino has to
+    /// resolve the <c>cli.</c>-prefixed name IKVM gives a CLR class, which it could not do under IKVM 8.14.0
+    /// or 8.15.0.
+    /// </remarks>
+    [TestClass]
+    public class GeographyExecutionTests
+    {
+
+        /// <summary>
+        /// Plans the given query into <c>EnumerableConvention</c> and runs it, returning each row's columns
+        /// as they arrive.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static List<object?[]> Run(string sql)
+        {
+            java.lang.Class.forName("org.apache.calcite.jdbc.Driver");
+
+            using var connection = java.sql.DriverManager.getConnection("jdbc:calcite:");
+            var calcite = (CalciteConnection)connection.unwrap((java.lang.Class)typeof(CalciteConnection));
+            var schema = calcite.getRootSchema();
+            schema.add("GEO", new GeographyTable());
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(schema)
+                .operatorTable(GeographyFixture.OperatorTable())
+                .programs(Programs.standard())
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+            var logical = planner.rel(planner.validate(planner.parse(sql))).project();
+            var physical = planner.transform(0, logical.getTraitSet().replace(EnumerableConvention.INSTANCE), logical);
+
+            var runner = (RelRunner)connection.unwrap((java.lang.Class)typeof(RelRunner));
+            using var statement = runner.prepareStatement(physical);
+            var results = statement.executeQuery();
+            var count = results.getMetaData().getColumnCount();
+
+            var rows = new List<object?[]>();
+
+            while (results.next())
+            {
+                var row = new object?[count];
+                for (var i = 0; i < count; i++)
+                    row[i] = results.getObject(i + 1);
+
+                rows.Add(row);
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// A constructor and a measurement, with no table involved.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRunAConstructorAndAMeasurement()
+        {
+            var rows = Run("SELECT ST_GEOG_DISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'))");
+
+            rows.Count.Should().Be(1);
+            ((java.lang.Number)rows[0][0]!).doubleValue().Should().BeApproximately(6371010.0 * Math.PI / 180, 0.001);
+        }
+
+        /// <summary>
+        /// A geography column, read from a table and carried into a predicate.
+        /// </summary>
+        /// <remarks>
+        /// The distance is written <c>200000.0</c>, which is <c>DECIMAL(7, 1)</c> and arrives at the body as
+        /// a <c>BigDecimal</c>. Calcite's own <c>ST_DWITHIN</c> cannot be called that way at all — it takes a
+        /// <c>double</c> and Janino refuses the call; see <c>GeographyFunctions.DWithin</c>.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRunAPredicateOverAGeographyColumn()
+        {
+            var rows = Run("SELECT ID FROM GEO WHERE ST_GEOG_DWITHIN(GEOG, ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), 200000.0)");
+
+            rows.Count.Should().Be(1);
+            ((java.lang.Number)rows[0][0]!).intValue().Should().Be(1);
+        }
+
+        /// <summary>
+        /// The crossing, run rather than validated: the same object comes out the other side and Calcite's
+        /// planar function measures it in degrees.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRunTheCrossingIntoCalcitesOwnFunction()
+        {
+            var rows = Run("SELECT ST_DISTANCE(ST_GEOG_ASGEOM(GEOG), ST_GEOG_ASGEOM(GEOG)) FROM GEO WHERE ID = 1");
+
+            rows.Count.Should().Be(1);
+            ((java.lang.Number)rows[0][0]!).doubleValue().Should().Be(0);
+        }
+
+        /// <summary>
+        /// A table of two rows, each holding a geography a degree apart on the equator.
+        /// </summary>
+        sealed class GeographyTable : AbstractTable, ScannableTable
+        {
+
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .add("GEOG", GeographyTypes.Of(typeFactory))
+                    .build();
+            }
+
+            public Enumerable scan(DataContext root)
+            {
+                return Linq4j.asEnumerable(java.util.Arrays.asList([
+                    new object[] { java.lang.Integer.valueOf(1), Geography("POINT(0.5 0)") },
+                    new object[] { java.lang.Integer.valueOf(2), Geography("POINT(20 0)") },
+                ]));
+            }
+
+            static Geometry Geography(string wkt)
+            {
+                return org.apache.calcite.runtime.SpatialTypeUtils.fromWkt(wkt);
+            }
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyFixture.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyFixture.cs
@@ -1,0 +1,88 @@
+using Apache.Calcite.Geography.Rel.Type;
+using Apache.Calcite.Geography.Sql;
+
+using org.apache.calcite.jdbc;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.fun;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.sql.util;
+using org.apache.calcite.tools;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// A schema holding one geography column and one geometry column, and a planner that can see Calcite's
+    /// spatial functions and this package's alongside them.
+    /// </summary>
+    /// <remarks>
+    /// The two columns are the whole of the fixture, because the property under test is that the same query
+    /// text is accepted over one and refused over the other.
+    /// </remarks>
+    static class GeographyFixture
+    {
+
+        /// <summary>
+        /// The operator table a host chains, with Calcite's spatial functions in it so that <c>ST_DISTANCE</c>
+        /// is a name that resolves at all.
+        /// </summary>
+        public static SqlOperatorTable OperatorTable()
+        {
+            return SqlOperatorTables.chain(
+                SqlStdOperatorTable.instance(),
+                new SqlSpatialTypeOperatorTable(),
+                GeographyOperatorTable.Instance());
+        }
+
+        /// <summary>
+        /// Returns a type factory of the kind a statement is planned with.
+        /// </summary>
+        public static RelDataTypeFactory TypeFactory()
+        {
+            return new JavaTypeFactoryImpl();
+        }
+
+        /// <summary>
+        /// Parses and validates the given query against the fixture, and returns the type of its row.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        public static RelDataType Validate(string sql)
+        {
+            var schema = Frameworks.createRootSchema(true);
+            schema.add("GEO", new GeographyTable());
+
+            var config = Frameworks.newConfigBuilder()
+                .defaultSchema(schema)
+                .operatorTable(OperatorTable())
+                .build();
+
+            var planner = Frameworks.getPlanner(config);
+
+            // Pair's left and right fields are shadowed by its static methods of the same name, so C#
+            // resolves either to a method group; a Pair is a Map.Entry and getValue is the way in
+            return (RelDataType)planner.validateAndGetType(planner.parse(sql)).getValue();
+        }
+
+        /// <summary>
+        /// A table with a geography column and a geometry column.
+        /// </summary>
+        sealed class GeographyTable : AbstractTable
+        {
+
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                return typeFactory.builder()
+                    .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .add("GEOG", GeographyTypes.Of(typeFactory))
+                    .add("GEOM", GeographyTypes.GeometryOf(typeFactory))
+                    .build();
+            }
+
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
@@ -220,6 +220,80 @@ namespace Apache.Calcite.Geography.Tests
             org.apache.calcite.runtime.SpatialTypeFunctions.ST_Within(point, polygon).Should().BeFalse();
         }
 
+        /// <summary>
+        /// Two points either side of the antimeridian are a fifth of a degree apart, not three hundred and
+        /// fifty-nine and four fifths.
+        /// </summary>
+        /// <remarks>
+        /// The antimeridian is one of the four places the design issue names as having to be measured against
+        /// a live store before any of this may recheck a pushed-down predicate. What is held here is the
+        /// nearer half of that: that this convention is on the right side of the seam at all, and that the
+        /// planar reading is not merely a different number but a different journey.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureAcrossTheAntimeridian()
+        {
+            var west = Wkt("POINT(179.9 0)");
+            var east = Wkt("POINT(-179.9 0)");
+
+            GeographyFunctions.Distance(west, east)!.doubleValue().Should().BeApproximately(0.2 * Degree, 0.001);
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(west, east).Should().BeApproximately(359.8, 1e-9);
+        }
+
+        /// <summary>
+        /// The shortest way between two places on opposite meridians near a pole is over the pole.
+        /// </summary>
+        [TestMethod]
+        public void ShouldMeasureOverThePole()
+        {
+            var here = Wkt("POINT(0 89.9)");
+            var there = Wkt("POINT(180 89.9)");
+
+            GeographyFunctions.Distance(here, there)!.doubleValue().Should().BeApproximately(0.2 * Degree, 0.001);
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(here, there).Should().BeApproximately(180, 1e-9);
+        }
+
+        /// <summary>
+        /// The pole has a longitude in the coordinates and no longitude on the Earth, so every spelling of it
+        /// is the same place.
+        /// </summary>
+        [TestMethod]
+        public void ShouldTreatEverySpellingOfThePoleAsOnePlace()
+        {
+            var pole = Wkt("POINT(0 90)");
+            var alsoPole = Wkt("POINT(180 90)");
+
+            GeographyFunctions.Distance(pole, alsoPole)!.doubleValue().Should().Be(0);
+            GeographyFunctions.Intersects(pole, alsoPole)!.booleanValue().Should().BeTrue();
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(pole, alsoPole).Should().Be(180);
+        }
+
+        /// <summary>
+        /// A polygon written across the antimeridian, where the two readings are not merely different but
+        /// exact inversions of one another.
+        /// </summary>
+        /// <remarks>
+        /// The ring runs from longitude 179 east to -179, which on the sphere is a two-degree box straddling
+        /// the seam and in the plane is a three-hundred-and-fifty-eight-degree band that is everything except
+        /// that box. So each of these three points is inside one polygon and outside the other, and there is
+        /// no tolerance and no reprojection that reconciles them. This is why the two readings need types
+        /// that cannot be confused.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadAPolygonAcrossTheAntimeridianInsideOutFromCalcite()
+        {
+            var box = Wkt("POLYGON((179 -1, -179 -1, -179 1, 179 1, 179 -1))");
+
+            foreach (var wkt in new[] { "POINT(179.5 0)", "POINT(-179.5 0)" })
+            {
+                GeographyFunctions.Within(Wkt(wkt), box)!.booleanValue().Should().BeTrue(wkt);
+                org.apache.calcite.runtime.SpatialTypeFunctions.ST_Within(Wkt(wkt), box).Should().BeFalse(wkt);
+            }
+
+            GeographyFunctions.Within(Wkt("POINT(0 0)"), box)!.booleanValue().Should().BeFalse();
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Within(Wkt("POINT(0 0)"), box).Should().BeTrue();
+        }
+
         [TestMethod]
         public void ShouldAnswerIsValid()
         {

--- a/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
@@ -1,0 +1,243 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// What the bodies behind the operators compute.
+    /// </summary>
+    /// <remarks>
+    /// Called directly rather than through a query, because what is under test is the geodesy and not the
+    /// plumbing. Where a case has a planar answer that differs, Calcite's own answer is asserted next to it:
+    /// the disagreement is the reason this package exists, so a test that only pinned our number would not
+    /// say anything.
+    /// </remarks>
+    [TestClass]
+    public class GeographyFunctionTests
+    {
+
+        /// <summary>
+        /// The radius S2 models the Earth with, in metres.
+        /// </summary>
+        const double EarthRadiusMeters = 6371010.0;
+
+        /// <summary>
+        /// One degree of arc on that sphere, in metres.
+        /// </summary>
+        const double Degree = EarthRadiusMeters * Math.PI / 180;
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        [TestMethod]
+        public void ShouldReadWkt()
+        {
+            var geography = Wkt("POINT(1 2)");
+
+            geography.getGeometryType().Should().Be("Point");
+            geography.getCoordinate().getX().Should().Be(1);
+            geography.getCoordinate().getY().Should().Be(2);
+            geography.getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldReadGeoJson()
+        {
+            var geography = GeographyFunctions.FromGeoJson("{\"type\":\"Point\",\"coordinates\":[1,2]}");
+
+            geography.Should().NotBeNull();
+            geography!.getCoordinate().getX().Should().Be(1);
+            geography.getCoordinate().getY().Should().Be(2);
+            geography.getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        /// <summary>
+        /// The crossings are re-typings and nothing else happens at run time.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCrossWithoutTouchingTheValue()
+        {
+            var geography = Wkt("POINT(1 2)");
+
+            GeographyFunctions.AsGeometry(geography).Should().BeSameAs(geography);
+            GeographyFunctions.AsGeography(geography).Should().BeSameAs(geography);
+        }
+
+        /// <summary>
+        /// A degree of longitude on the equator is a degree of arc, and the answer is in metres.
+        /// </summary>
+        [TestMethod]
+        public void ShouldMeasureADegreeOfArcInMetres()
+        {
+            var distance = GeographyFunctions.Distance(Wkt("POINT(0 0)"), Wkt("POINT(1 0)"));
+
+            distance.Should().NotBeNull();
+            distance!.doubleValue().Should().BeApproximately(Degree, 0.001);
+        }
+
+        /// <summary>
+        /// The same call under Calcite answers one — the number of degrees — and the difference is not a
+        /// scale factor.
+        /// </summary>
+        /// <remarks>
+        /// A degree of longitude is a degree of arc on the equator and about a hundred and eleven metres less
+        /// than that at fifty degrees north, while the planar answer is one in both places. No conversion of
+        /// the result recovers the other, and no transformation of the inputs does either.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldDisagreeWithThePlanarDistanceByMoreThanAScaleFactor()
+        {
+            var equator = GeographyFunctions.Distance(Wkt("POINT(0 0)"), Wkt("POINT(1 0)"))!.doubleValue();
+            var north = GeographyFunctions.Distance(Wkt("POINT(0 50)"), Wkt("POINT(1 50)"))!.doubleValue();
+
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(Wkt("POINT(0 0)"), Wkt("POINT(1 0)")).Should().Be(1);
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(Wkt("POINT(0 50)"), Wkt("POINT(1 50)")).Should().Be(1);
+
+            north.Should().BeLessThan(equator);
+            (equator / north).Should().BeApproximately(1 / Math.Cos(50 * Math.PI / 180), 0.001);
+        }
+
+        [TestMethod]
+        public void ShouldMeasureZeroBetweenIntersectingGeographies()
+        {
+            GeographyFunctions.Distance(Wkt("POINT(5 5)"), Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"))!.doubleValue().Should().Be(0);
+        }
+
+        /// <summary>
+        /// The distance from a point to a meridian edge one degree of longitude away.
+        /// </summary>
+        /// <remarks>
+        /// A meridian is a great circle, so the arc from the point to it is
+        /// <c>asin(sin(1°) · cos(5°))</c> exactly.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureToTheNearestEdgeOfAPolygon()
+        {
+            var expected = Math.Asin(Math.Sin(Math.PI / 180) * Math.Cos(5 * Math.PI / 180)) * EarthRadiusMeters;
+            var distance = GeographyFunctions.Distance(Wkt("POINT(11 5)"), Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"));
+
+            distance!.doubleValue().Should().BeApproximately(expected, 0.5);
+        }
+
+        /// <summary>
+        /// The nearest edge is the one that closes the ring.
+        /// </summary>
+        /// <remarks>
+        /// A ring arrives from JTS with its first coordinate repeated at the end, and dropping that repeat —
+        /// which is what an S2 loop wants — costs the ring its last edge. Nothing else here notices: the
+        /// containment tests go through the loop, which is built from the de-duplicated vertices and closes
+        /// itself, so only a distance or an intersection nearest that one edge tells the two apart. Without
+        /// the closing edge this answers the distance to a corner instead, some five times larger.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureToTheEdgeThatClosesARing()
+        {
+            var expected = Math.Asin(Math.Sin(Math.PI / 180) * Math.Cos(5 * Math.PI / 180)) * EarthRadiusMeters;
+            var distance = GeographyFunctions.Distance(Wkt("POINT(-1 5)"), Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"));
+
+            distance!.doubleValue().Should().BeApproximately(expected, 0.5);
+        }
+
+        [TestMethod]
+        public void ShouldAnswerDWithinAgainstTheDistance()
+        {
+            var a = Wkt("POINT(0 0)");
+            var b = Wkt("POINT(1 0)");
+
+            GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(Degree + 1))!.booleanValue().Should().BeTrue();
+            GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(Degree - 1))!.booleanValue().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerWithinAgainstAPolygon()
+        {
+            var polygon = Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+
+            GeographyFunctions.Within(Wkt("POINT(5 5)"), polygon)!.booleanValue().Should().BeTrue();
+            GeographyFunctions.Within(Wkt("POINT(15 5)"), polygon)!.booleanValue().Should().BeFalse();
+            GeographyFunctions.Within(Wkt("POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))"), polygon)!.booleanValue().Should().BeTrue();
+            GeographyFunctions.Within(polygon, Wkt("POINT(5 5)"))!.booleanValue().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerIntersects()
+        {
+            var polygon = Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+
+            GeographyFunctions.Intersects(polygon, Wkt("POLYGON((5 5, 15 5, 15 15, 5 15, 5 5))"))!.booleanValue().Should().BeTrue();
+            GeographyFunctions.Intersects(polygon, Wkt("POLYGON((20 20, 30 20, 30 30, 20 30, 20 20))"))!.booleanValue().Should().BeFalse();
+            GeographyFunctions.Intersects(polygon, Wkt("LINESTRING(-5 5, 5 5)"))!.booleanValue().Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A polygon edge is a great-circle arc, and a great-circle arc between two points at the same
+        /// latitude does not follow that parallel.
+        /// </summary>
+        /// <remarks>
+        /// This is the disagreement that no scale factor and no reprojection recovers, and it is why the two
+        /// readings need types that cannot be confused. The northern edge of the square runs from ten degrees
+        /// north at longitude zero to ten degrees north at longitude ten; as a straight line in longitude and
+        /// latitude it stays on the parallel, and as a great circle it reaches about ten degrees and two and
+        /// a quarter minutes at the midpoint. A point between the two is inside one polygon and outside the
+        /// other — not a different distance, a different answer.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldFollowAGreatCircleEdgeWhereCalciteFollowsAParallel()
+        {
+            var polygon = Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+            var point = Wkt("POINT(5 10.02)");
+
+            GeographyFunctions.Within(point, polygon)!.booleanValue().Should().BeTrue();
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Within(point, polygon).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerIsValid()
+        {
+            GeographyFunctions.IsValid(Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"))!.booleanValue().Should().BeTrue();
+            GeographyFunctions.IsValid(Wkt("POINT(1 2)"))!.booleanValue().Should().BeTrue();
+            GeographyFunctions.IsValid(Wkt("LINESTRING(0 0, 1 1)"))!.booleanValue().Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A coordinate that is not a place on the Earth. JTS has no opinion, because a plane has no edges.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseACoordinateThatIsNotOnTheEarth()
+        {
+            var polygon = Wkt("POLYGON((0 0, 400 0, 400 10, 0 10, 0 0))");
+
+            GeographyFunctions.IsValid(polygon)!.booleanValue().Should().BeFalse();
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_IsValid(polygon).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            var geography = Wkt("POINT(0 0)");
+
+            GeographyFunctions.FromWkt(null).Should().BeNull();
+            GeographyFunctions.FromGeoJson(null).Should().BeNull();
+            GeographyFunctions.AsGeometry(null).Should().BeNull();
+            GeographyFunctions.AsGeography(null).Should().BeNull();
+            GeographyFunctions.Distance(geography, null).Should().BeNull();
+            GeographyFunctions.Distance(null, geography).Should().BeNull();
+            GeographyFunctions.DWithin(geography, geography, null).Should().BeNull();
+            GeographyFunctions.Within(null, geography).Should().BeNull();
+            GeographyFunctions.Intersects(geography, null).Should().BeNull();
+            GeographyFunctions.IsValid(null).Should().BeNull();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
@@ -50,6 +50,25 @@ namespace Apache.Calcite.Geography.Tests
             geography.getSRID().Should().Be(GeographyFunctions.Wgs84);
         }
 
+        /// <summary>
+        /// The SRID a caller may name is the only one a geography can be in, and any other is refused rather
+        /// than ignored.
+        /// </summary>
+        [TestMethod]
+        public void ShouldReadWktWithAnSrid()
+        {
+            var geography = GeographyFunctions.FromWkt("POINT(1 2)", java.lang.Integer.valueOf(GeographyFunctions.Wgs84));
+
+            geography.Should().NotBeNull();
+            geography!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+
+            var refused = () => GeographyFunctions.FromWkt("POINT(1 2)", java.lang.Integer.valueOf(3857));
+            refused.Should().Throw<java.lang.IllegalArgumentException>().WithMessage("*3857*");
+
+            GeographyFunctions.FromWkt(null, java.lang.Integer.valueOf(GeographyFunctions.Wgs84)).Should().BeNull();
+            GeographyFunctions.FromWkt("POINT(1 2)", null).Should().BeNull();
+        }
+
         [TestMethod]
         public void ShouldReadGeoJson()
         {

--- a/src/Apache.Calcite.Geography.Tests/GeographyRandomDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyRandomDifferentialTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The same comparison <see cref="GeographyDifferentialTests"/> makes, over shapes nobody chose.
+    /// </summary>
+    /// <remarks>
+    /// The hand-written set is a set of cases someone thought of, and every defect it found was one that had
+    /// not been thought of until it was written down. This generates instead, and generates on a lattice
+    /// rather than from arbitrary doubles, because the interesting cases are the coincidences — a vertex
+    /// exactly on an edge, two edges collinear, two polygons sharing a corner — and random doubles never
+    /// produce one. A seven-by-seven grid produces them constantly.
+    ///
+    /// <para>Everything stays inside a small box on the equator, where a great-circle edge and a straight
+    /// line in longitude and latitude cannot be told apart, so any disagreement is a defect here rather than
+    /// a difference of model. The seed is fixed, so a failure is reproducible and reportable rather than a
+    /// thing that happened once.</para>
+    ///
+    /// <para>This is what stands in for the exact boolean operations. <c>S2BooleanOperation</c> would settle
+    /// <c>ST_GEOG_WITHIN</c> by construction, and it is not reachable: the version of S2 published to Maven
+    /// Central is the 2021 one, which does not have it, and the current source is compiled to Java 11, which
+    /// IKVM does not read. Porting it is a port of four thousand lines and the <c>S2Builder</c>,
+    /// <c>S2BuilderGraph</c>, <c>S2CrossingEdgesQuery</c> and <c>primitives</c> machinery underneath it. So
+    /// the relation here is this project's own, and what makes it trustworthy is the size of the oracle
+    /// rather than the pedigree of the algorithm.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyRandomDifferentialTests
+    {
+
+        /// <summary>
+        /// Degrees per step of the lattice.
+        /// </summary>
+        const double Unit = 0.001;
+
+        /// <summary>
+        /// How far the lattice runs either side of the origin, in steps.
+        /// </summary>
+        const int Extent = 3;
+
+        /// <summary>
+        /// Metres per degree of arc on the sphere S2 models the Earth as.
+        /// </summary>
+        const double Degree = 6371010.0 * Math.PI / 180;
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static string Ordinate(int step)
+        {
+            return (step * Unit).ToString("0.######", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        static string Point(Random random)
+        {
+            return $"{Ordinate(random.Next(-Extent, Extent + 1))} {Ordinate(random.Next(-Extent, Extent + 1))}";
+        }
+
+        /// <summary>
+        /// A rectangle on the lattice, or <c>null</c> if the corners drawn do not make one.
+        /// </summary>
+        static (int Left, int Bottom, int Right, int Top)? Rectangle(Random random)
+        {
+            var x0 = random.Next(-Extent, Extent + 1);
+            var x1 = random.Next(-Extent, Extent + 1);
+            var y0 = random.Next(-Extent, Extent + 1);
+            var y1 = random.Next(-Extent, Extent + 1);
+
+            if (x0 == x1 || y0 == y1)
+                return null;
+
+            return (Math.Min(x0, x1), Math.Min(y0, y1), Math.Max(x0, x1), Math.Max(y0, y1));
+        }
+
+        static string Ring((int Left, int Bottom, int Right, int Top) r)
+        {
+            return $"({Ordinate(r.Left)} {Ordinate(r.Bottom)}, {Ordinate(r.Right)} {Ordinate(r.Bottom)}, "
+                + $"{Ordinate(r.Right)} {Ordinate(r.Top)}, {Ordinate(r.Left)} {Ordinate(r.Top)}, "
+                + $"{Ordinate(r.Left)} {Ordinate(r.Bottom)})";
+        }
+
+        /// <summary>
+        /// A shape of some kind, or <c>null</c> when the draw did not make one.
+        /// </summary>
+        /// <remarks>
+        /// The hole of a donut is inset from its own shell rather than drawn on its own, because a hole drawn
+        /// independently is almost never inside the shell and the shape would be thrown away as invalid — the
+        /// case would live in the generator and never reach the comparison.
+        /// </remarks>
+        static string? Shape(Random random)
+        {
+            switch (random.Next(7))
+            {
+                case 0:
+                    return $"POINT({Point(random)})";
+                case 1:
+                    return $"MULTIPOINT(({Point(random)}), ({Point(random)}))";
+                case 2:
+                    return $"LINESTRING({Point(random)}, {Point(random)})";
+                case 3:
+                    return $"LINESTRING({Point(random)}, {Point(random)}, {Point(random)})";
+                case 4:
+                    return Rectangle(random) is { } one ? $"POLYGON({Ring(one)})" : null;
+                case 5:
+                    return Rectangle(random) is { } first && Rectangle(random) is { } second
+                        ? $"MULTIPOLYGON(({Ring(first)}), ({Ring(second)}))"
+                        : null;
+                default:
+                    if (Rectangle(random) is not { } shell)
+                        return null;
+
+                    if (shell.Right - shell.Left < 3 || shell.Top - shell.Bottom < 3)
+                        return $"POLYGON({Ring(shell)})";
+
+                    var hole = (shell.Left + 1, shell.Bottom + 1, shell.Right - 1, shell.Top - 1);
+                    return $"POLYGON({Ring(shell)}, {Ring(hole)})";
+            }
+        }
+
+        /// <summary>
+        /// Runs every operation over a few thousand generated pairs and reports every disagreement at once.
+        /// </summary>
+        /// <remarks>
+        /// Only shapes Calcite calls valid are compared: what a relation means over an invalid geometry is
+        /// not defined by either model, so a disagreement there would say nothing. Validity itself is
+        /// compared over everything generated, valid or not, because that operation does have an answer for
+        /// both.
+        ///
+        /// <para>The counts are asserted as well as the disagreements. A generator that quietly stopped
+        /// producing polygons, or a Calcite that started refusing every pair, would otherwise leave this
+        /// green by leaving it empty.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAgreeOverGeneratedShapes()
+        {
+            var differences = new List<string>();
+            var compared = 0;
+            var refused = 0;
+
+            foreach (var seed in new[] { 1, 2, 3, 4, 5, 6 })
+            {
+                var random = new Random(seed);
+
+                for (var i = 0; i < 5000 && differences.Count < 10; i++)
+                {
+                    if (Shape(random) is not { } left || Shape(random) is not { } right)
+                        continue;
+
+                    var a = Wkt(left);
+                    var b = Wkt(right);
+
+                    var ourValidity = GeographyFunctions.IsValid(a)!.booleanValue();
+                    var theirValidity = SpatialTypeFunctions.ST_IsValid(a);
+
+                    if (ourValidity != theirValidity)
+                        differences.Add($"ST_ISVALID {left}: ours {ourValidity}, Calcite {theirValidity}");
+
+                    if (theirValidity == false || SpatialTypeFunctions.ST_IsValid(b) == false)
+                        continue;
+
+                    compared++;
+
+                    Compare(differences, "INTERSECTS", left, right,
+                        () => GeographyFunctions.Intersects(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Intersects(a, b), ref refused);
+
+                    Compare(differences, "WITHIN", left, right,
+                        () => GeographyFunctions.Within(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Within(a, b), ref refused);
+
+                    Compare(differences, "DWITHIN", left, right,
+                        () => GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(0.0025 * Degree))!.booleanValue(),
+                        () => SpatialTypeFunctions.ST_DWithin(a, b, 0.0025), ref refused);
+
+                    var ours = GeographyFunctions.Distance(a, b)!.doubleValue();
+                    var theirs = SpatialTypeFunctions.ST_Distance(a, b) * Degree;
+
+                    if (Math.Abs(ours - theirs) > Math.Max(1e-4 * theirs, 1e-6))
+                        differences.Add($"DISTANCE {left} / {right}: ours {ours}, Calcite {theirs}");
+                }
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+            compared.Should().BeGreaterThan(10000);
+        }
+
+        static void Compare(List<string> differences, string what, string left, string right, Func<bool> geodesic, Func<bool> planar, ref int refused)
+        {
+            bool theirs;
+
+            try
+            {
+                theirs = planar();
+            }
+            catch (java.lang.IllegalArgumentException)
+            {
+                // Geometry.relate will not take a geometry collection; there is nothing to compare against
+                refused++;
+                return;
+            }
+
+            var ours = geodesic();
+
+            if (ours != theirs)
+                differences.Add($"{what} {left} / {right}: ours {ours}, Calcite {theirs}");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyTypeTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyTypeTests.cs
@@ -1,0 +1,133 @@
+using Apache.Calcite.Geography.Rel.Type;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.jdbc;
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql.type;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// What the <c>GEOGRAPHY</c> type reports about itself.
+    /// </summary>
+    [TestClass]
+    public class GeographyTypeTests
+    {
+
+        [TestMethod]
+        public void ShouldReportGeographyAsItsTypeString()
+        {
+            var type = GeographyTypes.Of(GeographyFixture.TypeFactory());
+
+            type.getFullTypeString().Should().Be("GEOGRAPHY");
+        }
+
+        [TestMethod]
+        public void ShouldReportOtherAsItsSqlTypeName()
+        {
+            var type = GeographyTypes.Of(GeographyFixture.TypeFactory());
+
+            type.getSqlTypeName().Should().BeSameAs(SqlTypeName.OTHER);
+        }
+
+        /// <summary>
+        /// The runtime carrier is an ordinary JTS geometry, asked either way round.
+        /// </summary>
+        /// <remarks>
+        /// This is what makes the type free: there is no new class, so nothing new for code generation to
+        /// name and nothing to convert at a boundary.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReportJtsGeometryAsItsJavaClass()
+        {
+            var typeFactory = new JavaTypeFactoryImpl();
+            var type = GeographyTypes.Of(typeFactory);
+
+            ((RelDataTypeFactoryImpl.JavaType)type).getJavaClass().Should().BeSameAs((java.lang.Class)typeof(Geometry));
+            typeFactory.getJavaClass(type).Should().BeSameAs((java.lang.Class)typeof(Geometry));
+        }
+
+        /// <summary>
+        /// The digest is what keeps the two apart, and it is the only thing that does.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBeDistinctFromCalcitesGeometryType()
+        {
+            var typeFactory = GeographyFixture.TypeFactory();
+            var geography = GeographyTypes.Of(typeFactory);
+            var geometry = GeographyTypes.GeometryOf(typeFactory);
+
+            geometry.getFullTypeString().Should().Be("JavaType(class org.locationtech.jts.geom.Geometry)");
+            geography.getFullTypeString().Should().NotBe(geometry.getFullTypeString());
+            geography.Equals(geometry).Should().BeFalse();
+            geometry.getSqlTypeName().Should().BeSameAs(SqlTypeName.GEOMETRY);
+        }
+
+        /// <summary>
+        /// One instance, however many times it is asked for and by however many type factories.
+        /// </summary>
+        /// <remarks>
+        /// <c>RelDataTypeFactoryImpl</c> interns types on a static cache keyed by digest, and
+        /// <c>GeographyTypes.Of</c> goes through <c>copyType</c> to reach it, since <c>canonize</c> is
+        /// protected.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldBeCanonizedToOneInstance()
+        {
+            var typeFactory = GeographyFixture.TypeFactory();
+
+            GeographyTypes.Of(typeFactory).Should().BeSameAs(GeographyTypes.Of(typeFactory));
+            GeographyTypes.Of(GeographyFixture.TypeFactory()).Should().BeSameAs(GeographyTypes.Of(typeFactory));
+        }
+
+        [TestMethod]
+        public void ShouldBeNullable()
+        {
+            GeographyTypes.Of(GeographyFixture.TypeFactory()).isNullable().Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Asking for the type <c>NOT NULL</c> loses the marking.
+        /// </summary>
+        /// <remarks>
+        /// <c>RelDataTypeFactoryImpl.copySimpleType</c> answers a change of nullability on any
+        /// <c>JavaType</c> with a plain <c>new JavaType(clazz, nullable)</c>, which is not this subclass. The
+        /// type is nullable so that the path everything actually takes —
+        /// <c>createTypeWithNullability(geography, true)</c> — finds nothing to change and returns it
+        /// unchanged, and so that no return type strategy here may run through
+        /// <c>SqlTypeTransforms.TO_NULLABLE</c>. Recorded rather than fixed: the copy is Calcite's and there
+        /// is no hook in it.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldLoseTheMarkingWhenMadeNotNullable()
+        {
+            var typeFactory = GeographyFixture.TypeFactory();
+            var geography = GeographyTypes.Of(typeFactory);
+
+            typeFactory.createTypeWithNullability(geography, true).Should().BeSameAs(geography);
+
+            var notNull = typeFactory.createTypeWithNullability(geography, false);
+            GeographyTypes.IsGeography(notNull).Should().BeFalse();
+            notNull.getSqlTypeName().Should().BeSameAs(SqlTypeName.GEOMETRY);
+        }
+
+        [TestMethod]
+        public void ShouldTellTheTwoApart()
+        {
+            var typeFactory = GeographyFixture.TypeFactory();
+
+            GeographyTypes.IsGeography(GeographyTypes.Of(typeFactory)).Should().BeTrue();
+            GeographyTypes.IsGeometry(GeographyTypes.Of(typeFactory)).Should().BeFalse();
+            GeographyTypes.IsGeography(GeographyTypes.GeometryOf(typeFactory)).Should().BeFalse();
+            GeographyTypes.IsGeometry(GeographyTypes.GeometryOf(typeFactory)).Should().BeTrue();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyValidationTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyValidationTests.cs
@@ -1,0 +1,190 @@
+using System;
+
+using Apache.Calcite.Geography.Rel.Type;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql.type;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// What the validator makes of a call over a geography column.
+    /// </summary>
+    /// <remarks>
+    /// The central property is the first test here. Calcite's spatial library is a set of reflective bindings
+    /// over <c>org.locationtech.jts.geom.Geometry</c>, and routine resolution refuses to pass a geography to
+    /// one — the harmless accessors included. Without that, a geodesic value would answer in degrees, in a
+    /// different ordering, with no error anywhere.
+    /// </remarks>
+    [TestClass]
+    public class GeographyValidationTests
+    {
+
+        /// <summary>
+        /// Validates the given query, requires it to be refused, and returns every message in the chain.
+        /// </summary>
+        /// <remarks>
+        /// The chain, because the validator wraps: a signature error from an operand checker arrives inside a
+        /// <c>ValidationException</c> and names the operator only further down. IKVM makes a Java throwable a
+        /// <see cref="Exception"/>, so its cause is the inner exception.
+        /// </remarks>
+        static string Refuse(string sql)
+        {
+            var thrown = ((Action)(() => GeographyFixture.Validate(sql))).Should().Throw<Exception>().Which;
+            var text = "";
+
+            for (Exception? current = thrown; current is not null; current = current.InnerException)
+                text += current.Message + "\n";
+
+            return text;
+        }
+
+        /// <summary>
+        /// Validates the given query and returns the type of the one column it selects.
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static RelDataType Column(string sql)
+        {
+            var row = GeographyFixture.Validate(sql);
+            row.getFieldList().size().Should().Be(1);
+            return ((RelDataTypeField)row.getFieldList().get(0)).getType();
+        }
+
+        [TestMethod]
+        public void ShouldRejectCalcitesStDistanceOverAGeographyColumn()
+        {
+            Refuse("SELECT ST_DISTANCE(GEOG, GEOG) FROM GEO").Should().Contain("ST_DISTANCE");
+        }
+
+        /// <summary>
+        /// The same accessors go the same way, so there is no group of Calcite's spatial functions that comes
+        /// free.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRejectCalcitesStSridOverAGeographyColumn()
+        {
+            Refuse("SELECT ST_SRID(GEOG) FROM GEO").Should().Contain("ST_SRID");
+        }
+
+        /// <summary>
+        /// The control. The rejection above is the type and not the fixture.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAcceptCalcitesStDistanceOverAGeometryColumn()
+        {
+            Column("SELECT ST_DISTANCE(GEOM, GEOM) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.DOUBLE);
+        }
+
+        [TestMethod]
+        public void ShouldAcceptStGeogDistanceOverAGeographyColumn()
+        {
+            Column("SELECT ST_GEOG_DISTANCE(GEOG, GEOG) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.DOUBLE);
+        }
+
+        /// <summary>
+        /// The refusal runs both ways: a geodesic operator will not take a plane's coordinates either.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRejectStGeogDistanceOverAGeometryColumn()
+        {
+            Refuse("SELECT ST_GEOG_DISTANCE(GEOM, GEOM) FROM GEO").Should().Contain("ST_GEOG_DISTANCE");
+        }
+
+        /// <summary>
+        /// The operand checker is what decides the error a caller sees, and a checker that took anything
+        /// would let this validate.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRejectStGeogDistanceOverCharacterArguments()
+        {
+            var message = Refuse("SELECT ST_GEOG_DISTANCE('a', 'b') FROM GEO");
+
+            message.Should().Contain("ST_GEOG_DISTANCE");
+            message.Should().Contain("GEOGRAPHY");
+        }
+
+        [TestMethod]
+        public void ShouldRejectStGeogDWithinWithoutADistance()
+        {
+            Refuse("SELECT ST_GEOG_DWITHIN(GEOG, GEOG) FROM GEO").Should().Contain("ST_GEOG_DWITHIN");
+        }
+
+        [TestMethod]
+        public void ShouldTypeTheWktConstructorAsGeography()
+        {
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOG_GEOMFROMTEXT('POINT(0 0)') FROM GEO")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldTypeTheGeoJsonConstructorAsGeography()
+        {
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOG_GEOMFROMGEOJSON('{\"type\":\"Point\",\"coordinates\":[0,0]}') FROM GEO")).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A constructed geography goes into a geodesic operator without a column to hold it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAcceptAConstructedGeography()
+        {
+            GeographyFixture.Validate("SELECT ST_GEOG_DISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), GEOG) FROM GEO");
+        }
+
+        /// <summary>
+        /// The crossing is deliberate and explicit: having said so, Calcite's planar functions will take the
+        /// value.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCarryAGeographyIntoCalcitesStDistanceThroughAsGeom()
+        {
+            Column("SELECT ST_DISTANCE(ST_GEOG_ASGEOM(GEOG), GEOM) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.DOUBLE);
+        }
+
+        [TestMethod]
+        public void ShouldTypeTheOtherCrossingAsGeography()
+        {
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOM_ASGEOG(GEOM) FROM GEO")).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Each crossing takes the reading it converts from, so neither is a way to launder the other.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRejectACrossingOverTheWrongReading()
+        {
+            Refuse("SELECT ST_GEOM_ASGEOG(GEOG) FROM GEO").Should().Contain("ST_GEOM_ASGEOG");
+            Refuse("SELECT ST_GEOG_ASGEOM(GEOM) FROM GEO").Should().Contain("ST_GEOG_ASGEOM");
+        }
+
+        [TestMethod]
+        public void ShouldTypeThePredicatesAsBoolean()
+        {
+            foreach (var sql in new[]
+            {
+                "SELECT ST_GEOG_INTERSECTS(GEOG, GEOG) FROM GEO",
+                "SELECT ST_GEOG_WITHIN(GEOG, GEOG) FROM GEO",
+                "SELECT ST_GEOG_DWITHIN(GEOG, GEOG, 100.0) FROM GEO",
+                "SELECT ST_GEOG_ISVALID(GEOG) FROM GEO",
+            })
+                Column(sql).getSqlTypeName().Should().BeSameAs(SqlTypeName.BOOLEAN, sql);
+        }
+
+        /// <summary>
+        /// A geodesic predicate in a WHERE clause, which is where one is actually written.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAcceptAPredicateInAWhereClause()
+        {
+            Column("SELECT ID FROM GEO WHERE ST_GEOG_DWITHIN(GEOG, ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), 1000.0)")
+                .getSqlTypeName().Should().BeSameAs(SqlTypeName.INTEGER);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyValidationTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyValidationTests.cs
@@ -128,6 +128,23 @@ namespace Apache.Calcite.Geography.Tests
         }
 
         /// <summary>
+        /// Calcite declares two arities for each WKT constructor, and so do we; the routine lookup picks
+        /// between them by argument count.
+        /// </summary>
+        [TestMethod]
+        public void ShouldTypeTheWktConstructorWithAnSridAsGeography()
+        {
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOG_GEOMFROMTEXT('POINT(0 0)', 4326) FROM GEO")).Should().BeTrue();
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOG_GEOMFROMWKT('POINT(0 0)', 4326) FROM GEO")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldRejectAWktConstructorWithATooLongArgumentList()
+        {
+            Refuse("SELECT ST_GEOG_GEOMFROMTEXT('POINT(0 0)', 4326, 1) FROM GEO").Should().Contain("ST_GEOG_GEOMFROMTEXT");
+        }
+
+        /// <summary>
         /// A constructed geography goes into a geodesic operator without a column to hold it.
         /// </summary>
         [TestMethod]

--- a/src/Apache.Calcite.Geography/Apache.Calcite.Geography.csproj
+++ b/src/Apache.Calcite.Geography/Apache.Calcite.Geography.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>Preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <Description>A GEOGRAPHY type and an ST_GEOG_* operator table for Apache Calcite. Calcite's spatial library is planar JTS answering in the units of an unprojected coordinate system; a store that speaks WGS84 is geodesic and answers in metres. This package gives the second reading a type of its own, so the two cannot be confused, and evaluates the operations backends push over Google's S2.</Description>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageTags>apache;calcite;sql;spatial;geography;geodesic;wgs84;s2;ikvm</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+        <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Apache.Calcite.Geography.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="IKVM" Version="8.16.0" />
+        <PackageReference Include="IKVM.Java.Extensions" Version="8.16.0" />
+        <!-- Not PrivateAssets, deliberately. This package ships only buildTransitive, which is the folder that
+             carries build assets to consumers; marking it private disables the one mechanism it has, and a project
+             that references ours then compiles and fails at run time with `Could not load file or assembly
+             'calcite.core'`. The default PrivateAssets keeps `build` to ourselves and lets buildTransitive through,
+             which is what we want. -->
+        <PackageReference Include="IKVM.Maven.Sdk" Version="1.12.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Pinned to the version the rest of the repository resolves. calcite-core drags linq4j in with it and
+             the two are not separable: a disagreement fails inside a type initializer on the first query rather
+             than at restore. json-path's published POM declares no jackson dependency at all
+             (json-path/JsonPath#1082); declare the missing edge, optional like json-path's own bundled descriptor
+             intends, so the version sorts ahead when the closure asks for jackson. -->
+        <MavenReference Include="org.apache.calcite:calcite-core" Version="1.42.0">
+            <Dependencies>
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-databind:2.18.6,optional=true;
+                com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
+            </Dependencies>
+        </MavenReference>
+        <!-- The geodesic engine. Google's own S2, which is what the stores this package exists to agree with
+             compute in: BigQuery and Snowflake are both S2. It is a sphere rather than an ellipsoid, so a
+             distance differs from an ellipsoidal one by a few tenths of a percent — one model for all five
+             operations, which is the point; mixing a spherical predicate with an ellipsoidal distance would put
+             two models in one plan. The .NET ports on NuGet were considered and rejected: the largest is a 2016
+             netstandard1.0 port of a 2011 snapshot with no S2Polyline at all. -->
+        <MavenReference Include="com.google.geometry:s2-geometry" Version="2.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -1,0 +1,120 @@
+# Apache.Calcite.Geography
+
+[![NuGet](https://img.shields.io/nuget/v/Apache.Calcite.Geography)](https://www.nuget.org/packages/Apache.Calcite.Geography)
+
+**Apache.Calcite.Geography** gives [Apache Calcite](https://calcite.apache.org/) a `GEOGRAPHY` type and a set of `ST_GEOG_*` operators that read coordinates as WGS84 and answer in metres.
+
+Calcite has `GEOMETRY` and no `GEOGRAPHY`. Its spatial library is planar [JTS](https://github.com/locationtech/jts) over an unprojected coordinate system, answering in the units of that system. The stores that speak WGS84 — PostGIS `geography`, BigQuery, Snowflake, Elasticsearch `geo_shape`, MongoDB's 2dsphere — are geodesic, and answer in metres. The two disagree about what identically-named functions *mean*, and the disagreement is not a scale factor: the ratio varies with latitude and with bearing, so no conversion of a result recovers it and no transformation of the inputs does either. An ordering is not merely wrong, it is differently ordered.
+
+This package is **optional** and nothing else in the repository depends on it. Reference it when you have geodesic data.
+
+Targets **.NET 8**, and is verified on **.NET 8** and **.NET 10**.
+
+## Install
+
+```sh
+dotnet add package Apache.Calcite.Geography
+```
+
+## Using it
+
+The operators are declared in a `SqlOperatorTable`, which a host chains onto whatever it already has:
+
+```csharp
+using Apache.Calcite.Geography.Sql;
+using org.apache.calcite.sql.fun;
+using org.apache.calcite.sql.util;
+
+var operatorTable = SqlOperatorTables.chain(
+    SqlStdOperatorTable.instance(),
+    GeographyOperatorTable.Instance());
+
+var config = Frameworks.newConfigBuilder()
+    .defaultSchema(schema)
+    .operatorTable(operatorTable)
+    .build();
+```
+
+A column holds a geography by declaring `GeographyTypes.Of(typeFactory)` as its type:
+
+```csharp
+using Apache.Calcite.Geography.Rel.Type;
+
+typeFactory.builder()
+    .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+    .add("LOCATION", GeographyTypes.Of(typeFactory))
+    .build();
+```
+
+and the values in it are ordinary JTS `Geometry` objects — the same class Calcite's own spatial library carries.
+
+```sql
+SELECT ID
+FROM PLACES
+WHERE ST_GEOG_DWITHIN(LOCATION, ST_GEOG_GEOMFROMTEXT('POINT(-0.1278 51.5074)'), 5000.0)
+```
+
+There is no other way in. A function declared through a schema cannot take a geography parameter at all — routine resolution runs an assignability check keyed on the parameter's `SqlTypeName` and throws `AssertionError: No assign rules for OTHER defined` — so something has to chain the table for the caller: the host, or a provider on their behalf.
+
+## What the type is
+
+A `RelDataTypeFactoryImpl.JavaType` over `org.locationtech.jts.geom.Geometry` that answers a different name.
+
+| | |
+| --- | --- |
+| `getSqlTypeName()` | `OTHER` — the base would answer `GEOMETRY` |
+| `getFullTypeString()` | `GEOGRAPHY` — a digest nothing else produces |
+| `getJavaClass()` | `org.locationtech.jts.geom.Geometry` |
+
+So the runtime carrier stays a plain JTS geometry — no new class, nothing new for code generation to name, and nothing to convert at a boundary — while the type system sees something else entirely.
+
+**Calcite's planar functions refuse it at validation.** `ST_DISTANCE(LOCATION, LOCATION)` over a geography column fails to resolve. That is the property that matters most and the one no naming scheme provides: without it, a geodesic value would answer in degrees, in a different ordering, with no error anywhere. It is not special to `ST_DISTANCE` — every function in Calcite's spatial library is a reflective binding over `Geometry`, so all of them refuse it, the harmless accessors included.
+
+The marking exists only in the type system, so a geography and a geometry are indistinguishable at run time. Anywhere the type is erased — a value on an `ANY` path, a third-party function declared over `Geometry` — the geodesic reading is silently lost. That is the same guarantee PostGIS gives, where both are the same bytes and only the declared type keeps them apart.
+
+## What is here
+
+The names mirror Calcite's `ST_*` one for one with an `ST_GEOG_` prefix. This is the first increment; Calcite's spatial library is about 130 names and every one of them needs a declaration, because Calcite's own reject the type.
+
+**Constructors** — the only way a geography comes into existence in a query. The return type is `GEOGRAPHY`, and the result carries SRID 4326.
+
+| | |
+| --- | --- |
+| `ST_GEOG_GEOMFROMTEXT(VARCHAR)` | reads WKT |
+| `ST_GEOG_GEOMFROMWKT(VARCHAR)` | the same, under Calcite's other spelling |
+| `ST_GEOG_GEOMFROMGEOJSON(VARCHAR)` | reads GeoJSON |
+
+**The crossing between the two readings.** Free at run time, since both sides are the same JTS object; explicit, because losing the geodesic reading should be something you wrote down.
+
+| | |
+| --- | --- |
+| `ST_GEOG_ASGEOM(GEOGRAPHY)` | read a geography as a geometry |
+| `ST_GEOM_ASGEOG(GEOMETRY)` | read a geometry as a geography |
+
+**The operations backends actually push.**
+
+| | |
+| --- | --- |
+| `ST_GEOG_DISTANCE(GEOGRAPHY, GEOGRAPHY)` | metres |
+| `ST_GEOG_DWITHIN(GEOGRAPHY, GEOGRAPHY, NUMERIC)` | within a distance in metres |
+| `ST_GEOG_WITHIN(GEOGRAPHY, GEOGRAPHY)` | containment |
+| `ST_GEOG_INTERSECTS(GEOGRAPHY, GEOGRAPHY)` | any point in common |
+| `ST_GEOG_ISVALID(GEOGRAPHY)` | valid on the sphere |
+
+Each answers `NULL` for a `NULL` argument.
+
+## The engine
+
+[Google's S2](https://github.com/google/s2-geometry-library-java), consumed as a Java library the same way `calcite-core` is. It models the Earth as a **sphere** of radius 6,371,010 m and joins two vertices with a great-circle arc.
+
+One model rather than two, deliberately. An ellipsoidal distance from GeographicLib next to a spherical containment from S2 would put two readings of the same coordinates in one plan; the sphere costs a few tenths of a percent against an ellipsoidal distance, and it is what BigQuery and Snowflake compute in. The choice is reversible.
+
+The difference this makes is not a scale factor. The northern edge of `POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))` runs between two points at ten degrees north: as a straight line in longitude and latitude it stays on that parallel, and as a great circle it reaches about 10° 2′ at the midpoint. A point between the two is inside one polygon and outside the other — not a different distance, a different answer.
+
+The pairwise operations are quadratic in the vertex counts. S2 has an indexed form of these queries and this does not use it yet.
+
+## What is not here
+
+- The remaining ~120 declarations. The full mapping is in [the design issue](https://github.com/ikvmnet/calcite-dotnet/issues/86).
+- `ST_SETSRID` and `ST_TRANSFORM` have no counterpart, and will not: geography is WGS84 by definition and there is no second reference system to reproject into. Nor do the planar affine transforms — `ST_ROTATE`, `ST_SCALE`, `ST_TRANSLATE` — or precision reduction, which snaps to a planar grid.
+- **Rechecking a pushed-down predicate.** These implementations must not be wired into a filter-recheck path until their agreement with each live store has been measured at the boundaries — a point on a polygon edge, an antimeridian crossing, the poles, a distance sitting on a threshold. A recheck that disagrees discards rows the store returned.

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -80,9 +80,11 @@ The names mirror Calcite's `ST_*` one for one with an `ST_GEOG_` prefix. This is
 
 | | |
 | --- | --- |
-| `ST_GEOG_GEOMFROMTEXT(VARCHAR)` | reads WKT |
-| `ST_GEOG_GEOMFROMWKT(VARCHAR)` | the same, under Calcite's other spelling |
+| `ST_GEOG_GEOMFROMTEXT(VARCHAR [, INTEGER])` | reads WKT |
+| `ST_GEOG_GEOMFROMWKT(VARCHAR [, INTEGER])` | the same, under Calcite's other spelling |
 | `ST_GEOG_GEOMFROMGEOJSON(VARCHAR)` | reads GeoJSON |
+
+Both arities are Calcite's. The SRID a caller may name has to be 4326 and anything else is refused rather than ignored — a geography is WGS84 and there is no second reference system to reproject into, which is the same reason `ST_SETSRID` and `ST_TRANSFORM` have no counterpart at all.
 
 **The crossing between the two readings.** Free at run time, since both sides are the same JTS object; explicit, because losing the geodesic reading should be something you wrote down.
 
@@ -102,6 +104,8 @@ The names mirror Calcite's `ST_*` one for one with an `ST_GEOG_` prefix. This is
 | `ST_GEOG_ISVALID(GEOGRAPHY)` | valid on the sphere |
 
 Each answers `NULL` for a `NULL` argument.
+
+What these *mean* is what Calcite means, with the plane swapped for the sphere: `ST_Within` is `geom1.within(geom2)`, so `ST_GEOG_WITHIN` is the DE-9IM relation and not containment — a point on a polygon's boundary is not within it. `GeographyDifferentialTests` runs every one of them against Calcite's over shapes small enough that the two models must agree, which is what holds them to that.
 
 ## The engine
 

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -115,6 +115,8 @@ One model rather than two, deliberately. An ellipsoidal distance from Geographic
 
 The difference this makes is not a scale factor. The northern edge of `POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))` runs between two points at ten degrees north: as a straight line in longitude and latitude it stays on that parallel, and as a great circle it reaches about 10° 2′ at the midpoint. A point between the two is inside one polygon and outside the other — not a different distance, a different answer.
 
+At the antimeridian the two readings are exact inversions. `POLYGON((179 -1, -179 -1, -179 1, 179 1, 179 -1))` is a two-degree box straddling the seam on the sphere, and in the plane it is the 358-degree band that is everything except that box: every point is inside one and outside the other. The same seam turns a fifth of a degree into 359.8, and near a pole the shortest way between opposite meridians runs over the pole rather than 180 degrees around.
+
 The pairwise operations are quadratic in the vertex counts. S2 has an indexed form of these queries and this does not use it yet.
 
 ## What is not here

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -119,6 +119,8 @@ At the antimeridian the two readings are exact inversions. `POLYGON((179 -1, -17
 
 The pairwise operations are quadratic in the vertex counts. S2 has an indexed form of these queries and this does not use it yet.
 
+The relations are this package's own rather than a library's. `S2BooleanOperation` would settle `ST_GEOG_WITHIN` by construction, and it cannot be had: the S2 published to Maven Central is the 2021 release, which does not have it, and the current source is compiled to Java 11, which IKVM does not read. What stands in for it is the size of the oracle — `GeographyDifferentialTests` over hand-written shapes, and `GeographyRandomDifferentialTests` over thirty thousand generated pairs a run, both answered by Calcite. Four defects in the relations were found by the generated half after the hand-written half was green.
+
 ## What is not here
 
 - The remaining ~120 declarations. The full mapping is in [the design issue](https://github.com/ikvmnet/calcite-dotnet/issues/86).

--- a/src/Apache.Calcite.Geography/Rel/Type/GeographySqlType.cs
+++ b/src/Apache.Calcite.Geography/Rel/Type/GeographySqlType.cs
@@ -1,0 +1,77 @@
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql.type;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Rel.Type
+{
+
+    /// <summary>
+    /// The <c>GEOGRAPHY</c> type: a geometry whose coordinates are read as WGS84 latitude and longitude
+    /// rather than as a plane.
+    /// </summary>
+    /// <remarks>
+    /// A <c>RelDataTypeFactoryImpl.JavaType</c> over <c>org.locationtech.jts.geom.Geometry</c> that answers a
+    /// different name. <c>SqlTypeName</c> is a closed enum, so <c>GEOGRAPHY</c> cannot be added to it
+    /// downstream; what can be done is give the type system something whose digest nothing else produces,
+    /// while leaving the runtime carrier alone.
+    ///
+    /// <para>Three things are overridden and one is deliberately not. <c>getSqlTypeName</c> answers
+    /// <see cref="SqlTypeName.OTHER"/> — the base would answer <see cref="SqlTypeName.GEOMETRY"/>, because
+    /// <c>JavaToSqlTypeConversionRules</c> maps <c>Geometry.class</c> to it, and that mapping is the whole of
+    /// what makes Calcite's planar functions accept a value. <c>generateTypeString</c> writes
+    /// <c>GEOGRAPHY</c>, which is the digest, and a digest distinct from
+    /// <c>JavaType(class org.locationtech.jts.geom.Geometry)</c> is what keeps the two apart everywhere
+    /// Calcite compares types. <c>getJavaClass</c> is left alone, so it still answers <c>Geometry</c>: the
+    /// runtime carrier is an ordinary JTS geometry, the class Calcite's own generated code already names, and
+    /// there is no new class for Janino to resolve.</para>
+    ///
+    /// <para>The consequence, and it is the same one PostGIS lives with: the marking exists only in the type
+    /// system. A geography and a geometry are indistinguishable at run time, so anywhere the type is erased —
+    /// a value on an <c>ANY</c> path, a third-party function declared over <c>Geometry</c> — the geodesic
+    /// reading is silently lost.</para>
+    ///
+    /// <para>The type is <em>nullable</em>, and that is load-bearing rather than incidental.
+    /// <c>RelDataTypeFactoryImpl.copySimpleType</c> answers a change of nullability on any <c>JavaType</c>
+    /// with a plain <c>new JavaType(clazz, nullable)</c> — it does not copy the subclass — so
+    /// <c>createTypeWithNullability(geography, false)</c> hands back an ordinary <c>JavaType(Geometry)</c>
+    /// and the marking is gone. A nullable type asked for nullability it already has is returned unchanged,
+    /// which is the path everything actually takes. Nothing here may run a return type through
+    /// <c>SqlTypeTransforms.TO_NULLABLE</c> for that reason; see
+    /// <c>Apache.Calcite.Geography.Sql.GeographyReturnTypes</c>.</para>
+    /// </remarks>
+    public sealed class GeographySqlType : RelDataTypeFactoryImpl.JavaType
+    {
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="typeFactory">The factory this type belongs to. <c>JavaType</c> is a non-static inner
+        /// class, so it is the enclosing instance, and IKVM makes it the constructor's first argument.</param>
+        /// <remarks>
+        /// Prefer <c>GeographyTypes.Of</c>, which interns the result the way the type factory's own
+        /// <c>createJavaType</c> does. Two uninterned instances are equal and have the same digest, so
+        /// nothing goes wrong if one escapes, but reference comparisons of types are common in Calcite and
+        /// cheap to keep true.
+        /// </remarks>
+        public GeographySqlType(RelDataTypeFactoryImpl typeFactory) :
+            base(typeFactory, (java.lang.Class)typeof(Geometry))
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override SqlTypeName getSqlTypeName()
+        {
+            return SqlTypeName.OTHER;
+        }
+
+        /// <inheritdoc />
+        protected override void generateTypeString(java.lang.StringBuilder sb, bool withDetail)
+        {
+            sb.append("GEOGRAPHY");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Rel/Type/GeographyTypes.cs
+++ b/src/Apache.Calcite.Geography/Rel/Type/GeographyTypes.cs
@@ -1,0 +1,84 @@
+using System;
+
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql.type;
+
+using JtsGeometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Rel.Type
+{
+
+    /// <summary>
+    /// The two types this package deals in, and the questions asked about them.
+    /// </summary>
+    /// <remarks>
+    /// <c>GEOGRAPHY</c> is <see cref="GeographySqlType"/>. <c>GEOMETRY</c> is whatever Calcite's own spatial
+    /// library produces and consumes, which is <c>createJavaType(Geometry.class)</c> — the type
+    /// <c>ScalarFunctionImpl</c> derives by reflection from an <c>ST_*</c> method's signature. Asking the type
+    /// factory for it here rather than for <c>createSqlType(GEOMETRY)</c> is what makes the crossing
+    /// operators line up with Calcite's declarations exactly.
+    /// </remarks>
+    public static class GeographyTypes
+    {
+
+        /// <summary>
+        /// Returns the <c>GEOGRAPHY</c> type for the given type factory.
+        /// </summary>
+        /// <param name="typeFactory"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The round trip through <c>copyType</c> is how the result gets interned. <c>canonize</c> is
+        /// protected on <c>RelDataTypeFactoryImpl</c>, so a caller outside the class cannot reach it; but
+        /// <c>copyType</c> is <c>createTypeWithNullability(type, type.isNullable())</c>, which finds the
+        /// nullability unchanged, keeps the instance and canonizes it. The type factory's own
+        /// <c>createJavaType</c> does the same thing by the same interner.
+        /// </remarks>
+        public static RelDataType Of(RelDataTypeFactory typeFactory)
+        {
+            ArgumentNullException.ThrowIfNull(typeFactory);
+
+            return typeFactory.copyType(new GeographySqlType((RelDataTypeFactoryImpl)typeFactory));
+        }
+
+        /// <summary>
+        /// Returns the <c>GEOMETRY</c> type Calcite's spatial library uses, which is the Java type over
+        /// <c>org.locationtech.jts.geom.Geometry</c>.
+        /// </summary>
+        /// <param name="typeFactory"></param>
+        /// <returns></returns>
+        public static RelDataType GeometryOf(RelDataTypeFactory typeFactory)
+        {
+            ArgumentNullException.ThrowIfNull(typeFactory);
+
+            return typeFactory.createJavaType((java.lang.Class)typeof(JtsGeometry));
+        }
+
+        /// <summary>
+        /// Returns whether the given type is <c>GEOGRAPHY</c>.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static bool IsGeography(RelDataType? type)
+        {
+            return type is GeographySqlType;
+        }
+
+        /// <summary>
+        /// Returns whether the given type is a geometry as Calcite means one — planar, in the units of
+        /// whatever coordinate system it is written in.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A geography is not one. It is carried by the same class, so <c>getJavaClass</c> cannot tell them
+        /// apart; what tells them apart is that a geography answers <see cref="SqlTypeName.OTHER"/> where a
+        /// geometry answers <see cref="SqlTypeName.GEOMETRY"/>.
+        /// </remarks>
+        public static bool IsGeometry(RelDataType? type)
+        {
+            return type is not null && !IsGeography(type) && type.getSqlTypeName() == SqlTypeName.GEOMETRY;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -62,6 +62,32 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_GEOMFROMTEXT</c> and <c>ST_GEOG_GEOMFROMWKT</c>, with the SRID Calcite lets a caller
+        /// name. Reads a geography from WKT.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The arity is Calcite's, and it is declared so that the mirror is complete rather than because
+        /// there is a choice to make: a geography is WGS84 and there is no second reference system to be in,
+        /// which is the same reason <c>ST_SETSRID</c> and <c>ST_TRANSFORM</c> have no counterpart at all.
+        /// Anything but 4326 is refused rather than ignored — a caller who names one is asking for a
+        /// reprojection that will not happen, and silence would hand them coordinates read as something they
+        /// are not.
+        /// </remarks>
+        public static Geometry? FromWkt(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            if (srid.intValue() != Wgs84)
+                throw new java.lang.IllegalArgumentException($"A geography is WGS84; SRID {srid.intValue()} is not a reference system it can be in.");
+
+            return FromWkt(wkt);
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_ASGEOM</c>. Reads a geography as a geometry.
         /// </summary>
         /// <param name="geography"></param>
@@ -103,8 +129,7 @@ namespace Apache.Calcite.Geography.Runtime
             if (a is null || b is null)
                 return null;
 
-            var distance = S2Geographies.Distance(S2Geographies.Of(a), S2Geographies.Of(b));
-            return double.IsNaN(distance) ? null : java.lang.Double.valueOf(distance);
+            return java.lang.Double.valueOf(S2Geographies.Distance(S2Geographies.Of(a), S2Geographies.Of(b)));
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1,0 +1,184 @@
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Runtime
+{
+
+    /// <summary>
+    /// The bodies behind the <c>ST_GEOG_*</c> operators.
+    /// </summary>
+    /// <remarks>
+    /// Bound by reflection, the way <c>SpatialTypeFunctions</c> is: <c>GeographyOperatorTable</c> resolves
+    /// each of these to a <c>java.lang.reflect.Method</c>, wraps it in a <c>ScalarFunctionImpl</c> and hands
+    /// that to a <c>SqlUserDefinedFunction</c>, which is how the call gets an implementor without a hook into
+    /// <c>RexImpTable</c> — that table's map is private and 1.42 has no <c>RexImplementorTable</c>.
+    ///
+    /// <para>Every parameter and every result is a reference type and every method tolerates a null argument.
+    /// <c>ScalarFunctionImpl</c> reads a null policy off the method's annotations and answers
+    /// <c>NullPolicy.NONE</c> when there are none, so no null check is generated around the call and a null
+    /// argument arrives here. A method returning a primitive would throw on one.</para>
+    ///
+    /// <para>The values are ordinary JTS geometries. That is the whole of what makes a geography free at
+    /// runtime, and the whole of why the two readings cannot be told apart once the type is gone.</para>
+    /// </remarks>
+    public static class GeographyFunctions
+    {
+
+        /// <summary>
+        /// The reference system a geography is in, always.
+        /// </summary>
+        /// <remarks>
+        /// There is no second one to reproject into, which is why <c>ST_SETSRID</c> and <c>ST_TRANSFORM</c>
+        /// have no <c>ST_GEOG_</c> counterpart. Calcite's own constructors leave a geometry on
+        /// <c>NO_SRID</c>, which is zero.
+        /// </remarks>
+        public const int Wgs84 = 4326;
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMGEOJSON</c>. Reads a geography from GeoJSON.
+        /// </summary>
+        /// <param name="geoJson"></param>
+        /// <returns></returns>
+        public static Geometry? FromGeoJson(string? geoJson)
+        {
+            if (geoJson is null)
+                return null;
+
+            return Wgs84Of(SpatialTypeUtils.fromGeoJson(geoJson));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMTEXT</c> and <c>ST_GEOG_GEOMFROMWKT</c>. Reads a geography from WKT.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? FromWkt(string? wkt)
+        {
+            if (wkt is null)
+                return null;
+
+            return Wgs84Of(SpatialTypeUtils.fromWkt(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASGEOM</c>. Reads a geography as a geometry.
+        /// </summary>
+        /// <param name="geography"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Nothing happens. The two types are carried by the same class, so the crossing is a re-typing and
+        /// the object goes through untouched — deliberately not copied, and deliberately not restamped with
+        /// an SRID, since the caller's object is not this function's to change. What it costs is the geodesic
+        /// reading: from here on the coordinates are a plane's and Calcite's <c>ST_*</c> will take them.
+        /// </remarks>
+        public static Geometry? AsGeometry(Geometry? geography)
+        {
+            return geography;
+        }
+
+        /// <summary>
+        /// <c>ST_GEOM_ASGEOG</c>. Reads a geometry as a geography.
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The other half of <see cref="AsGeometry"/>, and the assertion that the coordinates are WGS84. It
+        /// is an assertion and not a conversion: nothing checks, and nothing can, a geometry carrying no
+        /// record of what its coordinates mean.
+        /// </remarks>
+        public static Geometry? AsGeography(Geometry? geometry)
+        {
+            return geometry;
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_DISTANCE</c>. The distance between two geographies, in metres.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Double? Distance(Geometry? a, Geometry? b)
+        {
+            if (a is null || b is null)
+                return null;
+
+            var distance = S2Geographies.Distance(S2Geographies.Of(a), S2Geographies.Of(b));
+            return double.IsNaN(distance) ? null : java.lang.Double.valueOf(distance);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_DWITHIN</c>. Whether two geographies are within the given distance in metres.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The distance is a <c>Number</c> rather than a <c>Double</c> because the argument arrives as
+        /// whatever type the literal had. <c>2.0</c> is <c>DECIMAL(2, 1)</c> and reaches the call as a
+        /// <c>BigDecimal</c>: nothing converts it on the way, since
+        /// <c>ReflectiveCallNotNullImplementor</c> runs <c>EnumUtils.convertAssignableTypes</c>, which
+        /// converts <em>to</em> a decimal and not from one. Calcite's own <c>ST_DWITHIN</c> takes a
+        /// <c>double</c> and fails on the same literal — measured, both under Janino — so this is a
+        /// divergence and a deliberate one: a caller should not have to write
+        /// <c>CAST(2.0 AS DOUBLE)</c> to call a function that takes a distance.
+        /// </remarks>
+        public static java.lang.Boolean? DWithin(Geometry? a, Geometry? b, java.lang.Number? distance)
+        {
+            if (a is null || b is null || distance is null)
+                return null;
+
+            return java.lang.Boolean.valueOf(S2Geographies.DWithin(S2Geographies.Of(a), S2Geographies.Of(b), distance.doubleValue()));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_WITHIN</c>. Whether the first geography lies within the second.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Within(Geometry? a, Geometry? b)
+        {
+            if (a is null || b is null)
+                return null;
+
+            return java.lang.Boolean.valueOf(S2Geographies.Within(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_INTERSECTS</c>. Whether two geographies have any point in common.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Intersects(Geometry? a, Geometry? b)
+        {
+            if (a is null || b is null)
+                return null;
+
+            return java.lang.Boolean.valueOf(S2Geographies.Intersects(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ISVALID</c>. Whether the geography is valid on the sphere.
+        /// </summary>
+        /// <param name="geography"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? IsValid(Geometry? geography)
+        {
+            if (geography is null)
+                return null;
+
+            return java.lang.Boolean.valueOf(S2Geographies.IsValid(geography));
+        }
+
+        static Geometry? Wgs84Of(Geometry? geometry)
+        {
+            geometry?.setSRID(Wgs84);
+            return geometry;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -19,11 +19,20 @@ namespace Apache.Calcite.Geography.Runtime
     /// readings of the same coordinates in one plan. It costs a few tenths of a percent against an
     /// ellipsoidal distance, and it is what BigQuery and Snowflake compute in.
     ///
+    /// <para>What the operations <em>mean</em> is what Calcite means, because Calcite's spatial functions are
+    /// the specification with the plane swapped for the sphere: <c>ST_Within</c> is
+    /// <c>geom1.within(geom2)</c> and <c>ST_Intersects</c> is <c>geom1.intersects(geom2)</c>, which are JTS
+    /// words with JTS definitions. <c>within</c> is not containment — it is the DE-9IM relation, so every
+    /// point of the one must lie in the other <em>and</em> their interiors must meet, which is why a point on
+    /// a polygon's boundary is not within the polygon and a point at the end of a line is not within the
+    /// line. <c>GeographyDifferentialTests</c> runs every operation against Calcite's over shapes small
+    /// enough that the sphere and the plane must agree, which is what holds this to that specification.</para>
+    ///
     /// <para>A JTS coordinate is <c>(x, y)</c> and WGS84 order is longitude then latitude, so <c>x</c> is the
     /// longitude and <c>y</c> is the latitude — the order <c>POINT(lng lat)</c> in WKT and GeoJSON.</para>
     ///
     /// <para>The pairwise operations are quadratic in the vertex counts: every edge of one against every edge
-    /// of the other. S2 has an indexed form of these queries and this does not use it. That is deliberate for
+    /// of the other. S2 has indexed forms of these queries and this does not use them. That is deliberate for
     /// now — the shapes a store pushes a predicate over are small, and an index is a thing to add against a
     /// measurement rather than a guess.</para>
     /// </remarks>
@@ -35,6 +44,18 @@ namespace Apache.Calcite.Geography.Runtime
         /// answers is measured on.
         /// </summary>
         public const double EarthRadiusMeters = 6371010.0;
+
+        /// <summary>
+        /// The angle below which two things are taken to touch, in radians.
+        /// </summary>
+        /// <remarks>
+        /// A coordinate arrives as a pair of doubles and leaves as a unit vector, so a vertex written to lie
+        /// on an edge does not land on it exactly, and a predicate that asked for an exact zero would answer
+        /// no to <c>POINT(2 2)</c> on <c>LINESTRING(0 0, 4 4)</c>. This is about four tenths of a micrometre
+        /// on the Earth: far below any coordinate a store records, and some nine orders of magnitude above
+        /// the rounding of the conversion.
+        /// </remarks>
+        const double Tolerance = 1e-13;
 
         /// <summary>
         /// Reads a JTS geometry as WGS84 and builds its S2 shapes.
@@ -93,8 +114,7 @@ namespace Apache.Calcite.Geography.Runtime
 
         static bool IsValidLine(LineString line)
         {
-            var coordinates = line.getCoordinates();
-            var vertices = ToPoints(coordinates, coordinates.Length);
+            var vertices = ToPath(line);
             if (vertices is null)
                 return false;
 
@@ -126,7 +146,8 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         readonly List<S2Point> points = [];
-        readonly List<S2Point[]> paths = [];
+        readonly List<S2Point[]> lines = [];
+        readonly List<S2Point[]> rings = [];
         readonly java.util.ArrayList loops = new();
         S2Polygon? polygon;
 
@@ -139,9 +160,18 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
-        /// The areal part, as one polygon, or <c>null</c> when the geography has no area.
+        /// Whether the geography names nothing at all.
         /// </summary>
-        public S2Polygon? Polygon => polygon;
+        public bool IsEmpty => points.Count == 0 && lines.Count == 0 && rings.Count == 0;
+
+        /// <summary>
+        /// The dimension of the geography: two if it has area, one if it has length, zero otherwise.
+        /// </summary>
+        /// <remarks>
+        /// <c>Geometry.getDimension</c>, which for a collection is the largest of its parts. It decides which
+        /// relations are possible at all — nothing of a higher dimension lies within something of a lower one.
+        /// </remarks>
+        public int Dimension => rings.Count > 0 ? 2 : lines.Count > 0 ? 1 : 0;
 
         /// <summary>
         /// Every vertex the geography names, whatever it belongs to.
@@ -157,7 +187,7 @@ namespace Apache.Calcite.Geography.Runtime
                 foreach (var point in points)
                     yield return point;
 
-                foreach (var path in paths)
+                foreach (var path in Paths)
                     foreach (var vertex in path)
                         yield return vertex;
             }
@@ -171,14 +201,25 @@ namespace Apache.Calcite.Geography.Runtime
         /// coordinate repeated at the end: walking consecutive pairs closes it, and the closing edge is a
         /// real edge that a distance or an intersection can be nearest to.
         /// </remarks>
-        public IEnumerable<(S2Point, S2Point)> Edges
+        public IEnumerable<(S2Point, S2Point)> Edges => EdgesOf(Paths);
+
+        IEnumerable<S2Point[]> Paths
         {
             get
             {
-                foreach (var path in paths)
-                    for (var i = 1; i < path.Length; i++)
-                        yield return (path[i - 1], path[i]);
+                foreach (var line in lines)
+                    yield return line;
+
+                foreach (var ring in rings)
+                    yield return ring;
             }
+        }
+
+        static IEnumerable<(S2Point, S2Point)> EdgesOf(IEnumerable<S2Point[]> paths)
+        {
+            foreach (var path in paths)
+                for (var i = 1; i < path.Length; i++)
+                    yield return (path[i - 1], path[i]);
         }
 
         void Add(Geometry geometry)
@@ -192,7 +233,7 @@ namespace Apache.Calcite.Geography.Runtime
                     break;
                 case LineString line:
                     if (line.isEmpty() == false)
-                        AddPath(line);
+                        AddLine(line);
 
                     break;
                 case Polygon polygon:
@@ -218,21 +259,28 @@ namespace Apache.Calcite.Geography.Runtime
                 AddRing(polygon.getInteriorRingN(i));
         }
 
+        void AddLine(LineString line)
+        {
+            var vertices = ToPath(line);
+            if (vertices is not null)
+                lines.Add(vertices);
+        }
+
         void AddRing(LineString ring)
         {
-            AddPath(ring);
+            var vertices = ToPath(ring);
+            if (vertices is not null)
+                rings.Add(vertices);
 
             var loop = ToLoop(ring);
             if (loop is not null)
                 loops.add(loop);
         }
 
-        void AddPath(LineString path)
+        static S2Point[]? ToPath(LineString path)
         {
             var coordinates = path.getCoordinates();
-            var vertices = ToPoints(coordinates, coordinates.Length);
-            if (vertices is not null)
-                paths.Add(vertices);
+            return ToPoints(coordinates, coordinates.Length);
         }
 
         /// <summary>
@@ -254,16 +302,24 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
-        /// Returns the distance between two geographies, in metres, or <see cref="double.NaN"/> if either is
-        /// empty.
+        /// Returns the distance between two geographies, in metres.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// An empty geography is zero away from everything, which is JTS answering its own question:
+        /// <c>DistanceOp</c> returns zero the moment either side is empty, and <c>ST_Distance</c> is
+        /// <c>geom1.distance(geom2)</c>. PostGIS answers null there instead. Calcite is the specification
+        /// this mirrors, so a caller who writes the two functions side by side gets the same shape of answer
+        /// from both and the only difference between them is the one this package exists for.
+        /// </remarks>
         public static double Distance(S2Geographies a, S2Geographies b)
         {
-            var angle = Angle(a, b);
-            return double.IsNaN(angle) ? double.NaN : angle * EarthRadiusMeters;
+            if (a.IsEmpty || b.IsEmpty)
+                return 0;
+
+            return Angle(a, b) * EarthRadiusMeters;
         }
 
         /// <summary>
@@ -274,14 +330,12 @@ namespace Apache.Calcite.Geography.Runtime
         /// <param name="distance"></param>
         /// <returns></returns>
         /// <remarks>
-        /// The distance is computed rather than compared against a bound, so this is
-        /// <c>Distance(a, b) &lt;= distance</c> and nothing cheaper. An early exit would want the indexed
-        /// query this does not yet use.
+        /// <c>ST_DWithin</c> is <c>geom1.distance(geom2) &lt;= distance</c> and nothing cheaper, so this is
+        /// the same. An early exit would want the indexed query this does not yet use.
         /// </remarks>
         public static bool DWithin(S2Geographies a, S2Geographies b, double distance)
         {
-            var d = Distance(a, b);
-            return double.IsNaN(d) == false && d <= distance;
+            return Distance(a, b) <= distance;
         }
 
         /// <summary>
@@ -290,82 +344,263 @@ namespace Apache.Calcite.Geography.Runtime
         /// <param name="a"></param>
         /// <param name="b"></param>
         /// <returns></returns>
+        /// <remarks>
+        /// An empty geography intersects nothing, where it is zero away from everything. The two are not in
+        /// tension and both are JTS: an empty set shares no point with anything, and a distance to one is
+        /// answered before the geometry is looked at.
+        /// </remarks>
         public static bool Intersects(S2Geographies a, S2Geographies b)
         {
-            if (a.Polygon is not null && b.Polygon is not null && a.Polygon.intersects(b.Polygon))
-                return true;
-
-            if (Covers(a, b) || Covers(b, a))
-                return true;
-
-            foreach (var (a0, a1) in a.Edges)
-                foreach (var (b0, b1) in b.Edges)
-                    if (S2EdgeUtil.edgeOrVertexCrossing(a0, a1, b0, b1))
-                        return true;
-
-            // two point geographies, or a point on another's vertex, have no edges to cross
-            foreach (var va in a.Vertices)
-                foreach (var vb in b.Vertices)
-                    if (va.equals(vb))
-                        return true;
-
-            return false;
+            return a.IsEmpty == false && b.IsEmpty == false && Angle(a, b) == 0;
         }
 
         /// <summary>
-        /// Returns whether every point of <paramref name="a"/> lies in <paramref name="b"/>.
+        /// Returns whether <paramref name="a"/> lies within <paramref name="b"/>.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         /// <returns></returns>
         /// <remarks>
-        /// Containment against <paramref name="b"/>'s areal part: every vertex of <paramref name="a"/> inside
-        /// it, and no edge of <paramref name="a"/> crossing its boundary. A geography with no area contains
-        /// nothing, so <c>ST_GEOG_WITHIN</c> over two lines is false — which is what <c>ST_WITHIN</c> answers
-        /// for two lines that are not equal, and not what it answers for two that are.
+        /// The DE-9IM relation JTS means by the word, which is two conditions rather than one: every point of
+        /// <paramref name="a"/> lies in <paramref name="b"/>, and their interiors meet. The second is what
+        /// makes a point on a polygon's boundary not within it, and a line lying along a polygon's edge not
+        /// within it either.
         ///
-        /// <para>The boundary is where this and a store will disagree if they disagree at all, and it is
+        /// <para>An edge of <paramref name="a"/> is checked by cutting it wherever the boundary of
+        /// <paramref name="b"/> meets it and testing the middle of each piece — exact rather than a sample;
+        /// see <see cref="Pieces"/>.</para>
+        ///
+        /// <para>Where a store will disagree, if it disagrees at all, is on the boundary itself, and that is
         /// exactly what the agreement measurement in the design issue has to settle before any of this may
         /// recheck a pushed-down predicate.</para>
         /// </remarks>
         public static bool Within(S2Geographies a, S2Geographies b)
         {
-            if (b.Polygon is null)
+            if (a.IsEmpty || b.IsEmpty)
                 return false;
 
-            var empty = true;
+            // nothing of a higher dimension lies inside something of a lower one
+            if (a.Dimension > b.Dimension)
+                return false;
 
             foreach (var vertex in a.Vertices)
-            {
-                empty = false;
-
-                if (b.Polygon.contains(vertex) == false)
+                if (b.Contains(vertex) == false)
                     return false;
-            }
 
-            if (empty)
-                return false;
-
-            foreach (var (a0, a1) in a.Edges)
-                foreach (var (b0, b1) in b.Edges)
-                    if (S2EdgeUtil.robustCrossing(a0, a1, b0, b1) > 0)
+            foreach (var (p, q) in a.Edges)
+                foreach (var middle in b.Pieces(p, q))
+                    if (b.Contains(middle) == false)
                         return false;
 
-            return true;
+            // the boundary of a says nothing about a hole of b lying wholly inside a: no edge of a goes near
+            // one, so the areal parts have to be compared as areas rather than as boundaries
+            if (a.polygon is not null && (b.polygon is null || Encloses(b.polygon, a.polygon) == false))
+                return false;
+
+            return MeetsInterior(a, b);
         }
 
         /// <summary>
-        /// Returns the angle between two geographies in radians, or <see cref="double.NaN"/> if either is
-        /// empty.
+        /// Returns whether the interior of <paramref name="a"/>, already known to lie in
+        /// <paramref name="b"/>, meets the interior of <paramref name="b"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        static bool MeetsInterior(S2Geographies a, S2Geographies b)
+        {
+            switch (b.Dimension)
+            {
+                case 2:
+                    // an areal part of a lies in b and has interior of its own, so the two interiors meet
+                    if (a.Dimension == 2)
+                        return true;
+
+                    if (a.Dimension == 1)
+                    {
+                        foreach (var (p, q) in a.Edges)
+                            foreach (var middle in b.Pieces(p, q))
+                                if (b.ContainsInterior(middle))
+                                    return true;
+
+                        return false;
+                    }
+
+                    foreach (var point in a.points)
+                        if (b.ContainsInterior(point))
+                            return true;
+
+                    return false;
+
+                case 1:
+                    // a lies on b and has length of its own, and the boundary of b is finitely many points
+                    if (a.Dimension == 1)
+                        return true;
+
+                    foreach (var point in a.points)
+                        if (b.OnBoundary(point) == false)
+                            return true;
+
+                    return false;
+
+                default:
+                    // b is a set of points and a is contained in it; a point is its own interior
+                    return true;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the given point lies in this geography, boundary included.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        public bool Contains(S2Point point)
+        {
+            if (polygon is not null && polygon.contains(point))
+                return true;
+
+            if (OnEdge(point))
+                return true;
+
+            foreach (var isolated in points)
+                if (Near(isolated, point))
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether the given point lies in the interior of the areal part of this geography.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>S2Polygon.contains</c> is half-open on the boundary — it answers one way along one edge of a
+        /// shared vertex and the other way along the next — so the boundary is excluded here rather than
+        /// trusted to it.
+        /// </remarks>
+        public bool ContainsInterior(S2Point point)
+        {
+            return polygon is not null && polygon.contains(point) && OnEdge(rings, point) == false;
+        }
+
+        /// <summary>
+        /// Returns whether the given point is on an edge of this geography.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        public bool OnEdge(S2Point point)
+        {
+            return OnEdge(Paths, point);
+        }
+
+        static bool OnEdge(IEnumerable<S2Point[]> paths, S2Point point)
+        {
+            foreach (var (p, q) in EdgesOf(paths))
+                if (S2EdgeUtil.getDistance(point, p, q).radians() <= Tolerance)
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether the given point is on the boundary of the linear part of this geography.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The mod-2 rule JTS uses: an endpoint that an odd number of line ends meet is a boundary point, so
+        /// two lines joined end to end have none where they join and a closed line has none at all. A ring has
+        /// no boundary either, which is why only the lines are counted.
+        /// </remarks>
+        public bool OnBoundary(S2Point point)
+        {
+            var ends = 0;
+
+            foreach (var line in lines)
+            {
+                if (Near(line[0], point))
+                    ends++;
+
+                if (Near(line[^1], point))
+                    ends++;
+            }
+
+            return ends % 2 == 1;
+        }
+
+        /// <summary>
+        /// Returns the middle of each piece the given edge is cut into by this geography.
+        /// </summary>
+        /// <param name="p"></param>
+        /// <param name="q"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// An edge passes from inside this geography to outside it only where it meets an edge of it, and it
+        /// meets one only at a proper crossing or at a vertex of this geography lying on the edge — a stretch
+        /// that merely runs along an edge starts and ends at that edge's own vertices. So the middle of a
+        /// piece stands for the whole piece, and testing the middles is exact rather than a sample.
+        /// </remarks>
+        public IEnumerable<S2Point> Pieces(S2Point p, S2Point q)
+        {
+            var cuts = new List<double> { 0, 1 };
+
+            foreach (var (r, s) in Edges)
+            {
+                if (S2EdgeUtil.robustCrossing(p, q, r, s) > 0)
+                    Cut(cuts, p, q, S2EdgeUtil.getIntersection(p, q, r, s));
+
+                Cut(cuts, p, q, r);
+                Cut(cuts, p, q, s);
+            }
+
+            foreach (var point in points)
+                Cut(cuts, p, q, point);
+
+            cuts.Sort();
+
+            for (var i = 1; i < cuts.Count; i++)
+                yield return S2EdgeUtil.interpolate((cuts[i - 1] + cuts[i]) / 2, p, q);
+        }
+
+        static void Cut(List<double> cuts, S2Point p, S2Point q, S2Point vertex)
+        {
+            if (S2EdgeUtil.getDistance(vertex, p, q).radians() > Tolerance)
+                return;
+
+            var fraction = S2EdgeUtil.getDistanceFraction(vertex, p, q);
+            if (fraction > 0 && fraction < 1)
+                cuts.Add(fraction);
+        }
+
+        /// <summary>
+        /// Returns the angle between two geographies in radians. Neither may be empty.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         /// <returns></returns>
         static double Angle(S2Geographies a, S2Geographies b)
         {
-            if (Intersects(a, b))
+            var min = MinAngle(a, b);
+            if (min <= Tolerance)
                 return 0;
 
+            // the nearest edges of two shapes are far apart when one is wholly inside the other
+            if (Encloses(a, b) || Encloses(b, a))
+                return 0;
+
+            return min;
+        }
+
+        /// <summary>
+        /// Returns the least angle between any part of one geography and any part of the other, without
+        /// regard to whether one encloses the other.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        static double MinAngle(S2Geographies a, S2Geographies b)
+        {
             var min = double.NaN;
 
             foreach (var (a0, a1) in a.Edges)
@@ -394,21 +629,49 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
-        /// Returns whether <paramref name="b"/>'s areal part holds any vertex of <paramref name="a"/>.
+        /// Returns whether the areal part of <paramref name="a"/> holds any of <paramref name="b"/>.
         /// </summary>
         /// <param name="a"></param>
         /// <param name="b"></param>
         /// <returns></returns>
-        static bool Covers(S2Geographies a, S2Geographies b)
+        static bool Encloses(S2Geographies a, S2Geographies b)
         {
-            if (b.Polygon is null)
+            if (a.polygon is null)
                 return false;
 
-            foreach (var vertex in a.Vertices)
-                if (b.Polygon.contains(vertex))
+            foreach (var vertex in b.Vertices)
+                if (a.polygon.contains(vertex))
                     return true;
 
-            return false;
+            return b.polygon is not null && a.polygon.intersects(b.polygon);
+        }
+
+        /// <summary>
+        /// Returns whether one polygon covers another, boundary sharing allowed.
+        /// </summary>
+        /// <param name="outer"></param>
+        /// <param name="inner"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>S2Polygon.contains</c> alone will not do. It is strict about a shared boundary, so two squares
+        /// meeting the corners of a hole from opposite sides are not contained by the polygon they sit in,
+        /// though every point of them is. Taking the difference answers the question that was asked — is
+        /// there any part of the inner polygon outside the outer one — and <c>contains</c> is kept in front
+        /// of it because it settles the ordinary nested case without building a polygon.
+        /// </remarks>
+        static bool Encloses(S2Polygon outer, S2Polygon inner)
+        {
+            if (outer.contains(inner))
+                return true;
+
+            var difference = new S2Polygon();
+            difference.initToDifference(inner, outer);
+            return difference.isEmpty();
+        }
+
+        static bool Near(S2Point a, S2Point b)
+        {
+            return a.equals(b) || new S1Angle(a, b).radians() <= Tolerance;
         }
 
         static S2Point ToPoint(Coordinate coordinate)
@@ -460,10 +723,10 @@ namespace Apache.Calcite.Geography.Runtime
         /// <param name="ring"></param>
         /// <returns></returns>
         /// <remarks>
-        /// A loop's orientation is what says which side of it is the interior, and JTS carries no orientation
-        /// S2 can trust — a shell and a hole are told apart by which ring of the polygon they are, not by
-        /// their winding. <c>normalize</c> settles it by inverting any loop that covers more than half the
-        /// sphere, which is right for every polygon that is not itself most of the Earth.
+        /// The orientation of a loop is what says which side of it is the interior, and JTS carries no
+        /// orientation S2 can trust — a shell and a hole are told apart by which ring of the polygon they are,
+        /// not by their winding. <c>normalize</c> settles it by inverting any loop that covers more than half
+        /// the sphere, which is right for every polygon that is not itself most of the Earth.
         /// </remarks>
         static S2Loop? ToLoop(LineString ring)
         {

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -96,6 +96,8 @@ namespace Apache.Calcite.Geography.Runtime
                     return line.isEmpty() || IsValidLine(line);
                 case Polygon polygon:
                     return polygon.isEmpty() || IsValidPolygon(polygon);
+                case MultiPolygon multi:
+                    return multi.isEmpty() || IsValidPolygonSet(multi);
                 case GeometryCollection collection:
                     for (var i = 0; i < collection.getNumGeometries(); i++)
                         if (IsValid(collection.getGeometryN(i)) == false)
@@ -147,6 +149,122 @@ namespace Apache.Calcite.Geography.Runtime
             }
 
             return S2Polygon.isValid(loops);
+        }
+
+        /// <summary>
+        /// Returns whether the parts of a multi-polygon are each valid and do not overlap one another.
+        /// </summary>
+        /// <param name="multi"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Two things validating the parts one at a time cannot see, and JTS checks both. The interiors of
+        /// the parts may not meet, so two overlapping squares are an invalid multi-polygon however valid each
+        /// square is — handing every ring of every part to S2 at once answers that, because two overlapping
+        /// shells are two loops that cross. And the parts may touch at only finitely many points, so two
+        /// squares sharing a whole edge are invalid as well even though their interiors never meet; that one
+        /// S2 has no opinion about and <see cref="SharesAnEdge"/> answers.
+        ///
+        /// <para>A geometry collection is held to neither, and neither does JTS hold one to them — its parts
+        /// are validated separately. That is why this case sits above the collection case rather than
+        /// replacing it.</para>
+        /// </remarks>
+        static bool IsValidPolygonSet(MultiPolygon multi)
+        {
+            var loops = new java.util.ArrayList();
+            var parts = new List<S2Geographies>();
+
+            for (var i = 0; i < multi.getNumGeometries(); i++)
+            {
+                if (multi.getGeometryN(i) is not Polygon part)
+                    return false;
+
+                if (part.isEmpty())
+                    continue;
+
+                if (IsValidPolygon(part) == false)
+                    return false;
+
+                var shell = ToLoop(part.getExteriorRing());
+                if (shell is null)
+                    return false;
+
+                loops.add(shell);
+
+                for (var j = 0; j < part.getNumInteriorRing(); j++)
+                {
+                    var hole = ToLoop(part.getInteriorRingN(j));
+                    if (hole is null)
+                        return false;
+
+                    loops.add(hole);
+                }
+
+                parts.Add(Of(part));
+            }
+
+            if (loops.isEmpty())
+                return true;
+
+            if (S2Polygon.isValid(loops) == false)
+                return false;
+
+            for (var i = 0; i < parts.Count; i++)
+                for (var j = i + 1; j < parts.Count; j++)
+                    if (Separate(parts[i], parts[j]) == false)
+                        return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns whether two parts of a multi-polygon are separate enough to belong to one.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Two rules of the standard, and one predicate because either failing makes the same answer. The
+        /// interiors may not meet, which the boundary of one running through the interior of the other
+        /// reports — including the case a whole part sits inside another, which nothing else here would see,
+        /// because <c>S2Polygon.init</c> works out nesting and reads a shell inside a shell as a hole rather
+        /// than as an overlap. And the parts may touch at finitely many points only, which is
+        /// <see cref="SharesAnEdge"/>.
+        /// </remarks>
+        static bool Separate(S2Geographies a, S2Geographies b)
+        {
+            foreach (var (p, q) in a.RingEdges)
+                foreach (var middle in b.Pieces(p, q))
+                    if (b.ContainsInterior(middle))
+                        return false;
+
+            foreach (var (p, q) in b.RingEdges)
+                foreach (var middle in a.Pieces(p, q))
+                    if (a.ContainsInterior(middle))
+                        return false;
+
+            return SharesAnEdge(a, b) == false;
+        }
+
+        /// <summary>
+        /// Returns whether two geographies have a stretch of boundary in common, rather than meeting at
+        /// points.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Every edge of one is cut wherever the other meets it, and a piece whose middle lies on the other
+        /// is a piece that lies on it whole — which is a stretch of shared boundary and not a touch. Two
+        /// squares sharing a corner have no such piece; two sharing a side have one.
+        /// </remarks>
+        static bool SharesAnEdge(S2Geographies a, S2Geographies b)
+        {
+            foreach (var (p, q) in a.Edges)
+                foreach (var middle in b.Pieces(p, q))
+                    if (b.OnEdge(middle))
+                        return true;
+
+            return false;
         }
 
         readonly List<S2Point> points = [];
@@ -206,6 +324,11 @@ namespace Apache.Calcite.Geography.Runtime
         /// real edge that a distance or an intersection can be nearest to.
         /// </remarks>
         public IEnumerable<(S2Point, S2Point)> Edges => EdgesOf(Paths);
+
+        /// <summary>
+        /// Every edge of every ring, which is the whole boundary of the areal part.
+        /// </summary>
+        public IEnumerable<(S2Point, S2Point)> RingEdges => EdgesOf(rings);
 
         IEnumerable<S2Point[]> Paths
         {
@@ -396,10 +519,17 @@ namespace Apache.Calcite.Geography.Runtime
                     if (b.Contains(middle) == false)
                         return false;
 
-            // the boundary of a says nothing about a hole of b lying wholly inside a: no edge of a goes near
-            // one, so the areal parts have to be compared as areas rather than as boundaries
-            if (a.polygon is not null && (b.polygon is null || Encloses(b.polygon, a.polygon) == false))
-                return false;
+            // The boundary of a says nothing about a hole of b lying wholly inside a: no edge of a goes near
+            // one. Any part of a outside b sits in a region bounded by a ring of b, so if a is not within b
+            // then a ring of b runs through the interior of a. Cutting each of those edges wherever a meets
+            // it and testing the middles decides it: a piece is wholly inside a, wholly outside it, or wholly
+            // on its boundary. Testing the vertices of those rings instead is not enough and looks like it is
+            // — a hole can have every one of its corners on the boundary of a and still lie inside it.
+            if (a.polygon is not null)
+                foreach (var (p, q) in b.RingEdges)
+                    foreach (var middle in a.Pieces(p, q))
+                        if (a.ContainsInterior(middle))
+                            return false;
 
             return MeetsInterior(a, b);
         }
@@ -416,9 +546,11 @@ namespace Apache.Calcite.Geography.Runtime
             switch (b.Dimension)
             {
                 case 2:
-                    // an areal part of a lies in b and has interior of its own, so the two interiors meet
+                    // Not "a has area, so the interiors meet". Every point of a is in b by here, but a can be
+                    // exactly a hole of b — its whole boundary on the boundary of b, its whole interior
+                    // outside b — and nothing that walks boundaries can tell that from a being inside.
                     if (a.Dimension == 2)
-                        return true;
+                        return a.polygon is not null && b.polygon is not null && Overlaps(a.polygon, b.polygon);
 
                     // every part of a, not only the parts of its own dimension: a collection of a point and a
                     // line is one-dimensional, and it is within a polygon whose boundary its line runs along
@@ -649,26 +781,23 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
-        /// Returns whether one polygon covers another, boundary sharing allowed.
+        /// Returns whether two polygons have area in common, rather than only boundary.
         /// </summary>
-        /// <param name="outer"></param>
-        /// <param name="inner"></param>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
         /// <returns></returns>
         /// <remarks>
-        /// <c>S2Polygon.contains</c> alone will not do. It is strict about a shared boundary, so two squares
-        /// meeting the corners of a hole from opposite sides are not contained by the polygon they sit in,
-        /// though every point of them is. Taking the difference answers the question that was asked — is
-        /// there any part of the inner polygon outside the outer one — and <c>contains</c> is kept in front
-        /// of it because it settles the ordinary nested case without building a polygon.
+        /// The area of the intersection and not whether it is empty. S2 snaps while it intersects, so two
+        /// polygons that merely share a boundary can leave a sliver behind and an emptiness test would call
+        /// that an overlap. A sliver is the square of the snap radius, around a millionth of a millionth of
+        /// what the smallest real overlap here would be, so a threshold relative to the area of
+        /// <paramref name="a"/> separates them by twenty orders of magnitude rather than by a guess.
         /// </remarks>
-        static bool Encloses(S2Polygon outer, S2Polygon inner)
+        static bool Overlaps(S2Polygon a, S2Polygon b)
         {
-            if (outer.contains(inner))
-                return true;
-
-            var difference = new S2Polygon();
-            difference.initToDifference(inner, outer);
-            return difference.isEmpty();
+            var intersection = new S2Polygon();
+            intersection.initToIntersection(a, b);
+            return intersection.getArea() > a.getArea() * 1e-9;
         }
 
         static bool Near(S2Point a, S2Point b)

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -115,7 +115,11 @@ namespace Apache.Calcite.Geography.Runtime
         static bool IsValidLine(LineString line)
         {
             var vertices = ToPath(line);
-            if (vertices is null)
+
+            // a line of one distinct place is no line, which S2 does not mind and JTS does. The length is
+            // checked after the conversion because that is where a repeated coordinate is dropped, so
+            // LINESTRING(0 0, 0 0) arrives here as one vertex rather than two.
+            if (vertices is null || vertices.Length < 2)
                 return false;
 
             // the list overload is an instance method on this S2 release, so the polyline has to exist first;
@@ -416,19 +420,17 @@ namespace Apache.Calcite.Geography.Runtime
                     if (a.Dimension == 2)
                         return true;
 
-                    if (a.Dimension == 1)
-                    {
-                        foreach (var (p, q) in a.Edges)
-                            foreach (var middle in b.Pieces(p, q))
-                                if (b.ContainsInterior(middle))
-                                    return true;
-
-                        return false;
-                    }
-
+                    // every part of a, not only the parts of its own dimension: a collection of a point and a
+                    // line is one-dimensional, and it is within a polygon whose boundary its line runs along
+                    // as long as the point is inside, because the point is part of the interior of a too
                     foreach (var point in a.points)
                         if (b.ContainsInterior(point))
                             return true;
+
+                    foreach (var (p, q) in a.Edges)
+                        foreach (var middle in b.Pieces(p, q))
+                            if (b.ContainsInterior(middle))
+                                return true;
 
                     return false;
 
@@ -688,7 +690,7 @@ namespace Apache.Calcite.Geography.Runtime
         /// <returns></returns>
         static S2Point[]? ToPoints(Coordinate[] coordinates, int count)
         {
-            var points = new S2Point[count];
+            var points = new List<S2Point>(count);
 
             for (var i = 0; i < count; i++)
             {
@@ -696,10 +698,20 @@ namespace Apache.Calcite.Geography.Runtime
                 if (latLng.isValid() == false)
                     return null;
 
-                points[i] = latLng.toPoint();
+                var point = latLng.toPoint();
+
+                // A repeated coordinate is a zero-length edge, and S2 will not have one: S2Loop and
+                // S2Polyline both call themselves invalid over adjacent duplicates, which would take the area
+                // off a polygon that JTS and Calcite both consider perfectly valid — ToLoop would answer null
+                // and the geography would keep its rings and lose its polygon. JTS reads the repeat as
+                // notation rather than as geometry, and so does this.
+                if (points.Count > 0 && points[^1].equals(point))
+                    continue;
+
+                points.Add(point);
             }
 
-            return points;
+            return [.. points];
         }
 
         /// <summary>
@@ -737,11 +749,11 @@ namespace Apache.Calcite.Geography.Runtime
             if (count > 1 && coordinates[0].equals2D(coordinates[count - 1]))
                 count--;
 
-            if (count < 3)
-                return null;
-
             var vertices = ToPoints(coordinates, count);
-            if (vertices is null)
+
+            // after the conversion, because a repeated coordinate is dropped there and a ring written with
+            // one has fewer vertices than it has coordinates
+            if (vertices is null || vertices.Length < 3)
                 return null;
 
             var loop = new S2Loop(ToList(vertices));

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -1,0 +1,494 @@
+using System;
+using System.Collections.Generic;
+
+using com.google.common.geometry;
+
+using org.locationtech.jts.geom;
+
+namespace Apache.Calcite.Geography.Runtime
+{
+
+    /// <summary>
+    /// A JTS geometry read as WGS84 and carried as S2 shapes, and the geodesic questions asked of a pair of
+    /// them.
+    /// </summary>
+    /// <remarks>
+    /// The engine is Google's S2, which models the Earth as a sphere and joins two vertices with a
+    /// great-circle arc. That is the choice this package makes, and it is one model rather than two: an
+    /// ellipsoidal distance from GeographicLib next to a spherical containment from S2 would put two
+    /// readings of the same coordinates in one plan. It costs a few tenths of a percent against an
+    /// ellipsoidal distance, and it is what BigQuery and Snowflake compute in.
+    ///
+    /// <para>A JTS coordinate is <c>(x, y)</c> and WGS84 order is longitude then latitude, so <c>x</c> is the
+    /// longitude and <c>y</c> is the latitude — the order <c>POINT(lng lat)</c> in WKT and GeoJSON.</para>
+    ///
+    /// <para>The pairwise operations are quadratic in the vertex counts: every edge of one against every edge
+    /// of the other. S2 has an indexed form of these queries and this does not use it. That is deliberate for
+    /// now — the shapes a store pushes a predicate over are small, and an index is a thing to add against a
+    /// measurement rather than a guess.</para>
+    /// </remarks>
+    sealed class S2Geographies
+    {
+
+        /// <summary>
+        /// The radius S2 uses for the Earth, in metres, and therefore the radius every distance this package
+        /// answers is measured on.
+        /// </summary>
+        public const double EarthRadiusMeters = 6371010.0;
+
+        /// <summary>
+        /// Reads a JTS geometry as WGS84 and builds its S2 shapes.
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <returns></returns>
+        public static S2Geographies Of(Geometry geometry)
+        {
+            ArgumentNullException.ThrowIfNull(geometry);
+
+            var self = new S2Geographies();
+            self.Add(geometry);
+            self.Close();
+            return self;
+        }
+
+        /// <summary>
+        /// Returns whether the given geometry is a valid geography.
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Not what <c>ST_ISVALID</c> answers. JTS validity is planar and says nothing about whether a
+        /// coordinate names a place on the Earth; a ring whose edges do not cross as straight lines in
+        /// longitude and latitude may still cross as great-circle arcs. This asks S2: every coordinate a
+        /// valid latitude and longitude, every line a valid polyline, every ring a valid loop, and the rings
+        /// of a polygon a valid set.
+        /// </remarks>
+        public static bool IsValid(Geometry geometry)
+        {
+            ArgumentNullException.ThrowIfNull(geometry);
+
+            switch (geometry)
+            {
+                case Point point:
+                    return point.isEmpty() || IsValidCoordinate(point.getCoordinate());
+                case LineString line:
+                    return line.isEmpty() || IsValidLine(line);
+                case Polygon polygon:
+                    return polygon.isEmpty() || IsValidPolygon(polygon);
+                case GeometryCollection collection:
+                    for (var i = 0; i < collection.getNumGeometries(); i++)
+                        if (IsValid(collection.getGeometryN(i)) == false)
+                            return false;
+
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        static bool IsValidCoordinate(Coordinate coordinate)
+        {
+            return S2LatLng.fromDegrees(coordinate.getY(), coordinate.getX()).isValid();
+        }
+
+        static bool IsValidLine(LineString line)
+        {
+            var coordinates = line.getCoordinates();
+            var vertices = ToPoints(coordinates, coordinates.Length);
+            if (vertices is null)
+                return false;
+
+            // the list overload is an instance method on this S2 release, so the polyline has to exist first;
+            // its constructor stores the vertices without checking them
+            return new S2Polyline(ToList(vertices)).isValid();
+        }
+
+        static bool IsValidPolygon(Polygon polygon)
+        {
+            var loops = new java.util.ArrayList();
+
+            var shell = ToLoop(polygon.getExteriorRing());
+            if (shell is null)
+                return false;
+
+            loops.add(shell);
+
+            for (var i = 0; i < polygon.getNumInteriorRing(); i++)
+            {
+                var hole = ToLoop(polygon.getInteriorRingN(i));
+                if (hole is null)
+                    return false;
+
+                loops.add(hole);
+            }
+
+            return S2Polygon.isValid(loops);
+        }
+
+        readonly List<S2Point> points = [];
+        readonly List<S2Point[]> paths = [];
+        readonly java.util.ArrayList loops = new();
+        S2Polygon? polygon;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        S2Geographies()
+        {
+
+        }
+
+        /// <summary>
+        /// The areal part, as one polygon, or <c>null</c> when the geography has no area.
+        /// </summary>
+        public S2Polygon? Polygon => polygon;
+
+        /// <summary>
+        /// Every vertex the geography names, whatever it belongs to.
+        /// </summary>
+        /// <remarks>
+        /// The first vertex of a ring is named twice, since it arrives from JTS repeated at the end. Nothing
+        /// that reads this cares: every use is a minimum or a containment test over the whole sequence.
+        /// </remarks>
+        public IEnumerable<S2Point> Vertices
+        {
+            get
+            {
+                foreach (var point in points)
+                    yield return point;
+
+                foreach (var path in paths)
+                    foreach (var vertex in path)
+                        yield return vertex;
+            }
+        }
+
+        /// <summary>
+        /// Every edge the geography names, as a pair of endpoints.
+        /// </summary>
+        /// <remarks>
+        /// A line and a ring are the same thing here, because a ring arrives from JTS with its first
+        /// coordinate repeated at the end: walking consecutive pairs closes it, and the closing edge is a
+        /// real edge that a distance or an intersection can be nearest to.
+        /// </remarks>
+        public IEnumerable<(S2Point, S2Point)> Edges
+        {
+            get
+            {
+                foreach (var path in paths)
+                    for (var i = 1; i < path.Length; i++)
+                        yield return (path[i - 1], path[i]);
+            }
+        }
+
+        void Add(Geometry geometry)
+        {
+            switch (geometry)
+            {
+                case Point point:
+                    if (point.isEmpty() == false)
+                        points.Add(ToPoint(point.getCoordinate()));
+
+                    break;
+                case LineString line:
+                    if (line.isEmpty() == false)
+                        AddPath(line);
+
+                    break;
+                case Polygon polygon:
+                    if (polygon.isEmpty() == false)
+                        Add(polygon);
+
+                    break;
+                case GeometryCollection collection:
+                    for (var i = 0; i < collection.getNumGeometries(); i++)
+                        Add(collection.getGeometryN(i));
+
+                    break;
+                default:
+                    throw new NotSupportedException($"Cannot read '{geometry.getGeometryType()}' as a geography.");
+            }
+        }
+
+        void Add(Polygon polygon)
+        {
+            AddRing(polygon.getExteriorRing());
+
+            for (var i = 0; i < polygon.getNumInteriorRing(); i++)
+                AddRing(polygon.getInteriorRingN(i));
+        }
+
+        void AddRing(LineString ring)
+        {
+            AddPath(ring);
+
+            var loop = ToLoop(ring);
+            if (loop is not null)
+                loops.add(loop);
+        }
+
+        void AddPath(LineString path)
+        {
+            var coordinates = path.getCoordinates();
+            var vertices = ToPoints(coordinates, coordinates.Length);
+            if (vertices is not null)
+                paths.Add(vertices);
+        }
+
+        /// <summary>
+        /// Builds the areal part, once every ring has been read.
+        /// </summary>
+        /// <remarks>
+        /// <c>S2Polygon.init</c> works out the nesting itself and reorders the loops, so a shell and its holes
+        /// go in together in whatever order they arrived; what it wants is that each loop is normalized, which
+        /// <see cref="ToLoop"/> has already done.
+        /// </remarks>
+        void Close()
+        {
+            if (loops.isEmpty())
+                return;
+
+            var built = new S2Polygon();
+            built.init(loops);
+            polygon = built;
+        }
+
+        /// <summary>
+        /// Returns the distance between two geographies, in metres, or <see cref="double.NaN"/> if either is
+        /// empty.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static double Distance(S2Geographies a, S2Geographies b)
+        {
+            var angle = Angle(a, b);
+            return double.IsNaN(angle) ? double.NaN : angle * EarthRadiusMeters;
+        }
+
+        /// <summary>
+        /// Returns whether two geographies are within the given distance in metres of one another.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The distance is computed rather than compared against a bound, so this is
+        /// <c>Distance(a, b) &lt;= distance</c> and nothing cheaper. An early exit would want the indexed
+        /// query this does not yet use.
+        /// </remarks>
+        public static bool DWithin(S2Geographies a, S2Geographies b, double distance)
+        {
+            var d = Distance(a, b);
+            return double.IsNaN(d) == false && d <= distance;
+        }
+
+        /// <summary>
+        /// Returns whether two geographies have any point in common.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static bool Intersects(S2Geographies a, S2Geographies b)
+        {
+            if (a.Polygon is not null && b.Polygon is not null && a.Polygon.intersects(b.Polygon))
+                return true;
+
+            if (Covers(a, b) || Covers(b, a))
+                return true;
+
+            foreach (var (a0, a1) in a.Edges)
+                foreach (var (b0, b1) in b.Edges)
+                    if (S2EdgeUtil.edgeOrVertexCrossing(a0, a1, b0, b1))
+                        return true;
+
+            // two point geographies, or a point on another's vertex, have no edges to cross
+            foreach (var va in a.Vertices)
+                foreach (var vb in b.Vertices)
+                    if (va.equals(vb))
+                        return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether every point of <paramref name="a"/> lies in <paramref name="b"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Containment against <paramref name="b"/>'s areal part: every vertex of <paramref name="a"/> inside
+        /// it, and no edge of <paramref name="a"/> crossing its boundary. A geography with no area contains
+        /// nothing, so <c>ST_GEOG_WITHIN</c> over two lines is false — which is what <c>ST_WITHIN</c> answers
+        /// for two lines that are not equal, and not what it answers for two that are.
+        ///
+        /// <para>The boundary is where this and a store will disagree if they disagree at all, and it is
+        /// exactly what the agreement measurement in the design issue has to settle before any of this may
+        /// recheck a pushed-down predicate.</para>
+        /// </remarks>
+        public static bool Within(S2Geographies a, S2Geographies b)
+        {
+            if (b.Polygon is null)
+                return false;
+
+            var empty = true;
+
+            foreach (var vertex in a.Vertices)
+            {
+                empty = false;
+
+                if (b.Polygon.contains(vertex) == false)
+                    return false;
+            }
+
+            if (empty)
+                return false;
+
+            foreach (var (a0, a1) in a.Edges)
+                foreach (var (b0, b1) in b.Edges)
+                    if (S2EdgeUtil.robustCrossing(a0, a1, b0, b1) > 0)
+                        return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the angle between two geographies in radians, or <see cref="double.NaN"/> if either is
+        /// empty.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        static double Angle(S2Geographies a, S2Geographies b)
+        {
+            if (Intersects(a, b))
+                return 0;
+
+            var min = double.NaN;
+
+            foreach (var (a0, a1) in a.Edges)
+                foreach (var (b0, b1) in b.Edges)
+                    min = Least(min, S2EdgeUtil.getEdgePairDistance(a0, a1, b0, b1).toAngle().radians());
+
+            foreach (var vertex in a.Vertices)
+                foreach (var (b0, b1) in b.Edges)
+                    min = Least(min, S2EdgeUtil.getDistance(vertex, b0, b1).radians());
+
+            foreach (var vertex in b.Vertices)
+                foreach (var (a0, a1) in a.Edges)
+                    min = Least(min, S2EdgeUtil.getDistance(vertex, a0, a1).radians());
+
+            // a pair of point geographies names no edge at all, so nothing above reaches them
+            foreach (var va in a.Vertices)
+                foreach (var vb in b.Vertices)
+                    min = Least(min, new S1Angle(va, vb).radians());
+
+            return min;
+        }
+
+        static double Least(double min, double candidate)
+        {
+            return double.IsNaN(min) || candidate < min ? candidate : min;
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="b"/>'s areal part holds any vertex of <paramref name="a"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        static bool Covers(S2Geographies a, S2Geographies b)
+        {
+            if (b.Polygon is null)
+                return false;
+
+            foreach (var vertex in a.Vertices)
+                if (b.Polygon.contains(vertex))
+                    return true;
+
+            return false;
+        }
+
+        static S2Point ToPoint(Coordinate coordinate)
+        {
+            return S2LatLng.fromDegrees(coordinate.getY(), coordinate.getX()).toPoint();
+        }
+
+        /// <summary>
+        /// Converts the first <paramref name="count"/> of a JTS coordinate sequence to S2 points, or
+        /// <c>null</c> if any of them is not a place on the Earth.
+        /// </summary>
+        /// <param name="coordinates"></param>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        static S2Point[]? ToPoints(Coordinate[] coordinates, int count)
+        {
+            var points = new S2Point[count];
+
+            for (var i = 0; i < count; i++)
+            {
+                var latLng = S2LatLng.fromDegrees(coordinates[i].getY(), coordinates[i].getX());
+                if (latLng.isValid() == false)
+                    return null;
+
+                points[i] = latLng.toPoint();
+            }
+
+            return points;
+        }
+
+        /// <summary>
+        /// Hands S2 the vertex list its constructors take.
+        /// </summary>
+        /// <param name="points"></param>
+        /// <returns></returns>
+        static java.util.List ToList(S2Point[] points)
+        {
+            var list = new java.util.ArrayList(points.Length);
+
+            foreach (var point in points)
+                list.add(point);
+
+            return list;
+        }
+
+        /// <summary>
+        /// Converts a JTS ring to a normalized S2 loop, or <c>null</c> if it is not one.
+        /// </summary>
+        /// <param name="ring"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A loop's orientation is what says which side of it is the interior, and JTS carries no orientation
+        /// S2 can trust — a shell and a hole are told apart by which ring of the polygon they are, not by
+        /// their winding. <c>normalize</c> settles it by inverting any loop that covers more than half the
+        /// sphere, which is right for every polygon that is not itself most of the Earth.
+        /// </remarks>
+        static S2Loop? ToLoop(LineString ring)
+        {
+            var coordinates = ring.getCoordinates();
+            var count = coordinates.Length;
+
+            // JTS repeats the first coordinate of a ring at the end and S2 does not
+            if (count > 1 && coordinates[0].equals2D(coordinates[count - 1]))
+                count--;
+
+            if (count < 3)
+                return null;
+
+            var vertices = ToPoints(coordinates, count);
+            if (vertices is null)
+                return null;
+
+            var loop = new S2Loop(ToList(vertices));
+            if (loop.isValid() == false)
+                return null;
+
+            loop.normalize();
+            return loop;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -36,6 +36,15 @@ namespace Apache.Calcite.Geography.Sql
     /// the method itself, and Calcite's own engine reaches a CLR class through the class-loader stamp
     /// <c>IKVM.Maven.Sdk</c> puts on <c>calcite-core</c>.</para>
     ///
+    /// <para>Each operator is also a public field, which <c>SqlSpatialTypeOperatorTable</c> is not, and the
+    /// reason is that Calcite has a handle we cannot have. Its own spatial pushdown rules recognise a call by
+    /// <c>SqlKind</c> — <c>SpatialRules</c> matches <c>SqlKind.ST_DWITHIN</c> and <c>SqlKind.ST_CONTAINS</c>,
+    /// which reach the operator from a <c>@Hints({"SqlKind:ST_DWITHIN"})</c> annotation on the method that
+    /// <c>CalciteCatalogReader.toOp</c> reads. <c>SqlKind</c> is a closed enum, so <c>ST_GEOG_DWITHIN</c>
+    /// cannot be added to it, and taking <c>ST_DWITHIN</c> would be worse than having nothing: Calcite's own
+    /// rules would then match a geodesic call and plan it as a planar one. So an adapter that wants to push
+    /// one of these down has the operator itself or its name, and the field is the exact one.</para>
+    ///
     /// <para>This is the first increment of the surface. Calcite's spatial library is about 130 names and
     /// every one of them needs an <c>ST_GEOG_</c> declaration, because Calcite's own reject the type. What is
     /// here is the type's constructors, the two crossings, and the five operations a geodesic store actually
@@ -65,6 +74,20 @@ namespace Apache.Calcite.Geography.Sql
         public static readonly SqlFunction StGeogGeomFromWkt =
             Function("ST_GEOG_GEOMFROMWKT", nameof(GeographyFunctions.FromWkt), GeographyReturnTypes.Geography,
                 [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMTEXT(VARCHAR, INTEGER)</c>. Reads a geography from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromTextWithSrid =
+            Function("ST_GEOG_GEOMFROMTEXT", nameof(GeographyFunctions.FromWkt), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMWKT(VARCHAR, INTEGER)</c>. Reads a geography from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromWktWithSrid =
+            Function("ST_GEOG_GEOMFROMWKT", nameof(GeographyFunctions.FromWkt), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
 
         /// <summary>
         /// <c>ST_GEOG_ASGEOM(GEOGRAPHY)</c>. Reads a geography as a geometry.
@@ -128,9 +151,16 @@ namespace Apache.Calcite.Geography.Sql
         /// <returns></returns>
         static SqlFunction Function(string name, string method, SqlReturnTypeInference returnType, GeographyOperand[] operands, string[] names)
         {
-            // by name rather than by signature: ReflectiveFunctionBase.findMethod matches the name alone, and
-            // every method on GeographyFunctions has a distinct one
-            var function = ScalarFunctionImpl.create((java.lang.Class)typeof(GeographyFunctions), method) ??
+            // by signature and not by name. ScalarFunctionImpl.create(class, name) goes through
+            // ReflectiveFunctionBase.findMethod, which answers the first method of that name and would pick
+            // between two arities of a constructor at random. Deriving the signature from the operands is
+            // also what keeps the declaration and the body from drifting apart: a position that takes a
+            // geography is a Geometry parameter, and there is one place that says so.
+            var parameters = new java.lang.Class[operands.Length];
+            for (var i = 0; i < operands.Length; i++)
+                parameters[i] = ClassOf(operands[i]);
+
+            var found = ((java.lang.Class)typeof(GeographyFunctions)).getMethod(method, parameters) ??
                 throw new InvalidOperationException($"No method '{method}' on '{nameof(GeographyFunctions)}'.");
 
             return new SqlUserDefinedFunction(
@@ -139,7 +169,28 @@ namespace Apache.Calcite.Geography.Sql
                 returnType,
                 null,
                 new GeographyOperandTypeChecker(operands, names),
-                function);
+                ScalarFunctionImpl.create(found));
+        }
+
+        /// <summary>
+        /// The parameter class a position of the given kind is passed as.
+        /// </summary>
+        /// <param name="operand"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A number is a <c>Number</c> rather than a <c>Double</c> because a literal arrives as whatever type
+        /// it had, and <c>2.0</c> is a <c>BigDecimal</c>; see <c>GeographyFunctions.DWithin</c>.
+        /// </remarks>
+        static java.lang.Class ClassOf(GeographyOperand operand)
+        {
+            return operand switch
+            {
+                GeographyOperand.Geography => (java.lang.Class)typeof(org.locationtech.jts.geom.Geometry),
+                GeographyOperand.Geometry => (java.lang.Class)typeof(org.locationtech.jts.geom.Geometry),
+                GeographyOperand.Character => (java.lang.Class)typeof(string),
+                GeographyOperand.Numeric => (java.lang.Class)typeof(java.lang.Number),
+                _ => throw new NotSupportedException($"No parameter class for '{operand}'."),
+            };
         }
 
         /// <summary>
@@ -171,6 +222,8 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogGeomFromGeoJson,
                 StGeogGeomFromText,
                 StGeogGeomFromWkt,
+                StGeogGeomFromTextWithSrid,
+                StGeogGeomFromWktWithSrid,
                 StGeogAsGeom,
                 StGeomAsGeog,
                 StGeogDistance,

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -1,0 +1,198 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+using Apache.Calcite.Geography.Sql.Type;
+
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.parser;
+using org.apache.calcite.sql.type;
+using org.apache.calcite.sql.util;
+using org.apache.calcite.sql.validate;
+
+namespace Apache.Calcite.Geography.Sql
+{
+
+    /// <summary>
+    /// The <c>ST_GEOG_*</c> operators.
+    /// </summary>
+    /// <remarks>
+    /// Chained by a host onto whatever it already has:
+    ///
+    /// <code>
+    /// SqlOperatorTables.chain(SqlStdOperatorTable.instance(), GeographyOperatorTable.Instance())
+    /// </code>
+    ///
+    /// <para>There is no other way in. A function declared through a schema — <c>SchemaPlus.add(name,
+    /// Function)</c> — cannot take a geography parameter at all; see
+    /// <see cref="GeographyOperandTypeChecker"/> for the assertion it dies on. So a caller reaching Calcite
+    /// through a plain connection and a model file cannot resolve these names by themselves: something has to
+    /// chain this table for them.</para>
+    ///
+    /// <para>Each operator is a <c>SqlUserDefinedFunction</c> over a <c>ScalarFunctionImpl</c>, which is what
+    /// gives the call an implementor: <c>RexImpTable.get</c> answers a user-defined function by asking its
+    /// <c>Function</c> for one, and its own map is private with no <c>RexImplementorTable</c> to add to until
+    /// 1.43. The body is a .NET method and no class name is written out — this convention's translator holds
+    /// the method itself, and Calcite's own engine reaches a CLR class through the class-loader stamp
+    /// <c>IKVM.Maven.Sdk</c> puts on <c>calcite-core</c>.</para>
+    ///
+    /// <para>This is the first increment of the surface. Calcite's spatial library is about 130 names and
+    /// every one of them needs an <c>ST_GEOG_</c> declaration, because Calcite's own reject the type. What is
+    /// here is the type's constructors, the two crossings, and the five operations a geodesic store actually
+    /// pushes.</para>
+    /// </remarks>
+    public sealed class GeographyOperatorTable : SqlOperatorTable
+    {
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMGEOJSON(VARCHAR)</c>. Reads a geography from GeoJSON.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromGeoJson =
+            Function("ST_GEOG_GEOMFROMGEOJSON", nameof(GeographyFunctions.FromGeoJson), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["geoJson"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMTEXT(VARCHAR)</c>. Reads a geography from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromText =
+            Function("ST_GEOG_GEOMFROMTEXT", nameof(GeographyFunctions.FromWkt), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMWKT(VARCHAR)</c>. Reads a geography from WKT; Calcite's alias for the same
+        /// thing, mirrored.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromWkt =
+            Function("ST_GEOG_GEOMFROMWKT", nameof(GeographyFunctions.FromWkt), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASGEOM(GEOGRAPHY)</c>. Reads a geography as a geometry.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsGeom =
+            Function("ST_GEOG_ASGEOM", nameof(GeographyFunctions.AsGeometry), GeographyReturnTypes.Geometry,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOM_ASGEOG(GEOMETRY)</c>. Reads a geometry as a geography.
+        /// </summary>
+        public static readonly SqlFunction StGeomAsGeog =
+            Function("ST_GEOM_ASGEOG", nameof(GeographyFunctions.AsGeography), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geom"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_DISTANCE(GEOGRAPHY, GEOGRAPHY)</c>. The distance between two geographies, in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogDistance =
+            Function("ST_GEOG_DISTANCE", nameof(GeographyFunctions.Distance), ReturnTypes.DOUBLE_NULLABLE,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_DWITHIN(GEOGRAPHY, GEOGRAPHY, DOUBLE)</c>. Whether two geographies are within the given
+        /// distance in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogDWithin =
+            Function("ST_GEOG_DWITHIN", nameof(GeographyFunctions.DWithin), ReturnTypes.BOOLEAN_NULLABLE,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Numeric], ["geog1", "geog2", "distance"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_WITHIN(GEOGRAPHY, GEOGRAPHY)</c>. Whether the first geography lies within the second.
+        /// </summary>
+        public static readonly SqlFunction StGeogWithin =
+            Function("ST_GEOG_WITHIN", nameof(GeographyFunctions.Within), ReturnTypes.BOOLEAN_NULLABLE,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_INTERSECTS(GEOGRAPHY, GEOGRAPHY)</c>. Whether two geographies have any point in common.
+        /// </summary>
+        public static readonly SqlFunction StGeogIntersects =
+            Function("ST_GEOG_INTERSECTS", nameof(GeographyFunctions.Intersects), ReturnTypes.BOOLEAN_NULLABLE,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ISVALID(GEOGRAPHY)</c>. Whether the geography is valid on the sphere.
+        /// </summary>
+        public static readonly SqlFunction StGeogIsValid =
+            Function("ST_GEOG_ISVALID", nameof(GeographyFunctions.IsValid), ReturnTypes.BOOLEAN_NULLABLE,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// Declares one operator.
+        /// </summary>
+        /// <param name="name">The SQL name.</param>
+        /// <param name="method">The name of the method on <see cref="GeographyFunctions"/> that implements
+        /// it.</param>
+        /// <param name="returnType"></param>
+        /// <param name="operands">What each position takes.</param>
+        /// <param name="names">The name of each position.</param>
+        /// <returns></returns>
+        static SqlFunction Function(string name, string method, SqlReturnTypeInference returnType, GeographyOperand[] operands, string[] names)
+        {
+            // by name rather than by signature: ReflectiveFunctionBase.findMethod matches the name alone, and
+            // every method on GeographyFunctions has a distinct one
+            var function = ScalarFunctionImpl.create((java.lang.Class)typeof(GeographyFunctions), method) ??
+                throw new InvalidOperationException($"No method '{method}' on '{nameof(GeographyFunctions)}'.");
+
+            return new SqlUserDefinedFunction(
+                new SqlIdentifier(name, SqlParserPos.ZERO),
+                SqlKind.OTHER_FUNCTION,
+                returnType,
+                null,
+                new GeographyOperandTypeChecker(operands, names),
+                function);
+        }
+
+        /// <summary>
+        /// The one instance.
+        /// </summary>
+        /// <remarks>
+        /// Declared after the operators deliberately: a static field initializer runs in textual order, and
+        /// one placed above them builds the table out of ten nulls.
+        /// </remarks>
+        static readonly GeographyOperatorTable instance = new();
+
+        /// <summary>
+        /// Returns the operator table.
+        /// </summary>
+        /// <returns></returns>
+        public static GeographyOperatorTable Instance()
+        {
+            return instance;
+        }
+
+        readonly SqlOperatorTable operators;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        GeographyOperatorTable()
+        {
+            operators = SqlOperatorTables.of([
+                StGeogGeomFromGeoJson,
+                StGeogGeomFromText,
+                StGeogGeomFromWkt,
+                StGeogAsGeom,
+                StGeomAsGeog,
+                StGeogDistance,
+                StGeogDWithin,
+                StGeogWithin,
+                StGeogIntersects,
+                StGeogIsValid,
+            ]);
+        }
+
+        /// <inheritdoc />
+        public void lookupOperatorOverloads(SqlIdentifier opName, SqlFunctionCategory category, SqlSyntax syntax, java.util.List operatorList, SqlNameMatcher nameMatcher)
+        {
+            operators.lookupOperatorOverloads(opName, category, syntax, operatorList, nameMatcher);
+        }
+
+        /// <inheritdoc />
+        public java.util.List getOperatorList()
+        {
+            return operators.getOperatorList();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Sql/Type/GeographyOperand.cs
+++ b/src/Apache.Calcite.Geography/Sql/Type/GeographyOperand.cs
@@ -1,0 +1,37 @@
+namespace Apache.Calcite.Geography.Sql.Type
+{
+
+    /// <summary>
+    /// What an <c>ST_GEOG_*</c> operator will take in a given position.
+    /// </summary>
+    /// <remarks>
+    /// Not a <c>SqlTypeFamily</c>, and it cannot be one: a geography answers <c>OTHER</c>, which is the
+    /// family every unmapped Java type is in, so a family is exactly the thing that cannot tell a geography
+    /// from anything else carried by a class Calcite has no <c>SqlTypeName</c> for.
+    /// </remarks>
+    public enum GeographyOperand
+    {
+
+        /// <summary>
+        /// A geography, and nothing else — not a geometry, which is the same class read as a plane.
+        /// </summary>
+        Geography,
+
+        /// <summary>
+        /// A geometry as Calcite means one.
+        /// </summary>
+        Geometry,
+
+        /// <summary>
+        /// A character string.
+        /// </summary>
+        Character,
+
+        /// <summary>
+        /// A number.
+        /// </summary>
+        Numeric,
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Sql/Type/GeographyOperandTypeChecker.cs
+++ b/src/Apache.Calcite.Geography/Sql/Type/GeographyOperandTypeChecker.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Linq;
+
+using Apache.Calcite.Geography.Rel.Type;
+
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.type;
+
+namespace Apache.Calcite.Geography.Sql.Type
+{
+
+    /// <summary>
+    /// Checks that each operand of an <c>ST_GEOG_*</c> call is what that position takes.
+    /// </summary>
+    /// <remarks>
+    /// This is why the declarations are operators rather than schema functions. A function declared through a
+    /// schema carries its parameter types, and routine resolution runs an assignability check keyed on the
+    /// parameter's <c>SqlTypeName</c>: <c>SqlUtil.filterRoutinesByParameterTypeAndName</c> reaches
+    /// <c>SqlTypeMappingRule.canApplyFrom</c>, which throws <c>AssertionError: No assign rules for OTHER
+    /// defined</c> because no rule is keyed on <c>OTHER</c> and none can be supplied — the path consults the
+    /// immutable assignment rule, so <c>SqlTypeCoercionRule.THREAD_PROVIDERS</c> does not reach it. Operand
+    /// checking is our code and consults no rules at all.
+    ///
+    /// <para>That same filter is what <see cref="isFixedParameters"/> has to answer <c>false</c> for. It
+    /// runs the check only on a checker that says its parameters are fixed, and skips one that does not; a
+    /// <c>true</c> here would walk back into the assertion by way of our own declared parameter types.
+    /// <c>SqlOperandMetadata</c> is implemented because <c>SqlUserDefinedFunction.getOperandTypeChecker</c>
+    /// narrows its return type to it, not because the parameters are meant to be fixed.</para>
+    ///
+    /// <para>The checker is also the whole of the error a caller sees. One that accepted anything would let
+    /// <c>ST_GEOG_DISTANCE('a', 'b')</c> validate and fail somewhere further down, or not at all.</para>
+    /// </remarks>
+    public sealed class GeographyOperandTypeChecker : SqlOperandMetadata
+    {
+
+        readonly GeographyOperand[] operands;
+        readonly string[] names;
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="operands">What each position takes.</param>
+        /// <param name="names">The name of each position.</param>
+        public GeographyOperandTypeChecker(GeographyOperand[] operands, string[] names)
+        {
+            ArgumentNullException.ThrowIfNull(operands);
+            ArgumentNullException.ThrowIfNull(names);
+
+            if (operands.Length != names.Length)
+                throw new ArgumentException("An operand list and a name list must be the same length.", nameof(names));
+
+            this.operands = operands;
+            this.names = names;
+        }
+
+        /// <inheritdoc />
+        public bool checkOperandTypes(SqlCallBinding callBinding, bool throwOnFailure)
+        {
+            for (var i = 0; i < operands.Length; i++)
+            {
+                if (Matches(operands[i], callBinding.getOperandType(i)))
+                    continue;
+
+                if (throwOnFailure)
+                    throw callBinding.newValidationSignatureError();
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public SqlOperandCountRange getOperandCountRange()
+        {
+            return SqlOperandCountRanges.of(operands.Length);
+        }
+
+        /// <inheritdoc />
+        public string getAllowedSignatures(SqlOperator op, string opName)
+        {
+            return SqlUtil.getAliasedSignature(op, opName, java.util.Arrays.asList([.. operands.Select(NameOf)]));
+        }
+
+        /// <inheritdoc />
+        public java.util.List paramTypes(RelDataTypeFactory typeFactory)
+        {
+            var list = new java.util.ArrayList(operands.Length);
+
+            foreach (var operand in operands)
+                list.add(TypeOf(operand, typeFactory));
+
+            return list;
+        }
+
+        /// <inheritdoc />
+        public java.util.List paramNames()
+        {
+            return java.util.Arrays.asList([.. names]);
+        }
+
+        /// <summary>
+        /// Returns whether the list of parameters is fixed-length, which for this checker is always
+        /// <c>false</c>.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// Answering <c>true</c> puts the declared parameter types back in front of
+        /// <c>SqlUtil.filterRoutinesByParameterTypeAndName</c>, and a geography parameter there is the
+        /// <c>No assign rules for OTHER defined</c> assertion. Nothing else is lost by saying no: the flag
+        /// otherwise only tells the validator it may supply <c>DEFAULT</c> for a missing argument, and none
+        /// of these has an optional one.
+        /// </remarks>
+        public bool isFixedParameters()
+        {
+            return false;
+        }
+
+        // IKVM does not project a Java default method as a C# default interface member, so an implementer
+        // written here has to restate every one of them. These are Calcite's own bodies.
+
+        /// <inheritdoc />
+        public SqlOperandTypeChecker.Consistency getConsistency()
+        {
+            return SqlOperandTypeChecker.Consistency.NONE;
+        }
+
+        /// <inheritdoc />
+        public bool isOptional(int i)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public SqlOperandTypeInference typeInference()
+        {
+            return null!;
+        }
+
+        /// <inheritdoc />
+        public CompositeOperandTypeChecker withGenerator(java.util.function.BiFunction signatureGenerator)
+        {
+            throw new java.lang.UnsupportedOperationException("withGenerator");
+        }
+
+        /// <inheritdoc />
+        public SqlOperandTypeChecker and(SqlOperandTypeChecker checker)
+        {
+            return OperandTypes.and(this, checker);
+        }
+
+        /// <inheritdoc />
+        public SqlOperandTypeChecker or(SqlOperandTypeChecker checker)
+        {
+            return OperandTypes.or(this, checker);
+        }
+
+        static bool Matches(GeographyOperand operand, RelDataType type)
+        {
+            // a NULL argument is legal in every position; each body answers null for one
+            if (type.getSqlTypeName() == SqlTypeName.NULL)
+                return true;
+
+            return operand switch
+            {
+                GeographyOperand.Geography => GeographyTypes.IsGeography(type),
+                GeographyOperand.Geometry => GeographyTypes.IsGeometry(type),
+                GeographyOperand.Character => SqlTypeUtil.inCharFamily(type),
+                GeographyOperand.Numeric => SqlTypeUtil.isNumeric(type),
+                _ => false,
+            };
+        }
+
+        static RelDataType TypeOf(GeographyOperand operand, RelDataTypeFactory typeFactory)
+        {
+            return operand switch
+            {
+                GeographyOperand.Geography => GeographyTypes.Of(typeFactory),
+                GeographyOperand.Geometry => GeographyTypes.GeometryOf(typeFactory),
+                GeographyOperand.Character => typeFactory.createSqlType(SqlTypeName.VARCHAR),
+                GeographyOperand.Numeric => typeFactory.createSqlType(SqlTypeName.DOUBLE),
+                _ => throw new NotSupportedException($"No type for '{operand}'."),
+            };
+        }
+
+        static string NameOf(GeographyOperand operand)
+        {
+            return operand switch
+            {
+                GeographyOperand.Geography => "GEOGRAPHY",
+                GeographyOperand.Geometry => "GEOMETRY",
+                GeographyOperand.Character => "CHARACTER",
+                GeographyOperand.Numeric => "NUMERIC",
+                _ => throw new NotSupportedException($"No name for '{operand}'."),
+            };
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Sql/Type/GeographyReturnTypes.cs
+++ b/src/Apache.Calcite.Geography/Sql/Type/GeographyReturnTypes.cs
@@ -1,0 +1,85 @@
+using Apache.Calcite.Geography.Rel.Type;
+
+using org.apache.calcite.rel.type;
+using org.apache.calcite.sql;
+using org.apache.calcite.sql.type;
+
+namespace Apache.Calcite.Geography.Sql.Type
+{
+
+    /// <summary>
+    /// The return type strategies the <c>ST_GEOG_*</c> operators use, for the two types Calcite has no
+    /// strategy of its own for.
+    /// </summary>
+    /// <remarks>
+    /// The rest come from <c>ReturnTypes</c> unchanged: a predicate is <c>BOOLEAN_NULLABLE</c> and a
+    /// measurement is <c>DOUBLE_NULLABLE</c>, both of which are right, because each body answers null exactly
+    /// when one of its arguments is null.
+    ///
+    /// <para>Neither of these two runs through <c>SqlTypeTransforms.TO_NULLABLE</c>, and that is deliberate.
+    /// The transform calls <c>createTypeWithNullability</c>, and a change of nullability on a <c>JavaType</c>
+    /// is answered by <c>RelDataTypeFactoryImpl.copySimpleType</c> with a plain <c>new JavaType(clazz,
+    /// nullable)</c> — the subclass is not copied, so a geography asked to become <c>NOT NULL</c> comes back
+    /// an ordinary geometry and every guarantee this package makes is gone. The type is nullable already,
+    /// which is the answer the transform would give for a nullable argument anyway.</para>
+    /// </remarks>
+    public static class GeographyReturnTypes
+    {
+
+        /// <summary>
+        /// Returns <c>GEOGRAPHY</c>.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Geography = new GeographyReturnTypeInference();
+
+        /// <summary>
+        /// Returns <c>GEOMETRY</c>, as Calcite's own spatial library declares it.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Geometry = new GeometryReturnTypeInference();
+
+        /// <summary>
+        /// The half of <c>SqlReturnTypeInference</c> that is the same whatever the type is.
+        /// </summary>
+        /// <remarks>
+        /// IKVM does not project a Java default method as a C# default interface member, so an implementer
+        /// written here has to restate every one of them. These are Calcite's own bodies.
+        /// </remarks>
+        abstract class ReturnTypeInference : SqlReturnTypeInference
+        {
+
+            public abstract RelDataType inferReturnType(SqlOperatorBinding opBinding);
+
+            public SqlReturnTypeInference andThen(SqlTypeTransform transform)
+            {
+                return ReturnTypes.cascade(this, transform);
+            }
+
+            public SqlReturnTypeInference orElse(SqlReturnTypeInference transform)
+            {
+                return ReturnTypes.chain(this, transform);
+            }
+
+        }
+
+        sealed class GeographyReturnTypeInference : ReturnTypeInference
+        {
+
+            public override RelDataType inferReturnType(SqlOperatorBinding opBinding)
+            {
+                return GeographyTypes.Of(opBinding.getTypeFactory());
+            }
+
+        }
+
+        sealed class GeometryReturnTypeInference : ReturnTypeInference
+        {
+
+            public override RelDataType inferReturnType(SqlOperatorBinding opBinding)
+            {
+                return GeographyTypes.GeometryOf(opBinding.getTypeFactory());
+            }
+
+        }
+
+    }
+
+}

--- a/src/dist-nuget/dist-nuget.csproj
+++ b/src/dist-nuget/dist-nuget.csproj
@@ -16,7 +16,7 @@
         <PackageProjectReference Include="..\Apache.Calcite.Extensions\Apache.Calcite.Extensions.csproj">
             <PackageTargetPath>.</PackageTargetPath>
         </PackageProjectReference>
-        <PackageProjectReference Include="..\Apache.Calcite.Extensions\Apache.Calcite.Extensions.csproj">
+        <PackageProjectReference Include="..\Apache.Calcite.Geography\Apache.Calcite.Geography.csproj">
             <PackageTargetPath>.</PackageTargetPath>
         </PackageProjectReference>
     </ItemGroup>

--- a/src/dist-tests/dist-tests.csproj
+++ b/src/dist-tests/dist-tests.csproj
@@ -13,8 +13,8 @@
         <TestTarget Include="Apache.Calcite.Adapter.AdoNet.Tests|net10.0" ProjectName="Apache.Calcite.Adapter.AdoNet.Tests" TargetFramework="net10.0" />
         <TestTarget Include="Apache.Calcite.Data.Tests|net8.0" ProjectName="Apache.Calcite.Data.Tests" TargetFramework="net8.0" />
         <TestTarget Include="Apache.Calcite.Data.Tests|net10.0" ProjectName="Apache.Calcite.Data.Tests" TargetFramework="net10.0" />
-        <TestTarget Include="Apache.Calcite.Tests|net8.0" ProjectName="Apache.Calcite.Tests" TargetFramework="net8.0" />
-        <TestTarget Include="Apache.Calcite.Tests|net10.0" ProjectName="Apache.Calcite.Tests" TargetFramework="net10.0" />
+        <TestTarget Include="Apache.Calcite.Geography.Tests|net8.0" ProjectName="Apache.Calcite.Geography.Tests" TargetFramework="net8.0" />
+        <TestTarget Include="Apache.Calcite.Geography.Tests|net10.0" ProjectName="Apache.Calcite.Geography.Tests" TargetFramework="net10.0" />
     </ItemGroup>
 
     <!-- Runs once per TFM/RID combination to generate individual output. -->


### PR DESCRIPTION
First increment of the geography package proposed in #86: the `GEOGRAPHY` type, the `ST_GEOG_*` operator table, the constructors, the two crossings, and the five operations a geodesic store actually pushes.

Optional, and one-way. Nothing else in the repository references `Apache.Calcite.Geography`, and it references nothing else here — it takes calcite-core directly, pinned to the 1.42.0 the rest of the tree resolves.

## The type

`GeographySqlType` is a `RelDataTypeFactoryImpl.JavaType` over `org.locationtech.jts.geom.Geometry` that answers a different name.

| | |
| --- | --- |
| `getSqlTypeName()` | `OTHER` |
| `getFullTypeString()` | `GEOGRAPHY` |
| `getJavaClass()` | `org.locationtech.jts.geom.Geometry` |

The `OTHER` matters more than it looks: `JavaToSqlTypeConversionRules` maps `Geometry.class` to `GEOMETRY`, and that mapping is the whole of what makes Calcite's planar functions accept a value. `getJavaClass` is left alone, so the runtime carrier is an ordinary JTS geometry — no new class, nothing new for code generation to name, nothing to convert at a boundary.

**Calcite's own `ST_*` refuse a geography at validation**, accessors included. That is the property the package exists for; without it a geodesic value answers in degrees, in a different ordering, with no error anywhere.

The type is nullable, and that is load-bearing. `RelDataTypeFactoryImpl.copySimpleType` answers a change of nullability on any `JavaType` with a plain `new JavaType(clazz, nullable)` — not the subclass — so `createTypeWithNullability(geography, false)` hands back an ordinary geometry and the marking is gone. Nothing here runs a return type through `SqlTypeTransforms.TO_NULLABLE` for that reason, and `GeographyTypeTests` holds it.

## Why operators and not schema functions

Routine resolution runs an assignability check keyed on the parameter's `SqlTypeName`. `SqlUtil.filterRoutinesByParameterTypeAndName` reaches `SqlTypeMappingRule.canApplyFrom`, which throws `AssertionError: No assign rules for OTHER defined`, and no rule can be supplied because that path consults the immutable assignment rule rather than `SqlTypeCoercionRule.THREAD_PROVIDERS`.

The operand checkers stay out of it by answering `false` to `isFixedParameters`, which is the flag `SqlUtil` consults before running the check at all. They implement `SqlOperandMetadata` only because `SqlUserDefinedFunction.getOperandTypeChecker` narrows its return type to it.

Each operator is a `SqlUserDefinedFunction` over a `ScalarFunctionImpl`, which is how the call gets an implementor without a hook into `RexImpTable` — that map is private and 1.42 has no `RexImplementorTable`.

A host chains the table:

```csharp
SqlOperatorTables.chain(SqlStdOperatorTable.instance(), GeographyOperatorTable.Instance())
```

There is no other way in, so a caller reaching Calcite through a plain connection and a model file cannot resolve these names by themselves.

## The geodesic engine

**Google's S2**, taken as a Java library the way calcite-core is. One model for all five operations rather than two — an ellipsoidal distance from GeographicLib next to a spherical containment from S2 would put two readings of the same coordinates in one plan. Spherical, radius 6,371,010 m, which is what BigQuery and Snowflake compute in. The .NET ports on NuGet were considered and rejected: the largest is a 2016 `netstandard1.0` port of a 2011 snapshot with no `S2Polyline` at all. The choice is reversible.

It resolved against calcite's guava rather than downgrading it — `guava.dll` is byte-identical to the one `Apache.Calcite.Extensions` builds.

## What the operations mean

Calcite's function is the specification with the plane swapped for the sphere. `ST_Within` is `geom1.within(geom2)`, so `ST_GEOG_WITHIN` is the DE-9IM relation and not containment — every point of the one in the other **and** the interiors meeting, which is why a point on a polygon's boundary is not within it.

Two suites hold them to that, both answered by Calcite, both over shapes small enough and near enough the equator that a great-circle edge and a straight line in longitude and latitude cannot be told apart.

`GeographyDifferentialTests` is hand-written: 25 shapes crossed with themselves, 625 pairs per operation. It found what hand-written assertions had not — `ST_GEOG_INTERSECTS` missing fourteen pairs that were touches rather than crossings, `ST_GEOG_WITHIN` missing twenty-seven because it had been written as containment, a polygon swallowing another's hole without any edge going near it, a repeated ring coordinate silently taking the area off a polygon, and a mixed collection judged on its highest-dimensional part alone.

`GeographyRandomDifferentialTests` generates instead, on a seven-by-seven lattice rather than from arbitrary doubles, because the cases that break things are the coincidences — a vertex exactly on an edge, two edges collinear, two squares sharing a side, a hole whose every corner lies on the boundary of the polygon around it. Random doubles produce none of those; a lattice produces them constantly. It found four more after the hand-written suite was green:

- a multipolygon whose parts overlap, nest, or share a whole edge is invalid, and validating the parts one at a time cannot see any of the three;
- `within` said yes where a shared boundary made `S2Polygon.contains` say no and `initToDifference` leave a snapping sliver behind;
- testing the *vertices* of `b`'s rings against `a`'s interior is not enough and looks like it is — a hole can have every corner on `a`'s boundary and still lie inside it;
- `within` answered yes to `a` being exactly a hole of `b`, where no boundary walk can help because the boundaries are identical either way.

Twelve seeds at 25,000 pairs each — 300,000 — are clean across all five operations and validity. The committed test runs six seeds at 5,000 and asserts the number of comparisons as well as the disagreements, so a generator that quietly stopped producing polygons cannot leave it green by leaving it empty.

## What differs from Calcite, deliberately

- **`ST_GEOG_DWITHIN` takes a `Number`.** `2.0` is `DECIMAL(2, 1)` and arrives as a `BigDecimal`; nothing converts it on the way to a `double` parameter, because `ReflectiveCallNotNullImplementor` runs `convertAssignableTypes`, which converts *to* a decimal and not from one. Calcite's own `ST_DWITHIN` cannot be called with a decimal literal at all — measured on `ST_DWITHIN` itself, under Janino. A caller should not have to write `CAST(2.0 AS DOUBLE)` to give a function a distance.
- **A geometry collection is answered rather than refused.** `Geometry.within` throws `Operation does not support GeometryCollection arguments` from the `relate` underneath it — though only sometimes, since `contains` answers a rectangular container through `RectangleContains` without reaching `relate`. Reproducing an inability buys nothing.
- **An SRID that is not 4326 is refused rather than ignored.** Both arities of the WKT constructors are Calcite's, but a geography is WGS84 and there is no second reference system to reproject into — the same reason `ST_SETSRID` and `ST_TRANSFORM` have no counterpart.

## Measured on the way

**The type survives a whole statement**, which #86 left open. `GeographyExecutionTests` plans, generates, compiles under Janino and runs every one of the twelve declarations through `EnumerableConvention` — the harder of the two engines, since the body is a .NET method and Janino has to resolve the `cli.`-prefixed name IKVM gives a CLR class.

The four places #86 names as needing a live store now have their nearer half held here — not agreement with a store, but that this convention is on the right side of the seam at all:

| | geodesic | planar |
| --- | --- | --- |
| either side of the antimeridian | 0.2° of arc | 359.8° |
| opposite meridians near a pole | 0.2°, over the pole | 180° |
| the pole spelled two ways | one place | 180° |
| a polygon written across the antimeridian | a 2° box | the 358° band that is everything else |

That last is the argument for the package in one shape. `POLYGON((179 -1, -179 -1, -179 1, 179 1, 179 -1))` is a two-degree box straddling the seam on the sphere and the 358-degree band that is everything except that box in the plane. Every point is inside one and outside the other. No tolerance and no reprojection reconciles them.

## Not in this branch

- The remaining ~120 declarations. The full mapping is in #86.
- **Rechecking a pushed-down predicate.** These implementations are not wired into any filter-recheck path and must not be until their agreement with each live store has been measured at the boundaries. A recheck that disagrees discards rows the store returned.

## Known limits

- **The relations are this branch's own rather than a library's.** `S2BooleanOperation` would settle `ST_GEOG_WITHIN` by construction and cannot be had: the S2 published to Maven Central is the 2021 release, which does not have it, and the current source is compiled to Java 11, which IKVM does not read. Porting it is four thousand lines plus the `S2Builder`, `S2BuilderGraph`, `S2CrossingEdgesQuery` and `primitives` machinery underneath, plus a `fastutil` dependency. What stands in for it is the size of the oracle, above.
- The pairwise operations are quadratic in the vertex counts. S2 has indexed forms and this does not use them yet — an index is worth adding against a measurement rather than a guess.
- `SqlKind` is closed, so an adapter recognises one of these by the operator or by its name. `SqlKind.ST_DWITHIN` is deliberately not reused: Calcite's own `SpatialRules` matches on it and would plan a geodesic call as a planar one.

## Tests

1,700 across the repository, nothing red, nothing skipped.

| suite | |
| --- | --- |
| `Apache.Calcite.Tests` | 827 |
| `Apache.Calcite.Data.Tests` | 396 |
| `Apache.Calcite.Adapter.AdoNet.Tests` | 367 |
| `Apache.Calcite.Geography.Tests` | 56, on net8.0 and net10.0 |

Also fixed in passing: `dist-nuget` listed `Apache.Calcite.Extensions` twice and `dist-tests` listed `Apache.Calcite.Tests` twice. The duplicate was the line the new entry replaced.

Closes part of #86.
