### PR TITLE
Hold the root schema on the data source, and share it by connection string

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ driver this one is modelled on*, has the reading. Not to be confused with
   **they pass, and nothing in the suite is skipped.** The claim that they are red outlived the fix by four
   commits in this file.
 
+  **1.43's model loads no class by name unless told to.** From the August 2026 snapshots `ClassNameFilter`
+  carries an allowlist beside the denylist, read from the `calcite.model.classes.allowed` system property,
+  and an empty allowlist — the default — rejects every `factory`, function class and driver a model names,
+  Calcite's own `AbstractSchema$Factory` included. `Apache.Calcite.Data.Tests` sets the property in a module
+  initializer, before `CalciteSystemProperty` reads it; a .NET class needs both its CLR name and its IKVM
+  `cli.` name allowed, because Calcite writes `getClass().getName()` into the model it synthesises for
+  `SchemaFactory`. The 1.42 the provider ships has the denylist only, and `D:\calcite` has not caught up.
+
   **`AsofJoin` is neither** — `rel.core.AsofJoin`, `EnumerableAsofJoin` and `ENUMERABLE_ASOFJOIN_RULE` are
   all in 1.41, and a claim that it was 1.42 stood in this file for a while on the strength of the wrong
   class name. `rel.core.Asof` is a different class and is 1.43, not 1.42 as this file said.

--- a/TODO.md
+++ b/TODO.md
@@ -96,6 +96,90 @@ opens a connection to read the server version, and `AdoConvention.Dialect` is re
 that matches while planning. What is left is caching *across* metadata instances, which only matters
 when several schemas point at one database. Lowest priority; measure before assuming it matters.
 
+## A plan cache on the data source's root — *medium, and measured*
+
+Every statement pays parse, validate, Volcano, translation and `LambdaExpression.Compile` on every
+execution; parameters are bound at execution through the data context, so the same text with `?`
+placeholders is the same plan, and the EF Core provider emits exactly that shape repeatedly. The root a
+`CalciteDataSource` holds is where a cache of those plans belongs: a plan references the root's tables, the
+root's lifetime bounds the plans' validity, and the root's write lock is the one place the root changes.
+
+### What was measured, 2026-09-07
+
+Through `ClrPrepareImpl.PrepareSql` over the `ClrPrepareFixture` schema (six-row `SALES`, three-row
+`NUMS`), Debug build, medians of 15 runs after 3 warm-ups, milliseconds. The plan column is start to
+`Hook.PLAN_BEFORE_IMPLEMENTATION`; compile is `Compile()` alone, instrumented for the run and reverted.
+
+| statement | convention | parse+validate+plan | translate | compile | total prepare | execute |
+|---|---|---|---|---|---|---|
+| filter | sync | 19.2 | 1.4 | 0.6 | 22.8 | 0.35 |
+| aggregate | sync | 40.8 | 1.2 | 2.6 | 45.3 | 1.93 |
+| self join | sync | 46.5 | 1.2 | 2.2 | 51.4 | 1.56 |
+| window | sync | 38.1 | 1.6 | 2.2 | 42.2 | 1.84 |
+| sort limit | sync | 42.5 | 1.1 | 1.2 | 45.2 | 2.11 |
+| union | sync | 42.1 | 0.3 | 0.6 | 43.2 | 0.24 |
+| exists | sync | 89.9 | 0.4 | 0.9 | 91.8 | 0.34 |
+| parameter | sync | 34.4 | 2.3 | 1.0 | 36.5 | 0.82 |
+| filter | async | 14.6 | 1.6 | 0.7 | 17.6 | 0.56 |
+| aggregate | async | 26.1 | 0.9 | 2.4 | 29.6 | 1.86 |
+| self join | async | 34.6 | 0.9 | 2.0 | 37.9 | 1.55 |
+| window | async | 30.4 | 1.3 | 1.9 | 33.6 | 1.88 |
+| sort limit | async | 38.5 | 0.7 | 1.0 | 40.4 | 1.91 |
+| union | async | 42.5 | 0.3 | 0.6 | 43.7 | 0.22 |
+| exists | async | 92.2 | 0.4 | 0.8 | 93.5 | 0.32 |
+| parameter | async | 30.8 | 2.6 | 1.2 | 36.3 | 1.14 |
+
+**Planning is the cost, not compilation.** Translation and compilation together are 1 to 4 ms of a 18 to
+94 ms prepare. So Calcite's own shape — `EnumerableInterpretable`'s static cache of compiled `Bindable`s
+keyed by the generated source, `calcite.bindable.cache.maxSize` — would save a tenth of it here, and a
+cache that skips planning is the one worth having. Its key is therefore the SQL text and everything that
+changes what the text means, not a digest of a plan already made.
+
+**A compiled plan is re-bindable.** The same signature, bound a second time and then from 8 tasks 25 times
+each with a fresh `StatementDataContext` per bind, answered the same rows as its first bind for every
+statement above in both conventions. This is the property a prepared statement relies on in Calcite —
+`Bindable.bind` is called per execution — and the translation keeps it: an anonymous class's fields become
+variables of the block that builds the lambdas, and that block runs per bind.
+
+**A compiled plan does not reach back to the type factory it was planned with.** Bound with a data context
+carrying a fresh `JavaTypeFactoryImpl`, every statement above answered the same rows in both conventions.
+The emitted record types are baked into the delegate, and nothing read at execution asks the factory for
+one. So a cache on the root can hand a plan compiled under one connection's factory to another connection,
+which is what a cache on the root means, the factory being per connection.
+
+### The shape, when it is built
+
+- **Where:** `CalciteDataSourceRoot`. Retiring the root retires its plans.
+- **Key:** the SQL text; the engine configuration as a canonical string — lex, casing, conformance,
+  function library, type system, null collation all change what a statement means; the default schema
+  path; the convention. That is `CalciteConnectionStringBuilder.DataSourceKey` plus the two things it
+  leaves out, so the root owns the cache and the session contributes its part of the key.
+- **Invalidation, three kinds.** Schema change: DDL runs under the root's write lock, the one place the
+  root changes, so a version bumped there drops the cache. Learnt facts: an adapter's statistics expire —
+  calcite-cosmos on a five-minute lifetime — and a plan chosen while a table was small stays chosen after
+  it grows; Calcite has no answer, SQL Server recompiles on a statistics change, and a time-to-live on
+  entries is the cheap one. Size: bounded by count with LRU eviction, a keyword in the string with a
+  default, zero to turn it off.
+- **Semantics:** a cached plan is an implicit prepared statement, and Avatica's prepared statement already
+  defines them — it holds the signature's snapshot until closed, so a cached plan executes against the
+  snapshot it was planned on. `CalciteCommand.Prepare()`, a no-op today, becomes "plan it now and keep it".
+- **Hooks bypass it.** A connection or command with hooks registered plans every time; a hook exists to
+  watch planning happen.
+- **Precedents:** SQL Server's server-side plan cache — automatic, keyed by text plus the session's `SET`
+  options, invalidated by schema and statistics change — is the shape, since the engine is in-process and
+  we are the server. Npgsql's auto-prepare is per connector and off by default; per connector is the wrong
+  unit here, a plan not belonging to a connection.
+
+### What is still unproven
+
+- The numbers are one machine, a Debug build, six-row tables and a warm process. The split is what
+  matters and it is not close; the absolute figures are not a benchmark. A cold first statement costs far
+  more than any row above and is not what a cache saves.
+- Re-bindability was measured over eight statement shapes. `ClrEnumerableDifferentialTests` has far more,
+  and the cache's own test should be that list bound twice, since a state a bind leaves behind would show
+  as a differential failure on the second bind and nowhere else.
+- Nothing above measured a cache hit's cost — key canonicalisation and lookup — against the 15 ms floor.
+
 ## Test suites not yet written
 
 Sized against measured coverage: `Apache.Calcite.Data` 69.9%, `Apache.Calcite.Adapter.AdoNet` ~60%.

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Apache.Calcite.Data;
 
@@ -39,19 +39,15 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         /// </summary>
         CalciteConnection OpenConnection(bool synchronous = false)
         {
-            var c = new CalciteConnection(new CalciteConnectionStringBuilder
+            return new CalciteDataSourceBuilder(new CalciteConnectionStringBuilder
             {
                 Lex = "JAVA",
                 CaseSensitive = false,
                 Synchronous = synchronous ? true : null,
-            }.ToString());
-
-            c.Open();
-
-            var root = c.RootSchema;
-            root.add("ADO", AdoSchema.Create(root, "ADO", _sqlite.DataSource, null, null));
-
-            return c;
+            }.ToString())
+                .ConfigureRootSchema(root => root.add("ADO", AdoSchema.Create(root, "ADO", _sqlite.DataSource, null, null)))
+                .Build()
+                .OpenConnection();
         }
 
         [TestCleanup]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoViewMacroTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoViewMacroTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 using Apache.Calcite.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,25 +32,30 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         SqliteFixture _sqlite = null!;
-        CalciteConnection _connection = null!;
 
         [TestInitialize]
         public void Setup()
         {
             _sqlite = new SqliteFixture();
-
-            _connection = new CalciteConnection(new CalciteConnectionStringBuilder());
-            _connection.Open();
-
-            // the adapter, as one schema of the connection's root schema
-            _connection.RootSchema.add("ADO", AdoSchema.Create(_connection.RootSchema, "ADO", _sqlite.DataSource, null, null));
         }
 
         [TestCleanup]
         public void Cleanup()
         {
-            _connection?.Dispose();
             _sqlite?.Dispose();
+        }
+
+        /// <summary>
+        /// Opens a connection on a data source holding the adapter as one schema of its root, with
+        /// <paramref name="configure"/> run over the root after it.
+        /// </summary>
+        CalciteConnection Open(Action<SchemaPlus> configure)
+        {
+            return new CalciteDataSourceBuilder()
+                .ConfigureRootSchema(root => root.add("ADO", AdoSchema.Create(root, "ADO", _sqlite.DataSource, null, null)))
+                .ConfigureRootSchema(configure)
+                .Build()
+                .OpenConnection();
         }
 
         /// <summary>
