### PR TITLE
Measure on the WGS84 ellipsoid, not on a sphere

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyDifferentialTests.cs
@@ -36,7 +36,26 @@ namespace Apache.Calcite.Geography.Tests
         /// <summary>
         /// Metres per degree of arc on the sphere S2 models the Earth as.
         /// </summary>
-        const double Degree = 6371010.0 * Math.PI / 180;
+        /// <summary>
+        /// Metres per degree of longitude at the equator on WGS84, which is where the shapes below sit.
+        /// </summary>
+        /// <remarks>
+        /// A scale factor between a planar answer in degrees and a geodesic one in metres is a spherical
+        /// idea, and these measurements are no longer spherical. There is no single number here: a degree
+        /// east is 111319.49 and a degree north is 110574.39, so a comparison scaled by either is out by up
+        /// to 0.67% depending on which way the two shapes lie.
+        ///
+        /// <para>So the numeric comparisons below are a <em>bound</em> rather than an oracle. They catch a
+        /// wrong unit, a wrong factor, a wrong shape — what a differential test is for — and they cannot
+        /// confirm the model. <c>Wgs84MeasurementTests</c> is what does that, against figures measured from a
+        /// live geodesic service.</para>
+        /// </remarks>
+        const double Degree = 111319.49079327357;
+
+        /// <summary>
+        /// How far the two models may differ before a difference is real.
+        /// </summary>
+        const double ModelGap = 1e-2;
 
         /// <summary>
         /// Shapes of every dimension, overlapping, touching, nested and disjoint.
@@ -267,7 +286,7 @@ namespace Apache.Calcite.Geography.Tests
                     var ours = GeographyFunctions.Distance(a, b)!.doubleValue();
                     var theirs = SpatialTypeFunctions.ST_Distance(a, b) * Degree;
 
-                    if (Math.Abs(ours - theirs) > Math.Max(1e-4 * theirs, 1e-6))
+                    if (Math.Abs(ours - theirs) > Math.Max(ModelGap * theirs, 1e-6))
                         differences.Add($"{left} / {right}: ours {ours}, Calcite {theirs}");
                 }
             }
@@ -292,6 +311,14 @@ namespace Apache.Calcite.Geography.Tests
                     var b = Wkt(right);
 
                     var threshold = 0.003;
+
+                    // a boolean cannot be compared to a tolerance, so the band where the two models decide
+                    // differently is skipped instead: within it the answer turns on which Earth is being
+                    // measured, which is the disagreement rather than a defect. An adapter rechecking a
+                    // pushed-down predicate has the same band and the same problem.
+                    if (Math.Abs(SpatialTypeFunctions.ST_Distance(a, b) - threshold) <= ModelGap * threshold)
+                        continue;
+
                     var ours = GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(threshold * Degree))!.booleanValue();
                     var theirs = SpatialTypeFunctions.ST_DWithin(a, b, threshold);
 

--- a/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyExecutionTests.cs
@@ -89,7 +89,7 @@ namespace Apache.Calcite.Geography.Tests
             var rows = Run("SELECT ST_GEOG_DISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'))");
 
             rows.Count.Should().Be(1);
-            ((java.lang.Number)rows[0][0]!).doubleValue().Should().BeApproximately(6371010.0 * Math.PI / 180, 0.001);
+            ((java.lang.Number)rows[0][0]!).doubleValue().Should().BeApproximately(111319.49079327357, 0.001);
         }
 
         /// <summary>
