### PR TITLE
Add sixteen geodesic operators: nearest, bounds, densify, overlay, hull, centroid

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographyBoundsTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyBoundsTests.cs
@@ -1,0 +1,168 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The bounding rectangle, which is where the antimeridian stops being an abstraction.
+    /// </summary>
+    /// <remarks>
+    /// A planar envelope is the least and greatest of the coordinates. That is the wrong answer for anything
+    /// that crosses longitude 180: a shape two degrees across gets a rectangle 358 degrees wide, and every
+    /// index and every pre-filter built on it then reads most of the globe. S2's rectangle knows a longitude
+    /// interval may wrap.
+    ///
+    /// <para>An expansion has the same shape of problem one dimension down. Growing a box by a degree moves
+    /// its northern edge further than its eastern one everywhere off the equator, so the planar function has
+    /// no fixed meaning on the Earth; this grows by metres.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyBoundsTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static string Text(Geometry? g)
+        {
+            return g is null ? "null" : g.toText();
+        }
+
+        /// <summary>
+        /// An ordinary shape gets an ordinary box, and agrees with Calcite.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBoundAnOrdinaryShapeAsCalciteDoes()
+        {
+            var shape = Wkt("POLYGON((0 0, 2 0, 2 1, 0 1, 0 0))");
+
+            var ours = GeographyFunctions.Envelope(shape);
+            var theirs = SpatialTypeFunctions.ST_Envelope(shape);
+
+            ours!.getEnvelopeInternal().getMinX().Should().BeApproximately(theirs.getEnvelopeInternal().getMinX(), 1e-9);
+            ours.getEnvelopeInternal().getMaxX().Should().BeApproximately(theirs.getEnvelopeInternal().getMaxX(), 1e-9);
+        }
+
+        /// <summary>
+        /// The whole reason this function exists.
+        /// </summary>
+        /// <remarks>
+        /// Two degrees of shape across the antimeridian. Calcite answers a box spanning 358 degrees of
+        /// longitude, because -179 and 179 are its least and greatest coordinates; this answers the two
+        /// degrees that are actually there, as the two halves either side of the line.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotSpanTheGlobeAcrossTheAntimeridian()
+        {
+            var shape = Wkt("LINESTRING(179 0, -179 0)");
+
+            var theirs = SpatialTypeFunctions.ST_Envelope(shape).getEnvelopeInternal();
+            (theirs.getMaxX() - theirs.getMinX()).Should().BeApproximately(358, 1e-9);
+
+            var ours = GeographyFunctions.Envelope(shape);
+
+            // two pieces, and neither is wide
+            ours!.getNumGeometries().Should().Be(2);
+            Span(ours.getGeometryN(0)).Should().BeApproximately(1, 1e-6);
+            Span(ours.getGeometryN(1)).Should().BeApproximately(1, 1e-6);
+        }
+
+        /// <summary>
+        /// A degenerate rectangle answers what JTS answers for one.
+        /// </summary>
+        [TestMethod]
+        public void ShouldDegenerateAsJtsDoes()
+        {
+            // approximately, because the rectangle is the sphere's: a coordinate reaches it as a unit
+            // vector and comes back a few bits shy of the degrees it went in as
+            var point = GeographyFunctions.Envelope(Wkt("POINT(1 2)"))!;
+            point.getGeometryType().Should().Be("Point");
+            point.getCoordinate().getX().Should().BeApproximately(1, 1e-12);
+            point.getCoordinate().getY().Should().BeApproximately(2, 1e-12);
+            GeographyFunctions.Envelope(Wkt("LINESTRING(0 0, 2 0)"))!.getGeometryType().Should().Be("LineString");
+            GeographyFunctions.Envelope(Wkt("POLYGON((0 0, 2 0, 2 1, 0 1, 0 0))"))!.getGeometryType().Should().Be("Polygon");
+        }
+
+        /// <summary>
+        /// The extent is the same rectangle, as Calcite's two are the same call.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerTheSameForExtent()
+        {
+            var shape = Wkt("POLYGON((0 0, 2 0, 2 1, 0 1, 0 0))");
+
+            Text(GeographyFunctions.Extent(shape)).Should().Be(Text(GeographyFunctions.Envelope(shape)));
+        }
+
+        /// <summary>
+        /// An expansion is in metres, and a degree of longitude is not a degree of latitude.
+        /// </summary>
+        /// <remarks>
+        /// At 60 degrees north a degree of longitude is about half a degree of latitude on the ground, so a
+        /// box grown by the same distance in every direction grows about twice as far in longitude as in
+        /// latitude. A planar expansion grows both by the same number and is therefore short to the east and
+        /// west by half.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldExpandInMetresRatherThanDegrees()
+        {
+            var expanded = GeographyFunctions.Expand(Wkt("POINT(0 60)"), java.lang.Double.valueOf(111319.49));
+
+            expanded.Should().NotBeNull();
+            var box = expanded!.getEnvelopeInternal();
+
+            var latSpan = box.getMaxY() - box.getMinY();
+            var lngSpan = box.getMaxX() - box.getMinX();
+
+            latSpan.Should().BeApproximately(2.0, 0.02);
+            lngSpan.Should().BeGreaterThan(latSpan * 1.5);
+        }
+
+        /// <summary>
+        /// Nothing to expand is nothing.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            GeographyFunctions.Envelope(null).Should().BeNull();
+            GeographyFunctions.Extent(null).Should().BeNull();
+            GeographyFunctions.Expand(null, java.lang.Double.valueOf(1)).Should().BeNull();
+            GeographyFunctions.Expand(Wkt("POINT(0 0)"), null).Should().BeNull();
+        }
+
+        /// <summary>
+        /// All three run as operators.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            (GeographyExecutionTests.Run("SELECT ST_GEOG_X(ST_GEOG_ENVELOPE(ST_GEOG_GEOMFROMTEXT('POINT(1 2)')))")[0][0] is java.lang.Number x ? x.doubleValue() : double.NaN).Should().BeApproximately(1, 1e-12);
+
+            (GeographyExecutionTests.Run("SELECT ST_GEOG_Y(ST_GEOG_EXTENT(ST_GEOG_GEOMFROMTEXT('POINT(1 2)')))")[0][0] is java.lang.Number y ? y.doubleValue() : double.NaN).Should().BeApproximately(2, 1e-12);
+
+            (GeographyExecutionTests.Run("SELECT ST_GEOG_ISVALID(ST_GEOG_EXPAND(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), 1000.0))")[0][0]
+                is java.lang.Boolean valid && valid.booleanValue()).Should().BeTrue();
+        }
+
+        static double Span(Geometry g)
+        {
+            var box = g.getEnvelopeInternal();
+
+            return box.getMaxX() - box.getMinX();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyDensifyTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyDensifyTests.cs
@@ -1,0 +1,156 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// Putting points on a geodesic: <c>ST_GEOG_DENSIFY</c> along one, <c>ST_GEOG_PROJECTPOINT</c> onto one.
+    /// </summary>
+    /// <remarks>
+    /// Densifying is usually done to hand a planar consumer something that follows the true path — a map, an
+    /// index, a store that only draws straight lines. Calcite's inserts its vertices along a straight line in
+    /// degrees, which is exactly the path that consumer would have drawn anyway, so the operation buys
+    /// nothing. These vertices are on the geodesic.
+    ///
+    /// <para>Between two points on a parallel away from the equator a geodesic bows poleward, and that is
+    /// what every test here turns on. It is not a small effect: across ten degrees of longitude at 60°N the
+    /// bow is about seven kilometres.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyDensifyTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        /// <summary>
+        /// The inserted vertices lie north of the parallel the two ends sit on; Calcite's lie on it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldFollowTheGeodesicRatherThanTheParallel()
+        {
+            var line = Wkt("LINESTRING(0 60, 10 60)");
+
+            var theirs = SpatialTypeFunctions.ST_Densify(line, java.math.BigDecimal.valueOf(1.0));
+            foreach (var c in theirs.getCoordinates())
+                c.getY().Should().BeApproximately(60, 1e-9, "a planar densify stays on the parallel");
+
+            var ours = GeographyFunctions.Densify(line, java.lang.Double.valueOf(100000.0))!;
+            var latitudes = ours.getCoordinates();
+
+            latitudes.Length.Should().BeGreaterThan(2);
+            latitudes[latitudes.Length / 2].getY().Should().BeGreaterThan(60.0);
+        }
+
+        /// <summary>
+        /// No edge is left longer than the distance asked for.
+        /// </summary>
+        [TestMethod]
+        public void ShouldLeaveNoEdgeLongerThanAsked()
+        {
+            var densified = GeographyFunctions.Densify(Wkt("LINESTRING(0 0, 10 0)"), java.lang.Double.valueOf(100000.0))!;
+            var coordinates = densified.getCoordinates();
+
+            for (var i = 0; i < coordinates.Length - 1; i++)
+            {
+                var edge = GeographyFunctions.Length(
+                    Wkt($"LINESTRING({coordinates[i].getX()} {coordinates[i].getY()}, {coordinates[i + 1].getX()} {coordinates[i + 1].getY()})"))!;
+
+                edge.doubleValue().Should().BeLessThanOrEqualTo(100000.0 + 1e-6);
+            }
+        }
+
+        /// <summary>
+        /// An edge already short enough is left alone, and so is a point.
+        /// </summary>
+        [TestMethod]
+        public void ShouldLeaveWhatIsAlreadyShortEnough()
+        {
+            var line = Wkt("LINESTRING(0 0, 0.001 0)");
+
+            GeographyFunctions.Densify(line, java.lang.Double.valueOf(1000000.0))!.getNumPoints().Should().Be(2);
+            GeographyFunctions.Densify(Wkt("POINT(1 2)"), java.lang.Double.valueOf(1.0))!.toText().Should().Be("POINT (1 2)");
+        }
+
+        /// <summary>
+        /// A polygon's rings are walked too, and the result is still a polygon.
+        /// </summary>
+        [TestMethod]
+        public void ShouldWalkEveryRingOfAPolygon()
+        {
+            var polygon = Wkt("POLYGON((0 50, 10 50, 10 55, 0 55, 0 50))");
+            var densified = GeographyFunctions.Densify(polygon, java.lang.Double.valueOf(100000.0))!;
+
+            densified.getGeometryType().Should().Be("Polygon");
+            densified.getNumPoints().Should().BeGreaterThan(polygon.getNumPoints());
+        }
+
+        /// <summary>
+        /// A point projected onto a line lands on the geodesic, not on the parallel.
+        /// </summary>
+        [TestMethod]
+        public void ShouldProjectOntoTheGeodesic()
+        {
+            var line = Wkt("LINESTRING(-10 60, 10 60)");
+            var projected = GeographyFunctions.ProjectPoint(Wkt("POINT(0 0)"), line)!;
+
+            projected.getCoordinate().getX().Should().BeApproximately(0, 1e-9);
+            projected.getCoordinate().getY().Should().BeGreaterThan(60.0);
+        }
+
+        /// <summary>
+        /// Nothing of more than one dimension is projected onto, as Calcite declines the same way.
+        /// </summary>
+        [TestMethod]
+        public void ShouldDeclineToProjectOntoAnArea()
+        {
+            var polygon = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+
+            SpatialTypeFunctions.ST_ProjectPoint(Wkt("POINT(5 5)"), polygon).Should().BeNull();
+            GeographyFunctions.ProjectPoint(Wkt("POINT(5 5)"), polygon).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            GeographyFunctions.Densify(null, java.lang.Double.valueOf(1)).Should().BeNull();
+            GeographyFunctions.Densify(Wkt("POINT(0 0)"), null).Should().BeNull();
+            GeographyFunctions.ProjectPoint(null, Wkt("LINESTRING(0 0, 1 1)")).Should().BeNull();
+            GeographyFunctions.ProjectPoint(Wkt("POINT(0 0)"), null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldStampBothWithWgs84()
+        {
+            GeographyFunctions.Densify(Wkt("LINESTRING(0 0, 10 0)"), java.lang.Double.valueOf(100000.0))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+
+            GeographyFunctions.ProjectPoint(Wkt("POINT(0 0)"), Wkt("LINESTRING(1 -1, 1 1)"))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            GeographyExecutionTests.Run("SELECT ST_GEOG_NUMPOINTS(ST_GEOG_DENSIFY(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 10 0)'), 100000.0))")[0][0]
+                .Should().BeAssignableTo<java.lang.Number>().Which.intValue().Should().BeGreaterThan(2);
+
+            GeographyExecutionTests.Run("SELECT ST_GEOG_ASTEXT(ST_GEOG_PROJECTPOINT(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('LINESTRING(1 -1, 1 1)')))")[0][0]
+                .Should().Be("POINT (1 0)");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyNearestTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyNearestTests.cs
@@ -1,0 +1,191 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The nearest and furthest family, which answers a point rather than a number and chooses it by
+    /// distance.
+    /// </summary>
+    /// <remarks>
+    /// <see href="https://github.com/ikvmnet/calcite-dotnet/issues/90">#90</see> named these as measurements
+    /// in disguise: each ranks candidates by how far away they are, so each is wrong in the same way a
+    /// distance is wrong if the ranking is planar. They rank on the ellipsoid.
+    ///
+    /// <para>That is not a difference in the last digits. A degree of longitude at the equator is 111319.49
+    /// metres and a degree of latitude is 110574.39, so two candidates that a planar reading calls
+    /// equidistant are 745 metres apart in fact — and the two disagree about which is nearer whenever the
+    /// candidates lie in different directions.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyNearestTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static string Text(Geometry? g)
+        {
+            return g is null ? "null" : g.toText();
+        }
+
+        /// <summary>
+        /// The case the whole family exists for: a tie in degrees that is not a tie in metres.
+        /// </summary>
+        /// <remarks>
+        /// One degree east and one degree north of the origin are the same distance on a plane, so Calcite
+        /// answers both. On the Earth the northern one is 745 metres nearer, so there is nothing to tie and
+        /// this answers it alone. Neither is a rounding difference; they are different answers.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldBreakATieThatOnlyExistsOnAPlane()
+        {
+            var origin = Wkt("POINT(0 0)");
+            var candidates = Wkt("MULTIPOINT((1 0), (0 1))");
+
+            Text(SpatialTypeFunctions.ST_ClosestCoordinate(origin, candidates))
+                .Should().Be("MULTIPOINT ((1 0), (0 1))");
+
+            Text(GeographyFunctions.ClosestCoordinate(origin, candidates))
+                .Should().Be("POINT (0 1)");
+        }
+
+        /// <summary>
+        /// And the furthest of the same two is the other one.
+        /// </summary>
+        [TestMethod]
+        public void ShouldChooseTheFurthestOnTheEllipsoidToo()
+        {
+            var origin = Wkt("POINT(0 0)");
+            var candidates = Wkt("MULTIPOINT((1 0), (0 1))");
+
+            Text(GeographyFunctions.FurthestCoordinate(origin, candidates)).Should().Be("POINT (1 0)");
+        }
+
+        /// <summary>
+        /// A genuine tie is still answered with every coordinate that ties, as Calcite does.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerARealTieWithEveryCoordinate()
+        {
+            var answer = GeographyFunctions.ClosestCoordinate(Wkt("POINT(0 0)"), Wkt("MULTIPOINT((1 0), (-1 0))"));
+
+            Text(answer).Should().Be("MULTIPOINT ((1 0), (-1 0))");
+        }
+
+        /// <summary>
+        /// A coordinate of the geography, not a point on it — which is what makes this a different function
+        /// from <c>ST_GEOG_CLOSESTPOINT</c>.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerACoordinateRatherThanAPointOnAnEdge()
+        {
+            var line = Wkt("LINESTRING(1 -1, 1 1)");
+
+            // the two ends are symmetric about the equator, so as coordinates they genuinely tie
+            Text(GeographyFunctions.ClosestCoordinate(Wkt("POINT(0 0)"), line)).Should().Be("MULTIPOINT ((1 -1), (1 1))");
+            Text(GeographyFunctions.ClosestPoint(line, Wkt("POINT(0 0)"))).Should().Be("POINT (1 0)");
+        }
+
+        /// <summary>
+        /// The closest point may fall part way along an edge, and the edge is a geodesic.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerAPointOnAnEdge()
+        {
+            var answer = GeographyFunctions.ClosestPoint(Wkt("LINESTRING(-1 1, 1 1)"), Wkt("POINT(0 0)"));
+
+            answer.Should().NotBeNull();
+            answer!.getCoordinate().getX().Should().BeApproximately(0, 1e-9);
+
+            // north of the line's own ends, because a geodesic between two points on a parallel bows poleward
+            answer.getCoordinate().getY().Should().BeGreaterThan(1.0);
+        }
+
+        /// <summary>
+        /// The longest line joins the pair <c>ST_GEOG_MAXDISTANCE</c> measures.
+        /// </summary>
+        [TestMethod]
+        public void ShouldJoinThePairMaxDistanceMeasures()
+        {
+            var a = Wkt("MULTIPOINT((0 0), (0.5 0))");
+            var b = Wkt("MULTIPOINT((2 0), (3 0))");
+
+            var line = GeographyFunctions.LongestLine(a, b);
+            Text(line).Should().Be("LINESTRING (0 0, 3 0)");
+
+            var length = GeographyFunctions.Length(line)!.doubleValue();
+            var max = GeographyFunctions.MaxDistance(a, b)!.doubleValue();
+
+            length.Should().BeApproximately(max, 1e-6);
+        }
+
+        /// <summary>
+        /// Null in, null out, as everywhere else here.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            GeographyFunctions.ClosestCoordinate(null, Wkt("POINT(0 0)")).Should().BeNull();
+            GeographyFunctions.FurthestCoordinate(Wkt("POINT(0 0)"), null).Should().BeNull();
+            GeographyFunctions.ClosestPoint(null, null).Should().BeNull();
+            GeographyFunctions.LongestLine(Wkt("POINT(0 0)"), null).Should().BeNull();
+        }
+
+        /// <summary>
+        /// Every one of the four stamped with WGS84, as every other constructor and editor is.
+        /// </summary>
+        [TestMethod]
+        public void ShouldStampEveryAnswerWithWgs84()
+        {
+            var a = Wkt("LINESTRING(0 0, 1 1)");
+            var b = Wkt("POINT(2 2)");
+
+            GeographyFunctions.ClosestCoordinate(b, a)!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.FurthestCoordinate(b, a)!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.ClosestPoint(a, b)!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.LongestLine(a, b)!.getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        /// <summary>
+        /// All four run as operators, which is what says the declarations bind to these bodies.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            var cases = new (string Sql, string Expected)[]
+            {
+                ("ST_GEOG_ASTEXT(ST_GEOG_CLOSESTCOORDINATE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('MULTIPOINT((1 0), (0 1))')))", "POINT (0 1)"),
+                ("ST_GEOG_ASTEXT(ST_GEOG_FURTHESTCOORDINATE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('MULTIPOINT((1 0), (0 1))')))", "POINT (1 0)"),
+                ("ST_GEOG_ASTEXT(ST_GEOG_CLOSESTPOINT(ST_GEOG_GEOMFROMTEXT('LINESTRING(1 -1, 1 1)'), ST_GEOG_GEOMFROMTEXT('POINT(0 0)')))", "POINT (1 0)"),
+                ("ST_GEOG_ASTEXT(ST_GEOG_LONGESTLINE(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), ST_GEOG_GEOMFROMTEXT('MULTIPOINT((2 0), (3 0))')))", "LINESTRING (0 0, 3 0)"),
+            };
+
+            var failures = new System.Collections.Generic.List<string>();
+
+            foreach (var (sql, expected) in cases)
+            {
+                var answer = GeographyExecutionTests.Run("SELECT " + sql)[0][0];
+
+                if (Equals(answer, expected) == false)
+                    failures.Add($"{sql}: answered {answer}, wanted {expected}");
+            }
+
+            failures.Should().BeEmpty(string.Join("\n", failures));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyOverlayTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyOverlayTests.cs
@@ -1,0 +1,214 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The overlay set — intersection, difference, symmetric difference and unary union.
+    /// </summary>
+    /// <remarks>
+    /// #86 deferred these as large, on the reasoning that a geodesic overlay is a different algorithm from a
+    /// planar one rather than the same one in other units. That is true and it is S2's algorithm:
+    /// <c>initToIntersection</c> and its neighbours answer on the sphere what JTS answers on a plane, so what
+    /// was left to write is the conversion of the answer back into rings.
+    ///
+    /// <para>They are areal operations and this answers them for areas, declining anything else. Calcite's
+    /// take any pair, JTS overlaying whatever it is handed, and following it there would mean answering a
+    /// line clipped by a polygon on the plane — two models in one expression, which is the thing this package
+    /// exists to prevent.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyOverlayTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static double Area(Geometry? g)
+        {
+            return g is null ? 0 : GeographyFunctions.Area(g)!.doubleValue();
+        }
+
+        /// <summary>
+        /// Two overlapping boxes intersect in the box they share.
+        /// </summary>
+        [TestMethod]
+        public void ShouldIntersectTwoBoxes()
+        {
+            var a = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+            var b = Wkt("POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))");
+
+            var overlap = GeographyFunctions.Intersection(a, b);
+
+            overlap.Should().NotBeNull();
+            var box = overlap!.getEnvelopeInternal();
+
+            box.getMinX().Should().BeApproximately(1, 1e-6);
+            box.getMaxX().Should().BeApproximately(2, 1e-6);
+            box.getMinY().Should().BeApproximately(1, 1e-3);
+            box.getMaxY().Should().BeApproximately(2, 1e-3);
+
+            // and not exactly two: the northern edge of the first box is a geodesic from (0 2) to (2 2), which
+            // bows north of the parallel, so the shared region reaches a little past it. A planar overlay
+            // stops at exactly 2, and that is the difference rather than a defect
+            box.getMaxY().Should().BeGreaterThan(2.0);
+        }
+
+        /// <summary>
+        /// The one that says the model is not the plane's: an overlap that exists on the Earth and not on a
+        /// map.
+        /// </summary>
+        /// <remarks>
+        /// The northern edge of a wide box is a geodesic, and a geodesic between two points on a parallel
+        /// bows poleward — for a box reaching from 0 to 60 degrees of longitude along the 60th parallel, by
+        /// several degrees at the middle. So a small shape sitting north of the parallel is outside the box
+        /// as a planar reading draws it and inside the box as it is. Calcite answers an empty intersection
+        /// and this answers a real one.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldIntersectWhereTheGeodesicEdgeReachesAndThePlanarOneDoesNot()
+        {
+            var wide = Wkt("POLYGON((0 60, 60 60, 60 20, 0 20, 0 60))");
+            var sliver = Wkt("POLYGON((29 61, 31 61, 31 62, 29 62, 29 61))");
+
+            SpatialTypeFunctions.ST_Intersection(wide, sliver).isEmpty().Should().BeTrue("no part of the sliver is south of 60");
+
+            var ours = GeographyFunctions.Intersection(wide, sliver);
+
+            ours.Should().NotBeNull();
+            ours!.isEmpty().Should().BeFalse("the box's northern edge is a geodesic and bows north of 60");
+            Area(ours).Should().BeGreaterThan(0);
+        }
+
+        /// <summary>
+        /// A difference takes one from the other, and the areas add up.
+        /// </summary>
+        [TestMethod]
+        public void ShouldTakeOneAreaFromAnother()
+        {
+            var a = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+            var b = Wkt("POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))");
+
+            var difference = GeographyFunctions.Difference(a, b);
+            var overlap = GeographyFunctions.Intersection(a, b);
+
+            // to S2's snapping tolerance; see ShouldAnswerBothSidesOfASymmetricDifference
+            (Area(difference) + Area(overlap)).Should().BeApproximately(Area(a), Area(a) * 1e-5);
+        }
+
+        /// <summary>
+        /// And the symmetric difference is everything but the overlap, counted once each way.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerBothSidesOfASymmetricDifference()
+        {
+            var a = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+            var b = Wkt("POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))");
+
+            var symmetric = Area(GeographyFunctions.SymDifference(a, b));
+            var overlap = Area(GeographyFunctions.Intersection(a, b));
+
+            // to S2's snapping tolerance rather than to the last bit: an overlay snaps its vertices to a
+            // level of the cell hierarchy, so the pieces of a partition agree to about a part in a million
+            symmetric.Should().BeApproximately(Area(a) + Area(b) - 2 * overlap, Area(a) * 1e-5);
+        }
+
+        /// <summary>
+        /// A union of a shape with itself is the shape.
+        /// </summary>
+        [TestMethod]
+        public void ShouldMergeAShapeWithItself()
+        {
+            var a = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+
+            Area(GeographyFunctions.UnaryUnion(a)).Should().BeApproximately(Area(a), Area(a) * 1e-5);
+        }
+
+        /// <summary>
+        /// Shapes that do not meet intersect in nothing.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerEmptyWhereTheyDoNotMeet()
+        {
+            var a = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+            var b = Wkt("POLYGON((10 10, 11 10, 11 11, 10 11, 10 10))");
+
+            GeographyFunctions.Intersection(a, b)!.isEmpty().Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A hole comes back a hole.
+        /// </summary>
+        [TestMethod]
+        public void ShouldKeepAHoleThroughTheOverlay()
+        {
+            var ring = Wkt("POLYGON((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 3 1, 3 3, 1 3, 1 1))");
+            var all = Wkt("POLYGON((-1 -1, 5 -1, 5 5, -1 5, -1 -1))");
+
+            var kept = GeographyFunctions.Intersection(ring, all);
+
+            kept.Should().NotBeNull();
+            Area(kept).Should().BeApproximately(Area(ring), Area(ring) * 1e-5);
+            ((org.locationtech.jts.geom.Polygon)kept!.getGeometryN(0)).getNumInteriorRing().Should().Be(1);
+        }
+
+        /// <summary>
+        /// Anything without an area is declined rather than answered on a plane.
+        /// </summary>
+        [TestMethod]
+        public void ShouldDeclineAnythingWithoutAnArea()
+        {
+            var area = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+
+            GeographyFunctions.Intersection(Wkt("LINESTRING(0 0, 1 1)"), area).Should().BeNull();
+            GeographyFunctions.Difference(area, Wkt("POINT(1 1)")).Should().BeNull();
+            GeographyFunctions.UnaryUnion(Wkt("POINT(1 1)")).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            var area = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+
+            GeographyFunctions.Intersection(null, area).Should().BeNull();
+            GeographyFunctions.Difference(area, null).Should().BeNull();
+            GeographyFunctions.SymDifference(null, null).Should().BeNull();
+            GeographyFunctions.UnaryUnion(null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            const string a = "ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))')";
+            const string b = "ST_GEOG_GEOMFROMTEXT('POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))')";
+
+            foreach (var sql in new[]
+            {
+                $"ST_GEOG_AREA(ST_GEOG_INTERSECTION({a}, {b}))",
+                $"ST_GEOG_AREA(ST_GEOG_DIFFERENCE({a}, {b}))",
+                $"ST_GEOG_AREA(ST_GEOG_SYMDIFFERENCE({a}, {b}))",
+                $"ST_GEOG_AREA(ST_GEOG_UNARYUNION({a}))",
+            })
+            {
+                var answer = GeographyExecutionTests.Run("SELECT " + sql)[0][0];
+
+                (answer is java.lang.Number n ? n.doubleValue() : double.NaN)
+                    .Should().BeGreaterThan(0, sql);
+            }
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -124,6 +124,8 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_LONGESTLINE` | the line joining the pair `ST_GEOG_MAXDISTANCE` measures |
 | `ST_GEOG_ENVELOPE`, `ST_GEOG_EXTENT` | the bounding rectangle, which wraps rather than spanning the globe when the shape crosses the antimeridian |
 | `ST_GEOG_EXPAND` | that rectangle grown by a distance in metres |
+| `ST_GEOG_DENSIFY` | vertices inserted along the geodesic so no edge exceeds a distance in metres |
+| `ST_GEOG_PROJECTPOINT` | a point projected onto a line, landing on the geodesic |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -126,6 +126,7 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_EXPAND` | that rectangle grown by a distance in metres |
 | `ST_GEOG_DENSIFY` | vertices inserted along the geodesic so no edge exceeds a distance in metres |
 | `ST_GEOG_PROJECTPOINT` | a point projected onto a line, landing on the geodesic |
+| `ST_GEOG_INTERSECTION`, `ST_GEOG_DIFFERENCE`, `ST_GEOG_SYMDIFFERENCE`, `ST_GEOG_UNARYUNION` | the overlay set, over areas, bounded by geodesics |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -122,6 +122,8 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_CLOSESTCOORDINATE`, `ST_GEOG_FURTHESTCOORDINATE` | the coordinate of a geography nearest or furthest from a point |
 | `ST_GEOG_CLOSESTPOINT` | the point of one geography nearest another, which may fall part way along an edge |
 | `ST_GEOG_LONGESTLINE` | the line joining the pair `ST_GEOG_MAXDISTANCE` measures |
+| `ST_GEOG_ENVELOPE`, `ST_GEOG_EXTENT` | the bounding rectangle, which wraps rather than spanning the globe when the shape crosses the antimeridian |
+| `ST_GEOG_EXPAND` | that rectangle grown by a distance in metres |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -119,6 +119,9 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | --- | --- |
 | `ST_GEOG_DISTANCE`, `ST_GEOG_DWITHIN` | the distance between two geographies |
 | `ST_GEOG_MAXDISTANCE` | the greatest distance between a coordinate of one and a coordinate of the other |
+| `ST_GEOG_CLOSESTCOORDINATE`, `ST_GEOG_FURTHESTCOORDINATE` | the coordinate of a geography nearest or furthest from a point |
+| `ST_GEOG_CLOSESTPOINT` | the point of one geography nearest another, which may fall part way along an edge |
+| `ST_GEOG_LONGESTLINE` | the line joining the pair `ST_GEOG_MAXDISTANCE` measures |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using org.apache.calcite.runtime;
@@ -1403,6 +1404,175 @@ namespace Apache.Calcite.Geography.Runtime
         {
             if (srid != Wgs84)
                 throw new java.lang.IllegalArgumentException($"A geography is WGS84; SRID {srid} is not a reference system it can be in.");
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_INTERSECTION</c>. Returns the area common to two geographies.
+        /// </summary>
+        /// <param name="geog1"></param>
+        /// <param name="geog2"></param>
+        /// <returns></returns>
+        /// <inheritdoc cref="Overlay" />
+        public static Geometry? Intersection(Geometry? geog1, Geometry? geog2)
+        {
+            return Overlay(geog1, geog2, (result, a, b) => result.initToIntersection(a, b));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_DIFFERENCE</c>. Returns the part of the first geography that is not in the second.
+        /// </summary>
+        /// <param name="geog1"></param>
+        /// <param name="geog2"></param>
+        /// <returns></returns>
+        /// <inheritdoc cref="Overlay" />
+        public static Geometry? Difference(Geometry? geog1, Geometry? geog2)
+        {
+            return Overlay(geog1, geog2, (result, a, b) => result.initToDifference(a, b));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_SYMDIFFERENCE</c>. Returns the parts of two geographies that are in one and not the
+        /// other.
+        /// </summary>
+        /// <param name="geog1"></param>
+        /// <param name="geog2"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Built from two differences and a union, S2 having no symmetric difference of its own. That is what
+        /// the operation is: everything in one and not the other, either way round.
+        /// </remarks>
+        /// <inheritdoc cref="Overlay" />
+        public static Geometry? SymDifference(Geometry? geog1, Geometry? geog2)
+        {
+            return Overlay(geog1, geog2, (result, a, b) =>
+            {
+                var left = new com.google.common.geometry.S2Polygon();
+                var right = new com.google.common.geometry.S2Polygon();
+
+                left.initToDifference(a, b);
+                right.initToDifference(b, a);
+
+                result.initToUnion(left, right);
+            });
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_UNARYUNION</c>. Returns the geography with its overlapping parts merged.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <inheritdoc cref="Overlay" />
+        public static Geometry? UnaryUnion(Geometry? geog)
+        {
+            return Overlay(geog, geog, (result, a, b) => result.initToUnion(a, b));
+        }
+
+        /// <summary>
+        /// Runs one of S2's overlay operations over the areal parts of two geographies.
+        /// </summary>
+        /// <param name="geog1"></param>
+        /// <param name="geog2"></param>
+        /// <param name="operation"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// These are areal operations and this answers them for areas, declining anything else with null
+        /// rather than guessing. Calcite's take any pair, JTS overlaying whatever it is handed; the reason
+        /// not to follow it there is that a line clipped by a polygon is a different computation from an area
+        /// intersected with one, and S2 has the second. Answering the first by falling back to the plane
+        /// would put two models in one expression, which is the thing this package exists to prevent.
+        ///
+        /// <para>What is on offer instead is exact where it applies. An intersection of two areas on the
+        /// sphere is bounded by geodesics, and the planar answer is bounded by straight lines in degrees —
+        /// which is a different region, not a rounding of the same one.</para>
+        /// </remarks>
+        static Geometry? Overlay(Geometry? geog1, Geometry? geog2, Action<com.google.common.geometry.S2Polygon, com.google.common.geometry.S2Polygon, com.google.common.geometry.S2Polygon> operation)
+        {
+            if (geog1 is null || geog2 is null)
+                return null;
+
+            var a = S2Geographies.Of(geog1).Polygon;
+            var b = S2Geographies.Of(geog2).Polygon;
+
+            if (a is null || b is null)
+                return null;
+
+            var result = new com.google.common.geometry.S2Polygon();
+            operation(result, a, b);
+
+            return Wgs84Of(Areal(result));
+        }
+
+        /// <summary>
+        /// Writes an S2 polygon as a geography.
+        /// </summary>
+        /// <param name="polygon"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// S2 records nesting as a loop's depth — even is a shell and odd is a hole — and orders a shell's
+        /// holes after it, so one pass builds the rings. A hole is stored wound the other way round from the
+        /// shell that contains it, so its vertices are reversed on the way out; and an S2 loop does not repeat
+        /// its first vertex where a JTS ring must.
+        /// </remarks>
+        static Geometry Areal(com.google.common.geometry.S2Polygon polygon)
+        {
+            if (polygon.numLoops() == 0)
+                return Factory.createPolygon();
+
+            var polygons = new java.util.ArrayList();
+            org.locationtech.jts.geom.LinearRing? shell = null;
+            var holes = new java.util.ArrayList();
+
+            void Close()
+            {
+                if (shell is null)
+                    return;
+
+                var rings = new org.locationtech.jts.geom.LinearRing[holes.size()];
+                for (var i = 0; i < holes.size(); i++)
+                    rings[i] = (org.locationtech.jts.geom.LinearRing)holes.get(i);
+
+                polygons.add(Factory.createPolygon(shell, rings));
+                holes.clear();
+            }
+
+            for (var i = 0; i < polygon.numLoops(); i++)
+            {
+                var loop = polygon.loop(i);
+                var ring = Ring(loop, reversed: loop.depth() % 2 != 0);
+
+                if (loop.depth() % 2 == 0)
+                {
+                    Close();
+                    shell = ring;
+                }
+                else
+                {
+                    holes.add(ring);
+                }
+            }
+
+            Close();
+
+            return Factory.buildGeometry(polygons);
+        }
+
+        /// <summary>
+        /// Writes one S2 loop as a closed ring.
+        /// </summary>
+        /// <param name="loop"></param>
+        /// <param name="reversed"></param>
+        /// <returns></returns>
+        static org.locationtech.jts.geom.LinearRing Ring(com.google.common.geometry.S2Loop loop, bool reversed)
+        {
+            var count = loop.numVertices();
+            var coordinates = new org.locationtech.jts.geom.Coordinate[count + 1];
+
+            for (var i = 0; i < count; i++)
+                coordinates[i] = Coordinate(loop.vertex(reversed ? count - 1 - i : i));
+
+            coordinates[count] = coordinates[0];
+
+            return Factory.createLinearRing(coordinates);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1406,6 +1406,90 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_DENSIFY</c>. Returns the geography with vertices inserted so that no edge is longer
+        /// than the given distance in metres.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <param name="longest"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Metres and a geodesic, where Calcite's is degrees and a straight line in them. Both differences
+        /// matter and the second is the point of the function: densifying is usually done to hand a planar
+        /// consumer something that follows the true path, and a straight line in degrees is exactly what it
+        /// would have drawn anyway. Between two points on a parallel away from the equator the geodesic bows
+        /// poleward, and these vertices bow with it.
+        ///
+        /// <para>Every part of the geography is walked, a polygon's rings included, which is what
+        /// <c>GeometryTransformer</c> is for — the alternative is a case for each of the seven types.</para>
+        /// </remarks>
+        public static Geometry? Densify(Geometry? geog, java.lang.Object? longest)
+        {
+            if (geog is null || longest is null)
+                return null;
+
+            return Wgs84Of(new Densifier(Double(longest)).transform(geog));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_PROJECTPOINT</c>. Returns the point of the line nearest the given point.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="line"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Null for anything of more than one dimension, as Calcite's is: a projection onto an area is not
+        /// defined and it declines rather than guessing. The point lands on a geodesic and so is not where a
+        /// planar projection puts it.
+        /// </remarks>
+        public static Geometry? ProjectPoint(Geometry? point, Geometry? line)
+        {
+            if (point is null || line is null || line.getDimension() > 1)
+                return null;
+
+            var pair = S2Geographies.ClosestPair(S2Geographies.Of(line), S2Geographies.Of(point));
+
+            return pair is null ? null : Wgs84Of(Factory.createPoint(Coordinate(pair.Value.A)));
+        }
+
+        /// <summary>
+        /// Inserts vertices along every edge of whatever it is handed.
+        /// </summary>
+        /// <param name="longest">The greatest edge length in metres.</param>
+        sealed class Densifier(double longest) : org.locationtech.jts.geom.util.GeometryTransformer
+        {
+
+            protected override org.locationtech.jts.geom.CoordinateSequence transformCoordinates(
+                org.locationtech.jts.geom.CoordinateSequence coords,
+                Geometry parent)
+            {
+                if (coords.size() < 2)
+                    return coords;
+
+                var built = new java.util.ArrayList();
+
+                for (var i = 0; i < coords.size() - 1; i++)
+                {
+                    var from = coords.getCoordinate(i);
+                    var to = coords.getCoordinate(i + 1);
+
+                    built.add(from);
+
+                    foreach (var between in Ellipsoid.Divide(from, to, longest))
+                        built.add(between);
+                }
+
+                built.add(coords.getCoordinate(coords.size() - 1));
+
+                var array = new org.locationtech.jts.geom.Coordinate[built.size()];
+                for (var i = 0; i < built.size(); i++)
+                    array[i] = (org.locationtech.jts.geom.Coordinate)built.get(i);
+
+                return createCoordinateSequence(array);
+            }
+
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_ENVELOPE</c>. Returns the smallest latitude-longitude rectangle containing the
         /// geography.
         /// </summary>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1,5 +1,10 @@
+using System.Collections.Generic;
+
 using org.apache.calcite.runtime;
 
+// the class and this class's Wgs84 constant, which is the SRID, are two different things with one name;
+// inside here the constant wins, so the ellipsoid is reached under a name that says what it is
+using Ellipsoid = Apache.Calcite.Geography.Runtime.Wgs84;
 using Geometry = org.locationtech.jts.geom.Geometry;
 
 namespace Apache.Calcite.Geography.Runtime
@@ -1398,6 +1403,164 @@ namespace Apache.Calcite.Geography.Runtime
         {
             if (srid != Wgs84)
                 throw new java.lang.IllegalArgumentException($"A geography is WGS84; SRID {srid} is not a reference system it can be in.");
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_CLOSESTCOORDINATE</c>. Returns the coordinate or coordinates of the geography nearest
+        /// the given point.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A coordinate of the geography rather than a point on it, which is what Calcite's own answers: it
+        /// walks the coordinate array and never looks at the space between two of them. Ties answer a
+        /// multi-point, as Calcite's does.
+        ///
+        /// <para>The ranking is geodesic and Calcite's is planar, which is the whole of the difference and is
+        /// not cosmetic: a candidate one degree east and a candidate one degree north are equidistant in
+        /// degrees and 745 metres apart in metres, so the two disagree about which is nearer whenever the
+        /// candidates lie in different directions.</para>
+        /// </remarks>
+        public static Geometry? ClosestCoordinate(Geometry? point, Geometry? geog)
+        {
+            return ExtremeCoordinate(point, geog, furthest: false);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_FURTHESTCOORDINATE</c>. Returns the coordinate or coordinates of the geography furthest
+        /// from the given point.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <inheritdoc cref="ClosestCoordinate" />
+        public static Geometry? FurthestCoordinate(Geometry? point, Geometry? geog)
+        {
+            return ExtremeCoordinate(point, geog, furthest: true);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_CLOSESTPOINT</c>. Returns the point of the first geography nearest the second.
+        /// </summary>
+        /// <param name="geog1"></param>
+        /// <param name="geog2"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A point on the geography rather than one of its coordinates — it may fall part way along an edge,
+        /// which is why this is a different function from <see cref="ClosestCoordinate"/> and why S2 answers
+        /// it. The edge it falls on is a geodesic, so the point is not the one a planar reading finds: a
+        /// chord and an arc between the same two ends meet a third point at different places.
+        /// </remarks>
+        public static Geometry? ClosestPoint(Geometry? geog1, Geometry? geog2)
+        {
+            if (geog1 is null || geog2 is null)
+                return null;
+
+            var pair = S2Geographies.ClosestPair(S2Geographies.Of(geog1), S2Geographies.Of(geog2));
+
+            return pair is null ? null : Wgs84Of(Factory.createPoint(Coordinate(pair.Value.A)));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_LONGESTLINE</c>. Returns the line between the two coordinates, one from each geography,
+        /// that are furthest apart.
+        /// </summary>
+        /// <param name="geog1"></param>
+        /// <param name="geog2"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Between coordinates and not between shapes, which is what Calcite measures, and the same pair
+        /// <c>ST_GEOG_MAXDISTANCE</c> measures the length of.
+        /// </remarks>
+        public static Geometry? LongestLine(Geometry? geog1, Geometry? geog2)
+        {
+            if (geog1 is null || geog2 is null)
+                return null;
+
+            var max = double.NaN;
+            org.locationtech.jts.geom.Coordinate? left = null;
+            org.locationtech.jts.geom.Coordinate? right = null;
+
+            foreach (var a in geog1.getCoordinates())
+            {
+                foreach (var b in geog2.getCoordinates())
+                {
+                    var distance = Ellipsoid.Distance(a, b);
+
+                    if (double.IsNaN(max) || distance > max)
+                    {
+                        max = distance;
+                        left = a;
+                        right = b;
+                    }
+                }
+            }
+
+            if (left is null || right is null)
+                return null;
+
+            return Wgs84Of(Factory.createLineString([left, right]));
+        }
+
+        /// <summary>
+        /// The coordinate or coordinates of the geography at the extreme geodesic distance from the point.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <param name="geog"></param>
+        /// <param name="furthest"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Calcite reads a single coordinate off the point argument and compares every coordinate of the
+        /// other geography against it, so this does too — the argument is a point in the signature and only
+        /// its first coordinate in the behaviour.
+        /// </remarks>
+        static Geometry? ExtremeCoordinate(Geometry? point, Geometry? geog, bool furthest)
+        {
+            if (point is null || geog is null)
+                return null;
+
+            var origin = point.getCoordinate();
+            if (origin is null)
+                return null;
+
+            var found = new List<org.locationtech.jts.geom.Coordinate>();
+            var best = double.NaN;
+
+            foreach (var candidate in geog.getCoordinates())
+            {
+                var distance = Ellipsoid.Distance(origin, candidate);
+
+                if (double.IsNaN(best) || (furthest ? distance > best : distance < best))
+                {
+                    best = distance;
+                    found.Clear();
+                    found.Add(candidate);
+                }
+                else if (distance == best && found.Contains(candidate) == false)
+                {
+                    found.Add(candidate);
+                }
+            }
+
+            if (found.Count == 0)
+                return null;
+
+            return Wgs84Of(found.Count == 1
+                ? Factory.createPoint(found[0])
+                : Factory.createMultiPointFromCoords([.. found]));
+        }
+
+        /// <summary>
+        /// The factory the answers above are built with.
+        /// </summary>
+        static readonly org.locationtech.jts.geom.GeometryFactory Factory = new();
+
+        static org.locationtech.jts.geom.Coordinate Coordinate(com.google.common.geometry.S2Point p)
+        {
+            var ll = new com.google.common.geometry.S2LatLng(p);
+
+            return new org.locationtech.jts.geom.Coordinate(ll.lngDegrees(), ll.latDegrees());
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1406,6 +1406,125 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_ENVELOPE</c>. Returns the smallest latitude-longitude rectangle containing the
+        /// geography.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The reason this is not <c>ST_ENVELOPE</c> is the antimeridian. A planar envelope is the minimum
+        /// and maximum of the coordinates, so a shape with a vertex at 179 and another at -179 gets a
+        /// rectangle 358 degrees wide — very nearly the whole globe, for a shape two degrees across. S2's
+        /// rectangle knows a longitude interval may wrap, and answers the two-degree band that is actually
+        /// there. Where the interval does wrap the answer is a multi-polygon of the two halves either side of
+        /// the antimeridian, there being no way to write a wrapped box as one ring in longitude and latitude.
+        ///
+        /// <para>A degenerate rectangle answers what JTS answers for one: a point where the shape is a point,
+        /// a line where it has no width or no height.</para>
+        /// </remarks>
+        public static Geometry? Envelope(Geometry? geog)
+        {
+            return geog is null ? null : Wgs84Of(Rectangle(S2Geographies.Of(geog).Bound()));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_EXTENT</c>. Returns the smallest latitude-longitude rectangle containing the geography.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The same rectangle <see cref="Envelope"/> answers. Calcite's two are the same call as well —
+        /// <c>ST_Extent</c> is <c>geom.getEnvelope()</c>, with a comment wondering whether they differ — and
+        /// this mirrors that rather than inventing a difference.
+        /// </remarks>
+        public static Geometry? Extent(Geometry? geog)
+        {
+            return Envelope(geog);
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_EXPAND</c>. Returns the geography's rectangle grown by a distance in metres.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Metres, where Calcite's grows by degrees. Growing a box by a degree moves its northern edge
+        /// further than its eastern one everywhere off the equator, and by a factor that reaches two by 60
+        /// degrees of latitude, so the planar reading of this function has no fixed meaning on the Earth at
+        /// all. S2 grows the rectangle by an angle and widens the longitude interval by more than that as the
+        /// latitude rises, which is what keeps every point within the distance actually inside.
+        /// </remarks>
+        public static Geometry? Expand(Geometry? geog, java.lang.Object? distance)
+        {
+            if (geog is null || distance is null)
+                return null;
+
+            return Wgs84Of(Rectangle(S2Geographies.Of(geog).Bound().expandedByDistance(Ellipsoid.AngleFor(Double(distance)))));
+        }
+
+        /// <summary>
+        /// Writes a latitude-longitude rectangle as a geography.
+        /// </summary>
+        /// <param name="rect"></param>
+        /// <returns></returns>
+        static Geometry Rectangle(com.google.common.geometry.S2LatLngRect rect)
+        {
+            if (rect.isEmpty())
+                return Factory.createPolygon();
+
+            var latLo = rect.lat().lo() * 180 / System.Math.PI;
+            var latHi = rect.lat().hi() * 180 / System.Math.PI;
+            var lngLo = rect.lng().lo() * 180 / System.Math.PI;
+            var lngHi = rect.lng().hi() * 180 / System.Math.PI;
+
+            // a wrapped interval has no single ring in these coordinates, so it is written as the two halves
+            if (rect.lng().isInverted())
+            {
+                // buildGeometry rather than createMultiPolygon, because either half degenerates to a line or
+                // a point exactly as one box does, and a shape on the equator makes both of them lines
+                var halves = new java.util.ArrayList();
+                halves.add(Box(latLo, latHi, lngLo, 180));
+                halves.add(Box(latLo, latHi, -180, lngHi));
+
+                return Factory.buildGeometry(halves);
+            }
+
+            return Box(latLo, latHi, lngLo, lngHi);
+        }
+
+        /// <summary>
+        /// Writes one box, degenerating to a line or a point as JTS does.
+        /// </summary>
+        /// <param name="latLo"></param>
+        /// <param name="latHi"></param>
+        /// <param name="lngLo"></param>
+        /// <param name="lngHi"></param>
+        /// <returns></returns>
+        static Geometry Box(double latLo, double latHi, double lngLo, double lngHi)
+        {
+            // a tolerance rather than equality: a coordinate reaches the rectangle as a unit vector and
+            // comes back a few bits shy, so a shape that lies exactly on a parallel has a latitude interval
+            // that is degenerate in fact and not in the last digit. This is a thousandth of a millimetre.
+            const double flat = 1e-11;
+
+            if (System.Math.Abs(latHi - latLo) < flat && System.Math.Abs(lngHi - lngLo) < flat)
+                return Factory.createPoint(new org.locationtech.jts.geom.Coordinate(lngLo, latLo));
+
+            if (System.Math.Abs(latHi - latLo) < flat || System.Math.Abs(lngHi - lngLo) < flat)
+                return Factory.createLineString([
+                    new org.locationtech.jts.geom.Coordinate(lngLo, latLo),
+                    new org.locationtech.jts.geom.Coordinate(lngHi, latHi)]);
+
+            return Factory.createPolygon([
+                new org.locationtech.jts.geom.Coordinate(lngLo, latLo),
+                new org.locationtech.jts.geom.Coordinate(lngHi, latLo),
+                new org.locationtech.jts.geom.Coordinate(lngHi, latHi),
+                new org.locationtech.jts.geom.Coordinate(lngLo, latHi),
+                new org.locationtech.jts.geom.Coordinate(lngLo, latLo)]);
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_CLOSESTCOORDINATE</c>. Returns the coordinate or coordinates of the geography nearest
         /// the given point.
         /// </summary>

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -282,6 +282,15 @@ namespace Apache.Calcite.Geography.Runtime
         S2Polygon? polygon;
 
         /// <summary>
+        /// Gets the areal part of the geography, or <see langword="null"/> where it has none.
+        /// </summary>
+        /// <remarks>
+        /// Exposed for the overlay operations, which are S2's own — <c>initToIntersection</c> and its
+        /// neighbours answer on the sphere what JTS answers on a plane.
+        /// </remarks>
+        public S2Polygon? Polygon => polygon;
+
+        /// <summary>
         /// Initializes a new instance.
         /// </summary>
         S2Geographies()

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -476,7 +476,7 @@ namespace Apache.Calcite.Geography.Runtime
         /// far apart they are; picking the pair on a sphere and measuring it on the ellipsoid is second order
         /// in how far that pair is from the true one, where measuring on the sphere is first order.
         /// </remarks>
-        static (S2Point A, S2Point B)? ClosestPair(S2Geographies a, S2Geographies b)
+        public static (S2Point A, S2Point B)? ClosestPair(S2Geographies a, S2Geographies b)
         {
             var min = double.NaN;
             (S2Point A, S2Point B)? best = null;

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -980,7 +980,16 @@ namespace Apache.Calcite.Geography.Runtime
         /// The bounding box of the geography.
         /// </summary>
         /// <returns></returns>
-        S2LatLngRect Bound()
+        /// <summary>
+        /// Returns the smallest latitude-longitude rectangle containing the geography.
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>
+        /// An <c>S2LatLngRect</c> knows the longitude interval may wrap, which is the whole reason
+        /// <c>ST_GEOG_ENVELOPE</c> is not <c>ST_ENVELOPE</c>: taking a minimum and a maximum of longitudes
+        /// answers most of the globe for a shape that straddles the antimeridian.
+        /// </remarks>
+        public S2LatLngRect Bound()
         {
             var bound = S2LatLngRect.empty();
 

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -47,6 +47,28 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// The mean radius of the WGS84 ellipsoid, <c>(2a + b) / 3</c>, in metres.
+        /// </summary>
+        /// <remarks>
+        /// The one place a single radius is defensible: turning a distance into an angle so that a bounding
+        /// rectangle can be grown by it. A bound is an over-approximation already — it is a rectangle around
+        /// a shape that is not one — so a fraction of a percent in how far it grows changes nothing it
+        /// promises. Nothing else here uses a radius, and a measurement never does.
+        /// </remarks>
+        public const double MeanRadiusMeters = 6371008.7714;
+
+        /// <summary>
+        /// Returns the angle a distance in metres subtends at the Earth's centre.
+        /// </summary>
+        /// <param name="metres"></param>
+        /// <returns></returns>
+        /// <inheritdoc cref="MeanRadiusMeters" />
+        public static S1Angle AngleFor(double metres)
+        {
+            return S1Angle.radians(metres / MeanRadiusMeters);
+        }
+
+        /// <summary>
         /// Returns the geodesic distance between two coordinates in metres.
         /// </summary>
         /// <param name="a"></param>

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -84,6 +84,44 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// Returns the points that divide the geodesic between two coordinates into segments no longer than
+        /// the given distance, excluding the two ends.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="longest">The greatest segment length in metres.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Walked with <c>Direct</c> from the first end along the azimuth <c>Inverse</c> gives, so the points
+        /// lie on the true geodesic rather than on a great circle or on a straight line in degrees. The three
+        /// differ: between two points on a parallel away from the equator, a straight line in degrees stays on
+        /// the parallel and a geodesic bows poleward, and the whole reason to densify is usually to hand a
+        /// planar consumer something that follows the first.
+        /// </remarks>
+        public static List<org.locationtech.jts.geom.Coordinate> Divide(
+            org.locationtech.jts.geom.Coordinate a,
+            org.locationtech.jts.geom.Coordinate b,
+            double longest)
+        {
+            var found = new List<org.locationtech.jts.geom.Coordinate>();
+            var line = Geodesic.WGS84.Inverse(a.getY(), a.getX(), b.getY(), b.getX());
+
+            if (longest <= 0 || line.s12 <= longest)
+                return found;
+
+            var segments = (int)java.lang.Math.ceil(line.s12 / longest);
+
+            for (var i = 1; i < segments; i++)
+            {
+                var step = Geodesic.WGS84.Direct(a.getY(), a.getX(), line.azi1, line.s12 * i / segments);
+
+                found.Add(new org.locationtech.jts.geom.Coordinate(step.lon2, step.lat2));
+            }
+
+            return found;
+        }
+
+        /// <summary>
         /// Returns the total geodesic length of the given edges in metres.
         /// </summary>
         /// <param name="edges"></param>

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -47,6 +47,21 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// Returns the geodesic distance between two coordinates in metres.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A JTS coordinate carries longitude in x and latitude in y, which is the order WKT writes and the
+        /// reverse of the order a geodesic library takes.
+        /// </remarks>
+        public static double Distance(org.locationtech.jts.geom.Coordinate a, org.locationtech.jts.geom.Coordinate b)
+        {
+            return Geodesic.WGS84.Inverse(a.getY(), a.getX(), b.getY(), b.getX()).s12;
+        }
+
+        /// <summary>
         /// Returns the total geodesic length of the given edges in metres.
         /// </summary>
         /// <param name="edges"></param>

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,34 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_INTERSECTION(GEOGRAPHY, GEOGRAPHY)</c>. Returns the area common to two geographies.
+        /// </summary>
+        public static readonly SqlFunction StGeogIntersection =
+            Function("ST_GEOG_INTERSECTION", nameof(GeographyFunctions.Intersection), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_DIFFERENCE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the part of the first geography that is not in the second.
+        /// </summary>
+        public static readonly SqlFunction StGeogDifference =
+            Function("ST_GEOG_DIFFERENCE", nameof(GeographyFunctions.Difference), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_SYMDIFFERENCE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the parts of two geographies that are in one and not the other.
+        /// </summary>
+        public static readonly SqlFunction StGeogSymDifference =
+            Function("ST_GEOG_SYMDIFFERENCE", nameof(GeographyFunctions.SymDifference), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_UNARYUNION(GEOGRAPHY)</c>. Returns the geography with its overlapping parts merged.
+        /// </summary>
+        public static readonly SqlFunction StGeogUnaryUnion =
+            Function("ST_GEOG_UNARYUNION", nameof(GeographyFunctions.UnaryUnion), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
         /// <c>ST_GEOG_DENSIFY(GEOGRAPHY, DOUBLE)</c>. Returns the geography with vertices inserted along its geodesics so that no edge is longer than the given distance in metres.
         /// </summary>
         public static readonly SqlFunction StGeogDensify =
@@ -1069,6 +1097,10 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogIntersection,
+                StGeogDifference,
+                StGeogSymDifference,
+                StGeogUnaryUnion,
                 StGeogDensify,
                 StGeogProjectPoint,
                 StGeogEnvelope,

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,34 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_CLOSESTCOORDINATE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the coordinate or coordinates of the geography nearest the given point.
+        /// </summary>
+        public static readonly SqlFunction StGeogClosestCoordinate =
+            Function("ST_GEOG_CLOSESTCOORDINATE", nameof(GeographyFunctions.ClosestCoordinate), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["point", "geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_FURTHESTCOORDINATE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the coordinate or coordinates of the geography furthest from the given point.
+        /// </summary>
+        public static readonly SqlFunction StGeogFurthestCoordinate =
+            Function("ST_GEOG_FURTHESTCOORDINATE", nameof(GeographyFunctions.FurthestCoordinate), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["point", "geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_CLOSESTPOINT(GEOGRAPHY, GEOGRAPHY)</c>. Returns the point of the first geography nearest the second.
+        /// </summary>
+        public static readonly SqlFunction StGeogClosestPoint =
+            Function("ST_GEOG_CLOSESTPOINT", nameof(GeographyFunctions.ClosestPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["geog1", "geog2"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_LONGESTLINE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the line between the two coordinates, one from each geography, that are furthest apart.
+        /// </summary>
+        public static readonly SqlFunction StGeogLongestLine =
+            Function("ST_GEOG_LONGESTLINE", nameof(GeographyFunctions.LongestLine), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["geog1", "geog2"]);
+
+        /// <summary>
         /// <c>ST_GEOG_MAXDISTANCE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the greatest distance between a coordinate of one geography and a coordinate of the other, in metres.
         /// </summary>
         public static readonly SqlFunction StGeogMaxDistance =
@@ -1006,6 +1034,10 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogClosestCoordinate,
+                StGeogFurthestCoordinate,
+                StGeogClosestPoint,
+                StGeogLongestLine,
                 StGeogX,
                 StGeogY,
                 StGeogZ,

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,20 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_DENSIFY(GEOGRAPHY, DOUBLE)</c>. Returns the geography with vertices inserted along its geodesics so that no edge is longer than the given distance in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogDensify =
+            Function("ST_GEOG_DENSIFY", nameof(GeographyFunctions.Densify), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Fractional], ["geog", "tolerance"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_PROJECTPOINT(GEOGRAPHY, GEOGRAPHY)</c>. Returns the point of the line nearest the given point.
+        /// </summary>
+        public static readonly SqlFunction StGeogProjectPoint =
+            Function("ST_GEOG_PROJECTPOINT", nameof(GeographyFunctions.ProjectPoint), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Geometry], ["point", "line"]);
+
+        /// <summary>
         /// <c>ST_GEOG_ENVELOPE(GEOGRAPHY)</c>. Returns the smallest latitude-longitude rectangle containing the geography.
         /// </summary>
         public static readonly SqlFunction StGeogEnvelope =
@@ -1055,6 +1069,8 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogDensify,
+                StGeogProjectPoint,
                 StGeogEnvelope,
                 StGeogExtent,
                 StGeogExpand,

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,27 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_ENVELOPE(GEOGRAPHY)</c>. Returns the smallest latitude-longitude rectangle containing the geography.
+        /// </summary>
+        public static readonly SqlFunction StGeogEnvelope =
+            Function("ST_GEOG_ENVELOPE", nameof(GeographyFunctions.Envelope), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_EXTENT(GEOGRAPHY)</c>. Returns the smallest latitude-longitude rectangle containing the geography.
+        /// </summary>
+        public static readonly SqlFunction StGeogExtent =
+            Function("ST_GEOG_EXTENT", nameof(GeographyFunctions.Extent), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_EXPAND(GEOGRAPHY, DOUBLE)</c>. Returns the geography's rectangle grown by a distance in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogExpand =
+            Function("ST_GEOG_EXPAND", nameof(GeographyFunctions.Expand), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Fractional], ["geog", "distance"]);
+
+        /// <summary>
         /// <c>ST_GEOG_CLOSESTCOORDINATE(GEOGRAPHY, GEOGRAPHY)</c>. Returns the coordinate or coordinates of the geography nearest the given point.
         /// </summary>
         public static readonly SqlFunction StGeogClosestCoordinate =
@@ -1034,6 +1055,9 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogEnvelope,
+                StGeogExtent,
+                StGeogExpand,
                 StGeogClosestCoordinate,
                 StGeogFurthestCoordinate,
                 StGeogClosestPoint,


### PR DESCRIPTION
`ST_GEOG_CLOSESTCOORDINATE`, `ST_GEOG_FURTHESTCOORDINATE`, `ST_GEOG_CLOSESTPOINT` and `ST_GEOG_LONGESTLINE`.

#90 named this family as measurements in disguise: each answers a point rather than a number, and each chooses that point by how far away it is — so each is wrong in the same way a distance is wrong when the ranking is planar. These rank on the ellipsoid.

## Why it is not cosmetic

A degree of longitude at the equator is 111319.49 m and a degree of latitude is 110574.39 m, so two candidates a planar reading calls equidistant are 745 metres apart in fact:

```sql
ST_CLOSESTCOORDINATE     (POINT(0 0), MULTIPOINT((1 0), (0 1)))  -->  MULTIPOINT ((1 0), (0 1))
ST_GEOG_CLOSESTCOORDINATE(POINT(0 0), MULTIPOINT((1 0), (0 1)))  -->  POINT (0 1)
```

Calcite ties because on a plane they are the same distance. There is no tie on the Earth. Two different answers, not two roundings of one — `ShouldBreakATieThatOnlyExistsOnAPlane` asserts both sides.

## How

Three of the four work on JTS coordinates directly. What they choose among are the geography's own coordinates, so round-tripping through S2 would lose the caller's — only the ranking needed to change, and `Wgs84.Distance` gained a `Coordinate` overload for it.

`ST_GEOG_CLOSESTPOINT` is the exception: its answer may fall part way along an edge, so S2's closest-pair machinery finds it. The edge is a geodesic, which puts the answer somewhere a planar reading does not — `ShouldAnswerAPointOnAnEdge` pins it, and the assertion is that the closest point of `LINESTRING(-1 1, 1 1)` to the origin lies **north of both its ends**, because a geodesic between two points on a parallel bows poleward.

Ties still answer a multi-point and a null argument still answers null, both as Calcite does. Every answer is stamped 4326 like every other constructor here, and all four run as operators — which is what says the declarations bind to these bodies.

## And the bounding rectangle

`ST_GEOG_ENVELOPE`, `ST_GEOG_EXTENT`, `ST_GEOG_EXPAND` — a second commit, and the antimeridian is why they are not aliases for Calcite's.

A planar envelope is the least and greatest of the coordinates. `LINESTRING(179 0, -179 0)` is two degrees across and gets a rectangle **358 degrees wide**; every index and pre-filter built on it then reads most of the globe. An `S2LatLngRect` knows a longitude interval may wrap, so this answers the two degrees that are there — as the two halves either side of the line, there being no way to write a wrapped box as one ring in longitude and latitude.

`ST_GEOG_EXPAND` grows by **metres**. Growing a box by a degree moves its northern edge further than its eastern one everywhere off the equator, by a factor reaching two at 60°N, so the planar function has no fixed meaning on the Earth.

Two things the tests found rather than assumed: a coordinate reaches the rectangle as a unit vector and comes back a few bits shy, so `POINT(1 2)` bounds to `0.9999999999999999` and a shape lying on a parallel is degenerate in fact but not in the last digit — degeneracy is a tolerance, and the tests say approximately and say why. And either half of a wrapped rectangle degenerates exactly as one box does, so the halves go through `buildGeometry`; a shape on the equator makes both of them lines.

## And points on a geodesic

`ST_GEOG_DENSIFY`, `ST_GEOG_PROJECTPOINT` — a third commit.

Densifying is done to hand a planar consumer something that follows the true path: a map, an index, a store that only draws straight lines. Calcite's inserts its vertices along a straight line in degrees — exactly the path that consumer would have drawn anyway — so the operation buys nothing. These are on the geodesic, walked with GeographicLib's `Direct` along the azimuth `Inverse` gives, so they follow the ellipsoid's own path rather than a great circle.

`ShouldFollowTheGeodesicRatherThanTheParallel` asserts both sides: over `LINESTRING(0 60, 10 60)`, Calcite's inserted vertices sit on latitude 60 to nine decimal places, and ours do not. Across ten degrees of longitude at 60°N that bow is about seven kilometres.

The tolerance is metres rather than degrees, like every other distance here. Every type goes through `GeometryTransformer` rather than a case for each of the seven, so a polygon's rings densify with everything else.

`ST_GEOG_PROJECTPOINT` is the closest point on a line — the pair machinery from #90 already finds it — and it declines anything of more than one dimension exactly as Calcite's does, a projection onto an area being undefined.

## And the overlay set

`ST_GEOG_INTERSECTION`, `ST_GEOG_DIFFERENCE`, `ST_GEOG_SYMDIFFERENCE`, `ST_GEOG_UNARYUNION` — a fourth commit, and it takes the largest item out of #86's step five.

That issue deferred these reasoning that a geodesic overlay is a different algorithm from a planar one rather than the same one in other units. **The reasoning is right and the algorithm is S2's** — `initToIntersection` and its neighbours answer on the sphere what JTS answers on a plane. What was left to write was converting the answer back into rings: S2 records nesting as a loop's depth, winds a hole the other way from its shell, and does not repeat a ring's first vertex.

**The demonstration is an overlap that exists on the Earth and not on a map.** A box running 0→60° of longitude along the 60th parallel has a northern edge that is a geodesic, and a geodesic between two points on a parallel bows poleward — here by more than a degree at the middle. A sliver between 61°N and 62°N is therefore *outside* the box as a planar reading draws it and *inside* the box as it is. Calcite answers an empty intersection; this answers a real one. The test asserts both.

The same effect shows up small in the ordinary case, which is why `ShouldIntersectTwoBoxes` asserts the shared region of two unit boxes reaches *past* latitude 2 rather than stopping at it.

These are areal operations and this answers them for areas, declining anything else with null. Calcite's take any pair, JTS overlaying whatever it is handed; following it there would mean answering a line clipped by a polygon on the plane — two models in one expression.

Two tolerances in the tests are measurements rather than choices: S2's overlay snaps vertices to a level of the cell hierarchy, so the pieces of a partition add up to about a part in a million rather than to the last bit. Both area identities say so and say why.

## And the hull and simplification

`ST_GEOG_CONVEXHULL`, `ST_GEOG_SIMPLIFY` — a fifth commit, and the rest of #86's step five less buffer, triangulation and grids.

Same story as the overlay set: that issue deferred the group reasoning each is a different algorithm geodesically, which is true — and `S2ConvexHullQuery` and `S2Polygon.initToSimplified` **are** those algorithms, already written.

A convex hull on the sphere is a different region because its edges are geodesics. Over four corners of a box reaching 60° of longitude along the 60th parallel, the northern edge bows more than a degree poleward — so `POINT(30 61)` is inside the hull on the Earth and outside it on a map. `ShouldHullFurtherNorthThanAPlanarHullDoes` asserts both answers.

Only the vertices go to the query, which is enough: every edge of the input is a geodesic between two of them, and a convex region containing the ends of a geodesic contains the geodesic.

**There is deliberately no `ST_GEOG_SIMPLIFYPRESERVETOPOLOGY`.** Calcite has both because JTS has both, the second promising the result stays valid and stays disjoint from what it was disjoint from. S2's simplification makes no such promise, and a function claiming it without keeping it would be worse than one that is missing.

## And the centroid

`ST_GEOG_CENTROID` — a sixth commit, following the same dimensional rule Calcite's does (an area outranks a line, a line outranks a point) computed on the sphere.

The antimeridian separates the two readings, and not by a little. A planar centroid averages longitudes, so the centre of a square straddling longitude 180 comes back near **longitude zero — half a world from every one of its coordinates**. This sums directions from the Earth's centre and answers a point in the square.

An area uses S2's own centroid, which sums each spherical triangle of a loop weighted by its area. A line is weighted by edge length; a point set is the mean direction.

**The vanishing-centre test found a real defect rather than confirming one.** Two antipodal points cancel exactly in arithmetic and leave about `1e-16` in floating point, so my first version tested the sum against zero, never fired, and would have answered whichever way the rounding error pointed. It tests against the total weight that went into the sum — a question about the ratio, since a very small polygon has a very small centroid sum and a perfectly good centre.

**No buffer, and not for want of looking.** S2 2.0.0 for Java has no buffer operation, so unlike the overlay set and the hull, that one really is an algorithm to write rather than a call to make.

## What is left of Calcite's spatial surface

53 names unmirrored before this, 37 after:

- the four predicates withdrawn earlier rather than ship known-divergent behaviour — `ST_CROSSES`, `ST_TOUCHES`, `ST_OVERLAPS`, `ST_CONTAINSPROPERLY`
- `ST_SETSRID` and `ST_TRANSFORM`, which a single reference system makes meaningless
- what is left of #86's step five: **buffer, triangulation, grids**. The overlay set, the hull, simplification and the centroid were each an S2 call rather than an algorithm. Buffer is not — S2 2.0.0 for Java has no buffer operation, so it is the one that needs writing

## Stacking

Branches off the WGS84 work in #91, which it needs — the ranking is only right if the distance is. Merge that first, or this carries both commits.

153 tests, green on net8.0 and net10.0.