@@ -59,18 +64,18 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [TestMethod]
         public void View_over_the_adapter_should_behave_like_a_table()
         {
-            _connection.RootSchema.add("STAFF", ViewTable.viewMacro(
-                _connection.RootSchema,
+            using var connection = Open(root => root.add("STAFF", ViewTable.viewMacro(
+                root,
                 """
                 SELECT E.EMPNO AS EMPNO, E.NAME AS NAME, D.DNAME AS DNAME
                 FROM ADO.EMPS AS E
                 JOIN ADO.DEPTS AS D ON E.DEPTNO = D.DEPTNO
                 """,
                 null,
-                org.apache.calcite.jdbc.CalciteSchema.from(_connection.RootSchema).path("STAFF"),
-                null));
+                org.apache.calcite.jdbc.CalciteSchema.from(root).path("STAFF"),
+                null)));
 
-            using var cmd = _connection.CreateCommand();
+            using var cmd = connection.CreateCommand();
             cmd.CommandText = "SELECT NAME, DNAME FROM STAFF WHERE DNAME = 'Sales' ORDER BY NAME";
 
             using var r = cmd.ExecuteReader();
@@ -96,20 +101,23 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [TestMethod]
         public void View_should_bridge_the_adapter_and_a_local_schema()
         {
-            _connection.RootSchema.add("EXTRA", new GradeSchema());
+            using var connection = Open(root =>
+            {
+                root.add("EXTRA", new GradeSchema());
 
-            _connection.RootSchema.add("STAFF", ViewTable.viewMacro(
-                _connection.RootSchema,
-                """
-                SELECT E.EMPNO AS EMPNO, E.NAME AS NAME, D.DNAME AS DNAME
-                FROM ADO.EMPS AS E
-                JOIN ADO.DEPTS AS D ON E.DEPTNO = D.DEPTNO
-                """,
-                null,
-                org.apache.calcite.jdbc.CalciteSchema.from(_connection.RootSchema).path("STAFF"),
-                null));
+                root.add("STAFF", ViewTable.viewMacro(
+                    root,
+                    """
+                    SELECT E.EMPNO AS EMPNO, E.NAME AS NAME, D.DNAME AS DNAME
+                    FROM ADO.EMPS AS E
+                    JOIN ADO.DEPTS AS D ON E.DEPTNO = D.DEPTNO
+                    """,
+                    null,
+                    org.apache.calcite.jdbc.CalciteSchema.from(root).path("STAFF"),
+                    null));
+            });
 
-            using var cmd = _connection.CreateCommand();
+            using var cmd = connection.CreateCommand();
             cmd.CommandText =
                 """
                 SELECT S.DNAME, COUNT(*) AS N

--- a/src/Apache.Calcite.Data.Tests/CalciteAnyValueTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteAnyValueTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -30,14 +30,16 @@ namespace Apache.Calcite.Data.Tests
     {
 
         /// <summary>
-        /// Opens a connection with <see cref="AnyTable"/> registered as <c>ANYT</c>.
+        /// Opens a connection with <see cref="AnyTable"/> registered as <c>ANYT</c> and
+        /// <see cref="AnyClassFunction"/> as <c>ANYCLASS</c>.
         /// </summary>
         static CalciteConnection Open()
         {
-            var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
-            c.Open();
-            c.RootSchema.add("ANYT", new AnyTable());
-            return c;
+            return new CalciteDataSourceBuilder(TestModels.InlineEmptyModelConnectionString)
+                .ConfigureRootSchema(root => root.add("ANYT", new AnyTable()))
+                .ConfigureRootSchema(root => root.add("ANYCLASS", ScalarFunctionImpl.create((java.lang.Class)typeof(AnyClassFunction), "eval")))
+                .Build()
+                .OpenConnection();
         }
 
         /// <summary>
@@ -538,7 +540,6 @@ namespace Apache.Calcite.Data.Tests
         public void A_dictionary_parameter_should_arrive_as_a_java_map()
         {
             using var c = Open();
-            c.RootSchema.add("ANYCLASS", ScalarFunctionImpl.create((java.lang.Class)typeof(AnyClassFunction), "eval"));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT ANYCLASS(?)";
@@ -551,7 +552,6 @@ namespace Apache.Calcite.Data.Tests
         public void A_sequence_parameter_should_arrive_as_a_java_list()
         {
             using var c = Open();
-            c.RootSchema.add("ANYCLASS", ScalarFunctionImpl.create((java.lang.Class)typeof(AnyClassFunction), "eval"));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT ANYCLASS(?)";

--- a/src/Apache.Calcite.Data.Tests/CalciteConnectionStringBuilderTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteConnectionStringBuilderTests.cs
@@ -123,6 +123,24 @@ namespace Apache.Calcite.Data.Tests
             Assert.NotEqual(a.DataSourceKey, c.DataSourceKey);
         }
 
+        [Fact]
+        public void Pool_lifetimes_should_round_trip_and_default_to_unset()
+        {
+            var b = new CalciteConnectionStringBuilder();
+            Assert.Null(b.ConnectionIdleLifetime);
+            Assert.Null(b.ConnectionPruningInterval);
+
+            b.ConnectionIdleLifetime = 60;
+            b.ConnectionPruningInterval = 5;
+            var rebuilt = new CalciteConnectionStringBuilder(b.ConnectionString);
+            Assert.Equal(60, rebuilt.ConnectionIdleLifetime);
+            Assert.Equal(5, rebuilt.ConnectionPruningInterval);
+
+            var spelled = new CalciteConnectionStringBuilder("Connection Idle Lifetime=60;Connection Pruning Interval=5");
+            Assert.Equal(60, spelled.ConnectionIdleLifetime);
+            Assert.Equal(5, spelled.ConnectionPruningInterval);
+        }
+
     }
 
 }

--- a/src/Apache.Calcite.Data.Tests/CalciteConnectionStringBuilderTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteConnectionStringBuilderTests.cs
@@ -1,4 +1,4 @@
-using System.Data.Common;
+﻿using System.Data.Common;
 
 
 using Xunit;
@@ -92,6 +92,35 @@ namespace Apache.Calcite.Data.Tests
         {
             DbConnectionStringBuilder b = new CalciteConnectionStringBuilder();
             Assert.NotNull(b);
+        }
+
+        [Fact]
+        public void Pooling_should_round_trip_and_default_to_unset()
+        {
+            var b = new CalciteConnectionStringBuilder();
+            Assert.Null(b.Pooling);
+
+            b.Pooling = false;
+            var rebuilt = new CalciteConnectionStringBuilder(b.ConnectionString);
+            Assert.False(rebuilt.Pooling);
+
+            rebuilt.Pooling = null;
+            Assert.False(rebuilt.ContainsKey(CalciteConnectionStringBuilder.PoolingKey));
+        }
+
+        /// <summary>
+        /// The key a data source is looked up by: the same for every spelling of one connection string,
+        /// and without <c>Synchronous</c>, which decides nothing that is built.
+        /// </summary>
+        [Fact]
+        public void DataSourceKey_should_ignore_order_casing_and_the_convention()
+        {
+            var a = new CalciteConnectionStringBuilder("Model=inline:{};Schema=S;Lex=MYSQL");
+            var b = new CalciteConnectionStringBuilder("lex=MYSQL;SCHEMA=S;model=inline:{};Synchronous=true");
+            var c = new CalciteConnectionStringBuilder("Model=inline:{};Schema=T;Lex=MYSQL");
+
+            Assert.Equal(a.DataSourceKey, b.DataSourceKey);
+            Assert.NotEqual(a.DataSourceKey, c.DataSourceKey);
         }
 
     }

--- a/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDataReaderTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Data.Common;
 
@@ -28,6 +28,8 @@ namespace Apache.Calcite.Data.Tests
         {
             Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             Schema = "adhoc",
         };
 

--- a/src/Apache.Calcite.Data.Tests/CalciteDataSourceSharingTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDataSourceSharingTests.cs
@@ -2,7 +2,10 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+
+using org.apache.calcite.runtime;
 
 using org.apache.calcite.schema;
 using org.apache.calcite.schema.impl;
@@ -377,6 +380,132 @@ namespace Apache.Calcite.Data.Tests
 
             Assert.Equal(1, CountingSchemaFactory.Builds[token]);
             Assert.NotNull(c.RootSchema.getSubSchema("adhoc"));
+        }
+
+        [Fact]
+        public void An_evicted_root_should_be_disposed_when_its_last_connection_is()
+        {
+            var cs = ConnectionString(out var token);
+
+            var a = new CalciteConnection(cs);
+            a.Open();
+            CalciteConnection.ClearPool(a);
+
+            var schema = CountingSchemaFactory.Made[token].Single();
+            Assert.False(schema.Disposed);
+            Assert.Equal(2, Convert.ToInt32(Scalar(a, "SELECT 1 + 1")));
+
+            a.Dispose();
+            Assert.True(schema.Disposed);
+        }
+
+        [Fact]
+        public void Clear_should_dispose_the_dropped_root_when_its_last_connection_is()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var dataSource = new CalciteDataSource(cs);
+            var a = dataSource.OpenConnection();
+            dataSource.Clear();
+            using var b = dataSource.OpenConnection();
+
+            var made = CountingSchemaFactory.Made[token].ToArray();
+            Assert.Equal(2, made.Length);
+            Assert.False(made[0].Disposed);
+
+            a.Dispose();
+            Assert.True(made[0].Disposed);
+            Assert.False(made[1].Disposed);
+        }
+
+        /// <summary>
+        /// What bounds the set of data sources the provider keeps: time. One that has gone its idle
+        /// lifetime with no connection open is released, schemas disposed, and the next connection builds
+        /// again.
+        /// </summary>
+        [Fact]
+        public async Task An_idle_data_source_should_be_released_after_its_idle_lifetime()
+        {
+            var cs = ConnectionString(out var token, ";Connection Idle Lifetime=1;Connection Pruning Interval=1");
+
+            using (var a = new CalciteConnection(cs))
+                a.Open();
+
+            var schema = CountingSchemaFactory.Made[token].Single();
+            var deadline = DateTime.UtcNow.AddSeconds(15);
+            while (schema.Disposed == false && DateTime.UtcNow < deadline)
+                await Task.Delay(100);
+
+            Assert.True(schema.Disposed);
+
+            using var b = new CalciteConnection(cs);
+            b.Open();
+            Assert.Equal(2, CountingSchemaFactory.Builds[token]);
+        }
+
+        [Fact]
+        public async Task A_data_source_with_a_connection_open_should_not_be_released()
+        {
+            var cs = ConnectionString(out var token, ";Connection Idle Lifetime=1;Connection Pruning Interval=1");
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+
+            await Task.Delay(3500);
+
+            Assert.False(CountingSchemaFactory.Made[token].Single().Disposed);
+            Assert.Equal(2, Convert.ToInt32(Scalar(a, "SELECT 1 + 1")));
+
+            using var b = new CalciteConnection(cs);
+            b.Open();
+            Assert.Equal(1, CountingSchemaFactory.Builds[token]);
+        }
+
+        [Fact]
+        public void Pooling_settings_should_be_validated()
+        {
+            Assert.Throws<ArgumentException>(() => new CalciteDataSource(TestModels.InlineEmptyModelConnectionString + ";Connection Pruning Interval=0"));
+            Assert.Throws<ArgumentException>(() => new CalciteDataSource(TestModels.InlineEmptyModelConnectionString + ";Connection Idle Lifetime=5;Connection Pruning Interval=10"));
+
+            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString + ";Connection Pruning Interval=0");
+            Assert.Throws<ArgumentException>(() => c.Open());
+        }
+
+        /// <summary>
+        /// Planning holds the root's read lock and DDL wants its write lock, so a DDL statement on one
+        /// connection waits for a statement planning on another. The hook fires inside planning, which is
+        /// how the test holds a plan open.
+        /// </summary>
+        [Fact]
+        public async Task DDL_should_wait_for_a_statement_planning_on_another_connection()
+        {
+            var cs = ConnectionString(out _, Ddl);
+
+            using var inPlan = new ManualResetEventSlim();
+            using var release = new ManualResetEventSlim();
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            a.RegisterHook(Hook.PLAN_BEFORE_IMPLEMENTATION, _ =>
+            {
+                inPlan.Set();
+                release.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            var planning = Task.Run(() => Scalar(a, "SELECT COUNT(*) FROM (VALUES (1), (2)) AS t(x)"));
+            Assert.True(inPlan.Wait(TimeSpan.FromSeconds(30)));
+
+            using var b = new CalciteConnection(cs);
+            b.Open();
+            var ddl = Task.Run(() => NonQuery(b, "CREATE TABLE \"waits_t\" (\"id\" INTEGER NOT NULL)"));
+
+            Assert.False(ddl.Wait(TimeSpan.FromMilliseconds(750)));
+
+            release.Set();
+            await planning;
+            await ddl;
+
+            Assert.Equal(0, Convert.ToInt32(Scalar(b, "SELECT COUNT(*) FROM \"waits_t\"")));
         }
 
     }

--- a/src/Apache.Calcite.Data.Tests/CalciteDataSourceSharingTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDataSourceSharingTests.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+
+using Xunit;
+
+namespace Apache.Calcite.Data.Tests
+{
+
+    /// <summary>
+    /// A schema factory that counts how many times a model has been read, per <c>token</c> operand, and keeps
+    /// every schema it made so a test can see whether it was disposed. Public with a public parameterless
+    /// constructor, which is what a model's <c>factory</c> requires.
+    /// </summary>
+    public sealed class CountingSchemaFactory : SchemaFactory
+    {
+
+        /// <summary>
+        /// Builds per token.
+        /// </summary>
+        public static readonly ConcurrentDictionary<string, int> Builds = new();
+
+        /// <summary>
+        /// Schemas made per token, in the order they were made.
+        /// </summary>
+        public static readonly ConcurrentDictionary<string, ConcurrentQueue<DisposableSchema>> Made = new();
+
+        /// <inheritdoc />
+        public Schema create(SchemaPlus parentSchema, string name, java.util.Map operand)
+        {
+            var token = (string)operand.get("token");
+            Builds.AddOrUpdate(token, 1, (_, n) => n + 1);
+            var schema = new DisposableSchema();
+            Made.GetOrAdd(token, _ => new ConcurrentQueue<DisposableSchema>()).Enqueue(schema);
+            return schema;
+        }
+
+    }
+
+    /// <summary>
+    /// A schema that remembers being disposed, which is how an adapter holding a client would let it go.
+    /// </summary>
+    public sealed class DisposableSchema : AbstractSchema, IDisposable
+    {
+
+        /// <summary>
+        /// Whether <see cref="Dispose"/> has been called.
+        /// </summary>
+        public bool Disposed { get; private set; }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+
+    }
+
+    /// <summary>
+    /// What is shared between two connections: the root schema of one data source, keyed by the connection
+    /// string for the bare path and held by the caller for the built one.
+    /// </summary>
+    public class CalciteDataSourceSharingTests
+    {
+
+        static readonly string Factory = typeof(CountingSchemaFactory).FullName + ", " + typeof(CountingSchemaFactory).Assembly.GetName().Name;
+
+        /// <summary>
+        /// A connection string whose model names <see cref="CountingSchemaFactory"/> with a fresh token, so
+        /// that the count is this test's alone.
+        /// </summary>
+        static string ConnectionString(out string token, string extra = "")
+        {
+            token = Guid.NewGuid().ToString("N");
+            return "Model=inline:{\"version\":\"1.0\",\"defaultSchema\":\"S\",\"schemas\":[{\"name\":\"S\",\"type\":\"custom\",\"factory\":\"" + Factory + "\",\"operand\":{\"token\":\"" + token + "\"}}]};Schema=S" + extra;
+        }
+
+        const string Ddl = ";parserFactory=org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY";
+
+        /// <summary>
+        /// The schema the factory made, as reached through a connection — <c>plus()</c> wraps afresh on
+        /// every call, so the wrappers a connection hands out are never the same object and the schema
+        /// underneath is what says whether a root is shared.
+        /// </summary>
+        static DisposableSchema Underlying(CalciteConnection c)
+        {
+            return (DisposableSchema)((SchemaPlus)c.RootSchema.getSubSchema("S")!).unwrap((java.lang.Class)typeof(DisposableSchema));
+        }
+
+        static object? Scalar(CalciteConnection c, string sql)
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = sql;
+            return cmd.ExecuteScalar();
+        }
+
+        static void NonQuery(CalciteConnection c, string sql)
+        {
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        [Fact]
+        public void Two_connections_on_one_connection_string_should_share_one_root()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            using var b = new CalciteConnection(cs);
+            b.Open();
+
+            Assert.Equal(1, CountingSchemaFactory.Builds[token]);
+            Assert.Same(Underlying(a), Underlying(b));
+        }
+
+        [Fact]
+        public void The_root_should_outlive_the_connection_that_built_it()
+        {
+            var cs = ConnectionString(out var token);
+
+            using (var a = new CalciteConnection(cs))
+                a.Open();
+
+            using var b = new CalciteConnection(cs);
+            b.Open();
+
+            Assert.Equal(1, CountingSchemaFactory.Builds[token]);
+            Assert.False(CountingSchemaFactory.Made[token].Single().Disposed);
+        }
+
+        [Fact]
+        public void Pooling_false_should_build_a_root_per_connection_and_dispose_it_with_the_connection()
+        {
+            var cs = ConnectionString(out var token, ";Pooling=false");
+
+            var a = new CalciteConnection(cs);
+            a.Open();
+            using var b = new CalciteConnection(cs);
+            b.Open();
+
+            Assert.Equal(2, CountingSchemaFactory.Builds[token]);
+            Assert.NotSame(Underlying(a), Underlying(b));
+
+            a.Dispose();
+            var made = CountingSchemaFactory.Made[token].ToArray();
+            Assert.True(made[0].Disposed);
+            Assert.False(made[1].Disposed);
+        }
+
+        [Fact]
+        public void Key_order_and_casing_should_not_make_a_second_root()
+        {
+            var cs = ConnectionString(out var token);
+            var options = new CalciteConnectionStringBuilder(cs);
+            var reordered = "schema=" + options.Schema + ";MODEL=" + options.Model;
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            using var b = new CalciteConnection(reordered);
+            b.Open();
+
+            Assert.Equal(1, CountingSchemaFactory.Builds[token]);
+        }
+
+        /// <summary>
+        /// <c>Synchronous</c> chooses the convention a connection plans into and nothing that is built, so
+        /// it is not part of the key — as Npgsql leaves <c>TargetSessionAttributes</c> out of its.
+        /// </summary>
+        [Fact]
+        public void Synchronous_should_not_make_a_second_root()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            using var b = new CalciteConnection(cs + ";Synchronous=true");
+            b.Open();
+
+            Assert.Equal(1, CountingSchemaFactory.Builds[token]);
+            Assert.Same(Underlying(a), Underlying(b));
+        }
+
+        [Fact]
+        public void A_different_connection_string_should_build_a_root_of_its_own()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            using var b = new CalciteConnection(cs + ";Lex=MYSQL");
+            b.Open();
+
+            Assert.Equal(2, CountingSchemaFactory.Builds[token]);
+        }
+
+        [Fact]
+        public void A_built_data_source_should_not_be_shared_with_the_bare_path()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var dataSource = new CalciteDataSource(cs);
+            using var a = dataSource.OpenConnection();
+            using var b = new CalciteConnection(cs);
+            b.Open();
+
+            Assert.Equal(2, CountingSchemaFactory.Builds[token]);
+            Assert.NotSame(Underlying(a), Underlying(b));
+        }
+
+        [Fact]
+        public void ClearPool_should_make_the_next_connection_build_again_and_leave_open_ones_alone()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            CalciteConnection.ClearPool(a);
+            using var b = new CalciteConnection(cs);
+            b.Open();
+
+            Assert.Equal(2, CountingSchemaFactory.Builds[token]);
+            Assert.NotSame(Underlying(a), Underlying(b));
+            Assert.Equal(2, Convert.ToInt32(Scalar(a, "SELECT 1 + 1")));
+            Assert.False(CountingSchemaFactory.Made[token].First().Disposed);
+        }
+
+        [Fact]
+        public void Disposing_a_data_source_should_dispose_its_schemas_and_refuse_new_connections()
+        {
+            var schema = new DisposableSchema();
+            var dataSource = new CalciteDataSourceBuilder(TestModels.InlineEmptyModelConnectionString)
+                .AddSchema("D", schema)
+                .Build();
+
+            using (var c = dataSource.OpenConnection())
+                Assert.NotNull(c.RootSchema.getSubSchema("D"));
+
+            dataSource.Dispose();
+
+            Assert.True(schema.Disposed);
+            Assert.Throws<ObjectDisposedException>(() => dataSource.OpenConnection());
+        }
+
+        [Fact]
+        public void Clear_on_a_data_source_should_make_the_next_connection_build_again()
+        {
+            var cs = ConnectionString(out var token);
+
+            using var dataSource = new CalciteDataSource(cs);
+            using var a = dataSource.OpenConnection();
+            dataSource.Clear();
+            using var b = dataSource.OpenConnection();
+
+            Assert.Equal(2, CountingSchemaFactory.Builds[token]);
+            Assert.NotSame(Underlying(a), Underlying(b));
+        }
+
+        [Fact]
+        public void Configure_root_schema_should_run_after_the_model()
+        {
+            Schema? seen = null;
+            using var dataSource = new CalciteDataSourceBuilder(TestModels.InlineEmptyModelConnectionString)
+                .ConfigureRootSchema(root => seen = root.getSubSchema("adhoc"))
+                .Build();
+
+            using var c = dataSource.OpenConnection();
+
+            Assert.NotNull(seen);
+        }
+
+        /// <summary>
+        /// The root a connection hands out is typed as the read interface: <c>SchemaPlus</c>, which is what
+        /// carries <c>add</c>, is the data source's.
+        /// </summary>
+        [Fact]
+        public void A_connection_should_hand_out_the_root_as_a_schema()
+        {
+            Assert.Equal(typeof(Schema), typeof(CalciteConnection).GetProperty(nameof(CalciteConnection.RootSchema))!.PropertyType);
+        }
+
+        [Fact]
+        public void DDL_on_one_connection_should_be_visible_on_another()
+        {
+            var cs = ConnectionString(out _, Ddl);
+
+            using var a = new CalciteConnection(cs);
+            a.Open();
+            NonQuery(a, "CREATE TABLE \"shared_t\" (\"id\" INTEGER NOT NULL)");
+            NonQuery(a, "INSERT INTO \"shared_t\" VALUES (1), (2)");
+
+            using var b = new CalciteConnection(cs);
+            b.Open();
+
+            Assert.Equal(2, Convert.ToInt32(Scalar(b, "SELECT COUNT(*) FROM \"shared_t\"")));
+        }
+
+        /// <summary>
+        /// Connections used at once over one root: each plans with a type factory of its own, so the
+        /// grouped aggregates and windows here, which register synthetic types in the factory, do not race,
+        /// and the root is only read.
+        /// </summary>
+        [Fact]
+        public async Task Concurrent_connections_on_one_root_should_plan_and_read()
+        {
+            var cs = ConnectionString(out _, Ddl);
+
+            using (var setup = new CalciteConnection(cs))
+            {
+                setup.Open();
+                NonQuery(setup, "CREATE TABLE \"conc_t\" (\"g\" INTEGER NOT NULL, \"v\" INTEGER NOT NULL)");
+                NonQuery(setup, "INSERT INTO \"conc_t\" VALUES (1, 10), (1, 20), (2, 30), (2, 40), (3, 50)");
+            }
+
+            var tasks = Enumerable.Range(0, 8).Select(_ => Task.Run(async () =>
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    await using var c = new CalciteConnection(cs);
+                    await c.OpenAsync();
+
+                    await using (var cmd = c.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT \"g\", COUNT(*), SUM(\"v\") FROM \"conc_t\" GROUP BY \"g\" ORDER BY \"g\"";
+                        await using var r = await cmd.ExecuteReaderAsync();
+                        var groups = new List<(int, long, int)>();
+                        while (await r.ReadAsync())
+                            groups.Add((r.GetInt32(0), r.GetInt64(1), r.GetInt32(2)));
+                        Assert.Equal([(1, 2L, 30), (2, 2L, 70), (3, 1L, 50)], groups);
+                    }
+
+                    await using (var cmd = c.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT \"v\", ROW_NUMBER() OVER (PARTITION BY \"g\" ORDER BY \"v\") FROM \"conc_t\" ORDER BY \"v\"";
+                        await using var r = await cmd.ExecuteReaderAsync();
+                        var rows = new List<(int, long)>();
+                        while (await r.ReadAsync())
+                            rows.Add((r.GetInt32(0), r.GetInt64(1)));
+                        Assert.Equal([(10, 1L), (20, 2L), (30, 1L), (40, 2L), (50, 1L)], rows);
+                    }
+                }
+            }));
+
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// The driver's own model step: without a <c>Model</c>, a <c>SchemaType</c> names a factory Calcite
+        /// ships, and the schema it makes is named by the <c>Schema</c> key.
+        /// </summary>
+        [Fact]
+        public void SchemaType_should_make_a_schema_named_by_the_Schema_key()
+        {
+            using var c = new CalciteConnection("SchemaType=MAP;Schema=X;Pooling=false");
+            c.Open();
+
+            Assert.NotNull(c.RootSchema.getSubSchema("X"));
+            Assert.Equal(2, Convert.ToInt32(Scalar(c, "SELECT 1 + 1")));
+        }
+
+        /// <summary>
+        /// And a <c>SchemaFactory</c> names any factory, with every <c>schema.</c>-prefixed key handed to
+        /// it as an operand.
+        /// </summary>
+        [Fact]
+        public void SchemaFactory_should_make_a_schema_from_the_named_factory()
+        {
+            var token = Guid.NewGuid().ToString("N");
+            using var c = new CalciteConnection("SchemaFactory=\"" + Factory + "\";schema.token=" + token + ";Pooling=false");
+            c.Open();
+
+            Assert.Equal(1, CountingSchemaFactory.Builds[token]);
+            Assert.NotNull(c.RootSchema.getSubSchema("adhoc"));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data.Tests/CalciteDdlTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteDdlTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 using Apache.Calcite.Data.Internal;
 
@@ -23,6 +23,8 @@ namespace Apache.Calcite.Data.Tests
         {
             Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             Schema = "adhoc",
         };
 
@@ -96,6 +98,8 @@ namespace Apache.Calcite.Data.Tests
         {
             Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             Schema = "adhoc",
             Synchronous = true,
         };
@@ -170,6 +174,8 @@ namespace Apache.Calcite.Data.Tests
             // Model has NO defaultSchema — the connection-string Schema property is the sole source.
             Model = "inline:{\"version\":\"1.0\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             Schema = "adhoc",
         };
 
@@ -178,6 +184,8 @@ namespace Apache.Calcite.Data.Tests
             // Model carries defaultSchema — no Schema property on the connection string.
             Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
         };
 
         [Fact]
@@ -585,6 +593,8 @@ namespace Apache.Calcite.Data.Tests
             var rootDdl = new CalciteConnectionStringBuilder
             {
                 ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             };
 
             using var c = new CalciteConnection(rootDdl);

--- a/src/Apache.Calcite.Data.Tests/CalciteEngineExecutionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteEngineExecutionTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
@@ -250,9 +250,10 @@ namespace Apache.Calcite.Data.Tests
             // method then retrieves it with root.get("v0stashed"). This test verifies that stashed
             // values are present in the DataContext at execution time, i.e. that Bind() is called
             // after Plan() so that signature.internalParameters is already populated.
-            using var c = new CalciteConnection(TestModels.InlineEmptyModelConnectionString);
-            c.Open();
-            c.RootSchema.add("STASH_TEST", new StashTestTable());
+            using var c = new CalciteDataSourceBuilder(TestModels.InlineEmptyModelConnectionString)
+                .ConfigureRootSchema(root => root.add("STASH_TEST", new StashTestTable()))
+                .Build()
+                .OpenConnection();
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT * FROM \"STASH_TEST\"";

--- a/src/Apache.Calcite.Data.Tests/CalciteSessionConstructionTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteSessionConstructionTests.cs
@@ -390,9 +390,8 @@ namespace Apache.Calcite.Data.Tests
         public void Injected_type_factory_should_bypass_type_system_and_ragged_union_wrapper()
         {
             var typeFactory = new JavaTypeFactoryImpl();
-            var session = new CalciteSession(
-                new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString + ";Conformance=PRAGMATIC_2003;TypeSystem=\"" + typeof(TestTypeSystem).AssemblyQualifiedName + "\""),
-                typeFactory: typeFactory);
+            var options = new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString + ";Conformance=PRAGMATIC_2003;TypeSystem=\"" + typeof(TestTypeSystem).AssemblyQualifiedName + "\"");
+            var session = new CalciteSession(options, CalciteDataSourceRoot.Build(options, []), ownsRoot: true, typeFactory: typeFactory);
             Assert.Same(typeFactory, session.TypeFactory);
             Assert.Same(RelDataTypeSystem.DEFAULT, session.TypeFactory.getTypeSystem());
         }
@@ -402,11 +401,9 @@ namespace Apache.Calcite.Data.Tests
         {
             var root = CalciteSchema.createRootSchema(true);
             root.plus().add("PRE", new org.apache.calcite.schema.impl.AbstractSchema());
-            var session = new CalciteSession(
-                new CalciteConnectionStringBuilder(),
-                rootSchema: root);
-            Assert.Same(root, session.RootSchema.unwrap((java.lang.Class)typeof(CalciteSchema)));
-            Assert.NotNull(session.RootSchema.getSubSchema("PRE"));
+            var built = CalciteDataSourceRoot.Build(new CalciteConnectionStringBuilder(), [], rootSchema: root);
+            Assert.Same(root, built.Schema);
+            Assert.NotNull(built.Schema.plus().getSubSchema("PRE"));
         }
 
         [Fact]
@@ -414,11 +411,10 @@ namespace Apache.Calcite.Data.Tests
         {
             var root = CalciteSchema.createRootSchema(true);
             root.plus().add("PRE", new org.apache.calcite.schema.impl.AbstractSchema());
-            var session = new CalciteSession(
-                new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString),
-                rootSchema: root);
-            Assert.NotNull(session.RootSchema.getSubSchema("PRE"));
-            Assert.NotNull(session.RootSchema.getSubSchema("adhoc"));
+            var built = CalciteDataSourceRoot.Build(new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString), [], rootSchema: root);
+            Assert.NotNull(built.Schema.plus().getSubSchema("PRE"));
+            Assert.NotNull(built.Schema.plus().getSubSchema("adhoc"));
+            Assert.Equal("adhoc", built.DefaultSchemaName);
         }
 
         [Fact]
@@ -426,10 +422,40 @@ namespace Apache.Calcite.Data.Tests
         {
             // DUAL is a view macro, so it registers as a nullary function rather than a plain table
             var root = CalciteSchema.createRootSchema(true);
-            var session = new CalciteSession(
-                new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString + ";Conformance=ORACLE_12"),
-                rootSchema: root);
-            Assert.False(session.RootSchema.getFunctions("DUAL").isEmpty());
+            var built = CalciteDataSourceRoot.Build(new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString + ";Conformance=ORACLE_12"), [], rootSchema: root);
+            Assert.False(built.Schema.plus().getFunctions("DUAL").isEmpty());
+        }
+
+        /// <summary>
+        /// The session is the connection's half and the root the data source's, so a session over a root it
+        /// does not own leaves the root alone when it goes, and one over a root of its own takes it along.
+        /// </summary>
+        [Fact]
+        public void Session_should_dispose_the_root_only_where_it_owns_it()
+        {
+            var options = new CalciteConnectionStringBuilder(TestModels.InlineEmptyModelConnectionString);
+
+            var shared = new DisposableSchema();
+            var sharedRoot = CalciteDataSourceRoot.Build(options, [root => root.add("D", shared)]);
+            new CalciteSession(options, sharedRoot, ownsRoot: false).Dispose();
+            Assert.False(shared.Disposed);
+
+            var owned = new DisposableSchema();
+            var ownedRoot = CalciteDataSourceRoot.Build(options, [root => root.add("D", owned)]);
+            new CalciteSession(options, ownedRoot, ownsRoot: true).Dispose();
+            Assert.True(owned.Disposed);
+        }
+
+        sealed class DisposableSchema : org.apache.calcite.schema.impl.AbstractSchema, IDisposable
+        {
+
+            public bool Disposed { get; private set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
         }
 
     }

--- a/src/Apache.Calcite.Data.Tests/CalciteViewTests.cs
+++ b/src/Apache.Calcite.Data.Tests/CalciteViewTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
@@ -73,6 +73,8 @@ namespace Apache.Calcite.Data.Tests
         {
             Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             Schema = "adhoc",
         };
 
@@ -89,6 +91,8 @@ namespace Apache.Calcite.Data.Tests
         static readonly string RootDdlConnectionString = new CalciteConnectionStringBuilder
         {
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
         };
 
         // ------------------------------------------------------------------------------------------
@@ -416,16 +420,19 @@ namespace Apache.Calcite.Data.Tests
                 Fun = "standard,oracle",
             };
 
-            using var c = new CalciteConnection(withOracleFun);
-            c.Open();
-
-            var adhoc = c.RootSchema.getSubSchema("adhoc")!;
-            adhoc.add("NVLVIEW", ViewTable.viewMacro(
-                adhoc,
-                "SELECT NVL(CAST(NULL AS INTEGER), 7) AS Y",
-                null,
-                org.apache.calcite.jdbc.CalciteSchema.from(adhoc).path("NVLVIEW"),
-                null));
+            using var c = new CalciteDataSourceBuilder(withOracleFun)
+                .ConfigureRootSchema(root =>
+                {
+                    var adhoc = root.getSubSchema("adhoc")!;
+                    adhoc.add("NVLVIEW", ViewTable.viewMacro(
+                        adhoc,
+                        "SELECT NVL(CAST(NULL AS INTEGER), 7) AS Y",
+                        null,
+                        org.apache.calcite.jdbc.CalciteSchema.from(adhoc).path("NVLVIEW"),
+                        null));
+                })
+                .Build()
+                .OpenConnection();
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT Y FROM NVLVIEW";
@@ -440,24 +447,27 @@ namespace Apache.Calcite.Data.Tests
         [Fact]
         public void Added_view_should_bridge_two_back_ends()
         {
-            using var c = new CalciteConnection(RootDdlConnectionString);
-            c.Open();
+            using var c = new CalciteDataSourceBuilder(RootDdlConnectionString)
+                .ConfigureRootSchema(root =>
+                {
+                    root.add("BE3", new ViewTestBackEnd());
+
+                    root.add("cbridged", ViewTable.viewMacro(
+                        root,
+                        "SELECT \"s\".\"sid\" AS \"sid\", \"r\".\"RNAME\" AS \"rname\" " +
+                        "FROM \"csale\" \"s\" JOIN \"BE3\".\"REGIONS\" \"r\" ON \"s\".\"rid\" = \"r\".\"RID\"",
+                        null,
+                        org.apache.calcite.jdbc.CalciteSchema.from(root).path("cbridged"),
+                        null));
+                })
+                .Build()
+                .OpenConnection();
             using var cmd = c.CreateCommand();
 
             cmd.CommandText = "CREATE TABLE \"csale\" (\"sid\" INTEGER NOT NULL, \"rid\" INTEGER NOT NULL)";
             cmd.ExecuteNonQuery();
             cmd.CommandText = "INSERT INTO \"csale\" VALUES (1, 10), (2, 20)";
             cmd.ExecuteNonQuery();
-
-            c.RootSchema.add("BE3", new ViewTestBackEnd());
-
-            c.RootSchema.add("cbridged", ViewTable.viewMacro(
-                c.RootSchema,
-                "SELECT \"s\".\"sid\" AS \"sid\", \"r\".\"RNAME\" AS \"rname\" " +
-                "FROM \"csale\" \"s\" JOIN \"BE3\".\"REGIONS\" \"r\" ON \"s\".\"rid\" = \"r\".\"RID\"",
-                null,
-                org.apache.calcite.jdbc.CalciteSchema.from(c.RootSchema).path("cbridged"),
-                null));
 
             cmd.CommandText = "SELECT \"sid\", \"rname\" FROM \"cbridged\" ORDER BY \"sid\"";
             using var r = cmd.ExecuteReader();
@@ -947,8 +957,21 @@ namespace Apache.Calcite.Data.Tests
         [Fact]
         public void View_should_bridge_two_back_ends_and_still_join_and_aggregate()
         {
-            using var c = new CalciteConnection(RootDdlConnectionString);
-            c.Open();
+            using var c = new CalciteDataSourceBuilder(RootDdlConnectionString)
+                .ConfigureRootSchema(root =>
+                {
+                    root.add("BE2", new ViewTestBackEnd());
+
+                    root.add("bridged", ViewTable.viewMacro(
+                        root,
+                        "SELECT \"s\".\"sid\" AS \"sid\", \"r\".\"RNAME\" AS \"rname\" " +
+                        "FROM \"sale\" \"s\" JOIN \"BE2\".\"REGIONS\" \"r\" ON \"s\".\"rid\" = \"r\".\"RID\"",
+                        null,
+                        org.apache.calcite.jdbc.CalciteSchema.from(root).path("bridged"),
+                        null));
+                })
+                .Build()
+                .OpenConnection();
             using var cmd = c.CreateCommand();
 
             cmd.CommandText = "CREATE TABLE \"sale\" (\"sid\" INTEGER NOT NULL, \"rid\" INTEGER NOT NULL)";
@@ -959,16 +982,6 @@ namespace Apache.Calcite.Data.Tests
             cmd.ExecuteNonQuery();
             cmd.CommandText = "INSERT INTO \"tag\" VALUES (1, 'a'), (2, 'b'), (3, 'a')";
             cmd.ExecuteNonQuery();
-
-            c.RootSchema.add("BE2", new ViewTestBackEnd());
-
-            c.RootSchema.add("bridged", ViewTable.viewMacro(
-                c.RootSchema,
-                "SELECT \"s\".\"sid\" AS \"sid\", \"r\".\"RNAME\" AS \"rname\" " +
-                "FROM \"sale\" \"s\" JOIN \"BE2\".\"REGIONS\" \"r\" ON \"s\".\"rid\" = \"r\".\"RID\"",
-                null,
-                org.apache.calcite.jdbc.CalciteSchema.from(c.RootSchema).path("bridged"),
-                null));
 
             // selected from directly
             cmd.CommandText = "SELECT \"sid\", \"rname\" FROM \"bridged\" ORDER BY \"sid\"";
@@ -1033,25 +1046,25 @@ namespace Apache.Calcite.Data.Tests
         /// model view asking for <c>modifiable</c> can only sit over whatever the model can declare. So the
         /// macro is registered through the schema SPI, over a table <c>CREATE TABLE</c> made — that being a
         /// <c>MutableArrayTable</c>, which is the <c>ModifiableTable</c> the view needs underneath. This is
-        /// the one test here that reaches Calcite through <see cref="CalciteConnection.RootSchema"/> rather
-        /// than through SQL, because that is the only way in.
+        /// the one test here that reaches Calcite through <see cref="CalciteDataSourceBuilder.ConfigureRootSchema"/>
+        /// rather than through SQL, because that is the only way in.
         /// </remarks>
         [Fact]
         public void Insert_into_a_modifiable_view_should_write_through_to_its_table()
         {
-            using var c = new CalciteConnection(RootDdlConnectionString);
-            c.Open();
+            using var c = new CalciteDataSourceBuilder(RootDdlConnectionString)
+                .ConfigureRootSchema(root => root.add("modview", ViewTable.viewMacro(
+                    root,
+                    "SELECT \"id\" FROM \"modsrc\" WHERE \"g\" = 7",
+                    null,
+                    org.apache.calcite.jdbc.CalciteSchema.from(root).path("modview"),
+                    java.lang.Boolean.TRUE)))
+                .Build()
+                .OpenConnection();
             using var cmd = c.CreateCommand();
 
             cmd.CommandText = "CREATE TABLE \"modsrc\" (\"id\" INTEGER NOT NULL, \"g\" INTEGER NOT NULL)";
             cmd.ExecuteNonQuery();
-
-            c.RootSchema.add("modview", ViewTable.viewMacro(
-                c.RootSchema,
-                "SELECT \"id\" FROM \"modsrc\" WHERE \"g\" = 7",
-                null,
-                org.apache.calcite.jdbc.CalciteSchema.from(c.RootSchema).path("modview"),
-                java.lang.Boolean.TRUE));
 
             cmd.CommandText = "INSERT INTO \"modview\" VALUES (1)";
             cmd.ExecuteNonQuery();

--- a/src/Apache.Calcite.Data.Tests/ModelClasses.cs
+++ b/src/Apache.Calcite.Data.Tests/ModelClasses.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+
+namespace Apache.Calcite.Data.Tests
+{
+
+    /// <summary>
+    /// Lets a model name a class of this assembly.
+    /// </summary>
+    /// <remarks>
+    /// This project references calcite-core 1.43.0-SNAPSHOT, and from the snapshots of August 2026 a model
+    /// may load a class by name — a schema factory, a function, a driver — only where the
+    /// <c>calcite.model.classes.allowed</c> system property lists its package; the default is empty, and
+    /// empty means nothing. The 1.42.0 the provider ships against has only the denylist. The property is
+    /// read once, when <c>CalciteSystemProperty</c> initialises, so it is set here, before any test can
+    /// touch a Calcite class.
+    /// </remarks>
+    internal static class ModelClasses
+    {
+
+        [ModuleInitializer]
+        internal static void Allow()
+        {
+            // a .NET class is named by its CLR name in a model and by its IKVM name, cli.-prefixed, where
+            // Calcite writes a class's own getName() into a model it synthesises; and the factories Calcite
+            // ships are not allowed by default either
+            java.lang.System.setProperty("calcite.model.classes.allowed", "Apache.Calcite.Data.Tests.,cli.Apache.Calcite.Data.Tests.,org.apache.calcite.");
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/CalciteConnection.cs
+++ b/src/Apache.Calcite.Data/CalciteConnection.cs
@@ -26,17 +26,21 @@ namespace Apache.Calcite.Data
     /// done to release all engine resources.
     /// </para>
     /// <para>
-    /// The underlying Calcite session is created on the first call to <see cref="Open"/> and is kept
-    /// alive across <see cref="Close"/>/<see cref="Open"/> cycles. Schema objects registered on
-    /// <see cref="RootSchema"/>, tables created via DDL, and any other in-process state survive
-    /// a close and remain visible after reopening. The session is torn down permanently only when
-    /// the connection is disposed.
+    /// A connection is cheap and short-lived, as ADO.NET intends. The root schema it plans against —
+    /// the model, the schemas the model built, the tables DDL has created — belongs to a
+    /// <see cref="CalciteDataSource"/>, which outlives it: either one the application built and opened this
+    /// connection from, or the one the provider keeps for this connection string, shared by every connection
+    /// opened with an equivalent string. What the connection keeps to itself is created on the first call to
+    /// <see cref="Open"/>, survives <see cref="Close"/>/<see cref="Open"/> cycles, and is released when the
+    /// connection is disposed. <c>Pooling=false</c> in the connection string gives the connection a root of
+    /// its own instead, built when it first opens and released with it.
     /// </para>
     /// </remarks>
     public sealed class CalciteConnection : DbConnection
     {
 
         CalciteConnectionStringBuilder _options = new();
+        CalciteDataSource? _dataSource;
         CalciteSession? _session;
         ConnectionState _state = ConnectionState.Closed;
         bool _disposed;
@@ -148,12 +152,21 @@ namespace Apache.Calcite.Data
         /// Initializes a new instance of the <see cref="CalciteConnection"/> class with an empty connection string.
         /// </summary>
         /// <remarks>
-        /// Set <see cref="ConnectionString"/> before calling <see cref="Open"/>, or register schemas
-        /// directly on <see cref="RootSchema"/> after opening.
+        /// Set <see cref="ConnectionString"/> before calling <see cref="Open"/>.
         /// </remarks>
         public CalciteConnection()
         {
 
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CalciteConnection"/> class bound to a data source.
+        /// </summary>
+        /// <param name="dataSource">The data source whose root schema this connection plans against.</param>
+        internal CalciteConnection(CalciteDataSource dataSource)
+        {
+            _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+            _options = new CalciteConnectionStringBuilder(dataSource.ConnectionString);
         }
 
         /// <summary>
@@ -175,7 +188,9 @@ namespace Apache.Calcite.Data
         /// The connection string must be set <em>before</em> calling <see cref="Open"/> for the first
         /// time. Once the session has been started it cannot be changed — the Calcite engine is
         /// initialized once and reused for the lifetime of the connection. To use different settings,
-        /// create a new <see cref="CalciteConnection"/>.
+        /// create a new <see cref="CalciteConnection"/>. Setting it on a connection created by a
+        /// <see cref="CalciteDataSource"/> detaches the connection from that data source: it draws on the
+        /// data source the provider keeps for the new string instead.
         /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// Thrown when the connection string is set after the connection has already been opened.
@@ -194,6 +209,7 @@ namespace Apache.Calcite.Data
                         "To use a different connection string, create a new CalciteConnection.");
 
                 _options = new CalciteConnectionStringBuilder(value);
+                _dataSource = null;
             }
         }
 
@@ -230,12 +246,14 @@ namespace Apache.Calcite.Data
         /// </summary>
         /// <remarks>
         /// The Calcite session is created once on the first call and reused on all subsequent
-        /// <see cref="Open"/> calls. Closing and reopening the connection does not reset the engine —
-        /// any schemas registered on <see cref="RootSchema"/> or tables created via DDL remain visible
-        /// after reopening.
+        /// <see cref="Open"/> calls. The first connection to open on a data source is the one that reads
+        /// the model and builds its schemas; every connection after it finds them built. Closing and
+        /// reopening the connection does not reset anything — a table created via DDL remains visible after
+        /// reopening, as it does on every other connection of the same data source.
         /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown when the connection is already open.</exception>
         /// <exception cref="CalciteException">Thrown when the Calcite engine could not be initialized.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown when the data source the connection was created from has been disposed.</exception>
         public override void Open()
         {
             ThrowIfDisposed();
@@ -246,7 +264,13 @@ namespace Apache.Calcite.Data
             try
             {
                 // Session is created once on the first Open() and reused across Close/Open cycles.
-                _session ??= new CalciteSession(_options);
+                if (_session is null)
+                {
+                    _dataSource ??= CalciteDataSources.Resolve(_options);
+                    var (root, owned) = _dataSource.Acquire();
+                    _session = new CalciteSession(_options, root, owned);
+                }
+
                 SetState(ConnectionState.Open);
             }
             catch
@@ -261,9 +285,9 @@ namespace Apache.Calcite.Data
         /// </summary>
         /// <remarks>
         /// Closing the connection only changes its state to <see cref="System.Data.ConnectionState.Closed"/>;
-        /// the engine session is preserved so that calling <see cref="Open"/> again is inexpensive and
-        /// retains all in-process state. To fully release engine resources, call
-        /// <see cref="IDisposable.Dispose"/> instead.
+        /// the engine session is preserved so that calling <see cref="Open"/> again is inexpensive. To
+        /// release what the connection holds, call <see cref="IDisposable.Dispose"/> instead. Neither
+        /// touches the data source's root, which is shared and outlives the connection.
         /// </remarks>
         public override void Close()
         {
@@ -409,15 +433,50 @@ namespace Apache.Calcite.Data
         }
 
         /// <summary>
-        /// Gets the root <see cref="SchemaPlus"/> for this connection's Calcite engine.
+        /// Drops the data source the provider keeps for <paramref name="connection"/>'s connection string, so
+        /// that the next connection opened with that string reads the model again.
+        /// </summary>
+        /// <param name="connection">A connection whose connection string names the data source to drop.</param>
+        /// <remarks>
+        /// This is how a changed model file reaches a running process. Connections already open keep the
+        /// root they have; the dropped data source is not disposed, and goes when the last of them lets go
+        /// of it. A data source the application built with <see cref="CalciteDataSourceBuilder"/> is not
+        /// kept by the provider and is unaffected — <see cref="CalciteDataSource.Clear"/> is its equivalent.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="connection"/> is <see langword="null"/>.</exception>
+        public static void ClearPool(CalciteConnection connection)
+        {
+            ArgumentNullException.ThrowIfNull(connection);
+            CalciteDataSources.Clear(connection._options);
+        }
+
+        /// <summary>
+        /// Drops every data source the provider keeps, so that the next connection opened with any
+        /// connection string reads its model again.
         /// </summary>
         /// <remarks>
-        /// Use this to register schemas, tables, custom functions, or other Calcite artifacts that
-        /// should be visible to SQL statements executed on this connection. Objects added here
-        /// persist for the lifetime of the session, including across <see cref="Close"/>/<see cref="Open"/> cycles.
+        /// As <see cref="ClearPool"/>, for every connection string at once.
+        /// </remarks>
+        public static void ClearAllPools()
+        {
+            CalciteDataSources.ClearAll();
+        }
+
+        /// <summary>
+        /// Gets the root schema this connection plans against, read-only.
+        /// </summary>
+        /// <remarks>
+        /// The root belongs to the connection's <see cref="CalciteDataSource"/> and is shared by every
+        /// connection opened on it, so what is seen here is what every one of them sees: the schemas the
+        /// model built, the schemas registered on the data source's builder, the tables DDL has created.
+        /// It is handed out as a <see cref="Schema"/>, Calcite's read interface, because a change made
+        /// through one connection would reach all of them without any having asked; the
+        /// <see cref="SchemaPlus"/> Calcite adds to it is the data source's, reached through
+        /// <see cref="CalciteDataSourceBuilder.ConfigureRootSchema"/>, and a table is created with DDL. This
+        /// is a type and not a guard — the object is the root itself.
         /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown when the connection is not open.</exception>
-        public SchemaPlus RootSchema => RequireSession().RootSchema;
+        public Schema RootSchema => RequireSession().RootSchema;
 
         /// <summary>
         /// Gets the <see cref="JavaTypeFactory"/> used by this connection's Calcite engine.

--- a/src/Apache.Calcite.Data/CalciteConnection.cs
+++ b/src/Apache.Calcite.Data/CalciteConnection.cs
@@ -266,8 +266,24 @@ namespace Apache.Calcite.Data
                 // Session is created once on the first Open() and reused across Close/Open cycles.
                 if (_session is null)
                 {
-                    _dataSource ??= CalciteDataSources.Resolve(_options);
-                    var (root, owned) = _dataSource.Acquire();
+                    CalciteDataSourceRoot root;
+                    bool owned;
+                    if (_dataSource is not null)
+                    {
+                        (root, owned) = _dataSource.Acquire();
+                    }
+                    else
+                    {
+                        // the data source the provider keeps for this string, looked up again if it was
+                        // pruned between the lookup and the use
+                        CalciteDataSource dataSource;
+                        do
+                            dataSource = CalciteDataSources.Resolve(_options);
+                        while (dataSource.TryAcquire(out root, out owned) == false);
+
+                        _dataSource = dataSource;
+                    }
+
                     _session = new CalciteSession(_options, root, owned);
                 }
 
@@ -438,10 +454,11 @@ namespace Apache.Calcite.Data
         /// </summary>
         /// <param name="connection">A connection whose connection string names the data source to drop.</param>
         /// <remarks>
-        /// This is how a changed model file reaches a running process. Connections already open keep the
-        /// root they have; the dropped data source is not disposed, and goes when the last of them lets go
-        /// of it. A data source the application built with <see cref="CalciteDataSourceBuilder"/> is not
-        /// kept by the provider and is unaffected — <see cref="CalciteDataSource.Clear"/> is its equivalent.
+        /// This is how a changed model file reaches a running process before the data source's idle
+        /// lifetime would have released it. Connections already open keep the root they have, and it is
+        /// disposed once the last of them is. A data source the application built with
+        /// <see cref="CalciteDataSourceBuilder"/> is not kept by the provider and is unaffected —
+        /// <see cref="CalciteDataSource.Clear"/> is its equivalent.
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="connection"/> is <see langword="null"/>.</exception>
         public static void ClearPool(CalciteConnection connection)

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -39,6 +39,12 @@ namespace Apache.Calcite.Data
         public const string SynchronousKey = "Synchronous";
 
         /// <summary>
+        /// Connection string key for whether connections sharing this connection string share one root
+        /// schema.
+        /// </summary>
+        public const string PoolingKey = "Pooling";
+
+        /// <summary>
         /// Connection string key for whether identifiers are matched case-sensitively.
         /// </summary>
         public const string CaseSensitiveKey = "CaseSensitive";
@@ -211,6 +217,31 @@ namespace Apache.Calcite.Data
                     Remove(SynchronousKey);
                 else
                     this[SynchronousKey] = value.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether connections sharing this connection string share one root schema. Default is
+        /// <see langword="true"/>.
+        /// </summary>
+        /// <remarks>
+        /// A provider option rather than an engine one. By default every connection opened with the same
+        /// connection string, <see cref="Synchronous"/> aside, draws on one <see cref="CalciteDataSource"/>
+        /// held for the process, so the model is read and its schemas built once rather than per
+        /// connection, and a table created by DDL on one connection is visible on the next.
+        /// <see langword="false"/> gives each connection a root schema of its own, built when it first opens
+        /// and released when it is disposed. This is the switch every ADO.NET provider spells the same way,
+        /// and it means the same thing: shared by default, keyed by what was written, off if you say so.
+        /// </remarks>
+        public bool? Pooling
+        {
+            get => TryGetBool(PoolingKey);
+            set
+            {
+                if (value is null)
+                    Remove(PoolingKey);
+                else
+                    this[PoolingKey] = value.Value;
             }
         }
 
@@ -512,6 +543,34 @@ namespace Apache.Calcite.Data
             foreach (var key in Keys)
                 if (key is string s)
                     yield return s;
+        }
+
+        /// <summary>
+        /// The connection string a <see cref="CalciteDataSource"/> is looked up by.
+        /// </summary>
+        /// <remarks>
+        /// Two connection strings that differ only in the order or the casing of their keys describe one
+        /// data source, so the key is written with every key lower-cased and sorted. <see cref="Synchronous"/>
+        /// is left out: it chooses the convention a connection plans into and nothing that is built, and a
+        /// data source built twice for the two conventions would read the same model twice.
+        /// </remarks>
+        internal string DataSourceKey
+        {
+            get
+            {
+                var keys = new List<string>();
+                foreach (var key in EnumerateKeys())
+                    if (string.Equals(key, SynchronousKey, System.StringComparison.OrdinalIgnoreCase) == false)
+                        keys.Add(key);
+
+                keys.Sort(System.StringComparer.OrdinalIgnoreCase);
+
+                var canonical = new DbConnectionStringBuilder();
+                foreach (var key in keys)
+                    canonical[key.ToLowerInvariant()] = this[key];
+
+                return canonical.ConnectionString;
+            }
         }
 
         string? TryGetString(string key)

--- a/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteConnectionStringBuilder.cs
@@ -45,6 +45,17 @@ namespace Apache.Calcite.Data
         public const string PoolingKey = "Pooling";
 
         /// <summary>
+        /// Connection string key for how long, in seconds, the provider keeps a root schema no connection
+        /// is using.
+        /// </summary>
+        public const string ConnectionIdleLifetimeKey = "Connection Idle Lifetime";
+
+        /// <summary>
+        /// Connection string key for how often, in seconds, the provider looks for root schemas to release.
+        /// </summary>
+        public const string ConnectionPruningIntervalKey = "Connection Pruning Interval";
+
+        /// <summary>
         /// Connection string key for whether identifiers are matched case-sensitively.
         /// </summary>
         public const string CaseSensitiveKey = "CaseSensitive";
@@ -242,6 +253,49 @@ namespace Apache.Calcite.Data
                     Remove(PoolingKey);
                 else
                     this[PoolingKey] = value.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how long, in seconds, the provider keeps a root schema no connection is using before
+        /// releasing it. Default is 300.
+        /// </summary>
+        /// <remarks>
+        /// A provider option rather than an engine one. The data source the provider keeps for a connection
+        /// string is released — dropped, and its schemas disposed — once it has gone this long with no
+        /// connection open on it, so that a process which varies its connection strings does not keep a root
+        /// for every string it ever wrote. The next connection opened with the string builds a new one. It is
+        /// checked every <see cref="ConnectionPruningInterval"/>. A data source the application built is the
+        /// application's and is never released this way.
+        /// </remarks>
+        public int? ConnectionIdleLifetime
+        {
+            get => TryGetInt(ConnectionIdleLifetimeKey);
+            set
+            {
+                if (value is null)
+                    Remove(ConnectionIdleLifetimeKey);
+                else
+                    this[ConnectionIdleLifetimeKey] = value.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets how often, in seconds, the provider looks for root schemas that have passed their
+        /// <see cref="ConnectionIdleLifetime"/>. Default is 10.
+        /// </summary>
+        /// <remarks>
+        /// A provider option rather than an engine one.
+        /// </remarks>
+        public int? ConnectionPruningInterval
+        {
+            get => TryGetInt(ConnectionPruningIntervalKey);
+            set
+            {
+                if (value is null)
+                    Remove(ConnectionPruningIntervalKey);
+                else
+                    this[ConnectionPruningIntervalKey] = value.Value;
             }
         }
 

--- a/src/Apache.Calcite.Data/CalciteDataSource.cs
+++ b/src/Apache.Calcite.Data/CalciteDataSource.cs
@@ -1,51 +1,54 @@
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Apache.Calcite.Data.Internal;
 
 namespace Apache.Calcite.Data
 {
 
     /// <summary>
-    /// Represents a source of <see cref="CalciteConnection"/> instances configured by a single
-    /// connection string. This is the Apache Calcite implementation of the .NET 7+ <see cref="DbDataSource"/> pattern.
+    /// Represents a source of <see cref="CalciteConnection"/> instances sharing one root schema. This is the
+    /// Apache Calcite implementation of the .NET 7+ <see cref="DbDataSource"/> pattern.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A <see cref="CalciteDataSource"/> is intended to be created once per logical data source and shared across the application. Each call to <see cref="OpenConnection"/>,
-    /// <see cref="OpenConnectionAsync(CancellationToken)"/>, or the <see cref="DbDataSource.CreateConnection"/> override returns a fresh <see cref="CalciteConnection"/>
-    /// bound to the configured <see cref="DbDataSource.ConnectionString"/>.
+    /// A Calcite connection is meant to be long-lived — it owns the root schema and everything an adapter's
+    /// schema has learnt — and an ADO.NET connection is not. The data source is where the long-lived half
+    /// goes. It reads the model and builds the schemas once, on the first connection to open, and every
+    /// connection it produces plans against that root; what a connection keeps to itself is its
+    /// configuration, its type factory and the convention it plans into. A table created by DDL on one
+    /// connection is therefore visible on the next, as it is in any database, and an adapter that discovers
+    /// something at schema-build time discovers it once.
     /// </para>
     /// <para>
-    /// The Calcite provider does not perform connection pooling; each opened connection initializes its own in-process Calcite engine session.
+    /// A <see cref="CalciteDataSource"/> is intended to be created once per logical data source and shared
+    /// across the application — registered as a singleton, with connections transient. There are two ways
+    /// to one. A bare <c>new CalciteConnection(connectionString)</c> draws on a data source the provider
+    /// keeps for that connection string, made the first time the string is seen and shared by every
+    /// connection opened with an equivalent string afterwards; <c>Pooling=false</c> in the string opts a
+    /// connection out, giving it a root of its own. Or the application builds one with
+    /// <see cref="CalciteDataSourceBuilder"/>, which is the only way to hand over a schema instance the
+    /// application constructed, and which is the application's to dispose.
     /// </para>
     /// <para>
-    /// To share a pre-built schema across all connections produced by this data source, subclass <see cref="CalciteDataSource"/> and override <see cref="CreateDbConnection"/> to
-    /// open the connection and register schemas on <see cref="CalciteConnection.RootSchema"/> before returning it:
-    /// <code>
-    /// public class MyDataSource : CalciteDataSource
-    /// {
-    ///     readonly Schema _sharedSchema = new MySchema();
-    ///
-    ///     public MyDataSource(string connectionString) : base(connectionString) { }
-    ///
-    ///     protected override DbConnection CreateDbConnection()
-    ///     {
-    ///         var conn = (CalciteConnection)base.CreateDbConnection();
-    ///         conn.Open();
-    ///         conn.RootSchema.add("MY", _sharedSchema);
-    ///         return conn;
-    ///     }
-    /// }
-    /// </code>
-    /// Because each <see cref="CalciteConnection"/> owns its own Calcite engine session, the <c>Schema</c> instance itself must be thread-safe if the same instance is added to
-    /// connections that may be used concurrently.
+    /// Sharing a root means an adapter's schema may be read from several threads at once. Calcite serialises
+    /// nothing; a schema reachable from a data source has to tolerate concurrent reads. DDL is serialised
+    /// against DDL by the provider. Disposing the data source disposes every schema on its root that
+    /// implements <see cref="IDisposable"/>, and a connection still open on it fails at its next statement.
     /// </para>
     /// </remarks>
     public class CalciteDataSource : DbDataSource
     {
 
-        readonly string _connectionString;
+        readonly CalciteConnectionStringBuilder _options;
+        readonly IReadOnlyList<Action<org.apache.calcite.schema.SchemaPlus>> _configure;
+        readonly bool _pooling;
+        readonly object _sync = new();
+        CalciteDataSourceRoot? _root;
+        bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CalciteDataSource"/> class with the specified connection string.
@@ -53,9 +56,10 @@ namespace Apache.Calcite.Data
         /// <param name="connectionString">The connection string used by every connection produced from this data source.
         /// Recognized keys are described on <see cref="CalciteConnectionStringBuilder"/>.</param>
         /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is <see langword="null"/>.</exception>
-        public CalciteDataSource(string connectionString)
+        public CalciteDataSource(string connectionString) :
+            this(new CalciteConnectionStringBuilder(connectionString ?? throw new ArgumentNullException(nameof(connectionString))), [])
         {
-            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+
         }
 
         /// <summary>
@@ -63,38 +67,118 @@ namespace Apache.Calcite.Data
         /// </summary>
         /// <param name="connectionStringBuilder">The builder whose <see cref="DbConnectionStringBuilder.ConnectionString"/> is used to configure produced connections.</param>
         /// <exception cref="ArgumentNullException"><paramref name="connectionStringBuilder"/> is <see langword="null"/>.</exception>
-        public CalciteDataSource(CalciteConnectionStringBuilder connectionStringBuilder)
-            : this((connectionStringBuilder ?? throw new ArgumentNullException(nameof(connectionStringBuilder))).ConnectionString)
+        public CalciteDataSource(CalciteConnectionStringBuilder connectionStringBuilder) :
+            this(new CalciteConnectionStringBuilder((connectionStringBuilder ?? throw new ArgumentNullException(nameof(connectionStringBuilder))).ConnectionString), [])
         {
 
         }
 
-        /// <inheritdoc />
-        public override string ConnectionString => _connectionString;
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="options">The connection string, which this instance owns.</param>
+        /// <param name="configure">Steps to run over the root after the model, in order.</param>
+        internal CalciteDataSource(CalciteConnectionStringBuilder options, IReadOnlyList<Action<org.apache.calcite.schema.SchemaPlus>> configure)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _configure = configure ?? throw new ArgumentNullException(nameof(configure));
+            _pooling = options.Pooling ?? true;
+        }
 
         /// <inheritdoc />
-        protected override DbConnection CreateDbConnection() => new CalciteConnection(_connectionString);
+        public override string ConnectionString => _options.ConnectionString;
 
         /// <summary>
-        /// Creates a new closed <see cref="CalciteConnection"/> bound to this data source's connection string.
+        /// Gets the root a connection should plan against, and whether that connection owns it.
+        /// </summary>
+        /// <returns>The root, and <see langword="true"/> where it was built for this caller alone and is the
+        /// caller's to dispose.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the data source has been disposed.</exception>
+        /// <remarks>
+        /// Built once, by whichever connection opens first, with the others waiting on it — a failed build
+        /// leaves nothing behind, so the next connection tries again. With <c>Pooling=false</c> there is no
+        /// shared root: every call builds one, and the connection that asked disposes it.
+        /// </remarks>
+        internal (CalciteDataSourceRoot Root, bool Owned) Acquire()
+        {
+            ThrowIfDisposed();
+
+            if (_pooling == false)
+                return (CalciteDataSourceRoot.Build(_options, _configure), true);
+
+            lock (_sync)
+            {
+                ThrowIfDisposed();
+                _root ??= CalciteDataSourceRoot.Build(_options, _configure);
+                return (_root, false);
+            }
+        }
+
+        /// <summary>
+        /// Drops the root schema, so that the next connection to open builds a new one — re-reading the
+        /// model, and with it a model file that has changed on disk.
+        /// </summary>
+        /// <remarks>
+        /// A connection already open keeps the root it has. The dropped root is not disposed, for that
+        /// reason; it goes when the last such connection lets go of it.
+        /// </remarks>
+        public void Clear()
+        {
+            lock (_sync)
+                _root = null;
+        }
+
+        /// <inheritdoc />
+        protected override DbConnection CreateDbConnection() => new CalciteConnection(this);
+
+        /// <summary>
+        /// Creates a new closed <see cref="CalciteConnection"/> bound to this data source.
         /// </summary>
         /// <returns>A new <see cref="CalciteConnection"/> instance.</returns>
         public new CalciteConnection CreateConnection() => (CalciteConnection)base.CreateConnection();
 
         /// <summary>
-        /// Creates and opens a new <see cref="CalciteConnection"/> bound to this data source's connection string.
+        /// Creates and opens a new <see cref="CalciteConnection"/> bound to this data source.
         /// </summary>
         /// <returns>An opened <see cref="CalciteConnection"/> instance.</returns>
         public new CalciteConnection OpenConnection() => (CalciteConnection)base.OpenConnection();
 
         /// <summary>
-        /// Asynchronously creates and opens a new <see cref="CalciteConnection"/> bound to this data source's connection string.
+        /// Asynchronously creates and opens a new <see cref="CalciteConnection"/> bound to this data source.
         /// </summary>
         /// <param name="cancellationToken">A token that may be used to cancel the operation.</param>
         /// <returns>A task whose result is an opened <see cref="CalciteConnection"/> instance.</returns>
         public new async ValueTask<CalciteConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
         {
             return (CalciteConnection)await base.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                CalciteDataSourceRoot? root;
+                lock (_sync)
+                {
+                    if (_disposed)
+                        return;
+
+                    _disposed = true;
+                    root = _root;
+                    _root = null;
+                }
+
+                root?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().Name);
         }
 
     }

--- a/src/Apache.Calcite.Data/CalciteDataSource.cs
+++ b/src/Apache.Calcite.Data/CalciteDataSource.cs
@@ -27,25 +27,41 @@ namespace Apache.Calcite.Data
     /// A <see cref="CalciteDataSource"/> is intended to be created once per logical data source and shared
     /// across the application — registered as a singleton, with connections transient. There are two ways
     /// to one. A bare <c>new CalciteConnection(connectionString)</c> draws on a data source the provider
-    /// keeps for that connection string, made the first time the string is seen and shared by every
-    /// connection opened with an equivalent string afterwards; <c>Pooling=false</c> in the string opts a
-    /// connection out, giving it a root of its own. Or the application builds one with
-    /// <see cref="CalciteDataSourceBuilder"/>, which is the only way to hand over a schema instance the
-    /// application constructed, and which is the application's to dispose.
+    /// keeps for that connection string, made the first time the string is seen, shared by every
+    /// connection opened with an equivalent string afterwards, and released once it has gone
+    /// <see cref="CalciteConnectionStringBuilder.ConnectionIdleLifetime"/> with no connection open on it;
+    /// <c>Pooling=false</c> in the string opts a connection out, giving it a root of its own. Or the
+    /// application builds one with <see cref="CalciteDataSourceBuilder"/>, which is the only way to hand
+    /// over a schema instance the application constructed, and which is the application's to dispose.
     /// </para>
     /// <para>
     /// Sharing a root means an adapter's schema may be read from several threads at once. Calcite serialises
-    /// nothing; a schema reachable from a data source has to tolerate concurrent reads. DDL is serialised
-    /// against DDL by the provider. Disposing the data source disposes every schema on its root that
-    /// implements <see cref="IDisposable"/>, and a connection still open on it fails at its next statement.
+    /// nothing; a schema reachable from a data source has to tolerate concurrent reads. Planning takes the
+    /// root's read lock and DDL its write lock, so a statement never plans against a root another is
+    /// altering. Disposing the data source retires its root: every schema on it that implements
+    /// <see cref="IDisposable"/> is disposed once the last connection open on it is disposed, and no new
+    /// connection can be opened from it.
     /// </para>
     /// </remarks>
     public class CalciteDataSource : DbDataSource
     {
 
+        /// <summary>
+        /// The <see cref="CalciteConnectionStringBuilder.ConnectionIdleLifetime"/> where the string gives none.
+        /// </summary>
+        public const int DefaultConnectionIdleLifetime = 300;
+
+        /// <summary>
+        /// The <see cref="CalciteConnectionStringBuilder.ConnectionPruningInterval"/> where the string gives none.
+        /// </summary>
+        public const int DefaultConnectionPruningInterval = 10;
+
         readonly CalciteConnectionStringBuilder _options;
         readonly IReadOnlyList<Action<org.apache.calcite.schema.SchemaPlus>> _configure;
         readonly bool _pooling;
+        readonly TimeSpan _idleLifetime;
+        readonly TimeSpan _pruningInterval;
+        readonly long _created = Environment.TickCount64;
         readonly object _sync = new();
         CalciteDataSourceRoot? _root;
         bool _disposed;
@@ -56,6 +72,7 @@ namespace Apache.Calcite.Data
         /// <param name="connectionString">The connection string used by every connection produced from this data source.
         /// Recognized keys are described on <see cref="CalciteConnectionStringBuilder"/>.</param>
         /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The connection string's pooling settings are not valid.</exception>
         public CalciteDataSource(string connectionString) :
             this(new CalciteConnectionStringBuilder(connectionString ?? throw new ArgumentNullException(nameof(connectionString))), [])
         {
@@ -67,6 +84,7 @@ namespace Apache.Calcite.Data
         /// </summary>
         /// <param name="connectionStringBuilder">The builder whose <see cref="DbConnectionStringBuilder.ConnectionString"/> is used to configure produced connections.</param>
         /// <exception cref="ArgumentNullException"><paramref name="connectionStringBuilder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The connection string's pooling settings are not valid.</exception>
         public CalciteDataSource(CalciteConnectionStringBuilder connectionStringBuilder) :
             this(new CalciteConnectionStringBuilder((connectionStringBuilder ?? throw new ArgumentNullException(nameof(connectionStringBuilder))).ConnectionString), [])
         {
@@ -78,40 +96,107 @@ namespace Apache.Calcite.Data
         /// </summary>
         /// <param name="options">The connection string, which this instance owns.</param>
         /// <param name="configure">Steps to run over the root after the model, in order.</param>
-        internal CalciteDataSource(CalciteConnectionStringBuilder options, IReadOnlyList<Action<org.apache.calcite.schema.SchemaPlus>> configure)
+        /// <param name="pooled">Whether the root is shared, or <see langword="null"/> to read the
+        /// <c>Pooling</c> key.</param>
+        /// <exception cref="ArgumentException">The pooling settings are not valid.</exception>
+        internal CalciteDataSource(CalciteConnectionStringBuilder options, IReadOnlyList<Action<org.apache.calcite.schema.SchemaPlus>> configure, bool? pooled = null)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _configure = configure ?? throw new ArgumentNullException(nameof(configure));
-            _pooling = options.Pooling ?? true;
+            _pooling = pooled ?? options.Pooling ?? true;
+
+            var idleLifetime = options.ConnectionIdleLifetime ?? DefaultConnectionIdleLifetime;
+            var pruningInterval = options.ConnectionPruningInterval ?? DefaultConnectionPruningInterval;
+            if (pruningInterval <= 0)
+                throw new ArgumentException($"{CalciteConnectionStringBuilder.ConnectionPruningIntervalKey} can't be 0.", nameof(options));
+            if (idleLifetime < pruningInterval)
+                throw new ArgumentException($"Connection can't have {CalciteConnectionStringBuilder.ConnectionIdleLifetimeKey} {idleLifetime} under {CalciteConnectionStringBuilder.ConnectionPruningIntervalKey} {pruningInterval}.", nameof(options));
+
+            _idleLifetime = TimeSpan.FromSeconds(idleLifetime);
+            _pruningInterval = TimeSpan.FromSeconds(pruningInterval);
         }
 
         /// <inheritdoc />
         public override string ConnectionString => _options.ConnectionString;
 
         /// <summary>
+        /// Gets how often the provider looks at this data source for pruning, where it keeps it.
+        /// </summary>
+        internal TimeSpan PruningInterval => _pruningInterval;
+
+        /// <summary>
         /// Gets the root a connection should plan against, and whether that connection owns it.
         /// </summary>
         /// <returns>The root, and <see langword="true"/> where it was built for this caller alone and is the
-        /// caller's to dispose.</returns>
+        /// caller's to retire.</returns>
         /// <exception cref="ObjectDisposedException">Thrown when the data source has been disposed.</exception>
         /// <remarks>
         /// Built once, by whichever connection opens first, with the others waiting on it — a failed build
         /// leaves nothing behind, so the next connection tries again. With <c>Pooling=false</c> there is no
-        /// shared root: every call builds one, and the connection that asked disposes it.
+        /// shared root: every call builds one, and the connection that asked retires it.
         /// </remarks>
         internal (CalciteDataSourceRoot Root, bool Owned) Acquire()
         {
-            ThrowIfDisposed();
+            return TryAcquire(out var root, out var owned) ? (root, owned) : throw new ObjectDisposedException(GetType().Name);
+        }
 
-            if (_pooling == false)
-                return (CalciteDataSourceRoot.Build(_options, _configure), true);
-
+        /// <summary>
+        /// <see cref="Acquire"/>, answering <see langword="false"/> rather than throwing where the data source
+        /// has been disposed — which for one the provider keeps means it was pruned between being looked up
+        /// and being used, and the caller looks it up again.
+        /// </summary>
+        internal bool TryAcquire(out CalciteDataSourceRoot root, out bool owned)
+        {
             lock (_sync)
             {
-                ThrowIfDisposed();
+                if (_disposed)
+                {
+                    root = null!;
+                    owned = false;
+                    return false;
+                }
+
+                if (_pooling == false)
+                {
+                    root = CalciteDataSourceRoot.Build(_options, _configure);
+                    owned = true;
+                    return true;
+                }
+
                 _root ??= CalciteDataSourceRoot.Build(_options, _configure);
-                return (_root, false);
+                root = _root;
+                owned = false;
+                return true;
             }
+        }
+
+        /// <summary>
+        /// Disposes this data source where no connection is open on it and none has been for its idle
+        /// lifetime, answering whether it is now disposed.
+        /// </summary>
+        /// <param name="now">The current <see cref="Environment.TickCount64"/>.</param>
+        internal bool TryPrune(long now)
+        {
+            CalciteDataSourceRoot? root;
+            lock (_sync)
+            {
+                if (_disposed)
+                    return true;
+
+                if (_root is not null && _root.Users > 0)
+                    return false;
+
+                var idleSince = _root?.IdleSince ?? _created;
+                if (now - idleSince < _idleLifetime.TotalMilliseconds)
+                    return false;
+
+                _disposed = true;
+                root = _root;
+                _root = null;
+            }
+
+            root?.Retire();
+            return true;
         }
 
         /// <summary>
@@ -119,13 +204,19 @@ namespace Apache.Calcite.Data
         /// model, and with it a model file that has changed on disk.
         /// </summary>
         /// <remarks>
-        /// A connection already open keeps the root it has. The dropped root is not disposed, for that
-        /// reason; it goes when the last such connection lets go of it.
+        /// A connection already open keeps the root it has, and the dropped root is disposed once the last
+        /// such connection is.
         /// </remarks>
         public void Clear()
         {
+            CalciteDataSourceRoot? root;
             lock (_sync)
+            {
+                root = _root;
                 _root = null;
+            }
+
+            root?.Retire();
         }
 
         /// <inheritdoc />
@@ -154,6 +245,10 @@ namespace Apache.Calcite.Data
         }
 
         /// <inheritdoc />
+        /// <remarks>
+        /// Retires the root: no new connection can be opened, a connection already open keeps working, and
+        /// the root's disposable schemas are disposed once the last such connection is disposed.
+        /// </remarks>
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -169,16 +264,10 @@ namespace Apache.Calcite.Data
                     _root = null;
                 }
 
-                root?.Dispose();
+                root?.Retire();
             }
 
             base.Dispose(disposing);
-        }
-
-        void ThrowIfDisposed()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(GetType().Name);
         }
 
     }

--- a/src/Apache.Calcite.Data/CalciteDataSourceBuilder.cs
+++ b/src/Apache.Calcite.Data/CalciteDataSourceBuilder.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+
+using org.apache.calcite.schema;
+
+namespace Apache.Calcite.Data
+{
+
+    /// <summary>
+    /// Builds a <see cref="CalciteDataSource"/> from a connection string and whatever a connection string
+    /// cannot carry.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A connection string can name a model, and a model can name a schema factory, and that is as far as
+    /// text goes. A schema an application constructed itself — around a client it already owns, a token
+    /// cache, an in-memory collection — has to be handed over as an object, and this is where. What is
+    /// registered here is applied to the data source's root after the model, in the order it was added,
+    /// and every connection the data source opens sees it.
+    /// </para>
+    /// <code>
+    /// var dataSource = new CalciteDataSourceBuilder("Lex=MYSQL_ANSI")
+    ///     .AddSchema("MEM", new MySchema())
+    ///     .Build();
+    ///
+    /// await using var connection = await dataSource.OpenConnectionAsync();
+    /// </code>
+    /// <para>
+    /// A data source built this way is the caller's: it is not shared with connections opened by connection
+    /// string, and the caller disposes it.
+    /// </para>
+    /// </remarks>
+    public sealed class CalciteDataSourceBuilder
+    {
+
+        readonly List<Action<SchemaPlus>> _configure = [];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CalciteDataSourceBuilder"/> class.
+        /// </summary>
+        /// <param name="connectionString">The connection string, or <see langword="null"/> for an empty one.
+        /// Recognized keys are described on <see cref="CalciteConnectionStringBuilder"/>.</param>
+        public CalciteDataSourceBuilder(string? connectionString = null)
+        {
+            ConnectionStringBuilder = new CalciteConnectionStringBuilder(connectionString);
+        }
+
+        /// <summary>
+        /// Gets the connection string builder, which can be changed until <see cref="Build"/> is called.
+        /// </summary>
+        public CalciteConnectionStringBuilder ConnectionStringBuilder { get; }
+
+        /// <summary>
+        /// Gets the connection string as it currently stands.
+        /// </summary>
+        public string ConnectionString => ConnectionStringBuilder.ConnectionString;
+
+        /// <summary>
+        /// Adds a schema to the root of the data source being built.
+        /// </summary>
+        /// <param name="name">The name to register the schema under.</param>
+        /// <param name="schema">The schema.</param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> or <paramref name="schema"/> is <see langword="null"/>.</exception>
+        public CalciteDataSourceBuilder AddSchema(string name, Schema schema)
+        {
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(schema);
+
+            return ConfigureRootSchema(root => root.add(name, schema));
+        }
+
+        /// <summary>
+        /// Registers a step to run over the root of the data source being built, after the model.
+        /// </summary>
+        /// <param name="configure">The step, given the root as Calcite's mutable <see cref="SchemaPlus"/>.
+        /// Anything the root accepts can be added: a schema that needs its parent, a table, a function, a
+        /// view macro.</param>
+        /// <returns>This builder.</returns>
+        /// <remarks>
+        /// The step runs once per root — once for the data source, or once per connection under
+        /// <c>Pooling=false</c> — and is the one place a caller meets the root as a <see cref="SchemaPlus"/>.
+        /// A connection sees the root as a <see cref="Schema"/>, the read interface, because a change made
+        /// through one connection would reach every connection of the data source.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+        public CalciteDataSourceBuilder ConfigureRootSchema(Action<SchemaPlus> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+
+            _configure.Add(configure);
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the data source.
+        /// </summary>
+        /// <returns>A data source that is the caller's to dispose.</returns>
+        public CalciteDataSource Build()
+        {
+            return new CalciteDataSource(new CalciteConnectionStringBuilder(ConnectionString), _configure.ToArray());
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -109,13 +109,14 @@ Public, consumer-facing classes implementing the `System.Data.Common` contracts.
 
 | Class | Base | Role |
 | --- | --- | --- |
-| `CalciteConnection` | `DbConnection` | Owns connection state and the `CalciteSession`; exposes Calcite-native accessors and hook registration. |
+| `CalciteConnection` | `DbConnection` | Owns connection state and the `CalciteSession`; draws its root schema from a `CalciteDataSource`; exposes Calcite-native accessors and hook registration. |
 | `CalciteCommand` | `DbCommand` | Holds SQL text and parameters; builds a `CalciteExecuteRequest` and calls the session. |
 | `CalciteDataReader` | `DbDataReader` | Streams rows out of one or more `CalciteResult`s; `NextResult` walks a batch's results. |
 | `CalciteBatch` / `CalciteBatchCommand` / `CalciteBatchCommandCollection` | `DbBatch` / `DbBatchCommand` / `DbBatchCommandCollection` | Runs several statements sequentially on one session. |
 | `CalciteParameter` / `CalciteParameterCollection` | `DbParameter` / `DbParameterCollection` | Provider parameter model. Placeholders are positional `?`; `ParameterName` is informational. |
 | `CalciteTransaction` | `DbTransaction` | Exists to satisfy frameworks that require a non-null transaction. `Commit` and `Rollback` throw `NotSupportedException`, and `BeginDbTransaction` throws before one is ever handed out. |
-| `CalciteDataSource` | `DbDataSource` | The `DbDataSource` entry point. |
+| `CalciteDataSource` | `DbDataSource` | Holds the root schema — model, `DUAL`, whatever the builder added — for the life of the application, and hands it to every connection it opens. Every bare `new CalciteConnection(cs)` draws on one the provider keeps per connection string. |
+| `CalciteDataSourceBuilder` | — | Builds a `CalciteDataSource` from a connection string plus what a string cannot carry: a schema instance, or any step over the root as a `SchemaPlus`. |
 | `CalciteProviderFactory` | `DbProviderFactory` | Standard ADO.NET factory registration. |
 | `CalciteConnectionStringBuilder` | `DbConnectionStringBuilder` | Typed connection-string keys (`Model`, `Schema`, `Synchronous`, `CaseSensitive`, `Conformance`, …). Unknown keys are preserved and forwarded. |
 | `CalciteException` | `DbException` | Provider failures, including planning and execution errors. |
@@ -123,7 +124,8 @@ Public, consumer-facing classes implementing the `System.Data.Common` contracts.
 `CalciteConnection` also exposes Calcite-native objects directly, so there is no `Unwrap`-style
 escape hatch:
 
-- `RootSchema` → `org.apache.calcite.schema.SchemaPlus`
+- `RootSchema` → `org.apache.calcite.schema.Schema`, the read interface — the root is the data source's,
+  and what changes it is `CalciteDataSourceBuilder.ConfigureRootSchema` or DDL
 - `TypeFactory` → `org.apache.calcite.adapter.java.JavaTypeFactory`
 - `Config` → `org.apache.calcite.config.CalciteConnectionConfig`
 
@@ -136,25 +138,62 @@ The connection's hooks and the command's are concatenated per request, connectio
 
 ### 2. Session (`Internal/CalciteSession`)
 
-`CalciteSession` is the per-connection engine state, created on the first `CalciteConnection.Open()`
-and kept alive across `Close`/`Open` cycles — a schema registered on `RootSchema` or a table created
-by DDL survives a close. `Dispose` is what ends it, and only marks the session disposed so later
-execute calls throw `ObjectDisposedException`.
+A Calcite connection is long-lived — it is the engine, and Java applications hold one for the life of
+the process — and an ADO.NET connection is not. So Calcite's connection is split along the line
+between what lives as long as the application and what lives as long as a connection, and the two
+halves are two classes.
 
-Construction, from the `CalciteConnectionStringBuilder`:
+**`CalciteDataSourceRoot`** (`Internal/`) is the application-lived half, held by a `CalciteDataSource`:
+the root schema, `DUAL` where the conformance has one, and the model. It is `CalciteConnectionImpl`'s
+constructor minus the type factory, followed by the driver's `onConnectionInit` model step, in that
+order, so a model can overwrite `DUAL` and never the reverse; and the driver's `model()` is ported with
+it, so that without a `Model` a `SchemaFactory` or `SchemaType` key synthesises one, named by the
+`Schema` key, with every `schema.`-prefixed key as an operand. The steps a `CalciteDataSourceBuilder`
+registered run last. A data source builds its root once, under a lock, on the first connection to open —
+Npgsql's `Bootstrap` — and a build that throws leaves nothing behind, so the next connection tries again.
+`Pooling=false` builds one per connection instead, and the connection disposes it. Disposing a root
+disposes every schema on it that implements `IDisposable`, sub-schemas first, which is the release
+Calcite's schema SPI has no hook for.
 
-- Builds the root schema with `CalciteSchema.createRootSchema(addMetadataSchema: true)`, then
-  applies the `Model` key through Calcite's `ModelHandler` — either `inline:`-prefixed (or
-  brace-leading) JSON, or a file path, which must exist. The handler's `defaultSchemaName()` wins
-  over the `Schema` key.
-- Builds a `java.util.Properties` from every remaining key, translating each to the camelCase name
-  Calcite expects via a static map from connection-string key to `CalciteConnectionProperty`, and
-  wraps it in a `CalciteConnectionConfigImpl`.
-- Creates a `JavaTypeFactoryImpl`, and resolves the default schema path to zero or one name.
-- Reads the `Synchronous` key — a provider option, excluded from the engine properties like `Model` —
-  which decides the convention every query on this connection is planned into.
+**`CalciteDataSources`** (`Internal/`) is Npgsql's `PoolManager`: a process-wide dictionary of data
+sources keyed by `CalciteConnectionStringBuilder.DataSourceKey`, which is the connection string with
+its keys lower-cased and sorted and `Synchronous` left out — that key chooses the convention a
+connection plans into and nothing that is built, as Npgsql leaves `TargetSessionAttributes` out of its
+key. A bare `new CalciteConnection(cs)` resolves its data source here on `Open`; an empty connection
+string gets a private one, there being nothing to key on. `ClearPool` and `ClearAllPools` remove entries
+without disposing them, since a connection may still hold one; every entry left at process exit is
+disposed then. A data source the application built is never here.
 
-Anything thrown here that is not already a `CalciteException` is wrapped in one.
+**`CalciteSession`** is the connection-lived half: created on the first `CalciteConnection.Open()` over
+the root the data source handed it, and kept alive across `Close`/`Open` cycles. Construction is the
+rest of `CalciteConnectionImpl`'s constructor:
+
+- Builds a `java.util.Properties` from every key that is the engine's, translating each to the camelCase
+  name Calcite expects via `CalciteEngineProperties`, and wraps it in a `CalciteConnectionConfigImpl`.
+  `Model`, `Synchronous`, `Pooling` and `TypeSystem` are the provider's and are left out.
+- Creates a `JavaTypeFactoryImpl` over the type system the `TypeSystem` key names, under the
+  conformance's ragged-union wrapper. **The type factory is per connection and the root is per data
+  source, and that is the split Calcite makes itself** when it opens an internal connection over an
+  existing root, `CalciteMetaImpl.connect(schema.root(), null)`. It is not a nicety:
+  `JavaTypeFactoryImpl.syntheticTypes` is a plain `HashMap` written by every grouped aggregate and
+  window, so a factory shared by connections used concurrently would race, where a root shared by them
+  is read. `RelDataType`s are interned process-wide, so a table answers the same types to every factory.
+- Resolves the default schema path to zero or one name — the model's `defaultSchemaName()` wins over the
+  `Schema` key — and reads the `Synchronous` key, which decides the convention every query on this
+  connection is planned into.
+
+`Dispose` marks the session disposed so later execute calls throw `ObjectDisposedException`, and
+disposes the root where the session owns it.
+
+Anything thrown in either constructor that is not already a `CalciteException` is wrapped in one.
+
+Sharing a root is a contract adapters did not have before: a `Schema` reachable from a data source may
+be read from several threads at once, and Calcite serialises nothing. DDL is serialised against DDL —
+`ClrPrepareImpl.ExecuteDdl` takes the mutable root's monitor, because a DDL statement writes into
+`NameMap`s over `TreeMap`s, which two writers corrupt. A statement planning against the root while
+another alters it is Calcite's own exposure and is not closed; note that `createSnapshot` shares
+`tableMap` with the live root by its own javadoc, so the per-statement snapshot isolates the adapter's
+implicit tables and not the explicit ones.
 
 The session exposes three private steps and the execute entry points.
 
@@ -431,8 +470,10 @@ text form for it. If upstream exposes a variant's full `RuntimeTypeInformation`,
 
 1. **Construct.** The caller creates a `CalciteConnection` (directly, through
    `CalciteProviderFactory`, or from a `CalciteDataSource`) with a connection string.
-2. **Open.** `Open()` creates the `CalciteSession` on first call: root schema, model, config, type
-   factory, default schema path.
+2. **Open.** `Open()` resolves the connection's `CalciteDataSource` — the one it was created from, or
+   the one the provider keeps for its connection string — and asks it for the root, which the first
+   connection to open builds (model included) and the rest find built. Then it creates the
+   `CalciteSession` over that root: config, type factory, default schema path.
 3. **Build command.** The caller sets `CommandText` and adds parameters to a `CalciteCommand`.
 4. **Request.** `ExecuteReader` builds a `CalciteExecuteRequest` from the text, the parameters, the
    timeout and the resolved hooks, and hands it to the session's reader core.
@@ -452,7 +493,8 @@ text form for it. If upstream exposes a variant's full `RuntimeTypeInformation`,
 8. **Read.** `CalciteDataReader` pulls rows through `CalciteResult.ReadAsync`, and each accessor
    goes `CalciteResultRow` → `CalciteResultValue` → CLR value.
 9. **Dispose.** Disposing the reader disposes the result and its enumerator. Disposing the
-   connection disposes the session.
+   connection disposes the session, and the root with it only under `Pooling=false`; otherwise the
+   root is the data source's and goes when the data source is disposed.
 
 **A non-query** follows steps 1–6, then branches on the statement type as described above and
 returns a `CalciteResult` with a count and no enumerator.
@@ -478,8 +520,13 @@ plan wherever the query itself would.
 
 `CalciteConnection` exposes selected Calcite-native objects as public properties rather than
 providing a JDBC-style `unwrap`. This keeps the contract typed and discoverable while letting
-advanced consumers register schemas, tables, functions and views on `RootSchema`, build types with
-`TypeFactory`, and inspect resolved configuration through `Config`.
+advanced consumers inspect the root through `RootSchema`, build types with `TypeFactory`, and inspect
+resolved configuration through `Config`. `RootSchema` is a `Schema`, Calcite's read interface, and not
+the `SchemaPlus` Calcite adds to it: the root is the data source's, shared by every connection opened on
+it, and a change made through one connection would reach all of them without any having asked. Schemas,
+tables, functions and views are registered through `CalciteDataSourceBuilder.ConfigureRootSchema`, which
+is where a caller meets the root as a `SchemaPlus`. This is a type and not a guard; the object is the
+root itself.
 
 A user-defined function written in .NET works here without a class name being written out at all: IKVM
 names a CLR class `cli.Namespace.Type`, which `EnumerableConvention` writes into generated Java source,
@@ -506,12 +553,16 @@ src/
     CalciteParameter.cs                   DbParameter
     CalciteParameterCollection.cs         DbParameterCollection
     CalciteTransaction.cs                 DbTransaction (Commit/Rollback throw)
-    CalciteDataSource.cs                  DbDataSource
+    CalciteDataSource.cs                  DbDataSource; holds the root schema for the application
+    CalciteDataSourceBuilder.cs           Builds a data source from a string and what a string cannot carry
     CalciteProviderFactory.cs             DbProviderFactory
     CalciteConnectionStringBuilder.cs     DbConnectionStringBuilder
     CalciteException.cs                   DbException
     Internal/
-      CalciteSession.cs                   Per-connection engine state; plan, bind, execute
+      CalciteSession.cs                   Per-connection engine state over a data source's root; plan, bind, execute
+      CalciteDataSourceRoot.cs            The root schema, DUAL and the model, built once per data source
+      CalciteDataSources.cs               The data sources the provider keeps, one per connection string
+      CalciteEngineProperties.cs          Connection string keys → the engine's Properties
       CalciteExecuteRequest.cs            Execute payload
       CalciteParameterValue.cs            (DbType, value) pair
       ParameterBinder.cs                  CLR value → Calcite runtime representation, by DbType

--- a/src/Apache.Calcite.Data/DESIGN.md
+++ b/src/Apache.Calcite.Data/DESIGN.md
@@ -160,9 +160,19 @@ sources keyed by `CalciteConnectionStringBuilder.DataSourceKey`, which is the co
 its keys lower-cased and sorted and `Synchronous` left out — that key chooses the convention a
 connection plans into and nothing that is built, as Npgsql leaves `TargetSessionAttributes` out of its
 key. A bare `new CalciteConnection(cs)` resolves its data source here on `Open`; an empty connection
-string gets a private one, there being nothing to key on. `ClearPool` and `ClearAllPools` remove entries
-without disposing them, since a connection may still hold one; every entry left at process exit is
-disposed then. A data source the application built is never here.
+string gets a private one, there being nothing to key on. A data source the application built is never
+here.
+
+Entries are held strongly, not weakly: the point of one is to be there for the next connection when
+nothing else references it, so what bounds the set is time rather than reachability, as it is for a
+connection pool. A root counts the sessions on it, and each entry has a timer that fires every
+`Connection Pruning Interval` and releases the entry once it has gone `Connection Idle Lifetime` with no
+session on its root — removed here, and its root retired. `ClearPool` and `ClearAllPools` do the same on
+demand, and entries left at process exit are released then. Retiring a root disposes its `IDisposable`
+schemas at once where no session holds it and otherwise when the last session is disposed, so a connection
+still open keeps working, the way a pooled connector Npgsql has cleared is closed when it is returned
+rather than while it is busy. A connection that finds its entry pruned between lookup and use looks it up
+again. Both keywords are spelled as Npgsql spells them and validated as Npgsql validates them.
 
 **`CalciteSession`** is the connection-lived half: created on the first `CalciteConnection.Open()` over
 the root the data source handed it, and kept alive across `Close`/`Open` cycles. Construction is the
@@ -182,18 +192,25 @@ rest of `CalciteConnectionImpl`'s constructor:
   `Schema` key — and reads the `Synchronous` key, which decides the convention every query on this
   connection is planned into.
 
-`Dispose` marks the session disposed so later execute calls throw `ObjectDisposedException`, and
-disposes the root where the session owns it.
+`Dispose` marks the session disposed so later execute calls throw `ObjectDisposedException`, releases
+the session's count on the root, and retires the root first where the session owns it.
 
 Anything thrown in either constructor that is not already a `CalciteException` is wrapped in one.
 
 Sharing a root is a contract adapters did not have before: a `Schema` reachable from a data source may
-be read from several threads at once, and Calcite serialises nothing. DDL is serialised against DDL —
-`ClrPrepareImpl.ExecuteDdl` takes the mutable root's monitor, because a DDL statement writes into
-`NameMap`s over `TreeMap`s, which two writers corrupt. A statement planning against the root while
-another alters it is Calcite's own exposure and is not closed; note that `createSnapshot` shares
-`tableMap` with the live root by its own javadoc, so the per-statement snapshot isolates the adapter's
-implicit tables and not the explicit ones.
+be read from several threads at once, and Calcite serialises nothing. What the provider serialises is
+the root itself, with a reader-writer lock on `CalciteDataSourceRoot`. Planning is a reader: `Plan` holds
+the read side from the snapshot `PrepareContext` takes to the signature, and the `GetSchema` walkers hold
+it while they read. DDL is the writer: a DDL statement is told apart from a query only after the parse,
+inside the prepare, so `ClrPrepareImpl.ExecuteDdl` finds the lock on the context, gives up the read side
+it arrived holding, takes the write side for the DDL, and takes the read side back for `Plan` to release.
+A statement therefore never plans against a root another connection is altering, which Calcite's own
+connection never had to guarantee, its root being one connection's.
+
+What stays open is execution. The lock is thread-affine and a plan is read asynchronously, so the lock
+cannot span a reader; and a plan resolves its tables once more when it runs, from the snapshot, whose
+`tableMap` is the live root's by `createSnapshot`'s own javadoc. That lookup against a concurrent DDL is
+Calcite's exposure, and it is stated rather than closed.
 
 The session exposes three private steps and the execute entry points.
 

--- a/src/Apache.Calcite.Data/Internal/CalciteDataSourceRoot.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteDataSourceRoot.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using com.google.common.collect;
+
+using org.apache.calcite.adapter.jdbc;
+using org.apache.calcite.config;
+using org.apache.calcite.jdbc;
+using org.apache.calcite.model;
+using org.apache.calcite.schema;
+using org.apache.calcite.schema.impl;
+using org.apache.calcite.util;
+
+namespace Apache.Calcite.Data.Internal
+{
+
+    /// <summary>
+    /// A root schema built from a connection string: Calcite's root, <c>DUAL</c> where the conformance has
+    /// one, the model, and any schemas a <see cref="CalciteDataSource"/> was asked to hold.
+    /// </summary>
+    /// <remarks>
+    /// This is the half of Calcite's connection that lives as long as the data source rather than the
+    /// connection. Calcite's JDBC connection builds it in two steps — the root and <c>DUAL</c> in
+    /// <c>CalciteConnectionImpl</c>'s constructor, the model in the driver's <c>onConnectionInit</c> —
+    /// and this class is those two steps, in that order, so that a model can overwrite <c>DUAL</c> and never
+    /// the reverse. What Calcite builds once per connection is built here once per data source, and every
+    /// connection the data source opens shares it.
+    /// </remarks>
+    internal sealed class CalciteDataSourceRoot
+    {
+
+        readonly CalciteSchema _schema;
+        readonly string? _defaultSchemaName;
+        bool _disposed;
+
+        CalciteDataSourceRoot(CalciteSchema schema, string? defaultSchemaName)
+        {
+            _schema = schema;
+            _defaultSchemaName = defaultSchemaName;
+        }
+
+        /// <summary>
+        /// Builds a root schema.
+        /// </summary>
+        /// <param name="options">The connection string options.</param>
+        /// <param name="configure">Steps to run over the root after the model, in order.</param>
+        /// <param name="rootSchema">Root schema to build on, or null to create one. Used verbatim, as
+        /// upstream uses one handed to its connection, and <c>DUAL</c> and the model are applied to it all
+        /// the same.</param>
+        /// <exception cref="CalciteException">Thrown when the root or the model could not be built.</exception>
+        public static CalciteDataSourceRoot Build(CalciteConnectionStringBuilder options, IReadOnlyList<Action<SchemaPlus>> configure, CalciteSchema? rootSchema = null)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(configure);
+
+            try
+            {
+                var cfg = new CalciteConnectionConfigImpl(CalciteEngineProperties.Build(options));
+
+                var root = rootSchema ?? CalciteSchema.createRootSchema(true);
+
+                // Add dual table metadata when isSupportedDualTable return true
+                if (cfg.conformance().isSupportedDualTable())
+                {
+                    SchemaPlus schemaPlus = root.plus();
+                    // Dual table contains one row with a value X
+                    schemaPlus.add(
+                        "DUAL", ViewTable.viewMacro(schemaPlus, "VALUES ('X')",
+                        ImmutableList.of(), null, java.lang.Boolean.valueOf(false)));
+                }
+
+                // the driver's ModelHandler step, run after the constructor's work as upstream runs it
+                string? defaultSchemaName = null;
+                var model = Model(options, cfg);
+                if (model != null)
+                    ApplyModel(root, model, out defaultSchemaName);
+
+                foreach (var step in configure)
+                    step(root.plus());
+
+                return new CalciteDataSourceRoot(root, defaultSchemaName);
+            }
+            catch (Exception e) when (e is not CalciteException)
+            {
+                throw new CalciteException("Failed to initialize Calcite.", e);
+            }
+        }
+
+        /// <summary>
+        /// The model to read, which is the <c>Model</c> key where there is one, and otherwise a model written
+        /// around the schema factory the <c>SchemaFactory</c> or <c>SchemaType</c> key names, holding every
+        /// <c>schema.</c>-prefixed key as an operand. <c>Driver.createHandler().model</c>.
+        /// </summary>
+        static string? Model(CalciteConnectionStringBuilder options, CalciteConnectionConfig config)
+        {
+            var model = options.Model;
+            if (string.IsNullOrEmpty(model) == false)
+                return model;
+
+            var schemaFactory = (SchemaFactory?)config.schemaFactory((java.lang.Class)typeof(SchemaFactory), null);
+            var info = CalciteEngineProperties.Build(options);
+            var schemaName = Util.first(config.schema(), "adhoc");
+            if (schemaFactory == null)
+            {
+                var schemaType = config.schemaType();
+                if (schemaType != null)
+                {
+                    switch (schemaType.name())
+                    {
+                        case nameof(JsonSchema.Type.JDBC):
+                            schemaFactory = JdbcSchema.Factory.INSTANCE;
+                            break;
+                        case nameof(JsonSchema.Type.MAP):
+                            schemaFactory = AbstractSchema.Factory.INSTANCE;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            if (schemaFactory != null)
+            {
+                var json = new JsonBuilder();
+                var root = json.map();
+                root.put("version", "1.0");
+                root.put("defaultSchema", schemaName);
+                var schemaList = json.list();
+                root.put("schemas", schemaList);
+                var schema = json.map();
+                schemaList.add(schema);
+                schema.put("type", "custom");
+                schema.put("name", schemaName);
+                schema.put("factory", ikvm.runtime.Util.getClassFromObject(schemaFactory).getName());
+                var operandMap = json.map();
+                schema.put("operand", operandMap);
+                for (var it = Util.toMap(info).entrySet().iterator(); it.hasNext();)
+                {
+                    var entry = (java.util.Map.Entry)it.next();
+                    var key = (string)entry.getKey();
+                    if (key.StartsWith("schema.", StringComparison.Ordinal))
+                        operandMap.put(key.Substring("schema.".Length), entry.getValue());
+                }
+
+                return "inline:" + json.toJsonString(root);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Applies a Calcite model to the root schema, either from an inline JSON definition or a file path.
+        /// </summary>
+        /// <param name="rootSchema">The root schema to which the model will be applied.</param>
+        /// <param name="model">Either an inline JSON model definition (prefixed with "inline:" or starting with "{") or a file path to a
+        /// model definition.</param>
+        /// <param name="defaultSchema">When this method returns, contains the default schema name defined in the model, or <see langword="null"/>
+        /// if no default schema is defined.</param>
+        /// <exception cref="FileNotFoundException">Thrown when the specified model file does not exist.</exception>
+        /// <exception cref="CalciteException">Thrown when the model fails to load.</exception>
+        static void ApplyModel(CalciteSchema rootSchema, string model, out string? defaultSchema)
+        {
+            try
+            {
+                if (model.StartsWith("inline:", StringComparison.OrdinalIgnoreCase) || model.TrimStart().StartsWith("{"))
+                {
+                    var inline = model.StartsWith("inline:", StringComparison.OrdinalIgnoreCase) ? model.Substring("inline:".Length) : model;
+                    var handler = new ModelHandler(rootSchema.plus(), "inline:" + inline);
+                    defaultSchema = handler.defaultSchemaName();
+                }
+                else
+                {
+                    if (!File.Exists(model))
+                        throw new FileNotFoundException("Model file was not found.", model);
+
+                    var handler = new ModelHandler(rootSchema.plus(), model);
+                    defaultSchema = handler.defaultSchemaName();
+                }
+            }
+            catch (Exception e) when (e is not CalciteException)
+            {
+                throw new CalciteException("Failed to load Calcite model.", e);
+            }
+        }
+
+        /// <summary>
+        /// Gets the root schema.
+        /// </summary>
+        public CalciteSchema Schema => _schema;
+
+        /// <summary>
+        /// Gets the default schema the model named, or <see langword="null"/> where it named none.
+        /// </summary>
+        public string? DefaultSchemaName => _defaultSchemaName;
+
+        /// <summary>
+        /// Disposes every schema on the root that can be disposed, sub-schemas first.
+        /// </summary>
+        /// <remarks>
+        /// Calcite has no disposal hook for a schema: a <c>SchemaFactory</c> builds one and nothing ever
+        /// tells it the schema is done with, so an adapter holding a client holds it for the life of the
+        /// process. A root has a lifetime here, so the schemas on it get one too — a schema that implements
+        /// <see cref="IDisposable"/> is disposed when its root is, which for a shared root is when the data
+        /// source is and for a private one is when the connection is.
+        /// </remarks>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            DisposeSchemas(_schema);
+        }
+
+        static void DisposeSchemas(CalciteSchema schema)
+        {
+            for (var it = schema.getSubSchemaMap().values().iterator(); it.hasNext();)
+                DisposeSchemas((CalciteSchema)it.next());
+
+            if (schema.schema is IDisposable disposable)
+                disposable.Dispose();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/Internal/CalciteDataSourceRoot.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteDataSourceRoot.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 using com.google.common.collect;
 
@@ -194,6 +195,97 @@ namespace Apache.Calcite.Data.Internal
         /// </summary>
         public string? DefaultSchemaName => _defaultSchemaName;
 
+        readonly object _sync = new();
+        int _users;
+        bool _retired;
+        long _idleSince = Environment.TickCount64;
+
+        /// <summary>
+        /// Gets the lock a statement plans under and DDL alters the root under.
+        /// </summary>
+        /// <remarks>
+        /// Calcite's connection is driven by one thread and its root by one connection, so nothing in Calcite
+        /// guards the root: a <c>CalciteSchema</c> keeps its tables and sub-schemas in <c>NameMap</c>s over
+        /// <c>TreeMap</c>s, and a DDL statement writes into them while a statement planning reads them. A
+        /// root shared by connections used concurrently needs the reader-writer shape: planning — the
+        /// snapshot, validation, optimisation, implementation — under the read lock, many at a time, and DDL
+        /// under the write lock, alone. The lock is thread-affine, so it spans planning, which is one thread's
+        /// work, and not execution: a table is resolved again from the snapshot when a plan runs, the
+        /// snapshot shares its table map with the live root by Calcite's own javadoc, and an asynchronous
+        /// read cannot hold a lock across its awaits. That lookup against a concurrent DDL is the exposure
+        /// that stays open, and it is Calcite's.
+        /// </remarks>
+        public ReaderWriterLockSlim Lock { get; } = new(LockRecursionPolicy.SupportsRecursion);
+
+        /// <summary>
+        /// Gets the number of sessions holding this root.
+        /// </summary>
+        public int Users
+        {
+            get { lock (_sync) return _users; }
+        }
+
+        /// <summary>
+        /// Gets when this root last had no session holding it, as <see cref="Environment.TickCount64"/> —
+        /// its construction, or the last <see cref="Release"/> that left it with none.
+        /// </summary>
+        public long IdleSince
+        {
+            get { lock (_sync) return _idleSince; }
+        }
+
+        /// <summary>
+        /// Counts a session onto this root.
+        /// </summary>
+        public void Acquire()
+        {
+            lock (_sync)
+                _users++;
+        }
+
+        /// <summary>
+        /// Counts a session off this root, disposing it where it has been retired and this was the last.
+        /// </summary>
+        public void Release()
+        {
+            bool dispose;
+            lock (_sync)
+            {
+                _users--;
+                if (_users == 0)
+                    _idleSince = Environment.TickCount64;
+
+                dispose = _users == 0 && _retired;
+            }
+
+            if (dispose)
+                Dispose();
+        }
+
+        /// <summary>
+        /// Marks this root as done with, disposing it now where no session holds it and otherwise when
+        /// the last one lets go.
+        /// </summary>
+        /// <remarks>
+        /// This is what a data source does to a root it drops — on <see cref="CalciteDataSource.Clear"/>,
+        /// on its own disposal, and when the provider evicts or prunes it — and what a session does to a
+        /// root built for it alone. A connection still open keeps working: the root goes when the last
+        /// session on it is disposed, the way a pooled connector Npgsql has cleared is closed when it is
+        /// returned rather than while it is busy.
+        /// </remarks>
+        public void Retire()
+        {
+            bool dispose;
+            lock (_sync)
+            {
+                _retired = true;
+                dispose = _users == 0;
+            }
+
+            if (dispose)
+                Dispose();
+        }
+
         /// <summary>
         /// Disposes every schema on the root that can be disposed, sub-schemas first.
         /// </summary>
@@ -201,16 +293,21 @@ namespace Apache.Calcite.Data.Internal
         /// Calcite has no disposal hook for a schema: a <c>SchemaFactory</c> builds one and nothing ever
         /// tells it the schema is done with, so an adapter holding a client holds it for the life of the
         /// process. A root has a lifetime here, so the schemas on it get one too — a schema that implements
-        /// <see cref="IDisposable"/> is disposed when its root is, which for a shared root is when the data
-        /// source is and for a private one is when the connection is.
+        /// <see cref="IDisposable"/> is disposed when its root is, which is when it has been
+        /// <see cref="Retire">retired</see> and no session holds it.
         /// </remarks>
-        public void Dispose()
+        void Dispose()
         {
-            if (_disposed)
-                return;
+            lock (_sync)
+            {
+                if (_disposed)
+                    return;
 
-            _disposed = true;
+                _disposed = true;
+            }
+
             DisposeSchemas(_schema);
+            Lock.Dispose();
         }
 
         static void DisposeSchemas(CalciteSchema schema)

--- a/src/Apache.Calcite.Data/Internal/CalciteDataSources.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteDataSources.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Apache.Calcite.Data.Internal
+{
+
+    /// <summary>
+    /// Provides lookup for a data source based on a connection string.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="CalciteDataSource"/> a bare <c>new CalciteConnection(connectionString)</c> draws on.
+    /// A connection string that has not been seen before makes one, and every connection opened with an
+    /// equivalent string afterwards shares it, so a model is read once for the process rather than once per
+    /// connection. Data sources a caller builds for itself are referenced directly by the caller and are not
+    /// held here.
+    ///
+    /// <para>An entry lives until <see cref="Clear"/> or <see cref="ClearAll"/> removes it, or the process
+    /// ends. Removal does not dispose it: a connection already opened on it keeps using it, and it goes when
+    /// the last such connection lets go of it. Every entry still held at process exit is disposed then, so
+    /// that a schema holding a client gets to close it.</para>
+    /// </remarks>
+    internal static class CalciteDataSources
+    {
+
+        static readonly ConcurrentDictionary<string, CalciteDataSource> registered = new();
+
+        static CalciteDataSources()
+        {
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => DisposeAll();
+            AppDomain.CurrentDomain.DomainUnload += (_, _) => DisposeAll();
+        }
+
+        /// <summary>
+        /// Gets the data source for a connection string, making it if it is new.
+        /// </summary>
+        /// <param name="options">The connection string.</param>
+        /// <returns>The data source.</returns>
+        /// <remarks>
+        /// An empty connection string names nothing to key on, and two connections written that way have no
+        /// reason to meet, so it gets a data source of its own rather than the one every other empty string
+        /// would share.
+        /// </remarks>
+        public static CalciteDataSource Resolve(CalciteConnectionStringBuilder options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            if (options.Count == 0)
+                return new CalciteDataSource(options);
+
+            var key = options.DataSourceKey;
+            if (registered.TryGetValue(key, out var existing))
+                return existing;
+
+            // Really unseen, need to create a new data source. If someone beats us to it use what they put.
+            var created = new CalciteDataSource(new CalciteConnectionStringBuilder(key));
+            var winner = registered.GetOrAdd(key, created);
+            if (winner != created)
+                created.Dispose();
+
+            return winner;
+        }
+
+        /// <summary>
+        /// Removes the data source for a connection string, so that the next connection opened with it
+        /// builds a new one.
+        /// </summary>
+        /// <param name="options">The connection string.</param>
+        public static void Clear(CalciteConnectionStringBuilder options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            if (options.Count > 0)
+                registered.TryRemove(options.DataSourceKey, out _);
+        }
+
+        /// <summary>
+        /// Removes every data source, so that the next connection opened with any connection string builds a
+        /// new one.
+        /// </summary>
+        public static void ClearAll()
+        {
+            registered.Clear();
+        }
+
+        static void DisposeAll()
+        {
+            foreach (var dataSource in registered.Values)
+                dataSource.Dispose();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/Internal/CalciteDataSources.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteDataSources.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
 
 namespace Apache.Calcite.Data.Internal
 {
@@ -14,20 +16,42 @@ namespace Apache.Calcite.Data.Internal
     /// connection. Data sources a caller builds for itself are referenced directly by the caller and are not
     /// held here.
     ///
-    /// <para>An entry lives until <see cref="Clear"/> or <see cref="ClearAll"/> removes it, or the process
-    /// ends. Removal does not dispose it: a connection already opened on it keeps using it, and it goes when
-    /// the last such connection lets go of it. Every entry still held at process exit is disposed then, so
-    /// that a schema holding a client gets to close it.</para>
+    /// <para>An entry is held strongly, because the point of it is to be there for the next connection when
+    /// nothing else references it; what bounds the set is time rather than reachability. Each entry has a
+    /// timer that fires every <see cref="CalciteConnectionStringBuilder.ConnectionPruningInterval"/> and
+    /// prunes the entry once it has gone <see cref="CalciteConnectionStringBuilder.ConnectionIdleLifetime"/>
+    /// with no connection open on it — removed here and disposed, so a schema holding a client gets to close
+    /// it. <see cref="Clear"/> and <see cref="ClearAll"/> do the same on demand, and an entry still held at
+    /// process exit is disposed then. Disposal retires the root rather than tearing it down: a connection
+    /// still open keeps it until that connection is disposed.</para>
     /// </remarks>
     internal static class CalciteDataSources
     {
 
-        static readonly ConcurrentDictionary<string, CalciteDataSource> registered = new();
+        /// <summary>
+        /// A data source the provider keeps, with the timer that prunes it.
+        /// </summary>
+        sealed class Entry
+        {
+
+            public Entry(CalciteDataSource dataSource, string key)
+            {
+                DataSource = dataSource;
+                Timer = new Timer(_ => Prune(key, this), null, dataSource.PruningInterval, dataSource.PruningInterval);
+            }
+
+            public CalciteDataSource DataSource { get; }
+
+            public Timer Timer { get; }
+
+        }
+
+        static readonly ConcurrentDictionary<string, Entry> registered = new();
 
         static CalciteDataSources()
         {
-            AppDomain.CurrentDomain.ProcessExit += (_, _) => DisposeAll();
-            AppDomain.CurrentDomain.DomainUnload += (_, _) => DisposeAll();
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => ClearAll();
+            AppDomain.CurrentDomain.DomainUnload += (_, _) => ClearAll();
         }
 
         /// <summary>
@@ -38,54 +62,78 @@ namespace Apache.Calcite.Data.Internal
         /// <remarks>
         /// An empty connection string names nothing to key on, and two connections written that way have no
         /// reason to meet, so it gets a data source of its own rather than the one every other empty string
-        /// would share.
+        /// would share — one that is not kept here and builds its root for the one connection.
+        ///
+        /// <para>The data source answered may be pruned between this call and its use, so a caller that
+        /// finds it disposed looks it up again; <see cref="CalciteConnection.Open"/> does.</para>
         /// </remarks>
         public static CalciteDataSource Resolve(CalciteConnectionStringBuilder options)
         {
             ArgumentNullException.ThrowIfNull(options);
 
             if (options.Count == 0)
-                return new CalciteDataSource(options);
+                return new CalciteDataSource(options, [], pooled: false);
 
             var key = options.DataSourceKey;
             if (registered.TryGetValue(key, out var existing))
-                return existing;
+                return existing.DataSource;
 
             // Really unseen, need to create a new data source. If someone beats us to it use what they put.
-            var created = new CalciteDataSource(new CalciteConnectionStringBuilder(key));
+            var created = new Entry(new CalciteDataSource(new CalciteConnectionStringBuilder(key), []), key);
             var winner = registered.GetOrAdd(key, created);
             if (winner != created)
-                created.Dispose();
+                Remove(created);
 
-            return winner;
+            return winner.DataSource;
         }
 
         /// <summary>
-        /// Removes the data source for a connection string, so that the next connection opened with it
-        /// builds a new one.
+        /// Removes the data source for a connection string and disposes it, so that the next connection
+        /// opened with it builds a new one.
         /// </summary>
         /// <param name="options">The connection string.</param>
         public static void Clear(CalciteConnectionStringBuilder options)
         {
             ArgumentNullException.ThrowIfNull(options);
 
-            if (options.Count > 0)
-                registered.TryRemove(options.DataSourceKey, out _);
+            if (options.Count > 0 && registered.TryRemove(options.DataSourceKey, out var entry))
+                Remove(entry);
         }
 
         /// <summary>
-        /// Removes every data source, so that the next connection opened with any connection string builds a
-        /// new one.
+        /// Removes every data source and disposes it, so that the next connection opened with any
+        /// connection string builds a new one.
         /// </summary>
         public static void ClearAll()
         {
-            registered.Clear();
+            foreach (var key in new List<string>(registered.Keys))
+                if (registered.TryRemove(key, out var entry))
+                    Remove(entry);
         }
 
-        static void DisposeAll()
+        /// <summary>
+        /// The timer's tick: disposes and removes the entry where nothing has used it for its idle lifetime.
+        /// </summary>
+        static void Prune(string key, Entry entry)
         {
-            foreach (var dataSource in registered.Values)
-                dataSource.Dispose();
+            try
+            {
+                if (entry.DataSource.TryPrune(Environment.TickCount64) == false)
+                    return;
+
+                if (registered.TryRemove(new KeyValuePair<string, Entry>(key, entry)))
+                    entry.Timer.Dispose();
+            }
+            catch
+            {
+                // a timer callback has nowhere to throw to; the next tick tries again
+            }
+        }
+
+        static void Remove(Entry entry)
+        {
+            entry.Timer.Dispose();
+            entry.DataSource.Dispose();
         }
 
     }

--- a/src/Apache.Calcite.Data/Internal/CalciteEngineProperties.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteEngineProperties.cs
@@ -64,8 +64,13 @@ namespace Apache.Calcite.Data.Internal
                 if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                // a provider option, not an engine one: it decides whether connections share a root schema
+                // provider options, not engine ones: whether connections share a root schema, and for how
+                // long the provider keeps one nobody is using
                 if (string.Equals(key, CalciteConnectionStringBuilder.PoolingKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (string.Equals(key, CalciteConnectionStringBuilder.ConnectionIdleLifetimeKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (string.Equals(key, CalciteConnectionStringBuilder.ConnectionPruningIntervalKey, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 // a provider option, not an engine one: it names a .NET type, resolved by ClrPlugin, and

--- a/src/Apache.Calcite.Data/Internal/CalciteEngineProperties.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteEngineProperties.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+
+using java.util;
+
+using org.apache.calcite.config;
+
+namespace Apache.Calcite.Data.Internal
+{
+
+    /// <summary>
+    /// Turns a connection string into the <see cref="Properties"/> Calcite's own connection is configured by.
+    /// </summary>
+    internal static class CalciteEngineProperties
+    {
+
+        /// <summary>
+        /// Maps each <see cref="CalciteConnectionStringBuilder"/> key constant to the
+        /// corresponding <see cref="CalciteConnectionProperty"/>, which is the authoritative
+        /// source of the camelCase property name Calcite expects.
+        /// </summary>
+        static readonly Dictionary<string, CalciteConnectionProperty> KeyToProperty = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [CalciteConnectionStringBuilder.ApproximateDecimalKey] = CalciteConnectionProperty.APPROXIMATE_DECIMAL,
+            [CalciteConnectionStringBuilder.ApproximateDistinctCountKey] = CalciteConnectionProperty.APPROXIMATE_DISTINCT_COUNT,
+            [CalciteConnectionStringBuilder.ApproximateTopNKey] = CalciteConnectionProperty.APPROXIMATE_TOP_N,
+            [CalciteConnectionStringBuilder.CaseSensitiveKey] = CalciteConnectionProperty.CASE_SENSITIVE,
+            [CalciteConnectionStringBuilder.ConformanceKey] = CalciteConnectionProperty.CONFORMANCE,
+            [CalciteConnectionStringBuilder.CreateMaterializationsKey] = CalciteConnectionProperty.CREATE_MATERIALIZATIONS,
+            [CalciteConnectionStringBuilder.DefaultNullCollationKey] = CalciteConnectionProperty.DEFAULT_NULL_COLLATION,
+            [CalciteConnectionStringBuilder.DruidFetchKey] = CalciteConnectionProperty.DRUID_FETCH,
+            [CalciteConnectionStringBuilder.ForceDecorrelateKey] = CalciteConnectionProperty.FORCE_DECORRELATE,
+            [CalciteConnectionStringBuilder.FunKey] = CalciteConnectionProperty.FUN,
+            [CalciteConnectionStringBuilder.LexKey] = CalciteConnectionProperty.LEX,
+            [CalciteConnectionStringBuilder.MaterializationsEnabledKey] = CalciteConnectionProperty.MATERIALIZATIONS_ENABLED,
+            [CalciteConnectionStringBuilder.ParserFactoryKey] = CalciteConnectionProperty.PARSER_FACTORY,
+            [CalciteConnectionStringBuilder.QuotingKey] = CalciteConnectionProperty.QUOTING,
+            [CalciteConnectionStringBuilder.QuotedCasingKey] = CalciteConnectionProperty.QUOTED_CASING,
+            [CalciteConnectionStringBuilder.UnquotedCasingKey] = CalciteConnectionProperty.UNQUOTED_CASING,
+            [CalciteConnectionStringBuilder.SchemaKey] = CalciteConnectionProperty.SCHEMA,
+            [CalciteConnectionStringBuilder.SchemaFactoryKey] = CalciteConnectionProperty.SCHEMA_FACTORY,
+            [CalciteConnectionStringBuilder.SchemaTypeKey] = CalciteConnectionProperty.SCHEMA_TYPE,
+            [CalciteConnectionStringBuilder.SparkKey] = CalciteConnectionProperty.SPARK,
+            [CalciteConnectionStringBuilder.TimeZoneKey] = CalciteConnectionProperty.TIME_ZONE,
+            [CalciteConnectionStringBuilder.TypeCoercionKey] = CalciteConnectionProperty.TYPE_COERCION,
+        };
+
+        /// <summary>
+        /// Builds a Java Properties object from connection string options, mapping keys to their camel-cased property
+        /// names and excluding the keys that are the provider's rather than the engine's.
+        /// </summary>
+        /// <param name="options">The connection string builder containing the options to convert.</param>
+        /// <returns>A Properties object populated with the connection string options.</returns>
+        public static Properties Build(CalciteConnectionStringBuilder options)
+        {
+            var props = new Properties();
+
+            foreach (var key in options.EnumerateKeys())
+            {
+                if (string.Equals(key, CalciteConnectionStringBuilder.ModelKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // a provider option, not an engine one: it chooses the convention the session plans into
+                if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // a provider option, not an engine one: it decides whether connections share a root schema
+                if (string.Equals(key, CalciteConnectionStringBuilder.PoolingKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // a provider option, not an engine one: it names a .NET type, resolved by ClrPlugin, and
+                // nothing in calcite-core reads the engine property but the constructor line this ports
+                if (string.Equals(key, CalciteConnectionStringBuilder.TypeSystemKey, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (options.TryGetValue(key, out var v) && v is not null)
+                    props.setProperty(KeyToProperty.TryGetValue(key, out var prop) ? prop.camelName() : key, v.ToString());
+            }
+
+            return props;
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Data/Internal/CalciteSchemaInfo.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSchemaInfo.cs
@@ -235,7 +235,9 @@ namespace Apache.Calcite.Data.Internal
             var tableFilter     = restrictionValues?.Length > 2 ? restrictionValues[2] : null;
             var tableTypeFilter = restrictionValues?.Length > 3 ? restrictionValues[3] : null;
 
-            var root = connection.RequireSession().RootSchema;
+            var session = connection.RequireSession();
+            using var _ = session.ReadRoot();
+            var root = session.RootSchema;
             var schemaNames = root.getSubSchemaNames().iterator();
             while (schemaNames.hasNext())
             {
@@ -383,7 +385,9 @@ namespace Apache.Calcite.Data.Internal
             var columnFilter = restrictionValues?.Length > 3 ? restrictionValues[3] : null;
 
             var typeFactory = connection.TypeFactory;
-            var root = connection.RequireSession().RootSchema;
+            var session = connection.RequireSession();
+            using var _ = session.ReadRoot();
+            var root = session.RootSchema;
             var schemaNames = root.getSubSchemaNames().iterator();
             while (schemaNames.hasNext())
             {

--- a/src/Apache.Calcite.Data/Internal/CalciteSchemaInfo.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSchemaInfo.cs
@@ -235,7 +235,7 @@ namespace Apache.Calcite.Data.Internal
             var tableFilter     = restrictionValues?.Length > 2 ? restrictionValues[2] : null;
             var tableTypeFilter = restrictionValues?.Length > 3 ? restrictionValues[3] : null;
 
-            var root = connection.RootSchema;
+            var root = connection.RequireSession().RootSchema;
             var schemaNames = root.getSubSchemaNames().iterator();
             while (schemaNames.hasNext())
             {
@@ -383,7 +383,7 @@ namespace Apache.Calcite.Data.Internal
             var columnFilter = restrictionValues?.Length > 3 ? restrictionValues[3] : null;
 
             var typeFactory = connection.TypeFactory;
-            var root = connection.RootSchema;
+            var root = connection.RequireSession().RootSchema;
             var schemaNames = root.getSubSchemaNames().iterator();
             while (schemaNames.hasNext())
             {

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Apache.Calcite.Extensions.Prepare;
-
-using com.google.common.collect;
 
 using java.util;
 using java.util.concurrent.atomic;
@@ -16,17 +13,16 @@ using org.apache.calcite.adapter.java;
 using org.apache.calcite.avatica;
 using org.apache.calcite.config;
 using org.apache.calcite.jdbc;
-using org.apache.calcite.model;
 using org.apache.calcite.rel.type;
 using org.apache.calcite.runtime;
 using org.apache.calcite.schema;
-using org.apache.calcite.schema.impl;
 
 namespace Apache.Calcite.Data.Internal
 {
 
     /// <summary>
-    /// Represents an active session with the Calcite engine, encapsulating the root schema, type factory,  and connection configuration.
+    /// The connection-lived half of a Calcite connection: the type factory, the configuration and the
+    /// convention, over a root schema the data source holds.
     /// </summary>
     internal sealed class CalciteSession
     {
@@ -51,37 +47,8 @@ namespace Apache.Calcite.Data.Internal
             new org.apache.calcite.jdbc.Driver();
         }
 
-        /// <summary>
-        /// Maps each <see cref="CalciteConnectionStringBuilder"/> key constant to the
-        /// corresponding <see cref="CalciteConnectionProperty"/>, which is the authoritative
-        /// source of the camelCase property name Calcite expects.
-        /// </summary>
-        static readonly Dictionary<string, CalciteConnectionProperty> KeyToProperty = new(StringComparer.OrdinalIgnoreCase)
-        {
-            [CalciteConnectionStringBuilder.ApproximateDecimalKey] = CalciteConnectionProperty.APPROXIMATE_DECIMAL,
-            [CalciteConnectionStringBuilder.ApproximateDistinctCountKey] = CalciteConnectionProperty.APPROXIMATE_DISTINCT_COUNT,
-            [CalciteConnectionStringBuilder.ApproximateTopNKey] = CalciteConnectionProperty.APPROXIMATE_TOP_N,
-            [CalciteConnectionStringBuilder.CaseSensitiveKey] = CalciteConnectionProperty.CASE_SENSITIVE,
-            [CalciteConnectionStringBuilder.ConformanceKey] = CalciteConnectionProperty.CONFORMANCE,
-            [CalciteConnectionStringBuilder.CreateMaterializationsKey] = CalciteConnectionProperty.CREATE_MATERIALIZATIONS,
-            [CalciteConnectionStringBuilder.DefaultNullCollationKey] = CalciteConnectionProperty.DEFAULT_NULL_COLLATION,
-            [CalciteConnectionStringBuilder.DruidFetchKey] = CalciteConnectionProperty.DRUID_FETCH,
-            [CalciteConnectionStringBuilder.ForceDecorrelateKey] = CalciteConnectionProperty.FORCE_DECORRELATE,
-            [CalciteConnectionStringBuilder.FunKey] = CalciteConnectionProperty.FUN,
-            [CalciteConnectionStringBuilder.LexKey] = CalciteConnectionProperty.LEX,
-            [CalciteConnectionStringBuilder.MaterializationsEnabledKey] = CalciteConnectionProperty.MATERIALIZATIONS_ENABLED,
-            [CalciteConnectionStringBuilder.ParserFactoryKey] = CalciteConnectionProperty.PARSER_FACTORY,
-            [CalciteConnectionStringBuilder.QuotingKey] = CalciteConnectionProperty.QUOTING,
-            [CalciteConnectionStringBuilder.QuotedCasingKey] = CalciteConnectionProperty.QUOTED_CASING,
-            [CalciteConnectionStringBuilder.UnquotedCasingKey] = CalciteConnectionProperty.UNQUOTED_CASING,
-            [CalciteConnectionStringBuilder.SchemaKey] = CalciteConnectionProperty.SCHEMA,
-            [CalciteConnectionStringBuilder.SchemaFactoryKey] = CalciteConnectionProperty.SCHEMA_FACTORY,
-            [CalciteConnectionStringBuilder.SchemaTypeKey] = CalciteConnectionProperty.SCHEMA_TYPE,
-            [CalciteConnectionStringBuilder.SparkKey] = CalciteConnectionProperty.SPARK,
-            [CalciteConnectionStringBuilder.TimeZoneKey] = CalciteConnectionProperty.TIME_ZONE,
-            [CalciteConnectionStringBuilder.TypeCoercionKey] = CalciteConnectionProperty.TYPE_COERCION,
-        };
-
+        readonly CalciteDataSourceRoot _root;
+        readonly bool _ownsRoot;
         readonly CalciteSchema _rootSchema;
         readonly SchemaPlus _rootSchemaPlus;
         readonly JavaTypeFactory _typeFactory;
@@ -95,26 +62,29 @@ namespace Apache.Calcite.Data.Internal
         /// Initializes a new instance.
         /// </summary>
         /// <param name="options">The connection string options.</param>
-        /// <param name="rootSchema">Root schema, or null.</param>
+        /// <param name="root">The root schema to plan against, built by the data source.</param>
+        /// <param name="ownsRoot">Whether this session is the only user of <paramref name="root"/> and so
+        /// disposes it. <see langword="true"/> under <c>Pooling=false</c>, where the root was built for this
+        /// connection alone.</param>
         /// <param name="typeFactory">Type factory, or null. See the remarks for what the conventions require of one.</param>
         /// <param name="prepareFactory">Prepare factory, or null for <see cref="ClrPrepareImpl"/>.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="CalciteException"></exception>
         /// <remarks>
-        /// The body is <c>CalciteConnectionImpl</c>'s constructor, statement for statement — the config, the
-        /// prepare factory, the type factory resolved from the <c>typeSystem</c> property (by
-        /// <see cref="ClrPlugin"/>, this provider naming a plugin in .NET rather than in Java) under the
-        /// conformance's ragged-union wrapper, the root schema, and the conformance-gated <c>DUAL</c> view —
-        /// followed by the model step the JDBC driver runs after construction, in that order, so a model can
-        /// overwrite <c>DUAL</c> and never the reverse. The injection pair is upstream's too: an injected
-        /// <paramref name="typeFactory"/> bypasses both the configured type system and the ragged-union
-        /// wrapper, an injected <paramref name="rootSchema"/> is used verbatim, and <c>DUAL</c> is added to an
-        /// injected root all the same. Nothing in the provider passes either yet: they are the seam a
-        /// session needs to be built over a root schema and a type factory it does not own, which is what
-        /// sharing one session across several connections would require. Tests are the only callers today.
+        /// This is the half of <c>CalciteConnectionImpl</c>'s constructor that is the connection's rather than
+        /// the data source's: the config, the prepare factory, and the type factory resolved from the
+        /// <c>typeSystem</c> property (by <see cref="ClrPlugin"/>, this provider naming a plugin in .NET rather
+        /// than in Java) under the conformance's ragged-union wrapper. The root, <c>DUAL</c> and the model
+        /// are <see cref="CalciteDataSourceRoot"/>'s, built once per data source and shared by every connection
+        /// it opens, which is the split Calcite itself makes when it opens an internal connection over an
+        /// existing root — <c>CalciteMetaImpl.connect(schema.root(), null)</c> — and pairs it with a fresh
+        /// type factory. The pairing is not a nicety: <c>JavaTypeFactoryImpl.syntheticTypes</c> is a plain
+        /// <c>HashMap</c> written by every grouped aggregate and window, so a factory shared by connections
+        /// used concurrently would race, where a root shared by them is read.
         ///
-        /// <para>Both conventions require more of <paramref name="typeFactory"/> than its interface says,
-        /// and the requirement is stated rather than typed because no type expresses it. Every grouped
+        /// <para>An injected <paramref name="typeFactory"/> bypasses both the configured type system and the
+        /// ragged-union wrapper, as upstream's does. Both conventions require more of it than its interface
+        /// says, and the requirement is stated rather than typed because no type expresses it. Every grouped
         /// aggregate and every window builds its accumulator from <c>createSyntheticType</c> and then
         /// matches the result against <c>JavaTypeFactoryImpl.SyntheticRecordType</c>, a nested class of
         /// the implementation — Calcite's own coupling, <c>EnumerableAggregateBase</c> having the same
@@ -137,13 +107,14 @@ namespace Apache.Calcite.Data.Internal
         /// has no node for is still planned and run — implemented in <c>EnumerableConvention</c>, with a
         /// converter carrying its rows.</para>
         /// </remarks>
-        public CalciteSession(CalciteConnectionStringBuilder options, CalciteSchema? rootSchema = null, JavaTypeFactory? typeFactory = null, Func<ClrPrepareImpl>? prepareFactory = null)
+        public CalciteSession(CalciteConnectionStringBuilder options, CalciteDataSourceRoot root, bool ownsRoot, JavaTypeFactory? typeFactory = null, Func<ClrPrepareImpl>? prepareFactory = null)
         {
             ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(root);
 
             try
             {
-                var cfg = new CalciteConnectionConfigImpl(BuildEngineProperties(options));
+                var cfg = new CalciteConnectionConfigImpl(CalciteEngineProperties.Build(options));
 
                 _prepareFactory = prepareFactory ?? (static () => new ClrPrepareImpl());
                 if (typeFactory != null)
@@ -159,27 +130,14 @@ namespace Apache.Calcite.Data.Internal
                     _typeFactory = new JavaTypeFactoryImpl(typeSystem);
                 }
 
-                _rootSchema = rootSchema != null ? rootSchema : CalciteSchema.createRootSchema(true);
-
-                // Add dual table metadata when isSupportedDualTable return true
-                if (cfg.conformance().isSupportedDualTable())
-                {
-                    SchemaPlus schemaPlus = _rootSchema.plus();
-                    // Dual table contains one row with a value X
-                    schemaPlus.add(
-                        "DUAL", ViewTable.viewMacro(schemaPlus, "VALUES ('X')",
-                        ImmutableList.of(), null, java.lang.Boolean.valueOf(false)));
-                }
+                _root = root;
+                _ownsRoot = ownsRoot;
+                _rootSchema = root.Schema;
                 _config = cfg;
                 _rootSchemaPlus = _rootSchema.plus();
 
-                // the driver's ModelHandler step, run after the constructor's work as upstream runs it
-                string? modelDefaultSchema = null;
-                if (string.IsNullOrEmpty(options.Model) == false)
-                    ApplyModel(_rootSchema, options.Model, out modelDefaultSchema);
-
                 _synchronous = options.Synchronous ?? false;
-                var defaultSchema = modelDefaultSchema ?? options.Schema;
+                var defaultSchema = root.DefaultSchemaName ?? options.Schema;
                 _defaultSchemaPath = string.IsNullOrEmpty(defaultSchema) ? [] : [defaultSchema];
             }
             catch (Exception e) when (e is not CalciteException)
@@ -214,76 +172,10 @@ namespace Apache.Calcite.Data.Internal
         }
 
         /// <summary>
-        /// Applies a Calcite model to the root schema, either from an inline JSON definition or a file path.
-        /// </summary>
-        /// <param name="rootSchema">The root schema to which the model will be applied.</param>
-        /// <param name="model">Either an inline JSON model definition (prefixed with "inline:" or starting with "{") or a file path to a
-        /// model definition.</param>
-        /// <param name="defaultSchema">When this method returns, contains the default schema name defined in the model, or <see langword="null"/>
-        /// if no default schema is defined.</param>
-        /// <exception cref="FileNotFoundException">Thrown when the specified model file does not exist.</exception>
-        /// <exception cref="CalciteException">Thrown when the model fails to load.</exception>
-        void ApplyModel(CalciteSchema rootSchema, string model, out string? defaultSchema)
-        {
-            try
-            {
-                if (model.StartsWith("inline:", StringComparison.OrdinalIgnoreCase) || model.TrimStart().StartsWith("{"))
-                {
-                    var inline = model.StartsWith("inline:", StringComparison.OrdinalIgnoreCase) ? model.Substring("inline:".Length) : model;
-                    var handler = new ModelHandler(rootSchema.plus(), "inline:" + inline);
-                    defaultSchema = handler.defaultSchemaName();
-                }
-                else
-                {
-                    if (!File.Exists(model))
-                        throw new FileNotFoundException("Model file was not found.", model);
-
-                    var handler = new ModelHandler(rootSchema.plus(), model);
-                    defaultSchema = handler.defaultSchemaName();
-                }
-
-            }
-            catch (Exception e) when (e is not CalciteException)
-            {
-                throw new CalciteException("Failed to load Calcite model.", e);
-            }
-        }
-
-        /// <summary>
-        /// Builds a Java Properties object from connection string options, mapping keys to their camel-cased property
-        /// names and excluding the Model key.
-        /// </summary>
-        /// <param name="options">The connection string builder containing the options to convert.</param>
-        /// <returns>A Properties object populated with the connection string options.</returns>
-        Properties BuildEngineProperties(CalciteConnectionStringBuilder options)
-        {
-            var props = new Properties();
-
-            foreach (var key in options.EnumerateKeys())
-            {
-                if (string.Equals(key, CalciteConnectionStringBuilder.ModelKey, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                // a provider option, not an engine one: it chooses the convention the session plans into
-                if (string.Equals(key, CalciteConnectionStringBuilder.SynchronousKey, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                // a provider option, not an engine one: it names a .NET type, resolved by ClrPlugin, and
-                // nothing in calcite-core reads the engine property but the constructor line this ports
-                if (string.Equals(key, CalciteConnectionStringBuilder.TypeSystemKey, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                if (options.TryGetValue(key, out var v) && v is not null)
-                    props.setProperty(KeyToProperty.TryGetValue(key, out var prop) ? prop.camelName() : key, v.ToString());
-            }
-
-            return props;
-        }
-
-        /// <summary>
         /// Gets the root schema for the current context.
         /// </summary>
         public SchemaPlus RootSchema => _rootSchemaPlus;
+
 
         /// <summary>
         /// Gets the factory used to create Java type representations.
@@ -660,10 +552,18 @@ namespace Apache.Calcite.Data.Internal
             _ => Convert.ToInt64(value.ToString()),
         };
 
-        /// <summary>Marks the session as disposed. Further calls to execute methods will throw <see cref="ObjectDisposedException"/>.</summary>
+        /// <summary>
+        /// Marks the session as disposed, so that further calls to execute methods throw
+        /// <see cref="ObjectDisposedException"/>, and disposes the root where this session owns it.
+        /// </summary>
         public void Dispose()
         {
+            if (_disposed)
+                return;
+
             _disposed = true;
+            if (_ownsRoot)
+                _root.Dispose();
         }
 
         void ThrowIfDisposed()

--- a/src/Apache.Calcite.Data/Internal/CalciteSession.cs
+++ b/src/Apache.Calcite.Data/Internal/CalciteSession.cs
@@ -132,6 +132,7 @@ namespace Apache.Calcite.Data.Internal
 
                 _root = root;
                 _ownsRoot = ownsRoot;
+                _root.Acquire();
                 _rootSchema = root.Schema;
                 _config = cfg;
                 _rootSchemaPlus = _rootSchema.plus();
@@ -197,17 +198,61 @@ namespace Apache.Calcite.Data.Internal
         /// </remarks>
         IClrPrepare.Signature Plan(CalciteExecuteRequest request, bool async = false)
         {
-            var ctx = new PrepareContext(_typeFactory, _rootSchema, _config, _defaultSchemaPath);
-
-            CalcitePrepare.Dummy.push(ctx);
+            // the root's read lock, from the snapshot the context takes to the signature: the root may be
+            // shared with connections altering it by DDL, and DDL takes the write side inside the prepare
+            _root.Lock.EnterReadLock();
             try
             {
-                return _prepareFactory().PrepareSql(ctx, IClrPrepare.Query.Of(request.Sql), typeof(object[]), -1, async);
+                var ctx = new PrepareContext(_typeFactory, _rootSchema, _config, _defaultSchemaPath, _root.Lock);
+
+                CalcitePrepare.Dummy.push(ctx);
+                try
+                {
+                    return _prepareFactory().PrepareSql(ctx, IClrPrepare.Query.Of(request.Sql), typeof(object[]), -1, async);
+                }
+                finally
+                {
+                    CalcitePrepare.Dummy.pop(ctx);
+                }
             }
             finally
             {
-                CalcitePrepare.Dummy.pop(ctx);
+                _root.Lock.ExitReadLock();
             }
+        }
+
+        /// <summary>
+        /// Holds the root's read lock until the result is disposed, for a reader of the root outside planning.
+        /// </summary>
+        public ReadLockHold ReadRoot()
+        {
+            _root.Lock.EnterReadLock();
+            return new ReadLockHold(_root.Lock);
+        }
+
+        /// <summary>
+        /// A held read lock, released on dispose.
+        /// </summary>
+        public readonly struct ReadLockHold : IDisposable
+        {
+
+            readonly System.Threading.ReaderWriterLockSlim _lock;
+
+            /// <summary>
+            /// Initializes a new instance.
+            /// </summary>
+            /// <param name="lock">The lock held.</param>
+            public ReadLockHold(System.Threading.ReaderWriterLockSlim @lock)
+            {
+                _lock = @lock;
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+                _lock.ExitReadLock();
+            }
+
         }
 
         /// <summary>
@@ -563,7 +608,9 @@ namespace Apache.Calcite.Data.Internal
 
             _disposed = true;
             if (_ownsRoot)
-                _root.Dispose();
+                _root.Retire();
+
+            _root.Release();
         }
 
         void ThrowIfDisposed()

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -86,23 +86,35 @@ while (await reader.ReadAsync())
 
 ## Code-driven schemas
 
-Register .NET objects as Calcite schemas directly — no JSON model required:
+Register .NET objects as Calcite schemas directly — no JSON model required. A schema an application
+constructs is handed to a `CalciteDataSource`, which every connection opened from it shares:
 
 ```csharp
 using org.apache.calcite.schema;
 
-await using var conn = new CalciteConnection();
-await conn.OpenAsync();
+await using var dataSource = new CalciteDataSourceBuilder()
+    .AddSchema("MEM", new MyCustomSchema())   // any org.apache.calcite.schema.Schema implementation
+    .Build();
 
-SchemaPlus root = conn.RootSchema;
-root.add("MEM", new MyCustomSchema());   // any org.apache.calcite.schema.Schema implementation
-
+await using var conn = await dataSource.OpenConnectionAsync();
 await using var cmd = conn.CreateCommand();
 cmd.CommandText = "SELECT * FROM \"MEM\".\"USERS\" ORDER BY \"ID\"";
 await using var reader = await cmd.ExecuteReaderAsync();
 ```
 
-Objects registered this way live as long as the connection object does. Closing and reopening the connection keeps them — see [Connection lifetime](#connection-lifetime).
+`ConfigureRootSchema` is the general form: it hands you the root as Calcite's mutable `SchemaPlus`, after
+the model has been applied, so a table, a function or a view macro can be added as well as a schema, and a
+schema that needs its parent can have it:
+
+```csharp
+var dataSource = new CalciteDataSourceBuilder("Model=path/to/model.json")
+    .ConfigureRootSchema(root => root.add("STAFF", ViewTable.viewMacro(root, "SELECT ...", null, null, null)))
+    .Build();
+```
+
+The data source is the application's: create it once, register it as a singleton, and dispose it when the
+application is done. Disposing it disposes every schema on its root that implements `IDisposable`, which is
+the release Calcite's own schema SPI has no hook for.
 
 ## Batches
 
@@ -127,7 +139,9 @@ var first = batch.BatchCommands[0].RecordsAffected;      // per-command count
 
 ## Using `DbDataSource` (.NET 7+)
 
-`CalciteDataSource` implements the modern `DbDataSource` pattern for dependency-injection scenarios:
+`CalciteDataSource` implements the modern `DbDataSource` pattern, and it is where the long-lived half of a
+Calcite connection lives. It reads the model and builds the schemas once, on the first connection to open,
+and every connection it produces plans against that root:
 
 ```csharp
 using Apache.Calcite.Data;
@@ -140,6 +154,22 @@ cmd.CommandText = "SELECT COUNT(*) FROM \"ORDERS\"";
 var count = await cmd.ExecuteScalarAsync();
 Console.WriteLine($"Order count: {count}");
 ```
+
+A bare `new CalciteConnection(connectionString)` draws on a data source too — one the provider keeps for
+that connection string, made the first time the string is seen and shared by every connection opened with
+an equivalent string afterwards. So the idiomatic ADO.NET shape, a connection per unit of work, costs a
+model read once per process rather than once per request. That is the same bargain every ADO.NET provider
+makes with its connection pool, and it has the same switch: `Pooling=false` in the connection string gives
+each connection a root of its own, built when it opens and released when it is disposed.
+
+`CalciteConnection.ClearPool(connection)` drops the provider's data source for a connection string, so the
+next connection reads the model again — which is how a changed model file reaches a running process — and
+`ClearAllPools()` drops them all. A data source you built yourself is not kept by the provider;
+`CalciteDataSource.Clear()` is its equivalent.
+
+Sharing a root means an adapter's schema may be read from several threads at once. Calcite serialises
+nothing, so a schema reachable from a data source has to tolerate concurrent reads; DDL is serialised
+against DDL by the provider.
 
 ## Using `DbProviderFactory`
 
@@ -159,10 +189,16 @@ await conn.OpenAsync();
 
 ## Connection lifetime
 
-The Calcite session is created on the **first** `Open()` and reused for the life of the `CalciteConnection` object.
+A connection is cheap and short-lived. What it plans against — the model, the schemas the model built, the
+tables DDL has created — belongs to its data source and outlives it; what it keeps to itself is its
+configuration, its type factory and the convention it plans into, created on the **first** `Open()` and
+reused for the life of the `CalciteConnection` object.
 
-- `Close()` only moves the connection to the `Closed` state. Schemas registered on `RootSchema`, tables created by DDL, and every other in-process artifact survive it and are visible again after the next `Open()`.
-- `Dispose()` is what tears the session down.
+- `Close()` only moves the connection to the `Closed` state; the next `Open()` is free.
+- `Dispose()` releases what the connection holds. The data source's root is untouched — unless the
+  connection string said `Pooling=false`, in which case the root was the connection's own and goes with it.
+- A table created by DDL on one connection is visible on every connection of the same data source, as it
+  is in any database.
 - `ConnectionString` cannot be changed once the connection has been opened. Create a new `CalciteConnection` for different settings.
 
 ## Behaviour worth knowing
@@ -177,7 +213,7 @@ The Calcite session is created on the **first** `Open()` and reused for the life
 
 **`ExecuteNonQuery` return values** follow ADO.NET convention: `-1` for a `SELECT`, `0` for DDL, and the row count Calcite reports for `INSERT` / `UPDATE` / `DELETE` / `MERGE`.
 
-**DDL runs at prepare time.** A `CREATE` or `DROP` has already taken effect by the time the call returns, and produces no rows. DDL also needs a parser that understands it — set `parserFactory=org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl#FACTORY`.
+**DDL runs at prepare time.** A `CREATE` or `DROP` has already taken effect by the time the call returns, and produces no rows; it took effect on the data source's root, so every connection of that data source sees it. DDL also needs a parser that understands it — set `parserFactory=org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl#FACTORY`.
 
 **Materialized views are not substituted**, whatever `materializationsEnabled` says. Calcite builds them through a package-private class this provider cannot reach.
 
@@ -194,6 +230,7 @@ All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Ke
 | `Model` | `string` | — | Path to a Calcite model JSON file, or `inline:<json>` for an embedded model. |
 | `Schema` | `string` | — | Default schema name when identifiers are unqualified. |
 | `Synchronous` | `bool` | `false` | Plan queries in the synchronous convention instead of the asynchronous one. A provider option, not forwarded to the engine — see [Behaviour worth knowing](#behaviour-worth-knowing). |
+| `Pooling` | `bool` | `true` | Whether connections opened with this connection string share one root schema. A provider option, not forwarded to the engine — see [Using `DbDataSource`](#using-dbdatasource-net-7). |
 | `Lex` | `string` | `ORACLE` | Lexical policy: `ORACLE`, `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`. |
 | `CaseSensitive` | `bool` | from `Lex` | Whether identifier lookup is case-sensitive. |
 | `Quoting` | `string` | from `Lex` | Quote style: `DOUBLE_QUOTE`, `BACK_TICK`, `BACK_TICK_BACKSLASH`, `BRACKET`. |
@@ -212,8 +249,8 @@ All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Ke
 | `ApproximateTopN` | `bool` | `false` | Allow approximate Top-N results. |
 | `DruidFetch` | `int` | `16384` | Rows the Druid adapter fetches at a time. |
 | `Spark` | `bool` | `false` | Ignored by this provider. |
-| `SchemaFactory` | `string` | — | Schema factory class name, when not using a model. |
-| `SchemaType` | `string` | — | Schema type: `MAP`, `JDBC`, or `CUSTOM`. |
+| `SchemaFactory` | `string` | — | Schema factory class name, when not using a model: the factory makes one schema, named by `Schema` (default `adhoc`), with every `schema.`-prefixed key as an operand. |
+| `SchemaType` | `string` | — | Schema type when not using a model, `MAP` or `JDBC`, naming the factory Calcite ships for it. |
 | `TypeSystem` | `string` | — | Type system class name. |
 | `parserFactory` | `string` | — | Custom SQL parser factory, e.g. `org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl#FACTORY`. |
 
@@ -274,7 +311,7 @@ Overloads accept a Java `Consumer`, a .NET `Action<object>`, or a primitive valu
 
 | Property | Java type | Purpose |
 |----------|-----------|---------|
-| `RootSchema` | `org.apache.calcite.schema.SchemaPlus` | Add/remove schemas and tables at runtime. |
+| `RootSchema` | `org.apache.calcite.schema.Schema` | Inspect the root the connection plans against. It is the data source's, shared by every connection opened on it, and handed out as Calcite's read interface; to add to it, use `CalciteDataSourceBuilder.ConfigureRootSchema` or DDL. |
 | `TypeFactory` | `org.apache.calcite.adapter.java.JavaTypeFactory` | Construct Calcite `RelDataType` instances. |
 | `Config` | `org.apache.calcite.config.CalciteConnectionConfig` | Inspect resolved connection configuration. |
 

--- a/src/Apache.Calcite.Data/README.md
+++ b/src/Apache.Calcite.Data/README.md
@@ -162,14 +162,21 @@ model read once per process rather than once per request. That is the same barga
 makes with its connection pool, and it has the same switch: `Pooling=false` in the connection string gives
 each connection a root of its own, built when it opens and released when it is disposed.
 
-`CalciteConnection.ClearPool(connection)` drops the provider's data source for a connection string, so the
-next connection reads the model again — which is how a changed model file reaches a running process — and
-`ClearAllPools()` drops them all. A data source you built yourself is not kept by the provider;
-`CalciteDataSource.Clear()` is its equivalent.
+What the provider keeps is bounded by time, as a connection pool is. A data source that has gone
+`Connection Idle Lifetime` seconds (default 300) with no connection open on it is released — dropped, and
+every schema on its root that implements `IDisposable` disposed — checked every `Connection Pruning
+Interval` seconds (default 10); the next connection opened with that string builds again. So a process
+that varies its connection strings does not keep a root for every string it ever wrote.
+`CalciteConnection.ClearPool(connection)` releases one on demand, which is how a changed model file reaches
+a running process sooner, and `ClearAllPools()` releases them all. A connection already open keeps the
+root it has, and the root is disposed once the last such connection is. A data source you built yourself
+is not kept by the provider and is never released this way; `CalciteDataSource.Clear()` is its equivalent.
 
 Sharing a root means an adapter's schema may be read from several threads at once. Calcite serialises
-nothing, so a schema reachable from a data source has to tolerate concurrent reads; DDL is serialised
-against DDL by the provider.
+nothing, so a schema reachable from a data source has to tolerate concurrent reads. The provider holds
+the root's read lock while a statement plans and its write lock while DDL alters it, so a statement never
+plans against a root another connection is changing; a table is looked up once more when a plan runs, and
+that lookup is not under the lock.
 
 ## Using `DbProviderFactory`
 
@@ -231,6 +238,8 @@ All keys are exposed as typed properties on `CalciteConnectionStringBuilder`. Ke
 | `Schema` | `string` | — | Default schema name when identifiers are unqualified. |
 | `Synchronous` | `bool` | `false` | Plan queries in the synchronous convention instead of the asynchronous one. A provider option, not forwarded to the engine — see [Behaviour worth knowing](#behaviour-worth-knowing). |
 | `Pooling` | `bool` | `true` | Whether connections opened with this connection string share one root schema. A provider option, not forwarded to the engine — see [Using `DbDataSource`](#using-dbdatasource-net-7). |
+| `Connection Idle Lifetime` | `int` | `300` | Seconds a shared root schema is kept with no connection open on it before it is released. A provider option. |
+| `Connection Pruning Interval` | `int` | `10` | Seconds between checks for shared root schemas to release. A provider option. |
 | `Lex` | `string` | `ORACLE` | Lexical policy: `ORACLE`, `MYSQL`, `MYSQL_ANSI`, `SQL_SERVER`, `JAVA`, `BIG_QUERY`. |
 | `CaseSensitive` | `bool` | from `Lex` | Whether identifier lookup is case-sensitive. |
 | `Quoting` | `string` | from `Lex` | Quote style: `DOUBLE_QUOTE`, `BACK_TICK`, `BACK_TICK_BACKSLASH`, `BRACKET`. |

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
@@ -222,19 +222,45 @@ namespace Apache.Calcite.Extensions.Prepare
         /// Executes a DDL statement.
         /// </summary>
         /// <remarks>
-        /// Under the mutable root's monitor, which Calcite's <c>executeDdl</c> is not. Calcite's connection is
-        /// driven by one thread and its root schema by one connection, so a DDL statement never meets another;
-        /// here a root may be shared by connections used concurrently, and a DDL statement writes into
-        /// <c>NameMap</c>s over <c>TreeMap</c>s, which two writers corrupt. This serialises DDL against DDL on
-        /// one root and nothing else: a statement planning against the root while another alters it is
-        /// Calcite's own exposure, and it is not closed here.
+        /// Under the root's write lock, which Calcite's <c>executeDdl</c> is not. Calcite's connection is
+        /// driven by one thread and its root schema by one connection, so a DDL statement never meets a
+        /// statement planning; here a root may be shared by connections used concurrently, and a DDL
+        /// statement writes into <c>NameMap</c>s over <c>TreeMap</c>s while planning reads them. A context
+        /// that carries a root lock (<see cref="PrepareContext.RootLock"/>) arrives here holding its read
+        /// side, since the parse that told a DDL statement apart from a query ran under it; the read side is
+        /// given up, the write side taken for the DDL, and the read side taken back for the caller to
+        /// release. A context without one is a root one connection has to itself, and the mutable root's
+        /// monitor serialises DDL against DDL there.
         /// </remarks>
         public virtual void ExecuteDdl(CalcitePrepare.Context context, SqlNode node)
         {
             var config = context.config();
             var parserFactory = (SqlParserImplFactory)config.parserFactory((java.lang.Class)typeof(SqlParserImplFactory), org.apache.calcite.sql.parser.impl.SqlParserImpl.FACTORY);
-            lock (context.getMutableRootSchema())
+
+            var rootLock = (context as PrepareContext)?.RootLock;
+            if (rootLock is null)
+            {
+                lock (context.getMutableRootSchema())
+                    parserFactory.getDdlExecutor().executeDdl(context, node);
+
+                return;
+            }
+
+            var hadRead = rootLock.IsReadLockHeld;
+            if (hadRead)
+                rootLock.ExitReadLock();
+
+            rootLock.EnterWriteLock();
+            try
+            {
                 parserFactory.getDdlExecutor().executeDdl(context, node);
+            }
+            finally
+            {
+                rootLock.ExitWriteLock();
+                if (hadRead)
+                    rootLock.EnterReadLock();
+            }
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/ClrPrepareImpl.cs
@@ -221,11 +221,20 @@ namespace Apache.Calcite.Extensions.Prepare
         /// <summary>
         /// Executes a DDL statement.
         /// </summary>
+        /// <remarks>
+        /// Under the mutable root's monitor, which Calcite's <c>executeDdl</c> is not. Calcite's connection is
+        /// driven by one thread and its root schema by one connection, so a DDL statement never meets another;
+        /// here a root may be shared by connections used concurrently, and a DDL statement writes into
+        /// <c>NameMap</c>s over <c>TreeMap</c>s, which two writers corrupt. This serialises DDL against DDL on
+        /// one root and nothing else: a statement planning against the root while another alters it is
+        /// Calcite's own exposure, and it is not closed here.
+        /// </remarks>
         public virtual void ExecuteDdl(CalcitePrepare.Context context, SqlNode node)
         {
             var config = context.config();
             var parserFactory = (SqlParserImplFactory)config.parserFactory((java.lang.Class)typeof(SqlParserImplFactory), org.apache.calcite.sql.parser.impl.SqlParserImpl.FACTORY);
-            parserFactory.getDdlExecutor().executeDdl(context, node);
+            lock (context.getMutableRootSchema())
+                parserFactory.getDdlExecutor().executeDdl(context, node);
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Extensions/Prepare/PrepareContext.cs
+++ b/src/Apache.Calcite.Extensions/Prepare/PrepareContext.cs
@@ -24,19 +24,37 @@ namespace Apache.Calcite.Extensions.Prepare
         readonly CalciteSchema _rootSchema;
         readonly CalciteConnectionConfig _config;
         readonly IReadOnlyList<string> _defaultSchemaPath;
+        readonly System.Threading.ReaderWriterLockSlim? _rootLock;
 
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="typeFactory">The type factory.</param>
+        /// <param name="rootSchema">The root, of which a snapshot is taken here — so a caller sharing the root
+        /// between connections holds <paramref name="rootLock"/>'s read lock across this constructor.</param>
+        /// <param name="config">The connection configuration.</param>
+        /// <param name="defaultSchemaPath">The default schema path.</param>
+        /// <param name="rootLock">The lock the root is read and altered under, where it is shared, or
+        /// <see langword="null"/> where one connection has the root to itself, as Calcite's does.</param>
         public PrepareContext(
             JavaTypeFactory typeFactory,
             CalciteSchema rootSchema,
             CalciteConnectionConfig config,
-            IReadOnlyList<string> defaultSchemaPath)
+            IReadOnlyList<string> defaultSchemaPath,
+            System.Threading.ReaderWriterLockSlim? rootLock = null)
         {
             _typeFactory = typeFactory;
             _mutableRootSchema = rootSchema;
             _rootSchema = rootSchema.createSnapshot(new org.apache.calcite.schema.impl.LongSchemaVersion(java.lang.System.currentTimeMillis()));
             _config = config;
             _defaultSchemaPath = defaultSchemaPath;
+            _rootLock = rootLock;
         }
+
+        /// <summary>
+        /// Gets the lock the root is read and altered under, or <see langword="null"/> where there is none.
+        /// </summary>
+        public System.Threading.ReaderWriterLockSlim? RootLock => _rootLock;
 
         public JavaTypeFactory getTypeFactory()
         {

--- a/src/Apache.Calcite.Tests/AcquisitionTimingTests.cs
+++ b/src/Apache.Calcite.Tests/AcquisitionTimingTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Apache.Calcite.Data;
@@ -121,11 +121,11 @@ namespace Apache.Calcite.Tests
 
         static (CalciteConnection Connection, CountingTable Table) Open(string model)
         {
-            var c = new CalciteConnection(model);
-            c.Open();
-
             var table = new CountingTable();
-            c.RootSchema.add("T", table);
+            var c = new CalciteDataSourceBuilder(model)
+                .ConfigureRootSchema(root => root.add("T", table))
+                .Build()
+                .OpenConnection();
 
             return (c, table);
         }

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableAdoNetTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
@@ -40,13 +40,21 @@ namespace Apache.Calcite.Tests
 
         static (CalciteConnection Connection, AsyncRowsTable Table) Open()
         {
-            var c = new CalciteConnection(Model);
-            c.Open();
-
             var table = new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false);
-            c.RootSchema.add("SALES", table);
+            var c = Open(Model, root => root.add("SALES", table));
 
             return (c, table);
+        }
+
+        /// <summary>
+        /// Opens a connection on a data source of its own, with <paramref name="configure"/> run over the root.
+        /// </summary>
+        static CalciteConnection Open(string model, Action<org.apache.calcite.schema.SchemaPlus> configure)
+        {
+            return new CalciteDataSourceBuilder(model)
+                .ConfigureRootSchema(configure)
+                .Build()
+                .OpenConnection();
         }
 
         /// <summary>
@@ -130,11 +138,8 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public async Task ShouldBridgeAnAsyncOnlyTableInSynchronousMode()
         {
-            using var c = new CalciteConnection(SynchronousModel);
-            c.Open();
-
             var table = new AsyncRowsTable(AsyncTestRows.Sales, AsyncTestRows.SalesRowType, false);
-            c.RootSchema.add("SALES", table);
+            using var c = Open(SynchronousModel, root => root.add("SALES", table));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT ID FROM SALES ORDER BY ID";
@@ -206,19 +211,15 @@ namespace Apache.Calcite.Tests
         {
             const string Sql = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
 
-            using (var c = new CalciteConnection(Model))
+            using (var c = Open(Model, root => root.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false))))
             {
-                c.Open();
-                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
                 Explain(c, Sql).Should().Contain("ClrAsyncEnumerable");
                 (await ExplainAsync(c, Sql)).Should().Contain("ClrAsyncEnumerable");
             }
 
-            using (var c = new CalciteConnection(SynchronousModel))
+            using (var c = Open(SynchronousModel, root => root.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false))))
             {
-                c.Open();
-                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
                 Explain(c, Sql).Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
                 (await ExplainAsync(c, Sql)).Should().Contain("ClrEnumerable").And.NotContain("ClrAsyncEnumerable");
@@ -262,10 +263,8 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public async Task ShouldExplainThroughExecuteScalar()
         {
-            using (var c = new CalciteConnection(Model))
+            using (var c = Open(Model, root => root.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false))))
             {
-                c.Open();
-                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
                 using var cmd = c.CreateCommand();
                 cmd.CommandText = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
@@ -276,10 +275,8 @@ namespace Apache.Calcite.Tests
                     .Which.Should().Contain("ClrAsyncEnumerable");
             }
 
-            using (var c = new CalciteConnection(SynchronousModel))
+            using (var c = Open(SynchronousModel, root => root.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false))))
             {
-                c.Open();
-                c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
 
                 using var cmd = c.CreateCommand();
                 cmd.CommandText = "EXPLAIN PLAN FOR SELECT K FROM SYNCONLY WHERE V = 'A'";
@@ -306,9 +303,7 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public async Task ShouldPlanACalciteTableAsynchronously()
         {
-            using var c = new CalciteConnection(Model);
-            c.Open();
-            c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+            using var c = Open(Model, root => root.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false)));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT K, V FROM SYNCONLY ORDER BY K, V";
@@ -372,9 +367,7 @@ namespace Apache.Calcite.Tests
         public async Task ShouldReadASyncPlanAsynchronously()
         {
             // the synchronous plan, deliberately: the connection's mode is what asks for it
-            using var c = new CalciteConnection(SynchronousModel);
-            c.Open();
-            c.RootSchema.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false));
+            using var c = Open(SynchronousModel, root => root.add("SYNCONLY", new SyncRowsTable(AsyncTestRows.Sorted, AsyncTestRows.SortedRowType, false)));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT K, V FROM SYNCONLY ORDER BY K, V";
@@ -563,15 +556,12 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public async Task ShouldCancelAReadInProgress()
         {
-            using var c = new CalciteConnection(Model);
-            c.Open();
-
             var rows = new object[10_000][];
             for (int i = 0; i < rows.Length; i++)
                 rows[i] = [java.lang.Integer.valueOf(i), "R"];
 
             var table = new AsyncRowsTable(rows, AsyncTestRows.SortedRowType, false);
-            c.RootSchema.add("BIG", table);
+            using var c = Open(Model, root => root.add("BIG", table));
 
             using var cmd = c.CreateCommand();
             cmd.CommandText = "SELECT K, V FROM BIG";

--- a/src/Apache.Calcite.Tests/ClrEnumerableDmlTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDmlTests.cs
@@ -1,4 +1,4 @@
-using Apache.Calcite.Data;
+﻿using Apache.Calcite.Data;
 
 using FluentAssertions;
 
@@ -30,6 +30,8 @@ namespace Apache.Calcite.Tests
         {
             Model = "inline:{\"version\":\"1.0\",\"defaultSchema\":\"adhoc\",\"schemas\":[{\"name\":\"adhoc\"}]}",
             ParserFactory = "org.apache.calcite.server.ServerDdlExecutor#PARSER_FACTORY",
+            // these tests create tables by name, so each connection gets a root of its own
+            Pooling = false,
             Schema = "adhoc",
         };
 


### PR DESCRIPTION
Closes #93.

## What a connection shares

Npgsql's answer, whole, with the root schema as the thing kept. A bare `new CalciteConnection(cs)` draws on a `CalciteDataSource` the provider keeps for that connection string, made the first time the string is seen and shared by every connection opened with an equivalent string. The key is the string with its keys lower-cased and sorted, and without `Synchronous`, which chooses the convention a connection plans into and nothing that is built — as Npgsql leaves `TargetSessionAttributes` out of its. The data source builds its root once, under a lock, on the first connection to open; a failed build leaves nothing behind. `Pooling=false` gives a connection a root of its own, released with it.

`CalciteSession` is split along that line. `CalciteDataSourceRoot` is the application-lived half — the root, `DUAL`, the model, and the driver's `model()` step ported with it, so `SchemaFactory` and `SchemaType` now synthesise a model as Calcite's driver does; the README listed both and nothing read them. The session keeps config, type factory, default schema path and convention. The type factory stays per connection: `JavaTypeFactoryImpl.syntheticTypes` is a plain `HashMap` written by every grouped aggregate and window, and a shared root over a fresh factory is the pairing Calcite makes itself in `CalciteMetaImpl.connect(schema.root(), null)`.

## How the pool is bounded

By time, as a connection pool is, not by reachability: a weak reference would release an entry in the gap between two requests, which is the case the entry exists for. A root counts the sessions on it, and each entry the provider keeps has a timer that fires every `Connection Pruning Interval` (default 10 s) and releases the entry once it has gone `Connection Idle Lifetime` (default 300 s) with no session on its root. Both keywords are spelled and validated as Npgsql spells and validates them. Releasing, `ClearPool`, `Clear` and `Dispose` all retire the root, which disposes its `IDisposable` schemas at once where no session holds it and otherwise when the last session is disposed, so a connection still open keeps working — the way a pooled connector Npgsql has cleared is closed when it is returned rather than while it is busy. That is also the release Calcite's schema SPI has no hook for; `CosmosSchemaFactory` leaks a `CosmosClient` per connection today for want of it.

## What a connection can change

`CalciteDataSourceBuilder` holds what a string cannot carry: `AddSchema`, and `ConfigureRootSchema`, which hands over the root as a `SchemaPlus` after the model. That is now the only way to register on a root. `CalciteConnection.RootSchema` is typed as `Schema`, Calcite's read interface, over the same object: a change made through one connection would reach every connection of the data source. This is a type and not a guard, and the doc says so.

DDL lands on the shared root and is visible on every connection of the data source, as in any database. Planning and DDL share the root under a reader-writer lock: planning holds the read side from the snapshot to the signature, and `ClrPrepareImpl.ExecuteDdl`, which is where a DDL statement is told apart from a query, swaps it for the write side. A statement never plans against a root another connection is altering. Execution stays outside the lock — it is thread-affine and a plan is read asynchronously — and a plan resolves its tables once more when it runs, from a snapshot whose table map is the live root's by Calcite's own javadoc. That lookup against a concurrent DDL is Calcite's exposure, written down rather than closed.

## Breaking

`RootSchema.add(...)` on a connection no longer compiles. The EF Core sample's per-connection registrations and the calcite-cosmos README's `RootSchema` workaround are the two consumers I know of, both in other repositories.

## Tests

| suite | result |
|---|---|
| Data, net8 and net10 | 422 / 422 |
| Extensions | 827 / 827 |
| AdoNet adapter | 483 / 483 |
| Geography | 101 / 101 |

`CalciteDataSourceSharingTests` covers keying, `Pooling`, eviction and its disposal, `Clear`, the idle release and its absence while a connection is open, validation of the two lifetimes, DDL visibility across connections, DDL waiting on a statement planning on another connection, the synthesised-model path, and eight tasks planning aggregates and windows concurrently on one root. Every DDL-writing test string carries `Pooling=false`, because a shared root turns repeated table names into collisions, which is the point.

The Data tests reference a 1.43 snapshot whose model loader now rejects every class a model names unless `calcite.model.classes.allowed` lists it, Calcite's own `AbstractSchema$Factory` included. The test assembly sets the property in a module initializer; CLAUDE.md records the fact. The 1.42 the provider ships has only the denylist.

## Not here

No DI registration extension; Npgsql ships that as a separate package and it is a packaging decision.