@@ -158,10 +158,10 @@ namespace Apache.Calcite.Geography.Tests
                 ("ST_GEOG_DISJOINT(ST_GEOG_GEOMFROMTEXT('POINT(9 9)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
                 ("ST_GEOG_EQUALS(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 1)'), ST_GEOG_GEOMFROMTEXT('LINESTRING(1 1, 0 0)'))", true),
                 ("ST_GEOG_ENVELOPESINTERSECT(ST_GEOG_GEOMFROMTEXT('POINT(1 1)'), ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'))", true),
-                ("ST_GEOG_LENGTH(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 6371010.0 * Math.PI / 180),
+                ("ST_GEOG_LENGTH(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 111319.49079327357),
                 ("ST_GEOG_PERIMETER(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 0.0),
                 ("ST_GEOG_AREA(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0)'))", 0.0),
-                ("ST_GEOG_MAXDISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'))", 6371010.0 * Math.PI / 180),
+                ("ST_GEOG_MAXDISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'))", 111319.49079327357),
             };
 
             var failures = new List<string>();

--- a/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyFunctionTests.cs
@@ -25,14 +25,24 @@ namespace Apache.Calcite.Geography.Tests
     {
 
         /// <summary>
-        /// The radius S2 models the Earth with, in metres.
+        /// One degree of longitude at the equator on WGS84, in metres.
         /// </summary>
-        const double EarthRadiusMeters = 6371010.0;
+        /// <remarks>
+        /// The semi-major axis times <c>π/180</c>, and what a geodesic store answers — measured against a
+        /// live service in #90. It is not one degree of <em>latitude</em>, which is 110574.3885: that the two
+        /// differ is the whole of what says these are ellipsoidal. The figures below that have no closed form
+        /// on an ellipsoid are recorded rather than derived, for the same reason.
+        /// </remarks>
+        const double Degree = 111319.49079327357;
 
         /// <summary>
-        /// One degree of arc on that sphere, in metres.
+        /// The geodesic distance from a meridian to a point one degree of longitude off it at 5°N.
         /// </summary>
-        const double Degree = EarthRadiusMeters * Math.PI / 180;
+        /// <remarks>
+        /// Recorded, not derived. On a sphere this is <c>asin(sin(1°) · cos(5°)) · R</c>; the ellipsoid has no
+        /// such form, and the closest point on the edge is found by S2 before the distance to it is measured.
+        /// </remarks>
+        const double EdgeAtFiveDegrees = 110898.66346;
 
         static Geometry Wkt(string wkt)
         {
@@ -123,7 +133,10 @@ namespace Apache.Calcite.Geography.Tests
             org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(Wkt("POINT(0 50)"), Wkt("POINT(1 50)")).Should().Be(1);
 
             north.Should().BeLessThan(equator);
-            (equator / north).Should().BeApproximately(1 / Math.Cos(50 * Math.PI / 180), 0.001);
+            // near the spherical prediction 1/cos(50 degrees) and not equal to it, which on a sphere it
+            // would be exactly -- one more place the ellipsoid shows through
+            (equator / north).Should().BeApproximately(1.55268, 1e-4);
+            (equator / north).Should().NotBeApproximately(1 / Math.Cos(50 * Math.PI / 180), 1e-4);
         }
 
         [TestMethod]
@@ -142,10 +155,9 @@ namespace Apache.Calcite.Geography.Tests
         [TestMethod]
         public void ShouldMeasureToTheNearestEdgeOfAPolygon()
         {
-            var expected = Math.Asin(Math.Sin(Math.PI / 180) * Math.Cos(5 * Math.PI / 180)) * EarthRadiusMeters;
             var distance = GeographyFunctions.Distance(Wkt("POINT(11 5)"), Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"));
 
-            distance!.doubleValue().Should().BeApproximately(expected, 0.5);
+            distance!.doubleValue().Should().BeApproximately(EdgeAtFiveDegrees, 0.5);
         }
 
         /// <summary>
@@ -161,10 +173,9 @@ namespace Apache.Calcite.Geography.Tests
         [TestMethod]
         public void ShouldMeasureToTheEdgeThatClosesARing()
         {
-            var expected = Math.Asin(Math.Sin(Math.PI / 180) * Math.Cos(5 * Math.PI / 180)) * EarthRadiusMeters;
             var distance = GeographyFunctions.Distance(Wkt("POINT(-1 5)"), Wkt("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"));
 
-            distance!.doubleValue().Should().BeApproximately(expected, 0.5);
+            distance!.doubleValue().Should().BeApproximately(EdgeAtFiveDegrees, 0.5);
         }
 
         [TestMethod]
@@ -249,7 +260,9 @@ namespace Apache.Calcite.Geography.Tests
             var here = Wkt("POINT(0 89.9)");
             var there = Wkt("POINT(180 89.9)");
 
-            GeographyFunctions.Distance(here, there)!.doubleValue().Should().BeApproximately(0.2 * Degree, 0.001);
+            // 22338.795683 at the service, per #90's "near the pole" row -- this agrees with it to a
+            // micrometre, which is a second confirmation of the model on coordinates nothing here chose
+            GeographyFunctions.Distance(here, there)!.doubleValue().Should().BeApproximately(22338.795683, 1e-3);
             org.apache.calcite.runtime.SpatialTypeFunctions.ST_Distance(here, there).Should().BeApproximately(180, 1e-9);
         }
 
@@ -312,12 +325,12 @@ namespace Apache.Calcite.Geography.Tests
         public void ShouldMeasureAreaInSquareMetres()
         {
             var box = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
-            var radians = Math.PI / 180;
-            var betweenTheParallels = EarthRadiusMeters * EarthRadiusMeters * radians * Math.Sin(radians);
             var area = GeographyFunctions.Area(box)!.doubleValue();
 
-            area.Should().BeGreaterThan(betweenTheParallels);
-            area.Should().BeApproximately(betweenTheParallels, betweenTheParallels * 1e-4);
+            // recorded rather than derived: the spherical closed form this used to compare against has no
+            // ellipsoidal counterpart, and area diverges between the two models further than distance does --
+            // the sphere makes this box 12363722802, which is 0.45% more
+            area.Should().BeApproximately(12308778361.47, 1.0);
 
             org.apache.calcite.runtime.SpatialTypeFunctions.ST_Area(box)!.doubleValue().Should().BeApproximately(1, 1e-9);
         }

--- a/src/Apache.Calcite.Geography.Tests/GeographyRandomDifferentialTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyRandomDifferentialTests.cs
@@ -52,9 +52,25 @@ namespace Apache.Calcite.Geography.Tests
         const int Extent = 3;
 
         /// <summary>
-        /// Metres per degree of arc on the sphere S2 models the Earth as.
+        /// Metres per degree of longitude at the equator on WGS84, which is where the shapes below sit.
         /// </summary>
-        const double Degree = 6371010.0 * Math.PI / 180;
+        /// <remarks>
+        /// A scale factor between a planar answer in degrees and a geodesic one in metres is a spherical
+        /// idea, and these measurements are no longer spherical. There is no single number here: a degree
+        /// east is 111319.49 and a degree north is 110574.39, so a comparison scaled by either is out by up
+        /// to 0.67% depending on which way the two shapes lie.
+        ///
+        /// <para>So the numeric comparisons below are a <em>bound</em> rather than an oracle. They catch a
+        /// wrong unit, a wrong factor, a wrong shape — what a differential test is for — and they cannot
+        /// confirm the model. <c>Wgs84MeasurementTests</c> is what does that, against figures measured from a
+        /// live geodesic service.</para>
+        /// </remarks>
+        const double Degree = 111319.49079327357;
+
+        /// <summary>
+        /// How far the two models may differ before a difference is real.
+        /// </summary>
+        const double ModelGap = 1e-2;
 
         static Geometry Wkt(string wkt)
         {
@@ -199,9 +215,11 @@ namespace Apache.Calcite.Geography.Tests
                     Compare(differences, "ENVELOPESINTERSECT", left, right,
                         () => GeographyFunctions.EnvelopesIntersect(a, b)!.booleanValue(), () => SpatialTypeFunctions.ST_EnvelopesIntersect(a, b), ref refused);
 
-                    Compare(differences, "DWITHIN", left, right,
-                        () => GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(0.0025 * Degree))!.booleanValue(),
-                        () => SpatialTypeFunctions.ST_DWithin(a, b, 0.0025), ref refused);
+                    // outside the band where the two models decide differently; see Degree
+                    if (Math.Abs(SpatialTypeFunctions.ST_Distance(a, b) - 0.0025) > ModelGap * 0.0025)
+                        Compare(differences, "DWITHIN", left, right,
+                            () => GeographyFunctions.DWithin(a, b, java.lang.Double.valueOf(0.0025 * Degree))!.booleanValue(),
+                            () => SpatialTypeFunctions.ST_DWithin(a, b, 0.0025), ref refused);
 
                     Measure(differences, "DISTANCE", left, right,
                         () => GeographyFunctions.Distance(a, b)!.doubleValue(), SpatialTypeFunctions.ST_Distance(a, b) * Degree);
@@ -238,7 +256,7 @@ namespace Apache.Calcite.Geography.Tests
         {
             var ours = geodesic();
 
-            if (Math.Abs(ours - planar) > Math.Max(1e-4 * Math.Abs(planar), 1e-6))
+            if (Math.Abs(ours - planar) > Math.Max(ModelGap * Math.Abs(planar), 1e-6))
                 differences.Add($"{what} {left} / {right}: ours {ours}, Calcite {planar}");
         }
 

--- a/src/Apache.Calcite.Geography.Tests/GeographySchemaTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographySchemaTests.cs
@@ -72,7 +72,7 @@ namespace Apache.Calcite.Geography.Tests
             var rows = Run("SELECT ST_GEOG_DISTANCE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('POINT(1 0)'))");
 
             rows.Should().HaveCount(1);
-            ((java.lang.Number)rows[0][0]!).doubleValue().Should().BeApproximately(6371010.0 * Math.PI / 180, 0.001);
+            ((java.lang.Number)rows[0][0]!).doubleValue().Should().BeApproximately(111319.49079327357, 0.001);
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Geography.Tests/Wgs84MeasurementTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/Wgs84MeasurementTests.cs
@@ -1,0 +1,158 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The measurements answer the WGS84 ellipsoid, which is what a geodesic store answers.
+    /// </summary>
+    /// <remarks>
+    /// These reproduce the measurement in
+    /// <see href="https://github.com/ikvmnet/calcite-dotnet/issues/90">#90</see>, taken against a live Cosmos
+    /// DB account with <c>geospatialConfig</c> Geography. They were spherical before it, out by up to 0.56%,
+    /// which is far too much for an adapter to recheck a pushed-down predicate against: a recheck that
+    /// disagrees discards rows the service correctly returned.
+    ///
+    /// <para>The diagnosis is the first two. One degree east and one degree north of the equator are the same
+    /// distance on a sphere and are not on an ellipsoid, and the old implementation answered
+    /// <c>111195.101177</c> to both — which is <c>6371010 · π/180</c> exactly.</para>
+    /// </remarks>
+    [TestClass]
+    public class Wgs84MeasurementTests
+    {
+
+        /// <summary>
+        /// What the service answered, and what an ellipsoid answers.
+        /// </summary>
+        const double EastAtEquator = 111319.4907;
+
+        /// <summary>
+        /// The meridional degree, which differs from the equatorial one by more than half a percent.
+        /// </summary>
+        const double NorthAtEquator = 110574.3885;
+
+        /// <summary>
+        /// What the sphere answered to both, and what nothing should answer now.
+        /// </summary>
+        const double SphericalDegree = 6371010.0 * Math.PI / 180;
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static double Distance(string a, string b)
+        {
+            return GeographyFunctions.Distance(Wkt(a), Wkt(b))!.doubleValue();
+        }
+
+        /// <summary>
+        /// The equatorial degree is the WGS84 semi-major axis times <c>π/180</c>, to every digit the service
+        /// reported.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerTheEquatorialDegree()
+        {
+            Distance("POINT(0 0)", "POINT(1 0)").Should().BeApproximately(EastAtEquator, 1e-3);
+
+            // and it is the closed form, which is what says the ellipsoid is the one being measured
+            Distance("POINT(0 0)", "POINT(1 0)").Should().BeApproximately(6378137.0 * Math.PI / 180, 1e-3);
+        }
+
+        /// <summary>
+        /// The meridional degree is a different number, which on a sphere it could not be.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerADifferentMeridionalDegree()
+        {
+            var east = Distance("POINT(0 0)", "POINT(1 0)");
+            var north = Distance("POINT(0 0)", "POINT(0 1)");
+
+            north.Should().BeApproximately(NorthAtEquator, 1e-3);
+            north.Should().NotBeApproximately(east, 100);
+        }
+
+        /// <summary>
+        /// Neither is the sphere's answer, by the margin the issue measured.
+        /// </summary>
+        [TestMethod]
+        public void ShouldNoLongerAnswerTheSphere()
+        {
+            var east = Distance("POINT(0 0)", "POINT(1 0)");
+            var north = Distance("POINT(0 0)", "POINT(0 1)");
+
+            Relative(east, SphericalDegree).Should().BeApproximately(1.1e-3, 1e-4);
+            Relative(north, SphericalDegree).Should().BeApproximately(-5.6e-3, 1e-4);
+        }
+
+        /// <summary>
+        /// A length is the same measurement, summed.
+        /// </summary>
+        [TestMethod]
+        public void ShouldMeasureALengthOnTheEllipsoid()
+        {
+            var length = GeographyFunctions.Length(Wkt("LINESTRING(0 0, 1 0, 1 1)"))!.doubleValue();
+
+            // one equatorial degree east, then one meridional degree north -- the second leg is the same
+            // number as the meridional degree at the equator, a meridian being a meridian at any longitude
+            length.Should().BeApproximately(EastAtEquator + NorthAtEquator, 1e-3);
+        }
+
+        /// <summary>
+        /// And a perimeter, and an area, neither of which is the sphere's.
+        /// </summary>
+        /// <remarks>
+        /// Area diverges between the two models further than distance does. A one-degree square at the
+        /// equator is about 12,308 km² on WGS84; the sphere makes it about 12,364 km².
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureAnAreaOnTheEllipsoid()
+        {
+            var area = GeographyFunctions.Area(Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"))!.doubleValue();
+
+            area.Should().BeGreaterThan(1.22e10).And.BeLessThan(1.24e10);
+            Relative(area, SphericalDegree * SphericalDegree).Should().NotBe(0);
+        }
+
+        /// <summary>
+        /// A distance between shapes rather than points is measured between the points S2 chose.
+        /// </summary>
+        /// <remarks>
+        /// The closest pair of a point and a line running north from the equator is the line's own end, so
+        /// this is the equatorial degree again — which says the pair S2 picked was carried through to the
+        /// ellipsoidal measurement rather than being measured on the sphere.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureBetweenTheClosestPairOfTwoShapes()
+        {
+            Distance("POINT(0 0)", "LINESTRING(1 0, 1 1)").Should().BeApproximately(EastAtEquator, 1e-3);
+        }
+
+        /// <summary>
+        /// Shapes that touch or contain one another are zero apart, as before.
+        /// </summary>
+        [TestMethod]
+        public void ShouldStillAnswerZeroWhereTheyMeet()
+        {
+            Distance("POINT(0.5 0.5)", "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))").Should().Be(0);
+            Distance("POINT(0 0)", "POINT(0 0)").Should().Be(0);
+        }
+
+        static double Relative(double ours, double reference)
+        {
+            return (ours - reference) / ours;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/Apache.Calcite.Geography.csproj
+++ b/src/Apache.Calcite.Geography/Apache.Calcite.Geography.csproj
@@ -42,13 +42,19 @@
                 com.jayway.jsonpath:json-path/com.fasterxml.jackson.core:jackson-core:2.18.6,optional=true
             </Dependencies>
         </MavenReference>
-        <!-- The geodesic engine. Google's own S2, which is what the stores this package exists to agree with
-             compute in: BigQuery and Snowflake are both S2. It is a sphere rather than an ellipsoid, so a
-             distance differs from an ellipsoidal one by a few tenths of a percent — one model for all five
-             operations, which is the point; mixing a spherical predicate with an ellipsoidal distance would put
-             two models in one plan. The .NET ports on NuGet were considered and rejected: the largest is a 2016
-             netstandard1.0 port of a 2011 snapshot with no S2Polyline at all. -->
+        <!-- The topology. Google's own S2 decides what contains, crosses or touches what, and which points
+             of two shapes are the closest pair; the measuring is GeographicLib's, below. S2 is a sphere by
+             construction, and that is fine for a predicate — sphere against ellipsoid moves an edge by far less
+             than it moves a distance, and containment asks which side of an edge a point falls on rather than
+             how long the edge is. It was measuring distances too until #90, which is what that issue is about.
+             The .NET ports on NuGet were considered and rejected: the largest is a 2016 netstandard1.0 port of a
+             2011 snapshot with no S2Polyline at all. -->
         <MavenReference Include="com.google.geometry:s2-geometry" Version="2.0.0" />
+        <!-- The measurements. S2 is a sphere by construction, and a WGS84 store is not: a distance differs
+             by up to 0.56%, measured against a live service in #90, which is far too much for an adapter to
+             recheck a pushed-down predicate against. Karney's GeographicLib answers the ellipsoid exactly,
+             and is what #86 proposed for this half before either was written. -->
+        <MavenReference Include="net.sf.geographiclib:GeographicLib-Java" Version="2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -111,7 +111,9 @@ Both arities are Calcite's. The SRID a caller may name has to be 4326 and anythi
 
 `WITHIN` and `CONTAINS` are the DE-9IM relations JTS means by the words, not plain containment: a point on a polygon's boundary is covered by it and not within it.
 
-**Measurements**, in metres and square metres rather than in degrees.
+**Measurements**, in metres and square metres rather than in degrees, on the WGS84 ellipsoid.
+
+The two halves run on different engines, and deliberately. The predicates are S2's, which is a sphere; the measurements are [GeographicLib](https://geographiclib.sourceforge.io/)'s, which is the ellipsoid. S2 answers *which* points of two shapes are closest and GeographicLib answers *how far apart* they are. Measuring on the sphere was wrong by up to 0.56% against a live geodesic service — enough that an adapter could not recheck a predicate it had pushed down, since the recheck discards rows the store correctly returned. A degree of longitude at the equator is 111319.49 m and a degree of latitude is 110574.39 m; that these differ is the whole of what says the answers are ellipsoidal.
 
 | | |
 | --- | --- |
@@ -120,7 +122,7 @@ Both arities are Calcite's. The SRID a caller may name has to be 4326 and anythi
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 
-An area shows the difference plainly: a one-degree box at the equator is about 12,364 square kilometres, and it is a little *larger* than the region between the parallels through its corners, because its northern edge is a great circle that runs north of the parallel joining its two northern corners.
+An area shows the difference plainly: a one-degree box at the equator is about 12,309 square kilometres, and it is a little *larger* than the region between the parallels through its corners, because its northern edge is a geodesic that runs north of the parallel joining its two northern corners.
 
 **Reading a geography.** Accessors, which read or rearrange coordinates without interpreting the space between them, so each is a delegation to the very JTS method Calcite's `ST_*` of that name calls.
 

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -40,12 +40,6 @@ namespace Apache.Calcite.Geography.Runtime
     {
 
         /// <summary>
-        /// The radius S2 uses for the Earth, in metres, and therefore the radius every distance this package
-        /// answers is measured on.
-        /// </summary>
-        public const double EarthRadiusMeters = 6371010.0;
-
-        /// <summary>
         /// The angle below which two things are taken to touch, in radians.
         /// </summary>
         /// <remarks>
@@ -460,7 +454,62 @@ namespace Apache.Calcite.Geography.Runtime
             if (a.IsEmpty || b.IsEmpty)
                 return 0;
 
-            return Angle(a, b) * EarthRadiusMeters;
+            // S2 decides whether they touch at all, and whether one encloses the other; only when they are
+            // genuinely apart is there a distance to measure, and it is measured on the ellipsoid
+            if (Angle(a, b) == 0)
+                return 0;
+
+            var pair = ClosestPair(a, b);
+
+            return pair is null ? 0 : Wgs84.Distance(pair.Value.A, pair.Value.B);
+        }
+
+        /// <summary>
+        /// Returns the pair of points, one on each geography, that are closest on the sphere.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The same four passes <see cref="MinAngle"/> makes, keeping the pair that achieved the least angle
+        /// rather than the angle. S2 answers where the closest points are and <see cref="Wgs84"/> answers how
+        /// far apart they are; picking the pair on a sphere and measuring it on the ellipsoid is second order
+        /// in how far that pair is from the true one, where measuring on the sphere is first order.
+        /// </remarks>
+        static (S2Point A, S2Point B)? ClosestPair(S2Geographies a, S2Geographies b)
+        {
+            var min = double.NaN;
+            (S2Point A, S2Point B)? best = null;
+
+            void Consider(S2Point p, S2Point q)
+            {
+                var angle = new S1Angle(p, q).radians();
+
+                if (double.IsNaN(min) || angle < min)
+                {
+                    min = angle;
+                    best = (p, q);
+                }
+            }
+
+            // no edge-to-edge pass, and none is needed. Two edges that cross are zero apart and never reach
+            // here, Angle having answered already; for two that do not, the least distance is attained at a
+            // vertex of one and its projection on the other, which the passes below take. S2 does have a
+            // four-argument getClosestPoint, and it is not an edge pair -- the fourth argument is the
+            // precomputed normal a x b.
+            foreach (var vertex in a.Vertices)
+                foreach (var (b0, b1) in b.Edges)
+                    Consider(vertex, S2EdgeUtil.getClosestPoint(vertex, b0, b1));
+
+            foreach (var vertex in b.Vertices)
+                foreach (var (a0, a1) in a.Edges)
+                    Consider(S2EdgeUtil.getClosestPoint(vertex, a0, a1), vertex);
+
+            foreach (var va in a.Vertices)
+                foreach (var vb in b.Vertices)
+                    Consider(va, vb);
+
+            return best;
         }
 
         /// <summary>
@@ -845,12 +894,13 @@ namespace Apache.Calcite.Geography.Runtime
         /// <param name="g"></param>
         /// <returns></returns>
         /// <remarks>
-        /// The area S2 measures on the sphere, which is a real area rather than the square degrees a planar
-        /// reading answers. A geography with no areal part has none, as JTS has none for a line.
+        /// A real area rather than the square degrees a planar reading answers, and on the ellipsoid: area
+        /// diverges between the two models further than distance does, not less. A geography with no areal
+        /// part has none, as JTS has none for a line.
         /// </remarks>
         public static double Area(S2Geographies g)
         {
-            return g.polygon is null ? 0 : g.polygon.getArea() * EarthRadiusMeters * EarthRadiusMeters;
+            return g.polygon is null ? 0 : Wgs84.Area(g.polygon);
         }
 
         /// <summary>
@@ -864,7 +914,7 @@ namespace Apache.Calcite.Geography.Runtime
         /// </remarks>
         public static double Length(S2Geographies g)
         {
-            return Arc(g.Edges);
+            return Wgs84.Length(g.Edges);
         }
 
         /// <summary>
@@ -874,17 +924,7 @@ namespace Apache.Calcite.Geography.Runtime
         /// <returns></returns>
         public static double Perimeter(S2Geographies g)
         {
-            return Arc(g.RingEdges);
-        }
-
-        static double Arc(IEnumerable<(S2Point, S2Point)> edges)
-        {
-            var total = 0.0;
-
-            foreach (var (p, q) in edges)
-                total += new S1Angle(p, q).radians();
-
-            return total * EarthRadiusMeters;
+            return Wgs84.Length(g.RingEdges);
         }
 
         /// <summary>
@@ -905,9 +945,9 @@ namespace Apache.Calcite.Geography.Runtime
 
             foreach (var va in a.Vertices)
                 foreach (var vb in b.Vertices)
-                    max = System.Math.Max(max, new S1Angle(va, vb).radians());
+                    max = System.Math.Max(max, Wgs84.Distance(va, vb));
 
-            return max * EarthRadiusMeters;
+            return max;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+
+using com.google.common.geometry;
+
+using net.sf.geographiclib;
+
+namespace Apache.Calcite.Geography.Runtime
+{
+
+    /// <summary>
+    /// The measurements, on the WGS84 ellipsoid.
+    /// </summary>
+    /// <remarks>
+    /// S2 models the Earth as a sphere. That is not a defect in S2 — it is spherical by construction and says
+    /// so — but it is the wrong instrument for a distance, and the gap was measured rather than assumed:
+    /// against a live Cosmos DB account with <c>geospatialConfig</c> Geography, a spherical distance is out by
+    /// up to 0.56%. The diagnosis is in one pair of numbers. One degree east and one degree north of the
+    /// equator are the same distance on a sphere, and the service answers 111319.490736 and 110574.388493 —
+    /// the first being the WGS84 semi-major axis times π/180, to every digit reported.
+    ///
+    /// <para>Karney's algorithm answers the ellipsoid to nanometres, and reproduces those two figures here.
+    /// So the engines split by what each is for, which is what the design proposed before either was written:
+    /// S2 decides topology — which points of two shapes are closest, whether one contains another — and this
+    /// measures between the points S2 chose. Choosing the closest pair on a sphere and then measuring it on
+    /// the ellipsoid is not exact, but the error is second order in the distance between the true closest
+    /// pair and the spherical one, where using the sphere for the measurement itself is first order.</para>
+    ///
+    /// <para>A predicate stays on S2 entirely. Sphere against ellipsoid moves an edge by far less than it
+    /// moves a distance, and containment asks which side of an edge a point falls on rather than how long the
+    /// edge is.</para>
+    /// </remarks>
+    static class Wgs84
+    {
+
+        /// <summary>
+        /// Returns the geodesic distance between two points in metres.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static double Distance(S2Point a, S2Point b)
+        {
+            var p = new S2LatLng(a);
+            var q = new S2LatLng(b);
+
+            return Geodesic.WGS84.Inverse(p.latDegrees(), p.lngDegrees(), q.latDegrees(), q.lngDegrees()).s12;
+        }
+
+        /// <summary>
+        /// Returns the total geodesic length of the given edges in metres.
+        /// </summary>
+        /// <param name="edges"></param>
+        /// <returns></returns>
+        public static double Length(IEnumerable<(S2Point, S2Point)> edges)
+        {
+            var total = 0.0;
+
+            foreach (var (p, q) in edges)
+                total += Distance(p, q);
+
+            return total;
+        }
+
+        /// <summary>
+        /// Returns the geodesic area of the given polygon in square metres.
+        /// </summary>
+        /// <param name="polygon"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Loop by loop, because a hole subtracts. S2 records nesting as a loop's depth — even is a shell and
+        /// odd is a hole — and <c>PolygonArea</c> is asked for the magnitude of each, the winding being S2's
+        /// business rather than the measurement's.
+        /// </remarks>
+        public static double Area(S2Polygon polygon)
+        {
+            var total = 0.0;
+
+            for (var i = 0; i < polygon.numLoops(); i++)
+            {
+                var loop = polygon.loop(i);
+                var area = new PolygonArea(Geodesic.WGS84, false);
+
+                for (var j = 0; j < loop.numVertices(); j++)
+                {
+                    var vertex = new S2LatLng(loop.vertex(j));
+                    area.AddPoint(vertex.latDegrees(), vertex.lngDegrees());
+                }
+
+                var magnitude = java.lang.Math.abs(area.Compute(false, true).area);
+
+                total += loop.depth() % 2 == 0 ? magnitude : -magnitude;
+            }
+
+            return total;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Closes #90.

The `ST_GEOG_*` measurements answered a sphere of radius 6371010, and a WGS84 store does not. That issue measured the gap against a live Cosmos DB account at up to **0.56%** — far too much for an adapter to recheck a predicate it pushed down, because the recheck discards rows the store correctly returned.

## The split

The engines now divide by what each is for, which is what #86 proposed before either was written:

- **S2 keeps the topology** — what contains, crosses or touches what, and *which* points of two shapes are the closest pair. Every predicate is unchanged. Sphere against ellipsoid moves an edge by far less than it moves a distance, and containment asks which side of an edge a point falls on rather than how long the edge is.
- **GeographicLib measures** between the points S2 chose. Picking the pair on a sphere and measuring it on the ellipsoid is second order in how far that pair is from the true one; measuring on the sphere is first order.

`ST_GEOG_DISTANCE`, `ST_GEOG_MAXDISTANCE`, `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` and `ST_GEOG_AREA` move; `ST_GEOG_DWITHIN` follows the distance. The closest/furthest/projected-point family #90 also names does not exist yet — when it does, it measures the same way.

## Confirmation

Two rows of #90's table are reproduced without being aimed at:

| | old | new | service |
| --- | --- | --- | --- |
| equator, 1° east | 111195.101177 | 111319.490793 | 111319.490736 |
| equator, 1° north | 111195.101177 | 110574.388558 | 110574.388493 |

The old code answered the same number to both, which is `6371010 · π/180` exactly — that is the whole diagnosis, and it is only true on a sphere.

The pole row lands too, on coordinates a test already had: `ShouldMeasureOverThePole` answers **22338.795682** where the service said **22338.795683**.

## One bug, caught by the differential suite

The first version used S2's four-argument `getClosestPoint` as though it took an edge pair. It does not — the fourth argument is the precomputed normal `a × b` — so the closest pair was garbage and distances came back zero. The suite caught it immediately with `ours 0, Calcite 111.3`.

The edge-to-edge pass is now gone rather than fixed: two edges that cross are zero apart and never reach it, and for two that do not, the least distance is attained at a vertex of one and its projection on the other.

## The tests are most of this

Where a spherical closed form had no ellipsoidal counterpart, the expectation is **recorded rather than derived**, and says so.

The differential comparisons against Calcite's planar answer are now a **bound rather than an oracle**. There is no single metres-per-degree on an ellipsoid — a degree east is 111319.49 and a degree north is 110574.39 — so a comparison scaled by either is out by up to 0.67% depending on which way two shapes lie. They still catch a wrong unit, a wrong factor or a wrong shape, which is what a differential test is for, and they cannot confirm the model.

`ST_GEOG_DWITHIN` is a boolean and cannot be compared to a tolerance, so it skips the band where the two models decide differently — which is the band an adapter rechecking a pushed-down predicate has to skip too.

`Wgs84MeasurementTests` is the oracle instead, against the figures #90 measured from a live service.

101 tests, green on net8.0 and net10.0.

## Note on the branch

`feature/geography-accessors` was deleted when #89 merged; this push recreated it with only this commit on top of main.
