### PR TITLE
Declare the mechanical geography surface, and add the relations and measurements

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographyAccessorTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyAccessorTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The accessors and the serializers, against the <c>ST_*</c> each one mirrors.
+    /// </summary>
+    /// <remarks>
+    /// These read or rearrange coordinates without interpreting the space between them, so unlike the
+    /// relations there is no geodesy in them at all and each is a delegation to the very method Calcite's
+    /// operator of that name calls. What can go wrong is therefore not the arithmetic but the wiring: forty
+    /// declarations written to one pattern is forty chances to point a name at the wrong body. Comparing
+    /// every one against Calcite over shapes of every kind is what catches that.
+    ///
+    /// <para>The bounding-box accessors are the exception worth stating. <c>ST_GEOG_XMIN</c> and its four
+    /// relatives are computed structurally and are wrong in the usual way for anything crossing the
+    /// antimeridian, where the least longitude of a shape spanning the seam is not the westmost point of it.
+    /// That is inherited rather than introduced, and it is a documentation problem rather than a second
+    /// implementation; nothing here is near the seam.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyAccessorTests
+    {
+
+        /// <summary>
+        /// Shapes of every kind an accessor has something to say about.
+        /// </summary>
+        static readonly string[] shapes =
+        [
+            "POINT(1 2)",
+            "POINT Z(1 2 3)",
+            "POINT EMPTY",
+            "MULTIPOINT((1 2), (3 4))",
+            "LINESTRING(0 0, 1 1, 2 0)",
+            "LINESTRING(0 0, 1 1, 0 0)",
+            "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+            "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))",
+            "POLYGON((0 0, 6 0, 6 6, 0 6, 0 0), (2 2, 4 2, 4 4, 2 4, 2 2))",
+            "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))",
+            "GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(0 0, 1 1))",
+        ];
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        /// <summary>
+        /// Every one-argument accessor and serializer, ours beside Calcite's.
+        /// </summary>
+        static readonly (string Name, Func<Geometry, object?> Ours, Func<Geometry, object?> Theirs)[] unary =
+        [
+            ("ST_GEOG_X", g => GeographyFunctions.X(g), g => SpatialTypeFunctions.ST_X(g)),
+            ("ST_GEOG_Y", g => GeographyFunctions.Y(g), g => SpatialTypeFunctions.ST_Y(g)),
+            ("ST_GEOG_Z", g => GeographyFunctions.Z(g), g => SpatialTypeFunctions.ST_Z(g)),
+            ("ST_GEOG_XMIN", g => GeographyFunctions.XMin(g), g => SpatialTypeFunctions.ST_XMin(g)),
+            ("ST_GEOG_XMAX", g => GeographyFunctions.XMax(g), g => SpatialTypeFunctions.ST_XMax(g)),
+            ("ST_GEOG_YMIN", g => GeographyFunctions.YMin(g), g => SpatialTypeFunctions.ST_YMin(g)),
+            ("ST_GEOG_YMAX", g => GeographyFunctions.YMax(g), g => SpatialTypeFunctions.ST_YMax(g)),
+            ("ST_GEOG_ZMIN", g => GeographyFunctions.ZMin(g), g => SpatialTypeFunctions.ST_ZMin(g)),
+            ("ST_GEOG_ZMAX", g => GeographyFunctions.ZMax(g), g => SpatialTypeFunctions.ST_ZMax(g)),
+            ("ST_GEOG_COORDDIM", g => GeographyFunctions.CoordDim(g), g => SpatialTypeFunctions.ST_CoordDim(g)),
+            ("ST_GEOG_DIMENSION", g => GeographyFunctions.Dimension(g), g => SpatialTypeFunctions.ST_Dimension(g)),
+            ("ST_GEOG_GEOMETRYTYPE", g => GeographyFunctions.GeometryType(g), g => SpatialTypeFunctions.ST_GeometryType(g)),
+            ("ST_GEOG_GEOMETRYTYPECODE", g => GeographyFunctions.GeometryTypeCode(g), g => SpatialTypeFunctions.ST_GeometryTypeCode(g)),
+            ("ST_GEOG_NPOINTS", g => GeographyFunctions.NPoints(g), g => SpatialTypeFunctions.ST_NPoints(g)),
+            ("ST_GEOG_NUMPOINTS", g => GeographyFunctions.NumPoints(g), g => SpatialTypeFunctions.ST_NumPoints(g)),
+            ("ST_GEOG_NUMGEOMETRIES", g => GeographyFunctions.NumGeometries(g), g => SpatialTypeFunctions.ST_NumGeometries(g)),
+            ("ST_GEOG_NUMINTERIORRING", g => GeographyFunctions.NumInteriorRing(g), g => SpatialTypeFunctions.ST_NumInteriorRing(g)),
+            ("ST_GEOG_NUMINTERIORRINGS", g => GeographyFunctions.NumInteriorRings(g), g => SpatialTypeFunctions.ST_NumInteriorRings(g)),
+            ("ST_GEOG_STARTPOINT", g => GeographyFunctions.StartPoint(g), g => SpatialTypeFunctions.ST_StartPoint(g)),
+            ("ST_GEOG_ENDPOINT", g => GeographyFunctions.EndPoint(g), g => SpatialTypeFunctions.ST_EndPoint(g)),
+            ("ST_GEOG_EXTERIORRING", g => GeographyFunctions.ExteriorRing(g), g => SpatialTypeFunctions.ST_ExteriorRing(g)),
+            ("ST_GEOG_BOUNDARY", g => GeographyFunctions.Boundary(g), g => SpatialTypeFunctions.ST_Boundary(g)),
+            ("ST_GEOG_HOLES", g => GeographyFunctions.Holes(g), g => SpatialTypeFunctions.ST_Holes(g)),
+            ("ST_GEOG_ISEMPTY", g => GeographyFunctions.IsEmpty(g), g => SpatialTypeFunctions.ST_IsEmpty(g)),
+            ("ST_GEOG_IS3D", g => GeographyFunctions.Is3D(g), g => SpatialTypeFunctions.ST_Is3D(g)),
+            ("ST_GEOG_ISCLOSED", g => GeographyFunctions.IsClosed(g), g => SpatialTypeFunctions.ST_IsClosed(g)),
+            ("ST_GEOG_SRID", g => GeographyFunctions.Srid(g), g => SpatialTypeFunctions.ST_SRID(g)),
+            ("ST_GEOG_ASTEXT", g => GeographyFunctions.AsText(g), g => SpatialTypeFunctions.ST_AsText(g)),
+            ("ST_GEOG_ASWKT", g => GeographyFunctions.AsWkt(g), g => SpatialTypeFunctions.ST_AsWKT(g)),
+            ("ST_GEOG_ASEWKT", g => GeographyFunctions.AsEwkt(g), g => SpatialTypeFunctions.ST_AsEWKT(g)),
+            ("ST_GEOG_ASGEOJSON", g => GeographyFunctions.AsGeoJson(g), g => SpatialTypeFunctions.ST_AsGeoJSON(g)),
+            ("ST_GEOG_ASGML", g => GeographyFunctions.AsGml(g), g => SpatialTypeFunctions.ST_AsGML(g)),
+            ("ST_GEOG_ASBINARY", g => GeographyFunctions.AsBinary(g), g => SpatialTypeFunctions.ST_AsBinary(g)),
+            ("ST_GEOG_ASWKB", g => GeographyFunctions.AsWkb(g), g => SpatialTypeFunctions.ST_AsWKB(g)),
+            ("ST_GEOG_ASEWKB", g => GeographyFunctions.AsEwkb(g), g => SpatialTypeFunctions.ST_AsEWKB(g)),
+        ];
+
+        /// <summary>
+        /// Renders an answer so that two of them can be compared whatever their type.
+        /// </summary>
+        /// <param name="answer"></param>
+        /// <returns></returns>
+        static string Render(object? answer)
+        {
+            return answer switch
+            {
+                null => "null",
+                Geometry geometry => geometry.toText(),
+                // one side of a pair returns a boxed Boolean and the other a primitive, and the two spell
+                // themselves differently — java.lang.Boolean lowercase, System.Boolean capitalised
+                java.lang.Boolean boxed => boxed.booleanValue() ? "true" : "false",
+                bool value => value ? "true" : "false",
+                // a ByteString renders itself as lowercase hex, and the same value read back out of a result
+                // set is a byte array, which is what says the operator was typed VARBINARY
+                byte[] bytes => Convert.ToHexString(bytes).ToLowerInvariant(),
+                _ => answer.ToString() ?? "null",
+            };
+        }
+
+        /// <summary>
+        /// Calls a function and renders what came back, an exception included.
+        /// </summary>
+        /// <param name="call"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Some of Calcite's accessors throw over a shape they do not apply to, and a delegation throws the
+        /// same way. That is an answer to compare like any other, so the kind of the exception is rendered
+        /// rather than allowed to end the run.
+        /// </remarks>
+        static string Answer(Func<object?> call)
+        {
+            try
+            {
+                return Render(call());
+            }
+            catch (Exception e)
+            {
+                return e.GetType().Name;
+            }
+        }
+
+        [TestMethod]
+        public void ShouldAgreeWithCalciteOnEveryAccessor()
+        {
+            var differences = new List<string>();
+
+            foreach (var shape in shapes)
+            {
+                var geography = Wkt(shape);
+
+                foreach (var (name, ours, theirs) in unary)
+                {
+                    var mine = Answer(() => ours(geography));
+                    var calcite = Answer(() => theirs(geography));
+
+                    if (mine != calcite)
+                        differences.Add($"{name} over {shape}: ours {mine}, Calcite {calcite}");
+                }
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        /// <summary>
+        /// Every accessor, called as SQL rather than as a method, and answered the same.
+        /// </summary>
+        /// <remarks>
+        /// The comparison above is between two C# methods and says nothing about which of them a name is
+        /// wired to. This runs the operator, so a declaration pointing <c>ST_GEOG_XMIN</c> at
+        /// <c>XMax</c> — or typed as though it returned something else — is caught here and only here.
+        /// Everything goes in one statement per shape rather than one per operator, which is thirty-five
+        /// declarations checked in three round trips.
+        ///
+        /// <para>An accessor that throws over the shape is left out of the statement rather than expected to
+        /// throw: an exception in one column ends the whole query, and what it would prove is already proven
+        /// by the comparison above.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRunEveryAccessorAsAnOperator()
+        {
+            foreach (var shape in new[]
+            {
+                "POINT(1 2)",
+                "LINESTRING(0 0, 1 1, 2 0)",
+                "POLYGON((0 0, 6 0, 6 6, 0 6, 0 0), (2 2, 4 2, 4 4, 2 4, 2 2))",
+            })
+            {
+                var geography = Wkt(shape);
+                var wanted = new List<string>();
+                var expressions = new List<string>();
+                var names = new List<string>();
+
+                foreach (var (name, ours, _) in unary)
+                {
+                    var answer = Answer(() => ours(geography));
+                    if (answer.EndsWith("Exception"))
+                        continue;
+
+                    wanted.Add(answer);
+                    names.Add(name);
+                    expressions.Add($"{name}(ST_GEOG_GEOMFROMTEXT('{shape}'))");
+                }
+
+                var row = GeographyExecutionTests.Run("SELECT " + string.Join(", ", expressions))[0];
+
+                for (var i = 0; i < wanted.Count; i++)
+                    Render(row[i]).Should().Be(wanted[i], $"{names[i]} over {shape}");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldAgreeWithCalciteOnTheIndexedAccessors()
+        {
+            var differences = new List<string>();
+
+            foreach (var shape in shapes)
+            {
+                var geography = Wkt(shape);
+
+                for (var n = 0; n <= 2; n++)
+                {
+                    var index = java.lang.Integer.valueOf(n);
+
+                    Compare(differences, $"ST_GEOG_POINTN({shape}, {n})",
+                        () => GeographyFunctions.PointN(geography, index), () => SpatialTypeFunctions.ST_PointN(geography, n));
+
+                    Compare(differences, $"ST_GEOG_GEOMETRYN({shape}, {n})",
+                        () => GeographyFunctions.GeometryN(geography, index), () => SpatialTypeFunctions.ST_GeometryN(geography, n));
+
+                    Compare(differences, $"ST_GEOG_INTERIORRING({shape}, {n})",
+                        () => GeographyFunctions.InteriorRing(geography, index), () => SpatialTypeFunctions.ST_InteriorRing(geography, n));
+                }
+
+                foreach (var other in shapes)
+                    Compare(differences, $"ST_GEOG_ORDERINGEQUALS({shape}, {other})",
+                        () => GeographyFunctions.OrderingEquals(geography, Wkt(other)),
+                        () => SpatialTypeFunctions.ST_OrderingEquals(geography, Wkt(other)));
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        static void Compare(List<string> differences, string what, Func<object?> ours, Func<object?> theirs)
+        {
+            var mine = Answer(ours);
+            var calcite = Answer(theirs);
+
+            if (mine != calcite)
+                differences.Add($"{what}: ours {mine}, Calcite {calcite}");
+        }
+
+        /// <summary>
+        /// Every format writes something the matching reader takes back.
+        /// </summary>
+        /// <remarks>
+        /// The serializers and the constructors are declared as a pair for each format, and a round trip is
+        /// what says the pair was wired to one another rather than to a neighbour. GML is left out because
+        /// Calcite writes a form its own reader does not take, which is its defect and not one to reproduce
+        /// by asserting it.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadBackEveryFormatItWrites()
+        {
+            foreach (var shape in new[] { "POINT(1 2)", "LINESTRING(0 0, 1 1, 2 0)", "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))" })
+            {
+                var geography = Wkt(shape);
+
+                GeographyFunctions.FromWkt(GeographyFunctions.AsText(geography))!.toText().Should().Be(geography.toText(), shape);
+                GeographyFunctions.FromEwkt(GeographyFunctions.AsEwkt(geography))!.toText().Should().Be(geography.toText(), shape);
+                GeographyFunctions.FromGeoJson(GeographyFunctions.AsGeoJson(geography))!.toText().Should().Be(geography.toText(), shape);
+                GeographyFunctions.FromWkb(GeographyFunctions.AsWkb(geography))!.toText().Should().Be(geography.toText(), shape);
+                GeographyFunctions.FromEwkb(GeographyFunctions.AsEwkb(geography))!.toText().Should().Be(geography.toText(), shape);
+            }
+        }
+
+        [TestMethod]
+        public void ShouldStampEveryConstructorWithWgs84()
+        {
+            var geography = Wkt("POINT(1 2)");
+
+            GeographyFunctions.FromWkt("POINT(1 2)")!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.FromEwkt("POINT(1 2)")!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.FromGeoJson("{\"type\":\"Point\",\"coordinates\":[1,2]}")!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.FromWkb(GeographyFunctions.AsWkb(geography))!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.FromEwkb(GeographyFunctions.AsEwkb(geography))!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        /// <summary>
+        /// An SRID a geography cannot be in is refused however it arrives — as an argument, or written into
+        /// the text or the bytes themselves.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseAnSridThatIsNotWgs84()
+        {
+            var wrong = java.lang.Integer.valueOf(3857);
+            var wkb = GeographyFunctions.AsWkb(Wkt("POINT(1 2)"));
+
+            ((Action)(() => GeographyFunctions.FromWkt("POINT(1 2)", wrong))).Should().Throw<java.lang.IllegalArgumentException>();
+            ((Action)(() => GeographyFunctions.FromWkb(wkb, wrong))).Should().Throw<java.lang.IllegalArgumentException>();
+            ((Action)(() => GeographyFunctions.FromGml("<gml:Point><gml:coordinates>1,2</gml:coordinates></gml:Point>", wrong))).Should().Throw<java.lang.IllegalArgumentException>();
+            // Calcite spells the prefix srid:N; rather than the PostGIS SRID=N;, and reads no other form
+            ((Action)(() => GeographyFunctions.FromEwkt("srid:3857;POINT(1 2)"))).Should().Throw<java.lang.IllegalArgumentException>();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            foreach (var (name, ours, _) in unary)
+                Answer(() => ours(null!)).Should().Be("null", name);
+
+            GeographyFunctions.PointN(null, java.lang.Integer.valueOf(1)).Should().BeNull();
+            GeographyFunctions.PointN(Wkt("POINT(1 2)"), null).Should().BeNull();
+            GeographyFunctions.OrderingEquals(null, Wkt("POINT(1 2)")).Should().BeNull();
+            GeographyFunctions.FromEwkt(null).Should().BeNull();
+            GeographyFunctions.FromWkb(null).Should().BeNull();
+            GeographyFunctions.FromEwkb(null).Should().BeNull();
+            GeographyFunctions.FromGml(null).Should().BeNull();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyAccessorTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyAccessorTests.cs
@@ -104,7 +104,7 @@ namespace Apache.Calcite.Geography.Tests
         /// </summary>
         /// <param name="answer"></param>
         /// <returns></returns>
-        static string Render(object? answer)
+        internal static string Render(object? answer)
         {
             return answer switch
             {
@@ -131,7 +131,7 @@ namespace Apache.Calcite.Geography.Tests
         /// same way. That is an answer to compare like any other, so the kind of the exception is rendered
         /// rather than allowed to end the run.
         /// </remarks>
-        static string Answer(Func<object?> call)
+        internal static string Answer(Func<object?> call)
         {
             try
             {

--- a/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
@@ -195,6 +195,42 @@ namespace Apache.Calcite.Geography.Tests
         }
 
         [TestMethod]
+        public void ShouldAgreeOnContains()
+        {
+            Differ(GeographyFunctions.Contains, SpatialTypeFunctions.ST_Contains, refusals: 6);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnCovers()
+        {
+            Differ(GeographyFunctions.Covers, SpatialTypeFunctions.ST_Covers, refusals: 6);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnCoveredBy()
+        {
+            Differ(GeographyFunctions.CoveredBy, SpatialTypeFunctions.ST_CoveredBy, refusals: 6);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnDisjoint()
+        {
+            Differ(GeographyFunctions.Disjoint, SpatialTypeFunctions.ST_Disjoint, refusals: 0);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnEquals()
+        {
+            Differ(GeographyFunctions.Equals, SpatialTypeFunctions.ST_Equals, refusals: 1);
+        }
+
+        [TestMethod]
+        public void ShouldAgreeOnEnvelopesIntersect()
+        {
+            Differ(GeographyFunctions.EnvelopesIntersect, SpatialTypeFunctions.ST_EnvelopesIntersect, refusals: 0);
+        }
+
+        [TestMethod]
         public void ShouldAgreeOnIsValid()
         {
             var differences = new List<string>();

--- a/src/Apache.Calcite.Geography.Tests/GeographyEditingTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyEditingTests.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Collections.Generic;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The editing functions and the constructors that build a geography out of parts, against the
+    /// <c>ST_*</c> each one mirrors.
+    /// </summary>
+    /// <remarks>
+    /// The same kind of surface as the accessors and held the same way: these rearrange coordinates without
+    /// interpreting the space between them, so each is a delegation and the risk is the wiring rather than
+    /// the arithmetic.
+    ///
+    /// <para>One divergence, and it is deliberate. Every one of these hands back a geography built from a
+    /// geography, and it is stamped WGS84 on the way out — <c>ST_GEOG_FORCE2D</c> answers something with an
+    /// SRID of 4326 where <c>ST_FORCE2D</c> answers something with an SRID of zero, because the transformers
+    /// underneath build through a geometry factory that does not carry one across. Calcite has nothing to
+    /// keep there and this package does: every geography it produces says what it is. The comparison below
+    /// is on the coordinates rather than the stamp, and
+    /// <see cref="ShouldStampEveryEditedGeographyWithWgs84"/> holds the stamp.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyEditingTests
+    {
+
+        static readonly string[] shapes =
+        [
+            "POINT(1 2)",
+            "POINT Z(1 2 3)",
+            "MULTIPOINT((1 2), (3 4))",
+            "LINESTRING(0 0, 1 1, 2 0)",
+            "LINESTRING(0 0, 1 1, 1 1, 2 0)",
+            "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+            "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))",
+            "POLYGON((0 0, 6 0, 6 6, 0 6, 0 0), (2 2, 4 2, 4 4, 2 4, 2 2))",
+            "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))",
+            "GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(0 0, 1 1))",
+        ];
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static readonly (string Name, Func<Geometry, object?> Ours, Func<Geometry, object?> Theirs)[] unary =
+        [
+            ("ST_GEOG_FLIPCOORDINATES", g => GeographyFunctions.FlipCoordinates(g), g => SpatialTypeFunctions.ST_FlipCoordinates(g)),
+            ("ST_GEOG_FORCE2D", g => GeographyFunctions.Force2D(g), g => SpatialTypeFunctions.ST_Force2D(g)),
+            ("ST_GEOG_FORCE3D", g => GeographyFunctions.Force3D(g), g => SpatialTypeFunctions.ST_Force3D(g)),
+            ("ST_GEOG_NORMALIZE", g => GeographyFunctions.Normalize(g), g => SpatialTypeFunctions.ST_Normalize(g)),
+            ("ST_GEOG_REMOVEHOLES", g => GeographyFunctions.RemoveHoles(g), g => SpatialTypeFunctions.ST_RemoveHoles(g)),
+            ("ST_GEOG_REMOVEREPEATEDPOINTS", g => GeographyFunctions.RemoveRepeatedPoints(g), g => SpatialTypeFunctions.ST_RemoveRepeatedPoints(g)),
+            ("ST_GEOG_REVERSE", g => GeographyFunctions.Reverse(g), g => SpatialTypeFunctions.ST_Reverse(g)),
+            ("ST_GEOG_TOMULTILINE", g => GeographyFunctions.ToMultiLine(g), g => SpatialTypeFunctions.ST_ToMultiLine(g)),
+            ("ST_GEOG_TOMULTIPOINT", g => GeographyFunctions.ToMultiPoint(g), g => SpatialTypeFunctions.ST_ToMultiPoint(g)),
+            ("ST_GEOG_TOMULTISEGMENTS", g => GeographyFunctions.ToMultiSegments(g), g => SpatialTypeFunctions.ST_ToMultiSegments(g)),
+        ];
+
+        [TestMethod]
+        public void ShouldAgreeWithCalciteOnEveryEditingFunction()
+        {
+            var differences = new List<string>();
+
+            foreach (var shape in shapes)
+            {
+                var geography = Wkt(shape);
+
+                foreach (var (name, ours, theirs) in unary)
+                {
+                    var mine = GeographyAccessorTests.Answer(() => ours(geography));
+                    var calcite = GeographyAccessorTests.Answer(() => theirs(geography));
+
+                    if (mine != calcite)
+                        differences.Add($"{name} over {shape}: ours {mine}, Calcite {calcite}");
+                }
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        [TestMethod]
+        public void ShouldAgreeWithCalciteOnTheEditingFunctionsThatTakeAnArgument()
+        {
+            var differences = new List<string>();
+            var point = Wkt("POINT(9 9)");
+
+            foreach (var shape in shapes)
+            {
+                var g = Wkt(shape);
+
+                Compare(differences, $"ST_GEOG_ADDPOINT({shape}, POINT(9 9))",
+                    () => GeographyFunctions.AddPoint(g, point), () => SpatialTypeFunctions.ST_AddPoint(g, point));
+
+                for (var n = 0; n <= 2; n++)
+                {
+                    var index = java.lang.Integer.valueOf(n);
+
+                    Compare(differences, $"ST_GEOG_ADDPOINT({shape}, POINT(9 9), {n})",
+                        () => GeographyFunctions.AddPoint(g, point, index), () => SpatialTypeFunctions.ST_AddPoint(g, point, n));
+
+                    Compare(differences, $"ST_GEOG_REMOVEPOINT({shape}, {n})",
+                        () => GeographyFunctions.RemovePoint(g, index), () => SpatialTypeFunctions.ST_RemovePoint(g, n));
+                }
+
+                Compare(differences, $"ST_GEOG_ADDZ({shape}, 5)",
+                    () => GeographyFunctions.AddZ(g, java.lang.Integer.valueOf(5)),
+                    () => SpatialTypeFunctions.ST_AddZ(g, java.math.BigDecimal.valueOf(5.0)));
+
+                Compare(differences, $"ST_GEOG_REMOVEREPEATEDPOINTS({shape}, 0.5)",
+                    () => GeographyFunctions.RemoveRepeatedPoints(g, java.lang.Double.valueOf(0.5)),
+                    () => SpatialTypeFunctions.ST_RemoveRepeatedPoints(g, java.math.BigDecimal.valueOf(0.5)));
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        [TestMethod]
+        public void ShouldAgreeWithCalciteOnTheConstructors()
+        {
+            var differences = new List<string>();
+            var one = java.lang.Integer.valueOf(1);
+            var two = java.lang.Integer.valueOf(2);
+            var three = java.lang.Integer.valueOf(3);
+
+            Compare(differences, "ST_GEOG_POINT(1, 2)",
+                () => GeographyFunctions.Point(one, two), () => SpatialTypeFunctions.ST_Point(Dec(1), Dec(2)));
+
+            Compare(differences, "ST_GEOG_POINT(1, 2, 3)",
+                () => GeographyFunctions.Point(one, two, three),
+                () => SpatialTypeFunctions.ST_Point(Dec(1), Dec(2), Dec(3)));
+
+            var a = Wkt("POINT(0 0)");
+            var b = Wkt("POINT(1 1)");
+            var c = Wkt("POINT(2 0)");
+
+            Compare(differences, "ST_GEOG_MAKELINE(a, b)",
+                () => GeographyFunctions.MakeLine(a, b), () => SpatialTypeFunctions.ST_MakeLine(a, b));
+
+            Compare(differences, "ST_GEOG_MAKELINE(a, b, c)",
+                () => GeographyFunctions.MakeLine(a, b, c), () => SpatialTypeFunctions.ST_MakeLine(a, b, c));
+
+            var shell = Wkt("LINESTRING(0 0, 6 0, 6 6, 0 6, 0 0)");
+            var hole = Wkt("LINESTRING(2 2, 4 2, 4 4, 2 4, 2 2)");
+
+            Compare(differences, "ST_GEOG_MAKEPOLYGON(shell)",
+                () => GeographyFunctions.MakePolygon(shell), () => SpatialTypeFunctions.ST_MakePolygon(shell));
+
+            Compare(differences, "ST_GEOG_MAKEPOLYGON(shell, hole)",
+                () => GeographyFunctions.MakePolygon(shell, hole), () => SpatialTypeFunctions.ST_MakePolygon(shell, hole));
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        /// <summary>
+        /// A typed reader answers a shape of its own kind and null for anything else, which is Calcite's rule
+        /// and the whole of what makes the nine of them worth having.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeWithCalciteOnTheTypedReaders()
+        {
+            var differences = new List<string>();
+
+            foreach (var wkt in new[]
+            {
+                "POINT(1 2)",
+                "LINESTRING(0 0, 1 1)",
+                "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))",
+                "MULTIPOINT((1 2), (3 4))",
+                "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+                "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)))",
+            })
+            {
+                Compare(differences, $"ST_GEOG_POINTFROMTEXT({wkt})",
+                    () => GeographyFunctions.PointFromText(wkt), () => SpatialTypeFunctions.ST_PointFromText(wkt));
+                Compare(differences, $"ST_GEOG_LINEFROMTEXT({wkt})",
+                    () => GeographyFunctions.LineFromText(wkt), () => SpatialTypeFunctions.ST_LineFromText(wkt));
+                Compare(differences, $"ST_GEOG_POLYFROMTEXT({wkt})",
+                    () => GeographyFunctions.PolyFromText(wkt), () => SpatialTypeFunctions.ST_PolyFromText(wkt));
+                Compare(differences, $"ST_GEOG_MPOINTFROMTEXT({wkt})",
+                    () => GeographyFunctions.MPointFromText(wkt), () => SpatialTypeFunctions.ST_MPointFromText(wkt));
+                Compare(differences, $"ST_GEOG_MLINEFROMTEXT({wkt})",
+                    () => GeographyFunctions.MLineFromText(wkt), () => SpatialTypeFunctions.ST_MLineFromText(wkt));
+                Compare(differences, $"ST_GEOG_MPOLYFROMTEXT({wkt})",
+                    () => GeographyFunctions.MPolyFromText(wkt), () => SpatialTypeFunctions.ST_MPolyFromText(wkt));
+
+                var wkb = GeographyFunctions.AsWkb(Wkt(wkt));
+
+                Compare(differences, $"ST_GEOG_POINTFROMWKB({wkt})",
+                    () => GeographyFunctions.PointFromWkb(wkb), () => SpatialTypeFunctions.ST_PointFromWKB(wkb));
+                Compare(differences, $"ST_GEOG_LINEFROMWKB({wkt})",
+                    () => GeographyFunctions.LineFromWkb(wkb), () => SpatialTypeFunctions.ST_LineFromWKB(wkb));
+                Compare(differences, $"ST_GEOG_POLYFROMWKB({wkt})",
+                    () => GeographyFunctions.PolyFromWkb(wkb), () => SpatialTypeFunctions.ST_PolyFromWKB(wkb));
+            }
+
+            differences.Should().BeEmpty(string.Join("\n", differences));
+        }
+
+        /// <summary>
+        /// Every editing operator run as SQL, and answered the same as the body behind it.
+        /// </summary>
+        /// <remarks>
+        /// The comparisons above are between two C# methods and cannot see which of them a name is wired to.
+        /// The binding is by signature, so a declaration naming a method that does not exist with those
+        /// parameters fails when the table is built rather than when a query reaches it — but ten of these
+        /// take one geography and answer one geography, and nothing but running them tells
+        /// <c>ST_GEOG_FORCE2D</c> wired to <c>Force3D</c> from <c>ST_GEOG_FORCE2D</c> wired to
+        /// <c>Force2D</c>. Every result is wrapped in <c>ST_GEOG_ASTEXT</c>, since a geography is not
+        /// something a result set carries.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRunEveryEditingOperatorAsAnOperator()
+        {
+            const string shape = "POLYGON((0 0, 6 0, 6 6, 0 6, 0 0), (2 2, 4 2, 4 4, 2 4, 2 2))";
+            var geography = Wkt(shape);
+            var subject = $"ST_GEOG_GEOMFROMTEXT('{shape}')";
+
+            var wanted = new List<string>();
+            var names = new List<string>();
+            var expressions = new List<string>();
+
+            foreach (var (name, ours, _) in unary)
+            {
+                // through ST_GEOG_ASTEXT on both sides, because that is what the statement asks for and it is
+                // not the same rendering as Geometry.toText: the writer ST_ASTEXT builds is told how many
+                // ordinates the shape has, and the default one always writes two
+                var answer = GeographyAccessorTests.Answer(() => GeographyFunctions.AsText(ours(geography) as Geometry));
+                if (answer.EndsWith("Exception"))
+                    continue;
+
+                wanted.Add(answer);
+                names.Add(name);
+                expressions.Add($"ST_GEOG_ASTEXT({name}({subject}))");
+            }
+
+            var extra = new (string Sql, Func<object?> Ours)[]
+            {
+                // ST_AddPoint takes a line and throws over anything else, so this one gets a line
+                ("ST_GEOG_ASTEXT(ST_GEOG_ADDPOINT(ST_GEOG_LINEFROMTEXT('LINESTRING(0 0, 1 1, 2 0)'), ST_GEOG_POINT(9, 9)))",
+                    () => GeographyFunctions.AddPoint(Wkt("LINESTRING(0 0, 1 1, 2 0)"), Wkt("POINT(9 9)"))),
+                ("ST_GEOG_ASTEXT(ST_GEOG_REMOVEPOINT(ST_GEOG_LINEFROMTEXT('LINESTRING(0 0, 1 1, 2 0)'), 1))",
+                    () => GeographyFunctions.RemovePoint(Wkt("LINESTRING(0 0, 1 1, 2 0)"), java.lang.Integer.valueOf(1))),
+                // over a point, because ST_AddZ throws over a polygon; see
+                // ShouldInheritTheDefectInAddZOverAPolygon
+                ("ST_GEOG_ASTEXT(ST_GEOG_ADDZ(ST_GEOG_POINT(1, 2), 5))",
+                    () => GeographyFunctions.AddZ(Wkt("POINT(1 2)"), java.lang.Integer.valueOf(5))),
+                ($"ST_GEOG_ASTEXT(ST_GEOG_REMOVEREPEATEDPOINTS({subject}, 0.5))",
+                    () => GeographyFunctions.RemoveRepeatedPoints(geography, java.lang.Double.valueOf(0.5))),
+                ("ST_GEOG_ASTEXT(ST_GEOG_POINT(1, 2))",
+                    () => GeographyFunctions.Point(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2))),
+                ("ST_GEOG_ASTEXT(ST_GEOG_MAKEPOINT(1, 2))",
+                    () => GeographyFunctions.Point(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2))),
+                ("ST_GEOG_ASTEXT(ST_GEOG_MAKELINE(ST_GEOG_POINT(0, 0), ST_GEOG_POINT(1, 1), ST_GEOG_POINT(2, 0)))",
+                    () => GeographyFunctions.MakeLine(Wkt("POINT(0 0)"), Wkt("POINT(1 1)"), Wkt("POINT(2 0)"))),
+                ("ST_GEOG_ASTEXT(ST_GEOG_MAKEPOLYGON(ST_GEOG_LINEFROMTEXT('LINESTRING(0 0, 6 0, 6 6, 0 6, 0 0)')))",
+                    () => GeographyFunctions.MakePolygon(Wkt("LINESTRING(0 0, 6 0, 6 6, 0 6, 0 0)"))),
+                ("ST_GEOG_ASTEXT(ST_GEOG_POINTFROMTEXT('POINT(1 2)'))",
+                    () => GeographyFunctions.PointFromText("POINT(1 2)")),
+                ("ST_GEOG_ASTEXT(ST_GEOG_POLYFROMTEXT('POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))'))",
+                    () => GeographyFunctions.PolyFromText("POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))")),
+                ("ST_GEOG_ASTEXT(ST_GEOG_MLINEFROMTEXT('MULTILINESTRING((0 0, 1 1))'))",
+                    () => GeographyFunctions.MLineFromText("MULTILINESTRING((0 0, 1 1))")),
+            };
+
+            foreach (var (sql, ours) in extra)
+            {
+                var answer = GeographyAccessorTests.Answer(() => GeographyFunctions.AsText(ours() as Geometry));
+
+                // an expression that throws would end the whole statement rather than answer a column, and
+                // what it would prove is already proven by the comparisons above
+                if (answer.EndsWith("Exception"))
+                    continue;
+
+                wanted.Add(answer);
+                names.Add(sql);
+                expressions.Add(sql);
+            }
+
+            var row = GeographyExecutionTests.Run("SELECT " + string.Join(", ", expressions))[0];
+
+            for (var i = 0; i < wanted.Count; i++)
+                GeographyAccessorTests.Render(row[i]).Should().Be(wanted[i], names[i]);
+        }
+
+        static java.math.BigDecimal Dec(double value)
+        {
+            return java.math.BigDecimal.valueOf(value);
+        }
+
+        static void Compare(List<string> differences, string what, Func<object?> ours, Func<object?> theirs)
+        {
+            var mine = GeographyAccessorTests.Answer(ours);
+            var calcite = GeographyAccessorTests.Answer(theirs);
+
+            if (mine != calcite)
+                differences.Add($"{what}: ours {mine}, Calcite {calcite}");
+        }
+
+        /// <summary>
+        /// A geography that came out of one of these says it is WGS84, whatever Calcite's own would have
+        /// said.
+        /// </summary>
+        /// <remarks>
+        /// The transformers underneath build through a geometry factory that does not carry an SRID across,
+        /// so Calcite's answer is stamped zero. That is nothing to Calcite, which has no reference system to
+        /// keep, and it is a small lie here: a geography is WGS84 and every one this package hands out says
+        /// so.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldStampEveryEditedGeographyWithWgs84()
+        {
+            var geography = Wkt("POLYGON((0 0, 6 0, 6 6, 0 6, 0 0), (2 2, 4 2, 4 4, 2 4, 2 2))");
+
+            foreach (var (name, ours, _) in unary)
+            {
+                if (GeographyAccessorTests.Answer(() => ours(geography)).EndsWith("Exception"))
+                    continue;
+
+                (ours(geography) as Geometry)?.getSRID().Should().Be(GeographyFunctions.Wgs84, name);
+            }
+
+            GeographyFunctions.Point(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.MakeLine(Wkt("POINT(0 0)"), Wkt("POINT(1 1)"))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.PointFromText("POINT(1 2)")!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        /// <summary>
+        /// <c>ST_ADDZ</c> throws over a polygon, and so does <c>ST_GEOG_ADDZ</c>.
+        /// </summary>
+        /// <remarks>
+        /// A defect of Calcite's rather than one introduced here: the transformer it builds through hands a
+        /// <c>LinearRing</c> a coordinate sequence it then cannot read, and the null reference comes out of
+        /// JTS. It is inherited because the delegation is the whole of the implementation, and it is recorded
+        /// rather than worked around — a geography that behaves differently from the geometry it mirrors, in
+        /// a way that has nothing to do with geodesy, would be a divergence this package has no business
+        /// introducing.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldInheritTheDefectInAddZOverAPolygon()
+        {
+            var polygon = Wkt("POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))");
+            var five = java.lang.Integer.valueOf(5);
+
+            ((Action)(() => SpatialTypeFunctions.ST_AddZ(polygon, Dec(5)))).Should().Throw<NullReferenceException>();
+            ((Action)(() => GeographyFunctions.AddZ(polygon, five))).Should().Throw<NullReferenceException>();
+
+            // over a point it is well behaved, which is what the operator is exercised with
+            GeographyFunctions.AddZ(Wkt("POINT(1 2)"), five).Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            var geography = Wkt("LINESTRING(0 0, 1 1)");
+
+            foreach (var (name, ours, _) in unary)
+                GeographyAccessorTests.Answer(() => ours(null!)).Should().Be("null", name);
+
+            GeographyFunctions.AddPoint(null, geography).Should().BeNull();
+            GeographyFunctions.AddPoint(geography, null).Should().BeNull();
+            GeographyFunctions.RemovePoint(geography, null).Should().BeNull();
+            GeographyFunctions.AddZ(geography, null).Should().BeNull();
+            GeographyFunctions.RemoveRepeatedPoints(geography, null).Should().BeNull();
+            GeographyFunctions.Point(null, java.lang.Integer.valueOf(1)).Should().BeNull();
+            GeographyFunctions.MakeLine(null, geography).Should().BeNull();
+            GeographyFunctions.MakePolygon(null).Should().BeNull();
+            GeographyFunctions.PointFromText(null).Should().BeNull();
+            GeographyFunctions.PointFromWkb(null).Should().BeNull();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
@@ -42,7 +42,7 @@ namespace Apache.Calcite.Geography.Tests
         /// </summary>
         /// <param name="sql"></param>
         /// <returns></returns>
-        static List<object?[]> Run(string sql)
+        internal static List<object?[]> Run(string sql)
         {
             java.lang.Class.forName("org.apache.calcite.jdbc.Driver");
 

--- a/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
@@ -150,6 +150,18 @@ namespace Apache.Calcite.Geography.Tests
                 ("ST_GEOG_WITHIN(ST_GEOG_GEOMFROMTEXT('POINT(1 1)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
                 ("ST_GEOG_INTERSECTS(ST_GEOG_GEOMFROMTEXT('POINT(1 1)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
                 ("ST_GEOG_ISVALID(ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+
+                // the relations and the measurements
+                ("ST_GEOG_CONTAINS(ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'), ST_GEOG_GEOMFROMTEXT('POINT(1 1)'))", true),
+                ("ST_GEOG_COVERS(ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'), ST_GEOG_GEOMFROMTEXT('POINT(0 0)'))", true),
+                ("ST_GEOG_COVEREDBY(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+                ("ST_GEOG_DISJOINT(ST_GEOG_GEOMFROMTEXT('POINT(9 9)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+                ("ST_GEOG_EQUALS(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 1)'), ST_GEOG_GEOMFROMTEXT('LINESTRING(1 1, 0 0)'))", true),
+                ("ST_GEOG_ENVELOPESINTERSECT(ST_GEOG_GEOMFROMTEXT('POINT(1 1)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
+                ("ST_GEOG_LENGTH(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 6371010.0 * Math.PI / 180),
+                ("ST_GEOG_PERIMETER(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 0.0),
+                ("ST_GEOG_AREA(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 0.0),
+                ("ST_GEOG_MAXDISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'))", 6371010.0 * Math.PI / 180),
             };
 
             var failures = new List<string>();

--- a/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
@@ -294,6 +294,66 @@ namespace Apache.Calcite.Geography.Tests
             org.apache.calcite.runtime.SpatialTypeFunctions.ST_Within(Wkt("POINT(0 0)"), box).Should().BeTrue();
         }
 
+        /// <summary>
+        /// An area is in square metres, and its planar counterpart is in square degrees.
+        /// </summary>
+        /// <remarks>
+        /// The region bounded by the parallels and meridians through the four corners has an area of the
+        /// radius squared times the span of longitude in radians times the difference of the sines of the two
+        /// latitudes. This polygon is a little larger than that region and has to be: its northern edge is a
+        /// great circle between two places at one degree north, and a great circle between them runs north of
+        /// the parallel that joins them. So the closed form is a floor rather than an answer, and the excess
+        /// over it is the bulge — the same bulge that decides whether a point just north of the parallel is
+        /// inside the polygon.
+        ///
+        /// <para>Calcite answers one, which is the box measured in degrees.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureAreaInSquareMetres()
+        {
+            var box = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+            var radians = Math.PI / 180;
+            var betweenTheParallels = EarthRadiusMeters * EarthRadiusMeters * radians * Math.Sin(radians);
+            var area = GeographyFunctions.Area(box)!.doubleValue();
+
+            area.Should().BeGreaterThan(betweenTheParallels);
+            area.Should().BeApproximately(betweenTheParallels, betweenTheParallels * 1e-4);
+
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_Area(box)!.doubleValue().Should().BeApproximately(1, 1e-9);
+        }
+
+        [TestMethod]
+        public void ShouldMeasureLengthAndPerimeterInMetres()
+        {
+            var line = Wkt("LINESTRING(0 0, 1 0)");
+            var box = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+
+            GeographyFunctions.Length(line)!.doubleValue().Should().BeApproximately(Degree, 0.001);
+            GeographyFunctions.Perimeter(line)!.doubleValue().Should().Be(0);
+            GeographyFunctions.Area(line)!.doubleValue().Should().Be(0);
+
+            // the two edges on meridians are a degree each; the two that follow a parallel are shorter as
+            // great circles than the parallel they are written along, and the southern one is the equator
+            GeographyFunctions.Perimeter(box)!.doubleValue()
+                .Should().BeLessThan(4 * Degree).And.BeGreaterThan(3.9 * Degree);
+            GeographyFunctions.Length(box)!.doubleValue()
+                .Should().Be(GeographyFunctions.Perimeter(box)!.doubleValue());
+        }
+
+        /// <summary>
+        /// Two boxes either side of the antimeridian have bounding boxes that meet, and the planar reading
+        /// puts them at opposite ends of the world.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerEnvelopesIntersectAcrossTheAntimeridian()
+        {
+            var west = Wkt("POLYGON((179 -1, 180 -1, 180 1, 179 1, 179 -1))");
+            var east = Wkt("POLYGON((-180 -1, -179 -1, -179 1, -180 1, -180 -1))");
+
+            GeographyFunctions.EnvelopesIntersect(west, east)!.booleanValue().Should().BeTrue();
+            org.apache.calcite.runtime.SpatialTypeFunctions.ST_EnvelopesIntersect(west, east).Should().BeFalse();
+        }
+
         [TestMethod]
         public void ShouldAnswerIsValid()
         {

--- a/src/Apache.Calcite.Geography.Tests/GeographyRandomDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyRandomDifferentialTests.cs
@@ -181,20 +181,65 @@ namespace Apache.Calcite.Geography.Tests
                     Compare(differences, "WITHIN", left, right,
                         () => GeographyFunctions.Within(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Within(a, b), ref refused);
 
+                    Compare(differences, "CONTAINS", left, right,
+                        () => GeographyFunctions.Contains(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Contains(a, b), ref refused);
+
+                    Compare(differences, "COVERS", left, right,
+                        () => GeographyFunctions.Covers(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Covers(a, b), ref refused);
+
+                    Compare(differences, "COVEREDBY", left, right,
+                        () => GeographyFunctions.CoveredBy(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_CoveredBy(a, b), ref refused);
+
+                    Compare(differences, "DISJOINT", left, right,
+                        () => GeographyFunctions.Disjoint(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Disjoint(a, b), ref refused);
+
+                    Compare(differences, "EQUALS", left, right,
+                        () => GeographyFunctions.Equals(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_Equals(a, b), ref refused);
+
+                    Compare(differences, "ENVELOPESINTERSECT", left, right,
+                        () => GeographyFunctions.EnvelopesIntersect(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_EnvelopesIntersect(a, b), ref refused);
+
                     Compare(differences, "DWITHIN", left, right,
                         () => GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(0.0025 * Degree))!.booleanValue(),
                         () => SpatialTypeFunctions.ST_DWithin(a, b, 0.0025), ref refused);
 
-                    var ours = GeographyFunctions.Distance(a, b)!.doubleValue();
-                    var theirs = SpatialTypeFunctions.ST_Distance(a, b) * Degree;
+                    Measure(differences, "DISTANCE", left, right,
+                        () => GeographyFunctions.Distance(a, b)!.doubleValue(), SpatialTypeFunctions.ST_Distance(a, b) * Degree);
 
-                    if (Math.Abs(ours - theirs) > Math.Max(1e-4 * theirs, 1e-6))
-                        differences.Add($"DISTANCE {left} / {right}: ours {ours}, Calcite {theirs}");
+                    Measure(differences, "MAXDISTANCE", left, right,
+                        () => GeographyFunctions.MaxDistance(a, b)!.doubleValue(), SpatialTypeFunctions.ST_MaxDistance(a, b)!.doubleValue() * Degree);
+
+                    Measure(differences, "LENGTH", left, left,
+                        () => GeographyFunctions.Length(a)!.doubleValue(), SpatialTypeFunctions.ST_Length(a)!.doubleValue() * Degree);
+
+                    Measure(differences, "PERIMETER", left, left,
+                        () => GeographyFunctions.Perimeter(a)!.doubleValue(), SpatialTypeFunctions.ST_Perimeter(a)!.doubleValue() * Degree);
+
+                    // an area is two lengths, so the scale between the two readings is the square of the one
+                    // a distance uses
+                    Measure(differences, "AREA", left, left,
+                        () => GeographyFunctions.Area(a)!.doubleValue(), SpatialTypeFunctions.ST_Area(a)!.doubleValue() * Degree * Degree);
                 }
             }
 
             differences.Should().BeEmpty(string.Join("\n", differences));
             compared.Should().BeGreaterThan(10000);
+        }
+
+        /// <summary>
+        /// Compares a measurement, ours in metres against Calcite's in degrees brought to the same units.
+        /// </summary>
+        /// <remarks>
+        /// A relative tolerance, because these are quantities rather than answers: at this scale on the
+        /// equator a degree of arc and a degree of coordinate are the same length to far more places than a
+        /// hundredth of a per cent, and the absolute floor is there for the pairs whose answer is zero.
+        /// </remarks>
+        static void Measure(List<string> differences, string what, string left, string right, Func<double> geodesic, double planar)
+        {
+            var ours = geodesic();
+
+            if (Math.Abs(ours - planar) > Math.Max(1e-4 * Math.Abs(planar), 1e-6))
+                differences.Add($"{what} {left} / {right}: ours {ours}, Calcite {planar}");
         }
 
         static void Compare(List<string> differences, string what, string left, string right, Func<bool> geodesic, Func<bool> planar, ref int refused)

--- a/src/Apache.Calcite.Geography.Tests/GeographyTypeTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyTypeTests.cs
@@ -117,6 +117,72 @@ namespace Apache.Calcite.Geography.Tests
             notNull.getSqlTypeName().Should().BeSameAs(SqlTypeName.GEOMETRY);
         }
 
+        /// <summary>
+        /// A column declared <c>NOT NULL</c> is not a geography column, and nothing says so.
+        /// </summary>
+        /// <remarks>
+        /// The shape an adapter reaches for: build a row type, name a column, say it cannot be null. The last
+        /// of those goes through <c>createTypeWithNullability</c>, and that is the call
+        /// <c>RelDataTypeFactoryImpl.copySimpleType</c> answers with a plain <c>new JavaType(clazz,
+        /// nullable)</c> — so the column that comes out is an ordinary geometry, and Calcite's planar
+        /// <c>ST_*</c> will take it. A geodesic column becomes a planar one with no error anywhere, which is
+        /// the exact failure this package exists to prevent.
+        ///
+        /// <para>It cannot be fixed from here. <c>copySimpleType</c> is private;
+        /// <c>createTypeWithNullability</c> is public and could be overridden, but a type factory of our own
+        /// cannot be put in front of Calcite — <c>PlannerImpl</c> and <c>CalciteConnectionImpl</c> each build
+        /// a <c>JavaTypeFactoryImpl</c> outright, and only a protected constructor takes one. Nor does
+        /// dropping <c>JavaType</c> help: a type that is not one survives this untouched, and then
+        /// <c>getJavaClass</c> answers null and no plan compiles.</para>
+        ///
+        /// <para>So the rule for an adapter is that a geography column is declared nullable, and this is here
+        /// to keep that rule honest rather than to approve of it. Nullability at the level of the row is
+        /// fine — only the field-level call degrades.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotSurviveAColumnDeclaredNotNull()
+        {
+            var typeFactory = GeographyFixture.TypeFactory();
+            var geography = GeographyTypes.Of(typeFactory);
+
+            var row = typeFactory.builder().add("GEOG", geography).nullable(false).build();
+            var column = ((RelDataTypeField)row.getFieldList().get(0)).getType();
+
+            GeographyTypes.IsGeography(column).Should().BeFalse();
+            column.getSqlTypeName().Should().BeSameAs(SqlTypeName.GEOMETRY);
+
+            // the row being not-nullable is a different call and does not degrade the field
+            var nullableRow = typeFactory.builder().add("GEOG", geography).build();
+            var kept = ((RelDataTypeField)typeFactory.createTypeWithNullability(nullableRow, false)
+                .getFieldList().get(0)).getType();
+
+            GeographyTypes.IsGeography(kept).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Two geography columns can be brought together; a geography and a geometry cannot.
+        /// </summary>
+        /// <remarks>
+        /// <c>leastRestrictive</c> is what a <c>UNION</c> asks. Over two geographies it answers the geography,
+        /// which is what a set operation over two such columns needs. Over one of each it reaches the
+        /// assignment rules and throws the same <c>No assign rules for OTHER defined</c> the schema-function
+        /// route dies on — an error rather than a wrong answer, but an assertion rather than a validation
+        /// error, and worth knowing before it turns up in a query plan.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldBringTwoGeographiesTogetherAndRefuseAMixture()
+        {
+            var typeFactory = GeographyFixture.TypeFactory();
+            var geography = GeographyTypes.Of(typeFactory);
+            var geometry = GeographyTypes.GeometryOf(typeFactory);
+
+            var both = typeFactory.leastRestrictive(java.util.Arrays.asList([geography, geography]));
+            GeographyTypes.IsGeography(both).Should().BeTrue();
+
+            var mixed = () => typeFactory.leastRestrictive(java.util.Arrays.asList([geography, geometry]));
+            mixed.Should().Throw<java.lang.AssertionError>().WithMessage("*OTHER*");
+        }
+
         [TestMethod]
         public void ShouldTellTheTwoApart()
         {

--- a/src/Apache.Calcite.Geography.Tests/GeographyValidationTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyValidationTests.cs
@@ -1,12 +1,15 @@
 using System;
+using System.Linq;
 
 using Apache.Calcite.Geography.Rel.Type;
+using Apache.Calcite.Geography.Sql;
 
 using FluentAssertions;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using org.apache.calcite.rel.type;
+using org.apache.calcite.sql;
 using org.apache.calcite.sql.type;
 
 namespace Apache.Calcite.Geography.Tests
@@ -54,6 +57,66 @@ namespace Apache.Calcite.Geography.Tests
             var row = GeographyFixture.Validate(sql);
             row.getFieldList().size().Should().Be(1);
             return ((RelDataTypeField)row.getFieldList().get(0)).getType();
+        }
+
+        /// <summary>
+        /// Every operator the table declares is also an operator the table hands out.
+        /// </summary>
+        /// <remarks>
+        /// The declarations are one list and the registrations are another, and nothing but this connects
+        /// them. A field added without its line in the second list is an operator that exists, compiles,
+        /// resolves nowhere and fails only as <c>No match found for function signature</c> in whichever query
+        /// reaches for it first.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRegisterEveryDeclaredOperator()
+        {
+            var declared = typeof(GeographyOperatorTable)
+                .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                .Where(field => typeof(SqlFunction).IsAssignableFrom(field.FieldType))
+                .Select(field => (Name: field.Name, Operator: (SqlFunction)field.GetValue(null)!))
+                .ToList();
+
+            declared.Should().HaveCountGreaterThan(50);
+
+            var registered = GeographyOperatorTable.Instance().getOperatorList();
+            var missing = declared.Where(d => registered.contains(d.Operator) == false).Select(d => d.Name).ToList();
+
+            missing.Should().BeEmpty(string.Join(", ", missing));
+            registered.size().Should().Be(declared.Count);
+        }
+
+        /// <summary>
+        /// The accessors insist on a geography exactly as the operations do.
+        /// </summary>
+        /// <remarks>
+        /// They read coordinates without interpreting the space between them, so it would be tempting to let
+        /// them take either reading. They must not: <c>ST_GEOG_ASTEXT</c> over a geometry would be a way to
+        /// spell <c>ST_ASTEXT</c>, and every such way is a place the two readings can be confused.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldRejectAnAccessorOverAGeometryColumn()
+        {
+            foreach (var sql in new[]
+            {
+                "SELECT ST_GEOG_X(GEOM) FROM GEO",
+                "SELECT ST_GEOG_ASTEXT(GEOM) FROM GEO",
+                "SELECT ST_GEOG_NUMPOINTS(GEOM) FROM GEO",
+                "SELECT ST_GEOG_POINTN(GEOM, 1) FROM GEO",
+            })
+                Refuse(sql).Should().Contain("ST_GEOG_", sql);
+        }
+
+        [TestMethod]
+        public void ShouldTypeTheAccessorsOverAGeographyColumn()
+        {
+            Column("SELECT ST_GEOG_X(GEOG) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.DOUBLE);
+            Column("SELECT ST_GEOG_NUMPOINTS(GEOG) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.INTEGER);
+            Column("SELECT ST_GEOG_ISEMPTY(GEOG) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.BOOLEAN);
+            Column("SELECT ST_GEOG_ASTEXT(GEOG) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.VARCHAR);
+            Column("SELECT ST_GEOG_ASWKB(GEOG) FROM GEO").getSqlTypeName().Should().BeSameAs(SqlTypeName.VARBINARY);
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOG_BOUNDARY(GEOG) FROM GEO")).Should().BeTrue();
+            GeographyTypes.IsGeography(Column("SELECT ST_GEOG_GEOMFROMWKB(ST_GEOG_ASWKB(GEOG)) FROM GEO")).Should().BeTrue();
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -48,6 +48,8 @@ typeFactory.builder()
 
 and the values in it are ordinary JTS `Geometry` objects — the same class Calcite's own spatial library carries.
 
+**A geography column has to be nullable.** Saying `.nullable(false)` on the field — the ordinary thing an adapter does for a `NOT NULL` column — silently gives you an ordinary geometry, and Calcite's planar `ST_*` will then take it. `RelDataTypeFactoryImpl.copySimpleType` answers any change of a `JavaType`'s nullability with a plain `new JavaType(clazz, nullable)`, which is not this subclass; it is private, and a type factory of one's own cannot be put in front of Calcite, since `PlannerImpl` and `CalciteConnectionImpl` each build a `JavaTypeFactoryImpl` outright. Declaring the row not-nullable is a different call and is fine — only the field-level one degrades.
+
 ```sql
 SELECT ID
 FROM PLACES

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -116,7 +116,26 @@ Both arities are Calcite's. The SRID a caller may name has to be 4326 and anythi
 
 `ST_GEOG_XMIN` and its four relatives are computed structurally and are wrong in the usual way for anything crossing the antimeridian, where the least longitude of a shape spanning the seam is not its westmost point. That is inherited from the planar reading rather than introduced here.
 
-**Every format, both ways.** A reader and a writer for each.
+**Building one from parts.**
+
+| | |
+| --- | --- |
+| places | `ST_GEOG_POINT`, `ST_GEOG_MAKEPOINT` — two ordinates or three |
+| lines | `ST_GEOG_MAKELINE` — two to six places |
+| polygons | `ST_GEOG_MAKEPOLYGON` — a shell and up to ten holes |
+
+**Editing.** Rearranging coordinates without interpreting the space between them.
+
+| | |
+| --- | --- |
+| coordinates | `ST_GEOG_ADDPOINT`, `ST_GEOG_REMOVEPOINT`, `ST_GEOG_ADDZ`, `ST_GEOG_REMOVEREPEATEDPOINTS` |
+| order and form | `ST_GEOG_REVERSE`, `ST_GEOG_NORMALIZE`, `ST_GEOG_FLIPCOORDINATES` |
+| ordinates | `ST_GEOG_FORCE2D`, `ST_GEOG_FORCE3D` |
+| structure | `ST_GEOG_REMOVEHOLES`, `ST_GEOG_TOMULTILINE`, `ST_GEOG_TOMULTIPOINT`, `ST_GEOG_TOMULTISEGMENTS` |
+
+Every geography one of these hands back is stamped WGS84, which is a small divergence: `ST_FORCE2D` answers something with an SRID of zero, because the transformer underneath builds through a geometry factory that carries none across. Calcite has no reference system to keep there and this package does.
+
+**Every format, both ways.** A reader and a writer for each, plus a typed reader for each shape — `ST_GEOG_POINTFROMTEXT`, `ST_GEOG_LINEFROMTEXT`, `ST_GEOG_POLYFROMTEXT`, their `MULTI` counterparts and the three `FROMWKB` forms — each answering `NULL` for text that names a different shape.
 
 | | reads | writes |
 | --- | --- | --- |

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -93,15 +93,30 @@ Both arities are Calcite's. The SRID a caller may name has to be 4326 and anythi
 | `ST_GEOG_ASGEOM(GEOGRAPHY)` | read a geography as a geometry |
 | `ST_GEOM_ASGEOG(GEOMETRY)` | read a geometry as a geography |
 
-**The operations backends actually push.**
+**Relations.**
 
 | | |
 | --- | --- |
-| `ST_GEOG_DISTANCE(GEOGRAPHY, GEOGRAPHY)` | metres |
-| `ST_GEOG_DWITHIN(GEOGRAPHY, GEOGRAPHY, NUMERIC)` | within a distance in metres |
-| `ST_GEOG_WITHIN(GEOGRAPHY, GEOGRAPHY)` | containment |
-| `ST_GEOG_INTERSECTS(GEOGRAPHY, GEOGRAPHY)` | any point in common |
-| `ST_GEOG_ISVALID(GEOGRAPHY)` | valid on the sphere |
+| `ST_GEOG_INTERSECTS` | any point in common |
+| `ST_GEOG_DISJOINT` | none |
+| `ST_GEOG_WITHIN`, `ST_GEOG_CONTAINS` | inside, with the interiors meeting |
+| `ST_GEOG_COVEREDBY`, `ST_GEOG_COVERS` | inside, boundary allowed |
+| `ST_GEOG_EQUALS` | the same set of places |
+| `ST_GEOG_ENVELOPESINTERSECT` | bounding boxes meet |
+| `ST_GEOG_ISVALID` | valid on the sphere |
+
+`WITHIN` and `CONTAINS` are the DE-9IM relations JTS means by the words, not plain containment: a point on a polygon's boundary is covered by it and not within it.
+
+**Measurements**, in metres and square metres rather than in degrees.
+
+| | |
+| --- | --- |
+| `ST_GEOG_DISTANCE`, `ST_GEOG_DWITHIN` | the distance between two geographies |
+| `ST_GEOG_MAXDISTANCE` | the greatest distance between a coordinate of one and a coordinate of the other |
+| `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
+| `ST_GEOG_AREA` | square metres |
+
+An area shows the difference plainly: a one-degree box at the equator is about 12,364 square kilometres, and it is a little *larger* than the region between the parallels through its corners, because its northern edge is a great circle that runs north of the parallel joining its two northern corners.
 
 **Reading a geography.** Accessors, which read or rearrange coordinates without interpreting the space between them, so each is a delegation to the very JTS method Calcite's `ST_*` of that name calls.
 
@@ -166,6 +181,7 @@ The relations are this package's own rather than a library's. `S2BooleanOperatio
 
 ## What is not here
 
-- The remaining ~120 declarations. The full mapping is in [the design issue](https://github.com/ikvmnet/calcite-dotnet/issues/86).
+- The rest of the mapping in [the design issue](https://github.com/ikvmnet/calcite-dotnet/issues/86) — the constructed-geometry group (buffer, the boolean overlay set, hulls, simplification, triangulation, grids), the point-returning measurements, `ST_GEOG_RELATE`, and the aggregates and table functions, which need machinery this package does not have.
+- **`ST_GEOG_CROSSES`, `ST_GEOG_TOUCHES`, `ST_GEOG_OVERLAPS` and `ST_GEOG_CONTAINSPROPERLY`.** All four turn on whether the interiors of two geographies meet, and where a line comes back and touches itself that question has no answer without a node graph over both geometries: the place is the end of the whole line and the middle of one of its own edges at once, so it is boundary by the rule that counts ends and interior by the rule that reads the curve. Both rules were tried and each is wrong somewhere. That is the same machinery `S2BooleanOperation` would have brought.
 - `ST_SETSRID` and `ST_TRANSFORM` have no counterpart, and will not: geography is WGS84 by definition and there is no second reference system to reproject into. Nor do the planar affine transforms — `ST_ROTATE`, `ST_SCALE`, `ST_TRANSLATE` — or precision reduction, which snaps to a planar grid.
 - **Rechecking a pushed-down predicate.** These implementations must not be wired into a filter-recheck path until their agreement with each live store has been measured at the boundaries — a point on a polygon edge, an antimeridian crossing, the poles, a distance sitting on a threshold. A recheck that disagrees discards rows the store returned.

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -103,6 +103,30 @@ Both arities are Calcite's. The SRID a caller may name has to be 4326 and anythi
 | `ST_GEOG_INTERSECTS(GEOGRAPHY, GEOGRAPHY)` | any point in common |
 | `ST_GEOG_ISVALID(GEOGRAPHY)` | valid on the sphere |
 
+**Reading a geography.** Accessors, which read or rearrange coordinates without interpreting the space between them, so each is a delegation to the very JTS method Calcite's `ST_*` of that name calls.
+
+| | |
+| --- | --- |
+| ordinates | `ST_GEOG_X`, `ST_GEOG_Y`, `ST_GEOG_Z` |
+| bounds | `ST_GEOG_XMIN`, `ST_GEOG_XMAX`, `ST_GEOG_YMIN`, `ST_GEOG_YMAX`, `ST_GEOG_ZMIN`, `ST_GEOG_ZMAX` |
+| shape | `ST_GEOG_DIMENSION`, `ST_GEOG_COORDDIM`, `ST_GEOG_GEOMETRYTYPE`, `ST_GEOG_GEOMETRYTYPECODE`, `ST_GEOG_ISEMPTY`, `ST_GEOG_IS3D`, `ST_GEOG_ISCLOSED`, `ST_GEOG_SRID` |
+| counts | `ST_GEOG_NPOINTS`, `ST_GEOG_NUMPOINTS`, `ST_GEOG_NUMGEOMETRIES`, `ST_GEOG_NUMINTERIORRING`, `ST_GEOG_NUMINTERIORRINGS` |
+| parts | `ST_GEOG_STARTPOINT`, `ST_GEOG_ENDPOINT`, `ST_GEOG_POINTN`, `ST_GEOG_GEOMETRYN`, `ST_GEOG_EXTERIORRING`, `ST_GEOG_INTERIORRING`, `ST_GEOG_BOUNDARY`, `ST_GEOG_HOLES` |
+| comparison | `ST_GEOG_ORDERINGEQUALS` |
+
+`ST_GEOG_XMIN` and its four relatives are computed structurally and are wrong in the usual way for anything crossing the antimeridian, where the least longitude of a shape spanning the seam is not its westmost point. That is inherited from the planar reading rather than introduced here.
+
+**Every format, both ways.** A reader and a writer for each.
+
+| | reads | writes |
+| --- | --- | --- |
+| WKT | `ST_GEOG_GEOMFROMTEXT`, `ST_GEOG_GEOMFROMWKT` | `ST_GEOG_ASTEXT`, `ST_GEOG_ASWKT` |
+| EWKT | `ST_GEOG_GEOMFROMEWKT` | `ST_GEOG_ASEWKT` |
+| WKB | `ST_GEOG_GEOMFROMWKB` | `ST_GEOG_ASBINARY`, `ST_GEOG_ASWKB` |
+| EWKB | `ST_GEOG_GEOMFROMEWKB` | `ST_GEOG_ASEWKB` |
+| GeoJSON | `ST_GEOG_GEOMFROMGEOJSON` | `ST_GEOG_ASGEOJSON` |
+| GML | `ST_GEOG_GEOMFROMGML` | `ST_GEOG_ASGML` |
+
 Each answers `NULL` for a `NULL` argument.
 
 What these *mean* is what Calcite means, with the plane swapped for the sphere: `ST_Within` is `geom1.within(geom2)`, so `ST_GEOG_WITHIN` is the DE-9IM relation and not containment — a point on a polygon's boundary is not within it. `GeographyDifferentialTests` runs every one of them against Calcite's over shapes small enough that the two models must agree, which is what holds them to that.

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -671,6 +671,576 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_FLIPCOORDINATES</c>. Returns the geography with longitude and latitude swapped.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? FlipCoordinates(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_FlipCoordinates(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_FORCE2D</c>. Returns the geography with any third ordinate dropped.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? Force2D(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_Force2D(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_FORCE3D</c>. Returns the geography with a third ordinate on every coordinate.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? Force3D(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_Force3D(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_NORMALIZE</c>. Returns the geography in its canonical form.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? Normalize(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_Normalize(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEHOLES</c>. Returns the geography with the holes taken out of its polygons.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? RemoveHoles(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_RemoveHoles(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEREPEATEDPOINTS</c>. Returns the geography with repeated coordinates dropped.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? RemoveRepeatedPoints(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_RemoveRepeatedPoints(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_REVERSE</c>. Returns the geography with its coordinates in the opposite order.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? Reverse(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_Reverse(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_TOMULTILINE</c>. Returns the lines of the geography as a multi-line.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? ToMultiLine(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_ToMultiLine(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_TOMULTIPOINT</c>. Returns the coordinates of the geography as a multi-point.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? ToMultiPoint(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_ToMultiPoint(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_TOMULTISEGMENTS</c>. Returns the edges of the geography as a multi-line.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? ToMultiSegments(Geometry? g)
+        {
+            return g is null ? null : Wgs84Of(SpatialTypeFunctions.ST_ToMultiSegments(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ADDPOINT</c>. Returns the line with the coordinate added at its end.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        public static Geometry? AddPoint(Geometry? line, Geometry? point)
+        {
+            return line is null || point is null ? null : Wgs84Of(SpatialTypeFunctions.ST_AddPoint(line, point));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ADDPOINT</c>. Returns the line with the coordinate added at the given index.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="point"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static Geometry? AddPoint(Geometry? line, Geometry? point, java.lang.Number? index)
+        {
+            return line is null || point is null || index is null
+                ? null
+                : Wgs84Of(SpatialTypeFunctions.ST_AddPoint(line, point, index.intValue()));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEPOINT</c>. Returns the line with the coordinate at the given index taken out.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public static Geometry? RemovePoint(Geometry? line, java.lang.Number? index)
+        {
+            return line is null || index is null ? null : Wgs84Of(SpatialTypeFunctions.ST_RemovePoint(line, index.intValue()));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ADDZ</c>. Returns the geography with the given amount added to every third ordinate.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <param name="z"></param>
+        /// <returns></returns>
+        public static Geometry? AddZ(Geometry? g, java.lang.Number? z)
+        {
+            return g is null || z is null ? null : Wgs84Of(SpatialTypeFunctions.ST_AddZ(g, Decimal(z)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEREPEATEDPOINTS</c>. Returns the geography with coordinates closer together than
+        /// the given tolerance dropped.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <param name="tolerance"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The tolerance is in the units of the coordinates and not in metres, because what this does is drop
+        /// coordinates rather than measure between places. Calcite's is the same number.
+        /// </remarks>
+        public static Geometry? RemoveRepeatedPoints(Geometry? g, java.lang.Number? tolerance)
+        {
+            return g is null || tolerance is null
+                ? null
+                : Wgs84Of(SpatialTypeFunctions.ST_RemoveRepeatedPoints(g, Decimal(tolerance)));
+        }
+
+        /// <summary>
+        /// Reads a number as the decimal Calcite's own signature asks for.
+        /// </summary>
+        /// <param name="number"></param>
+        /// <returns></returns>
+        static java.math.BigDecimal Decimal(java.lang.Number number)
+        {
+            return number as java.math.BigDecimal ?? java.math.BigDecimal.valueOf(number.doubleValue());
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINT</c> and <c>ST_GEOG_MAKEPOINT</c>. Returns the place at the given longitude and
+        /// latitude.
+        /// </summary>
+        /// <param name="x">The longitude.</param>
+        /// <param name="y">The latitude.</param>
+        /// <returns></returns>
+        public static Geometry? Point(java.lang.Number? x, java.lang.Number? y)
+        {
+            return x is null || y is null ? null : Wgs84Of(SpatialTypeFunctions.ST_Point(Decimal(x), Decimal(y)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINT</c> and <c>ST_GEOG_MAKEPOINT</c>, with a third ordinate.
+        /// </summary>
+        /// <param name="x">The longitude.</param>
+        /// <param name="y">The latitude.</param>
+        /// <param name="z"></param>
+        /// <returns></returns>
+        public static Geometry? Point(java.lang.Number? x, java.lang.Number? y, java.lang.Number? z)
+        {
+            return x is null || y is null || z is null
+                ? null
+                : Wgs84Of(SpatialTypeFunctions.ST_Point(Decimal(x), Decimal(y), Decimal(z)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE</c>. Returns the line through 2 places.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakeLine(Geometry? g1, Geometry? g2)
+        {
+            return g1 is null || g2 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakeLine(g1, g2));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE</c>. Returns the line through 3 places.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakeLine(Geometry? g1, Geometry? g2, Geometry? g3)
+        {
+            return g1 is null || g2 is null || g3 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakeLine(g1, g2, g3));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE</c>. Returns the line through 4 places.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakeLine(Geometry? g1, Geometry? g2, Geometry? g3, Geometry? g4)
+        {
+            return g1 is null || g2 is null || g3 is null || g4 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakeLine(g1, g2, g3, g4));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE</c>. Returns the line through 5 places.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakeLine(Geometry? g1, Geometry? g2, Geometry? g3, Geometry? g4, Geometry? g5)
+        {
+            return g1 is null || g2 is null || g3 is null || g4 is null || g5 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakeLine(g1, g2, g3, g4, g5));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE</c>. Returns the line through 6 places.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakeLine(Geometry? g1, Geometry? g2, Geometry? g3, Geometry? g4, Geometry? g5, Geometry? g6)
+        {
+            return g1 is null || g2 is null || g3 is null || g4 is null || g5 is null || g6 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakeLine(g1, g2, g3, g4, g5, g6));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and no holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell)
+        {
+            return shell is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and one hole.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0)
+        {
+            return shell is null || hole0 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 2 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1)
+        {
+            return shell is null || hole0 is null || hole1 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 3 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 4 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 5 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3, Geometry? hole4)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null || hole4 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3, hole4));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 6 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3, Geometry? hole4, Geometry? hole5)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null || hole4 is null || hole5 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3, hole4, hole5));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 7 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3, Geometry? hole4, Geometry? hole5, Geometry? hole6)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null || hole4 is null || hole5 is null || hole6 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3, hole4, hole5, hole6));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 8 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3, Geometry? hole4, Geometry? hole5, Geometry? hole6, Geometry? hole7)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null || hole4 is null || hole5 is null || hole6 is null || hole7 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3, hole4, hole5, hole6, hole7));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 9 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3, Geometry? hole4, Geometry? hole5, Geometry? hole6, Geometry? hole7, Geometry? hole8)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null || hole4 is null || hole5 is null || hole6 is null || hole7 is null || hole8 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3, hole4, hole5, hole6, hole7, hole8));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON</c>. Returns the polygon with the given shell and 10 holes.
+        /// </summary>
+        /// <returns></returns>
+        public static Geometry? MakePolygon(Geometry? shell, Geometry? hole0, Geometry? hole1, Geometry? hole2, Geometry? hole3, Geometry? hole4, Geometry? hole5, Geometry? hole6, Geometry? hole7, Geometry? hole8, Geometry? hole9)
+        {
+            return shell is null || hole0 is null || hole1 is null || hole2 is null || hole3 is null || hole4 is null || hole5 is null || hole6 is null || hole7 is null || hole8 is null || hole9 is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MakePolygon(shell, hole0, hole1, hole2, hole3, hole4, hole5, hole6, hole7, hole8, hole9));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMTEXT</c>. Returns a line read from WKT, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? LineFromText(string? wkt)
+        {
+            return wkt is null ? null : Wgs84Of(SpatialTypeFunctions.ST_LineFromText(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMTEXT</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? LineFromText(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return LineFromText(wkt);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMWKB</c>. Returns a line read from WKB, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <returns></returns>
+        public static Geometry? LineFromWkb(org.apache.calcite.avatica.util.ByteString? wkb)
+        {
+            return wkb is null ? null : Wgs84Of(SpatialTypeFunctions.ST_LineFromWKB(wkb));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMWKB</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? LineFromWkb(org.apache.calcite.avatica.util.ByteString? wkb, java.lang.Number? srid)
+        {
+            if (wkb is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return LineFromWkb(wkb);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MLINEFROMTEXT</c>. Returns a multi-line read from WKT, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? MLineFromText(string? wkt)
+        {
+            return wkt is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MLineFromText(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MLINEFROMTEXT</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? MLineFromText(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return MLineFromText(wkt);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOINTFROMTEXT</c>. Returns a multi-point read from WKT, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? MPointFromText(string? wkt)
+        {
+            return wkt is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MPointFromText(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOINTFROMTEXT</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? MPointFromText(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return MPointFromText(wkt);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOLYFROMTEXT</c>. Returns a multi-polygon read from WKT, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? MPolyFromText(string? wkt)
+        {
+            return wkt is null ? null : Wgs84Of(SpatialTypeFunctions.ST_MPolyFromText(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOLYFROMTEXT</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? MPolyFromText(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return MPolyFromText(wkt);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMTEXT</c>. Returns a point read from WKT, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? PointFromText(string? wkt)
+        {
+            return wkt is null ? null : Wgs84Of(SpatialTypeFunctions.ST_PointFromText(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMTEXT</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? PointFromText(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return PointFromText(wkt);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMWKB</c>. Returns a point read from WKB, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <returns></returns>
+        public static Geometry? PointFromWkb(org.apache.calcite.avatica.util.ByteString? wkb)
+        {
+            return wkb is null ? null : Wgs84Of(SpatialTypeFunctions.ST_PointFromWKB(wkb));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMWKB</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? PointFromWkb(org.apache.calcite.avatica.util.ByteString? wkb, java.lang.Number? srid)
+        {
+            if (wkb is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return PointFromWkb(wkb);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMTEXT</c>. Returns a polygon read from WKT, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <returns></returns>
+        public static Geometry? PolyFromText(string? wkt)
+        {
+            return wkt is null ? null : Wgs84Of(SpatialTypeFunctions.ST_PolyFromText(wkt));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMTEXT</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkt"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? PolyFromText(string? wkt, java.lang.Number? srid)
+        {
+            if (wkt is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return PolyFromText(wkt);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMWKB</c>. Returns a polygon read from WKB, or null if the text does not name one.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <returns></returns>
+        public static Geometry? PolyFromWkb(org.apache.calcite.avatica.util.ByteString? wkb)
+        {
+            return wkb is null ? null : Wgs84Of(SpatialTypeFunctions.ST_PolyFromWKB(wkb));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMWKB</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? PolyFromWkb(org.apache.calcite.avatica.util.ByteString? wkb, java.lang.Number? srid)
+        {
+            if (wkb is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return PolyFromWkb(wkb);
+        }
+
+        /// <summary>
         /// Refuses an SRID a geography cannot be in.
         /// </summary>
         /// <param name="srid"></param>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -184,6 +184,135 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_CONTAINS</c>. Returns whether the first geography contains the second.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Contains(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Boolean.valueOf(S2Geographies.Contains(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+
+
+        /// <summary>
+        /// <c>ST_GEOG_COVERS</c>. Returns whether no point of the second geography is outside the first.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Covers(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Boolean.valueOf(S2Geographies.Covers(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_COVEREDBY</c>. Returns whether no point of the first geography is outside the second.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? CoveredBy(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Boolean.valueOf(S2Geographies.CoveredBy(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+
+
+        /// <summary>
+        /// <c>ST_GEOG_DISJOINT</c>. Returns whether two geographies have no point in common.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Disjoint(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Boolean.valueOf(S2Geographies.Disjoint(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_EQUALS</c>. Returns whether two geographies are the same set of places.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Equals(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Boolean.valueOf(S2Geographies.Equals(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+
+
+
+
+        /// <summary>
+        /// <c>ST_GEOG_ENVELOPESINTERSECT</c>. Returns whether the bounding boxes of two geographies meet.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? EnvelopesIntersect(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Boolean.valueOf(S2Geographies.EnvelopesIntersect(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_AREA</c>. Returns the area of the geography in square metres.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? Area(Geometry? g)
+        {
+            return g is null ? null : java.lang.Double.valueOf(S2Geographies.Area(S2Geographies.Of(g)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_LENGTH</c>. Returns the length of the geography in metres.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? Length(Geometry? g)
+        {
+            return g is null ? null : java.lang.Double.valueOf(S2Geographies.Length(S2Geographies.Of(g)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_PERIMETER</c>. Returns the perimeter of the areal part of the geography in metres.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? Perimeter(Geometry? g)
+        {
+            return g is null ? null : java.lang.Double.valueOf(S2Geographies.Perimeter(S2Geographies.Of(g)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MAXDISTANCE</c>. Returns the greatest distance between a coordinate of one geography and a coordinate of the other, in metres.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static java.lang.Double? MaxDistance(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null
+                ? null
+                : java.lang.Double.valueOf(S2Geographies.MaxDistance(S2Geographies.Of(a), S2Geographies.Of(b)));
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_ISVALID</c>. Whether the geography is valid on the sphere.
         /// </summary>
         /// <param name="geography"></param>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -81,9 +81,7 @@ namespace Apache.Calcite.Geography.Runtime
             if (wkt is null || srid is null)
                 return null;
 
-            if (srid.intValue() != Wgs84)
-                throw new java.lang.IllegalArgumentException($"A geography is WGS84; SRID {srid.intValue()} is not a reference system it can be in.");
-
+            RequireWgs84(srid.intValue());
             return FromWkt(wkt);
         }
 
@@ -196,6 +194,507 @@ namespace Apache.Calcite.Geography.Runtime
                 return null;
 
             return java.lang.Boolean.valueOf(S2Geographies.IsValid(geography));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_X</c>. Returns the longitude of a point.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? X(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_X(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_Y</c>. Returns the latitude of a point.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? Y(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_Y(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_Z</c>. Returns the third ordinate of a point.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? Z(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_Z(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_XMIN</c>. Returns the least longitude.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? XMin(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_XMin(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_XMAX</c>. Returns the greatest longitude.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? XMax(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_XMax(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_YMIN</c>. Returns the least latitude.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? YMin(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_YMin(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_YMAX</c>. Returns the greatest latitude.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? YMax(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_YMax(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ZMIN</c>. Returns the least third ordinate.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? ZMin(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_ZMin(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ZMAX</c>. Returns the greatest third ordinate.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Double? ZMax(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_ZMax(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_COORDDIM</c>. Returns how many ordinates a coordinate carries.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? CoordDim(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_CoordDim(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_DIMENSION</c>. Returns the dimension: 0, 1 or 2.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? Dimension(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_Dimension(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMETRYTYPE</c>. Returns the name of the kind of shape.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static string? GeometryType(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_GeometryType(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMETRYTYPECODE</c>. Returns the number of the kind of shape.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? GeometryTypeCode(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_GeometryTypeCode(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_NPOINTS</c>. Returns how many coordinates the shape names.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? NPoints(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_NPoints(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMPOINTS</c>. Returns how many coordinates a line names.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? NumPoints(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_NumPoints(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMGEOMETRIES</c>. Returns how many parts the shape has.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? NumGeometries(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_NumGeometries(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMINTERIORRING</c>. Returns how many holes a polygon has.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? NumInteriorRing(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_NumInteriorRing(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMINTERIORRINGS</c>. Returns how many holes a polygon has, under Calcite's other spelling.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? NumInteriorRings(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_NumInteriorRings(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_STARTPOINT</c>. Returns the first coordinate of a line.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? StartPoint(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_StartPoint(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ENDPOINT</c>. Returns the last coordinate of a line.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? EndPoint(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_EndPoint(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_EXTERIORRING</c>. Returns the shell of a polygon.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? ExteriorRing(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_ExteriorRing(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_BOUNDARY</c>. Returns the boundary of the shape.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? Boundary(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_Boundary(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_HOLES</c>. Returns the holes of a polygon.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static Geometry? Holes(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_Holes(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ISEMPTY</c>. Returns whether the shape names nothing.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? IsEmpty(Geometry? g)
+        {
+            return g is null ? null : java.lang.Boolean.valueOf(SpatialTypeFunctions.ST_IsEmpty(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_IS3D</c>. Returns whether the coordinates carry a third ordinate.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? Is3D(Geometry? g)
+        {
+            return g is null ? null : java.lang.Boolean.valueOf(SpatialTypeFunctions.ST_Is3D(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ISCLOSED</c>. Returns whether a line ends where it began.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Boolean? IsClosed(Geometry? g)
+        {
+            return g is null ? null : java.lang.Boolean.valueOf(SpatialTypeFunctions.ST_IsClosed(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_SRID</c>. Returns the reference system the coordinates are stamped with.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static java.lang.Integer? Srid(Geometry? g)
+        {
+            return g is null ? null : java.lang.Integer.valueOf(SpatialTypeFunctions.ST_SRID(g));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASTEXT</c>. Writes the geography as WKT.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static string? AsText(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsText(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASWKT</c>. Writes the geography as WKT, under Calcite's other spelling.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static string? AsWkt(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsWKT(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASEWKT</c>. Writes the geography as EWKT, which carries the SRID.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static string? AsEwkt(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsEWKT(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASGEOJSON</c>. Writes the geography as GeoJSON.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static string? AsGeoJson(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsGeoJSON(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASGML</c>. Writes the geography as GML.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static string? AsGml(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsGML(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASBINARY</c>. Writes the geography as WKB.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static org.apache.calcite.avatica.util.ByteString? AsBinary(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsBinary(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASWKB</c>. Writes the geography as WKB, under Calcite's other spelling.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static org.apache.calcite.avatica.util.ByteString? AsWkb(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsWKB(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ASEWKB</c>. Writes the geography as EWKB.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static org.apache.calcite.avatica.util.ByteString? AsEwkb(Geometry? g)
+        {
+            return g is null ? null : SpatialTypeFunctions.ST_AsEWKB(g);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTN</c>. Returns the <c>n</c>th coordinate of a line, counting from one.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        public static Geometry? PointN(Geometry? g, java.lang.Number? n)
+        {
+            return g is null || n is null ? null : SpatialTypeFunctions.ST_PointN(g, n.intValue());
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMETRYN</c>. Returns the <c>n</c>th part of the geography, counting from one.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        public static Geometry? GeometryN(Geometry? g, java.lang.Number? n)
+        {
+            return g is null || n is null ? null : SpatialTypeFunctions.ST_GeometryN(g, n.intValue());
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_INTERIORRING</c>. Returns the <c>n</c>th hole of a polygon, counting from one.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        public static Geometry? InteriorRing(Geometry? g, java.lang.Number? n)
+        {
+            return g is null || n is null ? null : SpatialTypeFunctions.ST_InteriorRing(g, n.intValue());
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ORDERINGEQUALS</c>. Whether two geographies name the same coordinates in the same
+        /// order.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The one comparison in this package that reads the coordinates as a list rather than as places, so
+        /// it means the same thing on a sphere as it does on a plane.
+        /// </remarks>
+        public static java.lang.Boolean? OrderingEquals(Geometry? a, Geometry? b)
+        {
+            return a is null || b is null ? null : java.lang.Boolean.valueOf(SpatialTypeFunctions.ST_OrderingEquals(a, b));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMEWKT</c>. Reads a geography from EWKT.
+        /// </summary>
+        /// <param name="ewkt"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// EWKT carries its own SRID, so unlike the plain WKT form there is nothing for a caller to pass and
+        /// the text itself can name a reference system a geography cannot be in. It is refused there for the
+        /// same reason it is refused as an argument.
+        /// </remarks>
+        public static Geometry? FromEwkt(string? ewkt)
+        {
+            return ewkt is null ? null : Wgs84Of(Stamped(SpatialTypeFunctions.ST_GeomFromEWKT(ewkt)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMWKB</c>. Reads a geography from WKB.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <returns></returns>
+        public static Geometry? FromWkb(org.apache.calcite.avatica.util.ByteString? wkb)
+        {
+            return wkb is null ? null : Wgs84Of(SpatialTypeFunctions.ST_GeomFromWKB(wkb));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMWKB</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="wkb"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? FromWkb(org.apache.calcite.avatica.util.ByteString? wkb, java.lang.Number? srid)
+        {
+            if (wkb is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return FromWkb(wkb);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMEWKB</c>. Reads a geography from EWKB.
+        /// </summary>
+        /// <param name="ewkb"></param>
+        /// <returns></returns>
+        public static Geometry? FromEwkb(org.apache.calcite.avatica.util.ByteString? ewkb)
+        {
+            return ewkb is null ? null : Wgs84Of(Stamped(SpatialTypeFunctions.ST_GeomFromEWKB(ewkb)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMGML</c>. Reads a geography from GML.
+        /// </summary>
+        /// <param name="gml"></param>
+        /// <returns></returns>
+        public static Geometry? FromGml(string? gml)
+        {
+            return gml is null ? null : Wgs84Of(SpatialTypeFunctions.ST_GeomFromGML(gml));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMGML</c>, with the SRID Calcite lets a caller name.
+        /// </summary>
+        /// <param name="gml"></param>
+        /// <param name="srid"></param>
+        /// <returns></returns>
+        public static Geometry? FromGml(string? gml, java.lang.Number? srid)
+        {
+            if (gml is null || srid is null)
+                return null;
+
+            RequireWgs84(srid.intValue());
+            return FromGml(gml);
+        }
+
+        /// <summary>
+        /// Refuses an SRID a geography cannot be in.
+        /// </summary>
+        /// <param name="srid"></param>
+        static void RequireWgs84(int srid)
+        {
+            if (srid != Wgs84)
+                throw new java.lang.IllegalArgumentException($"A geography is WGS84; SRID {srid} is not a reference system it can be in.");
+        }
+
+        /// <summary>
+        /// Refuses a geometry whose own SRID says it is in a reference system a geography cannot be in.
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Calcite leaves a geometry with no SRID on zero, which says nothing rather than says the wrong
+        /// thing, so that one is stamped rather than refused.
+        /// </remarks>
+        static Geometry? Stamped(Geometry? geometry)
+        {
+            if (geometry is not null && geometry.getSRID() != 0)
+                RequireWgs84(geometry.getSRID());
+
+            return geometry;
         }
 
         static Geometry? Wgs84Of(Geometry? geometry)

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -58,6 +58,20 @@ namespace Apache.Calcite.Geography.Runtime
         const double Tolerance = 1e-13;
 
         /// <summary>
+        /// The shortest run of edge that counts as a stretch shared between two geographies, in radians.
+        /// </summary>
+        /// <remarks>
+        /// Bigger than <see cref="Tolerance"/> by four orders, and it has to be. A great-circle edge does not
+        /// pass exactly through the coordinates a straight line in longitude and latitude would — over a
+        /// thousandth of a degree near the equator the two are about a picoradian apart — so where two lines
+        /// meet at a place both of them name, the edges either side of that place cross the other line just
+        /// short of it and just past it. That leaves a genuine piece of edge a picoradian long whose middle
+        /// lies on the other geography, and a predicate asking whether the two run along one another would
+        /// read it as yes. Six millimetres on the Earth is below anything a store records and far above that.
+        /// </remarks>
+        const double MinimumStretch = 1e-9;
+
+        /// <summary>
         /// Reads a JTS geometry as WGS84 and builds its S2 shapes.
         /// </summary>
         /// <param name="geometry"></param>
@@ -233,13 +247,13 @@ namespace Apache.Calcite.Geography.Runtime
         static bool Separate(S2Geographies a, S2Geographies b)
         {
             foreach (var (p, q) in a.RingEdges)
-                foreach (var middle in b.Pieces(p, q))
-                    if (b.ContainsInterior(middle))
+                foreach (var piece in b.Pieces(p, q))
+                    if (b.ContainsInterior(piece.Middle))
                         return false;
 
             foreach (var (p, q) in b.RingEdges)
-                foreach (var middle in a.Pieces(p, q))
-                    if (a.ContainsInterior(middle))
+                foreach (var piece in a.Pieces(p, q))
+                    if (a.ContainsInterior(piece.Middle))
                         return false;
 
             return SharesAnEdge(a, b) == false;
@@ -260,8 +274,8 @@ namespace Apache.Calcite.Geography.Runtime
         static bool SharesAnEdge(S2Geographies a, S2Geographies b)
         {
             foreach (var (p, q) in a.Edges)
-                foreach (var middle in b.Pieces(p, q))
-                    if (b.OnEdge(middle))
+                foreach (var piece in b.Pieces(p, q))
+                    if (piece.Length > MinimumStretch && b.OnEdge(piece.Middle))
                         return true;
 
             return false;
@@ -503,36 +517,132 @@ namespace Apache.Calcite.Geography.Runtime
         /// </remarks>
         public static bool Within(S2Geographies a, S2Geographies b)
         {
-            if (a.IsEmpty || b.IsEmpty)
+            return Covers(b, a) && MeetsInterior(a, b);
+        }
+
+        /// <summary>
+        /// Returns whether every point of <paramref name="inner"/> lies in <paramref name="outer"/>.
+        /// </summary>
+        /// <param name="outer"></param>
+        /// <param name="inner"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <c>ST_COVERS</c>, and the half of <c>within</c> that is about where the points are rather than
+        /// about the interiors meeting. Covering is the weaker relation and the more useful one: a polygon
+        /// covers a line lying along its own boundary and does not contain it.
+        ///
+        /// <para>An edge of <paramref name="inner"/> is checked by cutting it wherever the boundary of
+        /// <paramref name="outer"/> meets it and testing the middle of each piece, which is exact rather than
+        /// a sample; see <see cref="Pieces"/>. The last loop is the one that is easy to leave out: the
+        /// boundary of <paramref name="inner"/> says nothing about a hole of <paramref name="outer"/> lying
+        /// wholly inside it, because no edge of it goes near one. Any part of <paramref name="inner"/>
+        /// outside <paramref name="outer"/> sits in a region bounded by a ring of <paramref name="outer"/>,
+        /// so a ring of it must run through the interior. Testing the vertices of those rings instead is not
+        /// enough and looks like it is — a hole can have every one of its corners on the boundary and still
+        /// lie inside.</para>
+        /// </remarks>
+        public static bool Covers(S2Geographies outer, S2Geographies inner)
+        {
+            if (outer.IsEmpty || inner.IsEmpty)
                 return false;
 
             // nothing of a higher dimension lies inside something of a lower one
-            if (a.Dimension > b.Dimension)
+            if (inner.Dimension > outer.Dimension)
                 return false;
 
-            foreach (var vertex in a.Vertices)
-                if (b.Contains(vertex) == false)
+            foreach (var vertex in inner.Vertices)
+                if (outer.Holds(vertex) == false)
                     return false;
 
-            foreach (var (p, q) in a.Edges)
-                foreach (var middle in b.Pieces(p, q))
-                    if (b.Contains(middle) == false)
+            foreach (var (p, q) in inner.Edges)
+                foreach (var piece in outer.Pieces(p, q))
+                    if (outer.Holds(piece.Middle) == false)
                         return false;
 
-            // The boundary of a says nothing about a hole of b lying wholly inside a: no edge of a goes near
-            // one. Any part of a outside b sits in a region bounded by a ring of b, so if a is not within b
-            // then a ring of b runs through the interior of a. Cutting each of those edges wherever a meets
-            // it and testing the middles decides it: a piece is wholly inside a, wholly outside it, or wholly
-            // on its boundary. Testing the vertices of those rings instead is not enough and looks like it is
-            // — a hole can have every one of its corners on the boundary of a and still lie inside it.
-            if (a.polygon is not null)
-                foreach (var (p, q) in b.RingEdges)
-                    foreach (var middle in a.Pieces(p, q))
-                        if (a.ContainsInterior(middle))
+            if (inner.polygon is not null)
+            {
+                foreach (var (p, q) in outer.RingEdges)
+                    foreach (var piece in inner.Pieces(p, q))
+                        if (inner.ContainsInterior(piece.Middle))
                             return false;
 
-            return MeetsInterior(a, b);
+                // and the areas, because a polygon that is exactly a hole of the other has every one of its
+                // points on a boundary of it and none of its area inside it
+                if (outer.polygon is null || Enclosed(outer.polygon, inner.polygon) == false)
+                    return false;
+            }
+
+            return true;
         }
+
+        /// <summary>
+        /// Returns whether one polygon holds essentially all of another's area.
+        /// </summary>
+        /// <param name="outer"></param>
+        /// <param name="inner"></param>
+        /// <returns></returns>
+        static bool Enclosed(S2Polygon outer, S2Polygon inner)
+        {
+            var intersection = new S2Polygon();
+            intersection.initToIntersection(inner, outer);
+            return intersection.getArea() >= inner.getArea() * (1 - SliverShare);
+        }
+
+        /// <summary>
+        /// <c>ST_CONTAINS</c>. Returns whether <paramref name="a"/> contains <paramref name="b"/>.
+        /// </summary>
+        public static bool Contains(S2Geographies a, S2Geographies b)
+        {
+            return Within(b, a);
+        }
+
+        /// <summary>
+        /// <c>ST_COVEREDBY</c>. Returns whether every point of <paramref name="a"/> lies in
+        /// <paramref name="b"/>.
+        /// </summary>
+        public static bool CoveredBy(S2Geographies a, S2Geographies b)
+        {
+            return Covers(b, a);
+        }
+
+        /// <summary>
+        /// <c>ST_EQUALS</c>. Returns whether two geographies are the same set of places.
+        /// </summary>
+        /// <remarks>
+        /// Topological equality and not equality of the coordinates: a line named forwards and the same line
+        /// named backwards are equal, and <c>ST_GEOG_ORDERINGEQUALS</c> is the one that says otherwise. Each
+        /// covering the other is the whole of it.
+        /// </remarks>
+        public static bool Equals(S2Geographies a, S2Geographies b)
+        {
+            return Covers(a, b) && Covers(b, a);
+        }
+
+        /// <summary>
+        /// <c>ST_DISJOINT</c>. Returns whether two geographies have no point in common.
+        /// </summary>
+        public static bool Disjoint(S2Geographies a, S2Geographies b)
+        {
+            return Intersects(a, b) == false;
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
         /// <summary>
         /// Returns whether the interior of <paramref name="a"/>, already known to lie in
@@ -560,8 +670,8 @@ namespace Apache.Calcite.Geography.Runtime
                             return true;
 
                     foreach (var (p, q) in a.Edges)
-                        foreach (var middle in b.Pieces(p, q))
-                            if (b.ContainsInterior(middle))
+                        foreach (var piece in b.Pieces(p, q))
+                            if (b.ContainsInterior(piece.Middle))
                                 return true;
 
                     return false;
@@ -583,12 +693,23 @@ namespace Apache.Calcite.Geography.Runtime
             }
         }
 
+        // ST_GEOG_CROSSES, ST_GEOG_TOUCHES, ST_GEOG_OVERLAPS and ST_GEOG_CONTAINSPROPERLY are not here, and
+        // the reason is one place rather than four. All four turn on whether the interiors of two geographies
+        // meet, and where a line comes back and touches itself that question has no answer this file can
+        // give: the place is the end of the whole line and the middle of one of its own edges at once, so it
+        // is boundary by the rule that counts ends and interior by the rule that reads the curve. Measured
+        // both ways round over generated shapes, and each is wrong somewhere -- taking the end makes a
+        // genuine crossing read as a touch, and taking the curve makes a touch between a point and the end
+        // of a line read as a crossing. JTS settles it in a node graph built over the two geometries
+        // together, labelling every node from the edges that arrive at it, and that is the machinery
+        // S2BooleanOperation would have brought.
+
         /// <summary>
         /// Returns whether the given point lies in this geography, boundary included.
         /// </summary>
         /// <param name="point"></param>
         /// <returns></returns>
-        public bool Contains(S2Point point)
+        public bool Holds(S2Point point)
         {
             if (polygon is not null && polygon.contains(point))
                 return true;
@@ -637,6 +758,8 @@ namespace Apache.Calcite.Geography.Runtime
             return false;
         }
 
+
+
         /// <summary>
         /// Returns whether the given point is on the boundary of the linear part of this geography.
         /// </summary>
@@ -675,7 +798,7 @@ namespace Apache.Calcite.Geography.Runtime
         /// that merely runs along an edge starts and ends at that edge's own vertices. So the middle of a
         /// piece stands for the whole piece, and testing the middles is exact rather than a sample.
         /// </remarks>
-        public IEnumerable<S2Point> Pieces(S2Point p, S2Point q)
+        public IEnumerable<(S2Point Middle, double Length)> Pieces(S2Point p, S2Point q)
         {
             var cuts = new List<double> { 0, 1 };
 
@@ -693,8 +816,17 @@ namespace Apache.Calcite.Geography.Runtime
 
             cuts.Sort();
 
+            // Two cuts that fall in the same place — a crossing that is also a vertex of this geography, say
+            // — would otherwise leave a piece of no length between them, and the middle of a piece of no
+            // length is the cut itself, which lies on this geography by construction. A caller asking whether
+            // a stretch of edge runs along this one would then be told yes by a stretch that is a point.
+            const double Together = 1e-9;
+
+            var whole = new S1Angle(p, q).radians();
+
             for (var i = 1; i < cuts.Count; i++)
-                yield return S2EdgeUtil.interpolate((cuts[i - 1] + cuts[i]) / 2, p, q);
+                if (cuts[i] - cuts[i - 1] > Together)
+                    yield return (S2EdgeUtil.interpolate((cuts[i - 1] + cuts[i]) / 2, p, q), (cuts[i] - cuts[i - 1]) * whole);
         }
 
         static void Cut(List<double> cuts, S2Point p, S2Point q, S2Point vertex)
@@ -705,6 +837,123 @@ namespace Apache.Calcite.Geography.Runtime
             var fraction = S2EdgeUtil.getDistanceFraction(vertex, p, q);
             if (fraction > 0 && fraction < 1)
                 cuts.Add(fraction);
+        }
+
+        /// <summary>
+        /// <c>ST_AREA</c>. Returns the area of the geography in square metres.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The area S2 measures on the sphere, which is a real area rather than the square degrees a planar
+        /// reading answers. A geography with no areal part has none, as JTS has none for a line.
+        /// </remarks>
+        public static double Area(S2Geographies g)
+        {
+            return g.polygon is null ? 0 : g.polygon.getArea() * EarthRadiusMeters * EarthRadiusMeters;
+        }
+
+        /// <summary>
+        /// <c>ST_LENGTH</c>. Returns the length of the geography in metres.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Every edge, the rings of a polygon included, because <c>Geometry.getLength</c> answers a polygon
+        /// with its perimeter and this mirrors that.
+        /// </remarks>
+        public static double Length(S2Geographies g)
+        {
+            return Arc(g.Edges);
+        }
+
+        /// <summary>
+        /// <c>ST_PERIMETER</c>. Returns the perimeter of the areal part of the geography in metres.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        public static double Perimeter(S2Geographies g)
+        {
+            return Arc(g.RingEdges);
+        }
+
+        static double Arc(IEnumerable<(S2Point, S2Point)> edges)
+        {
+            var total = 0.0;
+
+            foreach (var (p, q) in edges)
+                total += new S1Angle(p, q).radians();
+
+            return total * EarthRadiusMeters;
+        }
+
+        /// <summary>
+        /// <c>ST_MAXDISTANCE</c>. Returns the greatest distance between a coordinate of one geography and a
+        /// coordinate of the other, in metres.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Between the coordinates and not between the shapes, which is what Calcite measures: it walks the
+        /// two coordinate arrays and takes the largest. The greatest distance between two shapes would want
+        /// the edges as well, and would be a different function.
+        /// </remarks>
+        public static double MaxDistance(S2Geographies a, S2Geographies b)
+        {
+            var max = 0.0;
+
+            foreach (var va in a.Vertices)
+                foreach (var vb in b.Vertices)
+                    max = System.Math.Max(max, new S1Angle(va, vb).radians());
+
+            return max * EarthRadiusMeters;
+        }
+
+        /// <summary>
+        /// <c>ST_ENVELOPESINTERSECT</c>. Returns whether the bounding boxes of two geographies meet.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The box is an <c>S2LatLngRect</c> rather than a rectangle in longitude and latitude, which is the
+        /// whole reason this one is not in the mechanical group: a shape crossing the antimeridian has no
+        /// correct bounding box in plain coordinates, and the planar reading answers one anyway. S2 builds
+        /// the bound from the edges rather than the vertices, so it also holds the bulge a great-circle edge
+        /// makes north of a parallel.
+        /// </remarks>
+        public static bool EnvelopesIntersect(S2Geographies a, S2Geographies b)
+        {
+            if (a.IsEmpty || b.IsEmpty)
+                return false;
+
+            // expanded, because the two bounds are built from unit vectors and compared as latitudes and
+            // longitudes, and boxes that meet exactly at a corner can miss each other by the last bit of that
+            // round trip. The margin is the same angle everything else here treats as touching.
+            var margin = S2LatLng.fromRadians(Tolerance, Tolerance);
+
+            return a.Bound().expanded(margin).intersects(b.Bound().expanded(margin));
+        }
+
+        /// <summary>
+        /// The bounding box of the geography.
+        /// </summary>
+        /// <returns></returns>
+        S2LatLngRect Bound()
+        {
+            var bound = S2LatLngRect.empty();
+
+            foreach (var point in points)
+                bound = bound.addPoint(point);
+
+            foreach (var line in lines)
+                bound = bound.union(new S2Polyline(ToList(line)).getRectBound());
+
+            if (polygon is not null)
+                bound = bound.union(polygon.getRectBound());
+
+            return bound;
         }
 
         /// <summary>
@@ -793,11 +1042,28 @@ namespace Apache.Calcite.Geography.Runtime
         /// what the smallest real overlap here would be, so a threshold relative to the area of
         /// <paramref name="a"/> separates them by twenty orders of magnitude rather than by a guess.
         /// </remarks>
+        /// <summary>
+        /// The share of a polygon's area below which an intersection is taken to be a snapping artefact
+        /// rather than an overlap.
+        /// </summary>
+        /// <remarks>
+        /// Measured rather than guessed. Two squares meeting along an edge leave an intersection of about a
+        /// billionth of a billionth of a steradian, which for the shapes this is asked about is a billionth
+        /// or two of their area — the sliver is the length of the shared boundary times the radius S2 snaps
+        /// to. A real overlap of two shapes that meet at all is a finite fraction of the smaller one. A
+        /// millionth sits three orders above the sliver and four below the smallest real overlap.
+        ///
+        /// <para>What it costs: two shapes whose genuine overlap is thinner than that are reported as
+        /// touching rather than as overlapping. That is the price of a boolean operation that snaps, and it
+        /// is the same price S2 charges its own callers.</para>
+        /// </remarks>
+        const double SliverShare = 1e-6;
+
         static bool Overlaps(S2Polygon a, S2Polygon b)
         {
             var intersection = new S2Polygon();
             intersection.initToIntersection(a, b);
-            return intersection.getArea() > a.getArea() * 1e-9;
+            return intersection.getArea() > a.getArea() * SliverShare;
         }
 
         static bool Near(S2Point a, S2Point b)

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -455,6 +455,377 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Character, GeographyOperand.Numeric], ["gml", "srid"]);
 
         /// <summary>
+        /// <c>ST_GEOG_FLIPCOORDINATES(GEOGRAPHY)</c>. Returns the geography with longitude and latitude swapped.
+        /// </summary>
+        public static readonly SqlFunction StGeogFlipCoordinates =
+            Function("ST_GEOG_FLIPCOORDINATES", nameof(GeographyFunctions.FlipCoordinates), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_FORCE2D(GEOGRAPHY)</c>. Returns the geography with any third ordinate dropped.
+        /// </summary>
+        public static readonly SqlFunction StGeogForce2D =
+            Function("ST_GEOG_FORCE2D", nameof(GeographyFunctions.Force2D), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_FORCE3D(GEOGRAPHY)</c>. Returns the geography with a third ordinate on every coordinate.
+        /// </summary>
+        public static readonly SqlFunction StGeogForce3D =
+            Function("ST_GEOG_FORCE3D", nameof(GeographyFunctions.Force3D), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_NORMALIZE(GEOGRAPHY)</c>. Returns the geography in its canonical form.
+        /// </summary>
+        public static readonly SqlFunction StGeogNormalize =
+            Function("ST_GEOG_NORMALIZE", nameof(GeographyFunctions.Normalize), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEHOLES(GEOGRAPHY)</c>. Returns the geography with the holes taken out of its polygons.
+        /// </summary>
+        public static readonly SqlFunction StGeogRemoveHoles =
+            Function("ST_GEOG_REMOVEHOLES", nameof(GeographyFunctions.RemoveHoles), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEREPEATEDPOINTS(GEOGRAPHY)</c>. Returns the geography with repeated coordinates dropped.
+        /// </summary>
+        public static readonly SqlFunction StGeogRemoveRepeatedPoints =
+            Function("ST_GEOG_REMOVEREPEATEDPOINTS", nameof(GeographyFunctions.RemoveRepeatedPoints), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_REVERSE(GEOGRAPHY)</c>. Returns the geography with its coordinates in the opposite order.
+        /// </summary>
+        public static readonly SqlFunction StGeogReverse =
+            Function("ST_GEOG_REVERSE", nameof(GeographyFunctions.Reverse), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_TOMULTILINE(GEOGRAPHY)</c>. Returns the lines of the geography as a multi-line.
+        /// </summary>
+        public static readonly SqlFunction StGeogToMultiLine =
+            Function("ST_GEOG_TOMULTILINE", nameof(GeographyFunctions.ToMultiLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_TOMULTIPOINT(GEOGRAPHY)</c>. Returns the coordinates of the geography as a multi-point.
+        /// </summary>
+        public static readonly SqlFunction StGeogToMultiPoint =
+            Function("ST_GEOG_TOMULTIPOINT", nameof(GeographyFunctions.ToMultiPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_TOMULTISEGMENTS(GEOGRAPHY)</c>. Returns the edges of the geography as a multi-line.
+        /// </summary>
+        public static readonly SqlFunction StGeogToMultiSegments =
+            Function("ST_GEOG_TOMULTISEGMENTS", nameof(GeographyFunctions.ToMultiSegments), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ADDPOINT(GEOGRAPHY, GEOGRAPHY)</c>. Returns the line with the coordinate added at its end.
+        /// </summary>
+        public static readonly SqlFunction StGeogAddPoint =
+            Function("ST_GEOG_ADDPOINT", nameof(GeographyFunctions.AddPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["line", "point"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ADDPOINT(GEOGRAPHY, GEOGRAPHY, INTEGER)</c>. Returns the line with the coordinate added at the given index.
+        /// </summary>
+        public static readonly SqlFunction StGeogAddPointAtIndex =
+            Function("ST_GEOG_ADDPOINT", nameof(GeographyFunctions.AddPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Numeric], ["line", "point", "index"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEPOINT(GEOGRAPHY, INTEGER)</c>. Returns the line with the coordinate at the given index taken out.
+        /// </summary>
+        public static readonly SqlFunction StGeogRemovePoint =
+            Function("ST_GEOG_REMOVEPOINT", nameof(GeographyFunctions.RemovePoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Numeric], ["line", "index"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ADDZ(GEOGRAPHY, NUMERIC)</c>. Returns the geography with the given amount added to every third ordinate.
+        /// </summary>
+        public static readonly SqlFunction StGeogAddZ =
+            Function("ST_GEOG_ADDZ", nameof(GeographyFunctions.AddZ), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Numeric], ["geog", "z"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_REMOVEREPEATEDPOINTS(GEOGRAPHY, NUMERIC)</c>. Returns the geography with coordinates closer together than the tolerance dropped.
+        /// </summary>
+        public static readonly SqlFunction StGeogRemoveRepeatedPointsWithTolerance =
+            Function("ST_GEOG_REMOVEREPEATEDPOINTS", nameof(GeographyFunctions.RemoveRepeatedPoints), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Numeric], ["geog", "tolerance"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINT(NUMERIC, NUMERIC)</c>. Returns the place at the given longitude and latitude.
+        /// </summary>
+        public static readonly SqlFunction StGeogPoint =
+            Function("ST_GEOG_POINT", nameof(GeographyFunctions.Point), GeographyReturnTypes.Geography,
+                [GeographyOperand.Numeric, GeographyOperand.Numeric], ["x", "y"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINT(NUMERIC, NUMERIC, NUMERIC)</c>. Returns the place at the given longitude, latitude and third ordinate.
+        /// </summary>
+        public static readonly SqlFunction StGeogPoint3D =
+            Function("ST_GEOG_POINT", nameof(GeographyFunctions.Point), GeographyReturnTypes.Geography,
+                [GeographyOperand.Numeric, GeographyOperand.Numeric, GeographyOperand.Numeric], ["x", "y", "z"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOINT(NUMERIC, NUMERIC)</c>. Returns the place at the given longitude and latitude.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePoint =
+            Function("ST_GEOG_MAKEPOINT", nameof(GeographyFunctions.Point), GeographyReturnTypes.Geography,
+                [GeographyOperand.Numeric, GeographyOperand.Numeric], ["x", "y"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOINT(NUMERIC, NUMERIC, NUMERIC)</c>. Returns the place at the given longitude, latitude and third ordinate.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePoint3D =
+            Function("ST_GEOG_MAKEPOINT", nameof(GeographyFunctions.Point), GeographyReturnTypes.Geography,
+                [GeographyOperand.Numeric, GeographyOperand.Numeric, GeographyOperand.Numeric], ["x", "y", "z"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the line through 2 places.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakeLine2 =
+            Function("ST_GEOG_MAKELINE", nameof(GeographyFunctions.MakeLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the line through 3 places.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakeLine3 =
+            Function("ST_GEOG_MAKELINE", nameof(GeographyFunctions.MakeLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2", "geog3"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the line through 4 places.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakeLine4 =
+            Function("ST_GEOG_MAKELINE", nameof(GeographyFunctions.MakeLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2", "geog3", "geog4"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the line through 5 places.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakeLine5 =
+            Function("ST_GEOG_MAKELINE", nameof(GeographyFunctions.MakeLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2", "geog3", "geog4", "geog5"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKELINE(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the line through 6 places.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakeLine6 =
+            Function("ST_GEOG_MAKELINE", nameof(GeographyFunctions.MakeLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2", "geog3", "geog4", "geog5", "geog6"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY)</c>. Returns the polygon with the given shell and no holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon1 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["shell"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and one hole.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon2 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 2 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon3 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 3 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon4 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 4 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon5 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 5 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon6 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3", "hole4"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 6 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon7 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3", "hole4", "hole5"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 7 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon8 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3", "hole4", "hole5", "hole6"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 8 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon9 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3", "hole4", "hole5", "hole6", "hole7"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 9 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon10 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3", "hole4", "hole5", "hole6", "hole7", "hole8"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAKEPOLYGON(GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY, GEOGRAPHY)</c>. Returns the polygon with the given shell and 10 holes.
+        /// </summary>
+        public static readonly SqlFunction StGeogMakePolygon11 =
+            Function("ST_GEOG_MAKEPOLYGON", nameof(GeographyFunctions.MakePolygon), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography, GeographyOperand.Geography], ["shell", "hole0", "hole1", "hole2", "hole3", "hole4", "hole5", "hole6", "hole7", "hole8", "hole9"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMTEXT(VARCHAR)</c>. Returns a line read from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogLineFromText =
+            Function("ST_GEOG_LINEFROMTEXT", nameof(GeographyFunctions.LineFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMTEXT(VARCHAR, INTEGER)</c>. Returns a line read from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogLineFromTextWithSrid =
+            Function("ST_GEOG_LINEFROMTEXT", nameof(GeographyFunctions.LineFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMWKB(VARBINARY)</c>. Returns a line read from WKB.
+        /// </summary>
+        public static readonly SqlFunction StGeogLineFromWkb =
+            Function("ST_GEOG_LINEFROMWKB", nameof(GeographyFunctions.LineFromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary], ["wkb"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_LINEFROMWKB(VARBINARY, INTEGER)</c>. Returns a line read from WKB; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogLineFromWkbWithSrid =
+            Function("ST_GEOG_LINEFROMWKB", nameof(GeographyFunctions.LineFromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary, GeographyOperand.Numeric], ["wkb", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MLINEFROMTEXT(VARCHAR)</c>. Returns a multi-line read from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogMLineFromText =
+            Function("ST_GEOG_MLINEFROMTEXT", nameof(GeographyFunctions.MLineFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MLINEFROMTEXT(VARCHAR, INTEGER)</c>. Returns a multi-line read from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogMLineFromTextWithSrid =
+            Function("ST_GEOG_MLINEFROMTEXT", nameof(GeographyFunctions.MLineFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOINTFROMTEXT(VARCHAR)</c>. Returns a multi-point read from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogMPointFromText =
+            Function("ST_GEOG_MPOINTFROMTEXT", nameof(GeographyFunctions.MPointFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOINTFROMTEXT(VARCHAR, INTEGER)</c>. Returns a multi-point read from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogMPointFromTextWithSrid =
+            Function("ST_GEOG_MPOINTFROMTEXT", nameof(GeographyFunctions.MPointFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOLYFROMTEXT(VARCHAR)</c>. Returns a multi-polygon read from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogMPolyFromText =
+            Function("ST_GEOG_MPOLYFROMTEXT", nameof(GeographyFunctions.MPolyFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MPOLYFROMTEXT(VARCHAR, INTEGER)</c>. Returns a multi-polygon read from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogMPolyFromTextWithSrid =
+            Function("ST_GEOG_MPOLYFROMTEXT", nameof(GeographyFunctions.MPolyFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMTEXT(VARCHAR)</c>. Returns a point read from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogPointFromText =
+            Function("ST_GEOG_POINTFROMTEXT", nameof(GeographyFunctions.PointFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMTEXT(VARCHAR, INTEGER)</c>. Returns a point read from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogPointFromTextWithSrid =
+            Function("ST_GEOG_POINTFROMTEXT", nameof(GeographyFunctions.PointFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMWKB(VARBINARY)</c>. Returns a point read from WKB.
+        /// </summary>
+        public static readonly SqlFunction StGeogPointFromWkb =
+            Function("ST_GEOG_POINTFROMWKB", nameof(GeographyFunctions.PointFromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary], ["wkb"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTFROMWKB(VARBINARY, INTEGER)</c>. Returns a point read from WKB; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogPointFromWkbWithSrid =
+            Function("ST_GEOG_POINTFROMWKB", nameof(GeographyFunctions.PointFromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary, GeographyOperand.Numeric], ["wkb", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMTEXT(VARCHAR)</c>. Returns a polygon read from WKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogPolyFromText =
+            Function("ST_GEOG_POLYFROMTEXT", nameof(GeographyFunctions.PolyFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["wkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMTEXT(VARCHAR, INTEGER)</c>. Returns a polygon read from WKT; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogPolyFromTextWithSrid =
+            Function("ST_GEOG_POLYFROMTEXT", nameof(GeographyFunctions.PolyFromText), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["wkt", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMWKB(VARBINARY)</c>. Returns a polygon read from WKB.
+        /// </summary>
+        public static readonly SqlFunction StGeogPolyFromWkb =
+            Function("ST_GEOG_POLYFROMWKB", nameof(GeographyFunctions.PolyFromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary], ["wkb"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POLYFROMWKB(VARBINARY, INTEGER)</c>. Returns a polygon read from WKB; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogPolyFromWkbWithSrid =
+            Function("ST_GEOG_POLYFROMWKB", nameof(GeographyFunctions.PolyFromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary, GeographyOperand.Numeric], ["wkb", "srid"]);
+
+        /// <summary>
         /// Declares one operator.
         /// </summary>
         /// <param name="name">The SQL name.</param>
@@ -592,6 +963,59 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogGeomFromEwkb,
                 StGeogGeomFromGml,
                 StGeogGeomFromGmlWithSrid,
+                StGeogFlipCoordinates,
+                StGeogForce2D,
+                StGeogForce3D,
+                StGeogNormalize,
+                StGeogRemoveHoles,
+                StGeogRemoveRepeatedPoints,
+                StGeogReverse,
+                StGeogToMultiLine,
+                StGeogToMultiPoint,
+                StGeogToMultiSegments,
+                StGeogAddPoint,
+                StGeogAddPointAtIndex,
+                StGeogRemovePoint,
+                StGeogAddZ,
+                StGeogRemoveRepeatedPointsWithTolerance,
+                StGeogPoint,
+                StGeogPoint3D,
+                StGeogMakePoint,
+                StGeogMakePoint3D,
+                StGeogMakeLine2,
+                StGeogMakeLine3,
+                StGeogMakeLine4,
+                StGeogMakeLine5,
+                StGeogMakeLine6,
+                StGeogMakePolygon1,
+                StGeogMakePolygon2,
+                StGeogMakePolygon3,
+                StGeogMakePolygon4,
+                StGeogMakePolygon5,
+                StGeogMakePolygon6,
+                StGeogMakePolygon7,
+                StGeogMakePolygon8,
+                StGeogMakePolygon9,
+                StGeogMakePolygon10,
+                StGeogMakePolygon11,
+                StGeogLineFromText,
+                StGeogLineFromTextWithSrid,
+                StGeogLineFromWkb,
+                StGeogLineFromWkbWithSrid,
+                StGeogMLineFromText,
+                StGeogMLineFromTextWithSrid,
+                StGeogMPointFromText,
+                StGeogMPointFromTextWithSrid,
+                StGeogMPolyFromText,
+                StGeogMPolyFromTextWithSrid,
+                StGeogPointFromText,
+                StGeogPointFromTextWithSrid,
+                StGeogPointFromWkb,
+                StGeogPointFromWkbWithSrid,
+                StGeogPolyFromText,
+                StGeogPolyFromTextWithSrid,
+                StGeogPolyFromWkb,
+                StGeogPolyFromWkbWithSrid,
             ]);
         }
 

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -140,6 +140,321 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geography], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_X(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogX =
+            Function("ST_GEOG_X", nameof(GeographyFunctions.X), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_Y(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogY =
+            Function("ST_GEOG_Y", nameof(GeographyFunctions.Y), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_Z(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogZ =
+            Function("ST_GEOG_Z", nameof(GeographyFunctions.Z), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_XMIN(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogXMin =
+            Function("ST_GEOG_XMIN", nameof(GeographyFunctions.XMin), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_XMAX(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogXMax =
+            Function("ST_GEOG_XMAX", nameof(GeographyFunctions.XMax), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_YMIN(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogYMin =
+            Function("ST_GEOG_YMIN", nameof(GeographyFunctions.YMin), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_YMAX(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogYMax =
+            Function("ST_GEOG_YMAX", nameof(GeographyFunctions.YMax), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ZMIN(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogZMin =
+            Function("ST_GEOG_ZMIN", nameof(GeographyFunctions.ZMin), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ZMAX(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogZMax =
+            Function("ST_GEOG_ZMAX", nameof(GeographyFunctions.ZMax), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_COORDDIM(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogCoordDim =
+            Function("ST_GEOG_COORDDIM", nameof(GeographyFunctions.CoordDim), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_DIMENSION(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogDimension =
+            Function("ST_GEOG_DIMENSION", nameof(GeographyFunctions.Dimension), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMETRYTYPE(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeometryType =
+            Function("ST_GEOG_GEOMETRYTYPE", nameof(GeographyFunctions.GeometryType), GeographyReturnTypes.Text,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMETRYTYPECODE(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeometryTypeCode =
+            Function("ST_GEOG_GEOMETRYTYPECODE", nameof(GeographyFunctions.GeometryTypeCode), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_NPOINTS(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogNPoints =
+            Function("ST_GEOG_NPOINTS", nameof(GeographyFunctions.NPoints), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMPOINTS(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogNumPoints =
+            Function("ST_GEOG_NUMPOINTS", nameof(GeographyFunctions.NumPoints), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMGEOMETRIES(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogNumGeometries =
+            Function("ST_GEOG_NUMGEOMETRIES", nameof(GeographyFunctions.NumGeometries), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMINTERIORRING(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogNumInteriorRing =
+            Function("ST_GEOG_NUMINTERIORRING", nameof(GeographyFunctions.NumInteriorRing), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_NUMINTERIORRINGS(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogNumInteriorRings =
+            Function("ST_GEOG_NUMINTERIORRINGS", nameof(GeographyFunctions.NumInteriorRings), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_STARTPOINT(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogStartPoint =
+            Function("ST_GEOG_STARTPOINT", nameof(GeographyFunctions.StartPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ENDPOINT(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogEndPoint =
+            Function("ST_GEOG_ENDPOINT", nameof(GeographyFunctions.EndPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_EXTERIORRING(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogExteriorRing =
+            Function("ST_GEOG_EXTERIORRING", nameof(GeographyFunctions.ExteriorRing), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_BOUNDARY(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogBoundary =
+            Function("ST_GEOG_BOUNDARY", nameof(GeographyFunctions.Boundary), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_HOLES(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogHoles =
+            Function("ST_GEOG_HOLES", nameof(GeographyFunctions.Holes), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ISEMPTY(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogIsEmpty =
+            Function("ST_GEOG_ISEMPTY", nameof(GeographyFunctions.IsEmpty), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_IS3D(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogIs3D =
+            Function("ST_GEOG_IS3D", nameof(GeographyFunctions.Is3D), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ISCLOSED(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogIsClosed =
+            Function("ST_GEOG_ISCLOSED", nameof(GeographyFunctions.IsClosed), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_SRID(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogSrid =
+            Function("ST_GEOG_SRID", nameof(GeographyFunctions.Srid), GeographyReturnTypes.Integer,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASTEXT(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsText =
+            Function("ST_GEOG_ASTEXT", nameof(GeographyFunctions.AsText), GeographyReturnTypes.Text,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASWKT(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsWkt =
+            Function("ST_GEOG_ASWKT", nameof(GeographyFunctions.AsWkt), GeographyReturnTypes.Text,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASEWKT(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsEwkt =
+            Function("ST_GEOG_ASEWKT", nameof(GeographyFunctions.AsEwkt), GeographyReturnTypes.Text,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASGEOJSON(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsGeoJson =
+            Function("ST_GEOG_ASGEOJSON", nameof(GeographyFunctions.AsGeoJson), GeographyReturnTypes.Text,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASGML(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsGml =
+            Function("ST_GEOG_ASGML", nameof(GeographyFunctions.AsGml), GeographyReturnTypes.Text,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASBINARY(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsBinary =
+            Function("ST_GEOG_ASBINARY", nameof(GeographyFunctions.AsBinary), GeographyReturnTypes.Binary,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASWKB(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsWkb =
+            Function("ST_GEOG_ASWKB", nameof(GeographyFunctions.AsWkb), GeographyReturnTypes.Binary,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ASEWKB(GEOGRAPHY)</c>.
+        /// </summary>
+        public static readonly SqlFunction StGeogAsEwkb =
+            Function("ST_GEOG_ASEWKB", nameof(GeographyFunctions.AsEwkb), GeographyReturnTypes.Binary,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_POINTN(GEOGRAPHY, INTEGER)</c>. Returns the nth coordinate of a line.
+        /// </summary>
+        public static readonly SqlFunction StGeogPointN =
+            Function("ST_GEOG_POINTN", nameof(GeographyFunctions.PointN), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Numeric], ["geog", "n"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMETRYN(GEOGRAPHY, INTEGER)</c>. Returns the nth part of the geography.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeometryN =
+            Function("ST_GEOG_GEOMETRYN", nameof(GeographyFunctions.GeometryN), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Numeric], ["geog", "n"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_INTERIORRING(GEOGRAPHY, INTEGER)</c>. Returns the nth hole of a polygon.
+        /// </summary>
+        public static readonly SqlFunction StGeogInteriorRing =
+            Function("ST_GEOG_INTERIORRING", nameof(GeographyFunctions.InteriorRing), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geography, GeographyOperand.Numeric], ["geog", "n"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ORDERINGEQUALS(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether two geographies name the same coordinates in the same order.
+        /// </summary>
+        public static readonly SqlFunction StGeogOrderingEquals =
+            Function("ST_GEOG_ORDERINGEQUALS", nameof(GeographyFunctions.OrderingEquals), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMEWKT(VARCHAR)</c>. Returns a geography read from EWKT.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromEwkt =
+            Function("ST_GEOG_GEOMFROMEWKT", nameof(GeographyFunctions.FromEwkt), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["ewkt"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMWKB(VARBINARY)</c>. Returns a geography read from WKB.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromWkb =
+            Function("ST_GEOG_GEOMFROMWKB", nameof(GeographyFunctions.FromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary], ["wkb"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMWKB(VARBINARY, INTEGER)</c>. Returns a geography read from WKB; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromWkbWithSrid =
+            Function("ST_GEOG_GEOMFROMWKB", nameof(GeographyFunctions.FromWkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary, GeographyOperand.Numeric], ["wkb", "srid"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMEWKB(VARBINARY)</c>. Returns a geography read from EWKB.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromEwkb =
+            Function("ST_GEOG_GEOMFROMEWKB", nameof(GeographyFunctions.FromEwkb), GeographyReturnTypes.Geography,
+                [GeographyOperand.Binary], ["ewkb"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMGML(VARCHAR)</c>. Returns a geography read from GML.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromGml =
+            Function("ST_GEOG_GEOMFROMGML", nameof(GeographyFunctions.FromGml), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character], ["gml"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_GEOMFROMGML(VARCHAR, INTEGER)</c>. Returns a geography read from GML; the SRID must be 4326.
+        /// </summary>
+        public static readonly SqlFunction StGeogGeomFromGmlWithSrid =
+            Function("ST_GEOG_GEOMFROMGML", nameof(GeographyFunctions.FromGml), GeographyReturnTypes.Geography,
+                [GeographyOperand.Character, GeographyOperand.Numeric], ["gml", "srid"]);
+
+        /// <summary>
         /// Declares one operator.
         /// </summary>
         /// <param name="name">The SQL name.</param>
@@ -189,6 +504,7 @@ namespace Apache.Calcite.Geography.Sql
                 GeographyOperand.Geometry => (java.lang.Class)typeof(org.locationtech.jts.geom.Geometry),
                 GeographyOperand.Character => (java.lang.Class)typeof(string),
                 GeographyOperand.Numeric => (java.lang.Class)typeof(java.lang.Number),
+                GeographyOperand.Binary => (java.lang.Class)typeof(org.apache.calcite.avatica.util.ByteString),
                 _ => throw new NotSupportedException($"No parameter class for '{operand}'."),
             };
         }
@@ -231,6 +547,51 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogWithin,
                 StGeogIntersects,
                 StGeogIsValid,
+                StGeogX,
+                StGeogY,
+                StGeogZ,
+                StGeogXMin,
+                StGeogXMax,
+                StGeogYMin,
+                StGeogYMax,
+                StGeogZMin,
+                StGeogZMax,
+                StGeogCoordDim,
+                StGeogDimension,
+                StGeogGeometryType,
+                StGeogGeometryTypeCode,
+                StGeogNPoints,
+                StGeogNumPoints,
+                StGeogNumGeometries,
+                StGeogNumInteriorRing,
+                StGeogNumInteriorRings,
+                StGeogStartPoint,
+                StGeogEndPoint,
+                StGeogExteriorRing,
+                StGeogBoundary,
+                StGeogHoles,
+                StGeogIsEmpty,
+                StGeogIs3D,
+                StGeogIsClosed,
+                StGeogSrid,
+                StGeogAsText,
+                StGeogAsWkt,
+                StGeogAsEwkt,
+                StGeogAsGeoJson,
+                StGeogAsGml,
+                StGeogAsBinary,
+                StGeogAsWkb,
+                StGeogAsEwkb,
+                StGeogPointN,
+                StGeogGeometryN,
+                StGeogInteriorRing,
+                StGeogOrderingEquals,
+                StGeogGeomFromEwkt,
+                StGeogGeomFromWkb,
+                StGeogGeomFromWkbWithSrid,
+                StGeogGeomFromEwkb,
+                StGeogGeomFromGml,
+                StGeogGeomFromGmlWithSrid,
             ]);
         }
 

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -826,6 +826,84 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Binary, GeographyOperand.Numeric], ["wkb", "srid"]);
 
         /// <summary>
+        /// <c>ST_GEOG_CONTAINS(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether the first geography contains the second.
+        /// </summary>
+        public static readonly SqlFunction StGeogContains =
+            Function("ST_GEOG_CONTAINS", nameof(GeographyFunctions.Contains), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+
+
+        /// <summary>
+        /// <c>ST_GEOG_COVERS(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether no point of the second geography is outside the first.
+        /// </summary>
+        public static readonly SqlFunction StGeogCovers =
+            Function("ST_GEOG_COVERS", nameof(GeographyFunctions.Covers), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_COVEREDBY(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether no point of the first geography is outside the second.
+        /// </summary>
+        public static readonly SqlFunction StGeogCoveredBy =
+            Function("ST_GEOG_COVEREDBY", nameof(GeographyFunctions.CoveredBy), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+
+
+        /// <summary>
+        /// <c>ST_GEOG_DISJOINT(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether two geographies have no point in common.
+        /// </summary>
+        public static readonly SqlFunction StGeogDisjoint =
+            Function("ST_GEOG_DISJOINT", nameof(GeographyFunctions.Disjoint), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_EQUALS(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether two geographies are the same set of places.
+        /// </summary>
+        public static readonly SqlFunction StGeogEquals =
+            Function("ST_GEOG_EQUALS", nameof(GeographyFunctions.Equals), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+
+
+
+
+        /// <summary>
+        /// <c>ST_GEOG_ENVELOPESINTERSECT(GEOGRAPHY, GEOGRAPHY)</c>. Returns whether the bounding boxes of two geographies meet.
+        /// </summary>
+        public static readonly SqlFunction StGeogEnvelopesIntersect =
+            Function("ST_GEOG_ENVELOPESINTERSECT", nameof(GeographyFunctions.EnvelopesIntersect), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_AREA(GEOGRAPHY)</c>. Returns the area of the geography in square metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogArea =
+            Function("ST_GEOG_AREA", nameof(GeographyFunctions.Area), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_LENGTH(GEOGRAPHY)</c>. Returns the length of the geography in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogLength =
+            Function("ST_GEOG_LENGTH", nameof(GeographyFunctions.Length), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_PERIMETER(GEOGRAPHY)</c>. Returns the perimeter of the areal part of the geography in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogPerimeter =
+            Function("ST_GEOG_PERIMETER", nameof(GeographyFunctions.Perimeter), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MAXDISTANCE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the greatest distance between a coordinate of one geography and a coordinate of the other, in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogMaxDistance =
+            Function("ST_GEOG_MAXDISTANCE", nameof(GeographyFunctions.MaxDistance), GeographyReturnTypes.Double,
+                [GeographyOperand.Geography, GeographyOperand.Geography], ["geog1", "geog2"]);
+
+        /// <summary>
         /// Declares one operator.
         /// </summary>
         /// <param name="name">The SQL name.</param>
@@ -918,6 +996,16 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogWithin,
                 StGeogIntersects,
                 StGeogIsValid,
+                StGeogContains,
+                StGeogCovers,
+                StGeogCoveredBy,
+                StGeogDisjoint,
+                StGeogEquals,
+                StGeogEnvelopesIntersect,
+                StGeogArea,
+                StGeogLength,
+                StGeogPerimeter,
+                StGeogMaxDistance,
                 StGeogX,
                 StGeogY,
                 StGeogZ,

--- a/src/Apache.Calcite.Geography/Sql/Type/GeographyOperand.cs
+++ b/src/Apache.Calcite.Geography/Sql/Type/GeographyOperand.cs
@@ -32,6 +32,11 @@ namespace Apache.Calcite.Geography.Sql.Type
         /// </summary>
         Numeric,
 
+        /// <summary>
+        /// A string of bytes.
+        /// </summary>
+        Binary,
+
     }
 
 }

--- a/src/Apache.Calcite.Geography/Sql/Type/GeographyOperandTypeChecker.cs
+++ b/src/Apache.Calcite.Geography/Sql/Type/GeographyOperandTypeChecker.cs
@@ -168,6 +168,7 @@ namespace Apache.Calcite.Geography.Sql.Type
                 GeographyOperand.Geometry => GeographyTypes.IsGeometry(type),
                 GeographyOperand.Character => SqlTypeUtil.inCharFamily(type),
                 GeographyOperand.Numeric => SqlTypeUtil.isNumeric(type),
+                GeographyOperand.Binary => SqlTypeUtil.isBinary(type),
                 _ => false,
             };
         }
@@ -180,6 +181,7 @@ namespace Apache.Calcite.Geography.Sql.Type
                 GeographyOperand.Geometry => GeographyTypes.GeometryOf(typeFactory),
                 GeographyOperand.Character => typeFactory.createSqlType(SqlTypeName.VARCHAR),
                 GeographyOperand.Numeric => typeFactory.createSqlType(SqlTypeName.DOUBLE),
+                GeographyOperand.Binary => typeFactory.createSqlType(SqlTypeName.VARBINARY),
                 _ => throw new NotSupportedException($"No type for '{operand}'."),
             };
         }
@@ -192,6 +194,7 @@ namespace Apache.Calcite.Geography.Sql.Type
                 GeographyOperand.Geometry => "GEOMETRY",
                 GeographyOperand.Character => "CHARACTER",
                 GeographyOperand.Numeric => "NUMERIC",
+                GeographyOperand.Binary => "BINARY",
                 _ => throw new NotSupportedException($"No name for '{operand}'."),
             };
         }

--- a/src/Apache.Calcite.Geography/Sql/Type/GeographyReturnTypes.cs
+++ b/src/Apache.Calcite.Geography/Sql/Type/GeographyReturnTypes.cs
@@ -37,6 +37,48 @@ namespace Apache.Calcite.Geography.Sql.Type
         public static readonly SqlReturnTypeInference Geometry = new GeometryReturnTypeInference();
 
         /// <summary>
+        /// Returns the type the type factory gives a Java class, which is how Calcite's own spatial
+        /// functions are typed.
+        /// </summary>
+        /// <param name="clazz"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A function declared through a schema is typed by <c>createJavaType</c> over the return type of the
+        /// method behind it, so <c>ST_ASTEXT</c> is <c>JavaType(String)</c> and not <c>VARCHAR(2000)</c>.
+        /// Naming the class rather than picking a <c>SqlTypeName</c> and a precision is what keeps an
+        /// <c>ST_GEOG_</c> operator typed exactly as the <c>ST_</c> one it mirrors.
+        /// </remarks>
+        public static SqlReturnTypeInference Of(java.lang.Class clazz)
+        {
+            return new JavaReturnTypeInference(clazz);
+        }
+
+        /// <summary>
+        /// Returns <c>DOUBLE</c>.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Double = Of((java.lang.Class)typeof(java.lang.Double));
+
+        /// <summary>
+        /// Returns <c>INTEGER</c>.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Integer = Of((java.lang.Class)typeof(java.lang.Integer));
+
+        /// <summary>
+        /// Returns <c>BOOLEAN</c>.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Boolean = Of((java.lang.Class)typeof(java.lang.Boolean));
+
+        /// <summary>
+        /// Returns <c>VARCHAR</c>.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Text = Of((java.lang.Class)typeof(string));
+
+        /// <summary>
+        /// Returns <c>VARBINARY</c>.
+        /// </summary>
+        public static readonly SqlReturnTypeInference Binary = Of((java.lang.Class)typeof(org.apache.calcite.avatica.util.ByteString));
+
+        /// <summary>
         /// The half of <c>SqlReturnTypeInference</c> that is the same whatever the type is.
         /// </summary>
         /// <remarks>
@@ -56,6 +98,23 @@ namespace Apache.Calcite.Geography.Sql.Type
             public SqlReturnTypeInference orElse(SqlReturnTypeInference transform)
             {
                 return ReturnTypes.chain(this, transform);
+            }
+
+        }
+
+        sealed class JavaReturnTypeInference : ReturnTypeInference
+        {
+
+            readonly java.lang.Class clazz;
+
+            public JavaReturnTypeInference(java.lang.Class clazz)
+            {
+                this.clazz = clazz;
+            }
+
+            public override RelDataType inferReturnType(SqlOperatorBinding opBinding)
+            {
+                return opBinding.getTypeFactory().createJavaType(clazz);
             }
 
         }


### PR DESCRIPTION
Steps three and four of the mapping in #86. The surface goes from **12 declarations to 120**, across 86 distinct names.

Three commits, each its own kind of work:

| | |
| --- | --- |
| Declare the accessors and every format | 45 declarations, all delegation |
| Declare the editing group and the rest of the constructors | 53 declarations, all delegation |
| Add the relations and the measurements | 10 declarations, all geodesy |

## The mechanical group

The accessors, the serializers, the editing functions and the constructors read or rearrange coordinates without interpreting the space between them. There is no geodesy in any of them — each is a delegation to the very JTS method Calcite's `ST_*` of that name calls — and every one still needs declaring, because Calcite's own refuse the type.

What can go wrong in ninety-eight declarations written to one pattern is not the arithmetic but the wiring, so three tests aim at exactly that:

1. **Each body against the Calcite function it delegates to**, over shapes of every kind. Catches a body pointed at the wrong method.
2. **Each operator run as SQL**, its answer compared against calling the body directly. Catches a table entry pointed at the wrong body or typed as though it returned something else. Binding is by signature, so a declaration *cannot* name a method that does not exist with those parameters — but nothing except running it tells `ST_GEOG_FORCE2D` wired to `Force3D` from `ST_GEOG_FORCE2D` wired to `Force2D`.
3. **Reflection over the declared fields**, requiring every one to be an operator the table hands out. The declarations and the registrations are two lists and nothing else connects them.

Every format now reads and writes both ways — WKT, EWKT, WKB, EWKB, GeoJSON, GML — and a round-trip test says each writer was wired to its own reader rather than to a neighbour.

The arities are Calcite's rather than a choice. It writes `ST_MakePolygon` out eleven times because Java gives it no varargs, and a caller writing three holes needs the three-hole declaration to exist.

## The relations and the measurements

`ST_GEOG_CONTAINS`, `COVERS`, `COVEREDBY`, `EQUALS`, `DISJOINT`, `ENVELOPESINTERSECT`, and `AREA`, `LENGTH`, `PERIMETER`, `MAXDISTANCE`.

Five of the relations fall out of `Covers`, which is the half of `Within` that asks where the points are rather than whether the interiors meet. Covering is the weaker relation and the more useful one: a polygon covers a line lying along its own boundary and does not contain it.

`ENVELOPESINTERSECT` is here rather than in the mechanical group for the reason #86 gives — a shape crossing the antimeridian has no correct bounding box in plain longitude and latitude, and the planar reading answers one anyway. The box is an `S2LatLngRect`, which wraps, and which S2 builds from the edges rather than the vertices so it holds the bulge a great-circle edge makes north of a parallel.

`MAXDISTANCE` is between the coordinates and not between the shapes, which is what Calcite measures: it walks the two coordinate arrays and takes the largest.

## What the generated shapes found

The lattice generator earned its keep again. Eight defects across the three commits, none of them found by hand-written cases:

- **`InteriorMeetsExterior` could not answer its own question for a polygon.** Every place worth probing lies on a boundary and a polygon's interior is precisely what its boundary is not, so "has this polygon area outside that one" was asked of a set of points none of which was inside either. Covering answers it in one call.
- **The place where two edges cross was never probed.** It is an end of every piece and the middle of none, and for two lines it is the only place their interiors share.
- **Two cuts falling together left a piece of no length**, and the middle of a piece of no length is the cut itself, which lies on the other geography by construction. Anything asking whether a stretch of edge ran along another was told yes by a stretch that was a point.
- **An intersection of two polygons that merely touch is not empty.** S2 snaps while it intersects, so a shared boundary leaves a sliver — measured at about a billionth of the area of the shapes it came from, which is the length of that boundary times the radius S2 snaps to. The threshold is now measured rather than guessed, and `Covers` compares areas as well as boundaries, because a polygon that is exactly a hole of another has every one of its points on a boundary of it and none of its area inside it.

## Withdrawn rather than shipped

`ST_GEOG_CROSSES`, `ST_GEOG_TOUCHES`, `ST_GEOG_OVERLAPS` and `ST_GEOG_CONTAINSPROPERLY` were written, passed the hand-written suite, and were then withdrawn when the generator found them failing in half the seed blocks.

All four turn on whether two interiors meet, and where a line comes back and touches itself that question has no answer without a node graph over both geometries: the place is the end of the whole line and the middle of one of its own edges at once, so it is boundary by the rule that counts ends and interior by the rule that reads the curve. Both rules were tried against generated shapes and each is wrong somewhere — counting ends makes a genuine crossing read as a touch, reading the curve makes a touch between a point and the end of a line read as a crossing.

Shipping either would be a divergence dressed as a decision. It wants the node graph, which is the machinery `S2BooleanOperation` would have brought and which is already recorded as out of reach: the S2 published to Maven Central is the 2021 release, which does not have it, and the current source is compiled to Java 11, which IKVM does not read.

## Deliberate divergences

- **Every geography this package hands back is stamped WGS84.** `ST_FORCE2D` answers something with an SRID of zero, because the transformer underneath builds through a geometry factory that carries none across. Calcite has no reference system to keep there and this package does.
- **An SRID that is not 4326 is refused however it arrives** — as an argument, or written into the text or the bytes by EWKT and EWKB. Calcite spells that prefix `srid:N;` rather than the PostGIS `SRID=N;`, and reads no other form.
- **`ST_ADDZ` throws a null reference over a polygon**, and so does `ST_GEOG_ADDZ`. The transformer hands a `LinearRing` a coordinate sequence it then cannot read, and it comes out of JTS. Inherited rather than worked around, and recorded in a test: a geography behaving differently from the geometry it mirrors, in a way with nothing to do with geodesy, is not a divergence this package has any business introducing.

## Tests

83 in the geography suite, on net8.0 and net10.0. The generated-shape suite is clean over **960,000 pairs** — 48 seeds at 20,000 each — across every relation and every measurement.

| suite | |
| --- | --- |
| `Apache.Calcite.Tests` | 827 |
| `Apache.Calcite.Adapter.AdoNet.Tests` | 483 |
| `Apache.Calcite.Geography.Tests` | 83 |

## Still not here

- The constructed-geometry group — buffer, the boolean overlay set, hulls, simplification, triangulation, grids — which #86 defers.
- The point-returning measurements, `ST_GEOG_RELATE`, and the four withdrawn above.
- The aggregates and table functions: `ST_ACCUM`, `ST_COLLECT`, `ST_EXPLODE` and the grids need machinery this package does not have.
- **Rechecking a pushed-down predicate.** Still not wired anywhere, and must not be until agreement with each live store has been measured at the boundaries.
