### PR TITLE
Add the buffer, the convex hull, simplification and the centroid

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographyBufferTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyBufferTests.cs
@@ -1,0 +1,187 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The buffer, which is the one operation here that S2 does not have.
+    /// </summary>
+    /// <remarks>
+    /// Everything else geodesic in this package turned out to be an S2 call. S2's Java release has no buffer,
+    /// so this one is built from the definition — the set of places within a distance of the shape — and its
+    /// correctness is therefore worth testing as a property rather than by comparing shapes. What these
+    /// assert is containment: a place nearer than the distance is in the answer, a place further is not.
+    ///
+    /// <para>Calcite's buffers by degrees, which on the ground means a different distance at every latitude
+    /// and in every direction. Ours buffers by metres.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyBufferTests
+    {
+
+        const double Kilometre = 1000.0;
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static Geometry Buffer(string wkt, double metres)
+        {
+            return GeographyFunctions.Buffer(Wkt(wkt), java.lang.Double.valueOf(metres))!;
+        }
+
+        static bool Contains(Geometry area, string point)
+        {
+            return GeographyFunctions.Contains(area, Wkt(point))!.booleanValue();
+        }
+
+        /// <summary>
+        /// What a buffer is: everything nearer than the distance and nothing further.
+        /// </summary>
+        /// <remarks>
+        /// Walked around the compass, because a buffer that was right to the east and wrong to the north
+        /// would be a buffer measured in degrees. The outer probe is at 1.05 rather than 1.0 because the ring
+        /// is a polygon inscribed in the circle and so falls a little inside it.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldContainWhatIsNearerAndNotWhatIsFurther()
+        {
+            var buffer = Buffer("POINT(0 0)", 100 * Kilometre);
+            var centre = new org.locationtech.jts.geom.Coordinate(0, 0);
+
+            for (var azimuth = 0; azimuth < 360; azimuth += 45)
+            {
+                var near = Wgs84.Offset(centre, azimuth, 90 * Kilometre);
+                var far = Wgs84.Offset(centre, azimuth, 105 * Kilometre);
+
+                Contains(buffer, $"POINT({near.getX()} {near.getY()})").Should().BeTrue($"90km, azimuth {azimuth}");
+                Contains(buffer, $"POINT({far.getX()} {far.getY()})").Should().BeFalse($"105km, azimuth {azimuth}");
+            }
+        }
+
+        /// <summary>
+        /// The area of a disc, near enough.
+        /// </summary>
+        /// <remarks>
+        /// A geodesic disc of radius r covers about πr² while r is small beside the Earth. The answer is a
+        /// little under that, being a thirty-two sided polygon inscribed in the circle rather than the circle
+        /// — by the factor a regular polygon of that many sides loses, which is about six parts in a
+        /// thousand.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCoverAboutTheAreaOfADisc()
+        {
+            var area = GeographyFunctions.Area(Buffer("POINT(0 0)", 100 * Kilometre))!.doubleValue();
+            var disc = Math.PI * Math.Pow(100 * Kilometre, 2);
+
+            area.Should().BeLessThan(disc);
+            area.Should().BeGreaterThan(disc * 0.98);
+        }
+
+        /// <summary>
+        /// The distance is metres, so the same buffer covers the same ground wherever it is drawn.
+        /// </summary>
+        /// <remarks>
+        /// The one that separates the two readings. A buffer of a fixed number of degrees covers less ground
+        /// the further north it is drawn — at 60 degrees a degree of longitude is half what it is at the
+        /// equator — so Calcite's answers shrink with latitude. These do not.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCoverTheSameGroundAtEveryLatitude()
+        {
+            var equator = GeographyFunctions.Area(Buffer("POINT(0 0)", 50 * Kilometre))!.doubleValue();
+            var north = GeographyFunctions.Area(Buffer("POINT(0 60)", 50 * Kilometre))!.doubleValue();
+
+            north.Should().BeApproximately(equator, equator * 0.01);
+
+            // and Calcite's, buffered by a degree at each, do not agree at all
+            var theirsAtEquator = GeographyFunctions.Area(SpatialTypeFunctions.ST_Buffer(Wkt("POINT(0 0)"), 0.5))!.doubleValue();
+            var theirsAtNorth = GeographyFunctions.Area(SpatialTypeFunctions.ST_Buffer(Wkt("POINT(0 60)"), 0.5))!.doubleValue();
+
+            theirsAtNorth.Should().BeLessThan(theirsAtEquator * 0.75);
+        }
+
+        /// <summary>
+        /// A line's buffer is a corridor, and every part of the line is inside it.
+        /// </summary>
+        [TestMethod]
+        public void ShouldBufferEveryPartOfALine()
+        {
+            var buffer = Buffer("LINESTRING(0 0, 1 0)", 10 * Kilometre);
+
+            Contains(buffer, "POINT(0 0)").Should().BeTrue();
+            Contains(buffer, "POINT(0.5 0)").Should().BeTrue("the middle of an edge is buffered, not only its ends");
+            Contains(buffer, "POINT(1 0)").Should().BeTrue();
+            Contains(buffer, "POINT(0.5 0.5)").Should().BeFalse("that is some fifty kilometres away");
+        }
+
+        /// <summary>
+        /// An area's buffer contains the area itself, rather than only skinning its boundary.
+        /// </summary>
+        [TestMethod]
+        public void ShouldContainTheAreaItBuffers()
+        {
+            var square = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+            var buffer = GeographyFunctions.Buffer(square, java.lang.Double.valueOf(5 * Kilometre))!;
+
+            GeographyFunctions.Covers(buffer, square)!.booleanValue().Should().BeTrue();
+            GeographyFunctions.Area(buffer)!.doubleValue()
+                .Should().BeGreaterThan(GeographyFunctions.Area(square)!.doubleValue());
+        }
+
+        /// <summary>
+        /// A larger distance is a larger buffer.
+        /// </summary>
+        [TestMethod]
+        public void ShouldGrowWithTheDistance()
+        {
+            var small = GeographyFunctions.Area(Buffer("POINT(0 0)", 10 * Kilometre))!.doubleValue();
+            var large = GeographyFunctions.Area(Buffer("POINT(0 0)", 20 * Kilometre))!.doubleValue();
+
+            large.Should().BeApproximately(small * 4, small * 4 * 0.01, "area goes as the square of the radius");
+        }
+
+        /// <summary>
+        /// Nothing to buffer, or nothing to buffer by, is nothing.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerEmptyForNothingToDo()
+        {
+            Buffer("POINT(0 0)", 0).isEmpty().Should().BeTrue();
+            Buffer("POINT(0 0)", -1).isEmpty().Should().BeTrue();
+            Buffer("POINT EMPTY", 1000).isEmpty().Should().BeTrue();
+
+            GeographyFunctions.Buffer(null, java.lang.Double.valueOf(1)).Should().BeNull();
+            GeographyFunctions.Buffer(Wkt("POINT(0 0)"), null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldStampTheBufferWithWgs84()
+        {
+            Buffer("POINT(0 0)", 1000).getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldRunAsAnOperator()
+        {
+            var answer = GeographyExecutionTests.Run(
+                "SELECT ST_GEOG_AREA(ST_GEOG_BUFFER(ST_GEOG_GEOMFROMTEXT('POINT(0 0)'), 10000.0))")[0][0];
+
+            (answer is java.lang.Number n ? n.doubleValue() : double.NaN)
+                .Should().BeApproximately(Math.PI * 1e8, Math.PI * 1e8 * 0.02);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyCentroidTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyCentroidTests.cs
@@ -1,0 +1,147 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The centre of a geography, which is a direction from the Earth's centre rather than an average of two
+    /// coordinates.
+    /// </summary>
+    /// <remarks>
+    /// The antimeridian is what separates the two readings, and not by a little. Averaging the longitudes of
+    /// a shape sitting either side of longitude 180 gives zero, which is the far side of the planet; summing
+    /// directions gives a point in the shape. That is the same failure the bounding rectangle has and the
+    /// same fix.
+    /// </remarks>
+    [TestClass]
+    public class GeographyCentroidTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static Geometry Centroid(string wkt)
+        {
+            return GeographyFunctions.Centroid(Wkt(wkt))!;
+        }
+
+        /// <summary>
+        /// An ordinary shape near the origin agrees with the planar answer.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAgreeWithCalciteNearTheOrigin()
+        {
+            var square = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+
+            var ours = GeographyFunctions.Centroid(square)!;
+            var theirs = SpatialTypeFunctions.ST_Centroid(square);
+
+            ours.getCoordinate().getX().Should().BeApproximately(theirs.getCoordinate().getX(), 1e-3);
+            ours.getCoordinate().getY().Should().BeApproximately(theirs.getCoordinate().getY(), 1e-3);
+        }
+
+        /// <summary>
+        /// The one that separates the two readings: a shape across the antimeridian.
+        /// </summary>
+        /// <remarks>
+        /// Every coordinate of this square is within a degree of longitude 180, so its centre is too. Calcite
+        /// averages the longitudes — 179 and -179 and their like — and answers a point near longitude zero,
+        /// half a world away. This answers a point in the square.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotPutTheCentreOnTheFarSideOfThePlanet()
+        {
+            var square = Wkt("POLYGON((179 0, -179 0, -179 2, 179 2, 179 0))");
+
+            var theirs = SpatialTypeFunctions.ST_Centroid(square).getCoordinate();
+            Math.Abs(theirs.getX()).Should().BeLessThan(1, "the planar centroid averages the longitudes to about zero");
+
+            var ours = GeographyFunctions.Centroid(square)!.getCoordinate();
+            Math.Abs(ours.getX()).Should().BeGreaterThan(179, "the centre of the square is on the antimeridian");
+            ours.getY().Should().BeApproximately(1, 0.1);
+        }
+
+        /// <summary>
+        /// An area outranks a line and a line outranks a point, as JTS orders them.
+        /// </summary>
+        [TestMethod]
+        public void ShouldLetTheHighestDimensionDecide()
+        {
+            // the point is far away and contributes nothing, the square deciding alone
+            var mixed = Centroid("GEOMETRYCOLLECTION(POLYGON((0 0, 2 0, 2 2, 0 2, 0 0)), POINT(40 40))");
+
+            mixed.getCoordinate().getX().Should().BeApproximately(1, 0.01);
+            mixed.getCoordinate().getY().Should().BeApproximately(1, 0.01);
+        }
+
+        /// <summary>
+        /// A line's centre is weighted by length, so a long edge counts for more than a short one.
+        /// </summary>
+        [TestMethod]
+        public void ShouldWeightALineByItsLength()
+        {
+            var centre = Centroid("LINESTRING(0 0, 10 0, 11 0)").getCoordinate();
+
+            centre.getY().Should().BeApproximately(0, 1e-6);
+            centre.getX().Should().BeApproximately(5.5, 0.01);
+        }
+
+        /// <summary>
+        /// A set of points is their mean direction.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAverageAPointSet()
+        {
+            var centre = Centroid("MULTIPOINT((0 0), (2 0))").getCoordinate();
+
+            centre.getX().Should().BeApproximately(1, 1e-6);
+            centre.getY().Should().BeApproximately(0, 1e-6);
+        }
+
+        /// <summary>
+        /// Where there is no direction to answer, there is no answer.
+        /// </summary>
+        /// <remarks>
+        /// Two antipodal points sum to nothing, and every direction between them is as good as its opposite.
+        /// An empty point says so, which is what JTS answers for a shape with no centroid too.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAnswerNothingWhereThereIsNoCentre()
+        {
+            Centroid("MULTIPOINT((0 0), (180 0))").isEmpty().Should().BeTrue();
+            Centroid("POINT EMPTY").isEmpty().Should().BeTrue();
+            GeographyFunctions.Centroid(null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldStampTheCentreWithWgs84()
+        {
+            Centroid("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))").getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldRunAsAnOperator()
+        {
+            // the longitude comes back a few bits shy of one, a coordinate having gone out and back as a
+            // unit vector, so this asks the operator for the number rather than for its spelling
+            var longitude = GeographyExecutionTests.Run(
+                "SELECT ST_GEOG_X(ST_GEOG_CENTROID(ST_GEOG_GEOMFROMTEXT('MULTIPOINT((0 0), (2 0))')))")[0][0];
+
+            (longitude is java.lang.Number n ? n.doubleValue() : double.NaN).Should().BeApproximately(1, 1e-12);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography.Tests/GeographyHullTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyHullTests.cs
@@ -1,0 +1,167 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The convex hull and simplification, both of which S2 already had.
+    /// </summary>
+    /// <remarks>
+    /// The rest of #86's step five, less buffer, triangulation and grids. That issue deferred the group as
+    /// large on the reasoning that each is a different algorithm geodesically, which is true — and
+    /// <c>S2ConvexHullQuery</c> and <c>S2Polygon.initToSimplified</c> are those algorithms, already written.
+    /// </remarks>
+    [TestClass]
+    public class GeographyHullTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        /// <summary>
+        /// Four corners of a box hull to the box.
+        /// </summary>
+        [TestMethod]
+        public void ShouldHullPointsToTheirBox()
+        {
+            var hull = GeographyFunctions.ConvexHull(Wkt("MULTIPOINT((0 0), (2 0), (2 2), (0 2))"));
+
+            hull.Should().NotBeNull();
+            hull!.getGeometryType().Should().BeOneOf("Polygon", "MultiPolygon");
+
+            var box = hull.getEnvelopeInternal();
+            box.getMinX().Should().BeApproximately(0, 1e-9);
+            box.getMaxX().Should().BeApproximately(2, 1e-9);
+        }
+
+        /// <summary>
+        /// A point inside the geodesic hull and outside the planar one.
+        /// </summary>
+        /// <remarks>
+        /// The hull's northern edge runs between two points on the 60th parallel and is a geodesic, so it
+        /// bows poleward — by more than a degree across sixty degrees of longitude. A point just north of the
+        /// parallel is therefore inside the hull on the Earth and outside the hull on a map, and the two
+        /// answers are asserted side by side.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldHullFurtherNorthThanAPlanarHullDoes()
+        {
+            var corners = Wkt("MULTIPOINT((0 60), (60 60), (60 20), (0 20))");
+            var probe = Wkt("POINT(30 61)");
+
+            SpatialTypeFunctions.ST_Contains(SpatialTypeFunctions.ST_ConvexHull(corners), probe)
+                .Should().BeFalse("the planar hull's northern edge is the parallel");
+
+            var ours = GeographyFunctions.ConvexHull(corners)!;
+
+            GeographyFunctions.Contains(ours, probe)!.booleanValue()
+                .Should().BeTrue("the geodesic hull's northern edge bows past 61");
+        }
+
+        /// <summary>
+        /// The hull of a shape contains the shape.
+        /// </summary>
+        [TestMethod]
+        public void ShouldContainWhatItWasBuiltFrom()
+        {
+            var shape = Wkt("POLYGON((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 3 1, 3 3, 1 3, 1 1))");
+            var hull = GeographyFunctions.ConvexHull(shape)!;
+
+            GeographyFunctions.Covers(hull, shape)!.booleanValue().Should().BeTrue();
+            GeographyFunctions.Area(hull)!.doubleValue()
+                .Should().BeGreaterThan(GeographyFunctions.Area(shape)!.doubleValue(), "the hole is filled in");
+        }
+
+        /// <summary>
+        /// Nothing to hull is an empty hull.
+        /// </summary>
+        [TestMethod]
+        public void ShouldHullNothingToNothing()
+        {
+            GeographyFunctions.ConvexHull(Wkt("POLYGON EMPTY"))!.isEmpty().Should().BeTrue();
+            GeographyFunctions.ConvexHull(null).Should().BeNull();
+        }
+
+        /// <summary>
+        /// Simplifying removes vertices and keeps the shape within the tolerance.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRemoveVerticesWithinTheTolerance()
+        {
+            // a square with a great many near-collinear points along its southern edge
+            var points = new System.Text.StringBuilder("POLYGON((0 0");
+            for (var i = 1; i < 40; i++)
+                points.Append($", {i * 0.05} 0.000001");
+            points.Append(", 2 0, 2 2, 0 2, 0 0))");
+
+            var detailed = Wkt(points.ToString());
+            var simplified = GeographyFunctions.Simplify(detailed, java.lang.Double.valueOf(1000.0))!;
+
+            simplified.isEmpty().Should().BeFalse();
+            simplified.getNumPoints().Should().BeLessThan(detailed.getNumPoints());
+        }
+
+        /// <summary>
+        /// A tolerance of nothing removes nothing that matters.
+        /// </summary>
+        [TestMethod]
+        public void ShouldKeepTheShapeUnderATinyTolerance()
+        {
+            var square = Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))");
+            var simplified = GeographyFunctions.Simplify(square, java.lang.Double.valueOf(0.001))!;
+
+            GeographyFunctions.Area(simplified)!.doubleValue()
+                .Should().BeApproximately(GeographyFunctions.Area(square)!.doubleValue(), GeographyFunctions.Area(square)!.doubleValue() * 1e-5);
+        }
+
+        /// <summary>
+        /// Simplification is an areal operation, as the overlay set is.
+        /// </summary>
+        [TestMethod]
+        public void ShouldDeclineToSimplifyAnythingWithoutAnArea()
+        {
+            GeographyFunctions.Simplify(Wkt("LINESTRING(0 0, 1 1, 2 0)"), java.lang.Double.valueOf(1000.0)).Should().BeNull();
+            GeographyFunctions.Simplify(null, java.lang.Double.valueOf(1)).Should().BeNull();
+            GeographyFunctions.Simplify(Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))"), null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldStampBothWithWgs84()
+        {
+            GeographyFunctions.ConvexHull(Wkt("MULTIPOINT((0 0), (2 0), (1 2))"))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+
+            GeographyFunctions.Simplify(Wkt("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))"), java.lang.Double.valueOf(1.0))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            foreach (var sql in new[]
+            {
+                "ST_GEOG_AREA(ST_GEOG_CONVEXHULL(ST_GEOG_GEOMFROMTEXT('MULTIPOINT((0 0), (2 0), (1 2))')))",
+                "ST_GEOG_AREA(ST_GEOG_SIMPLIFY(ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))'), 1.0))",
+            })
+            {
+                var answer = GeographyExecutionTests.Run("SELECT " + sql)[0][0];
+
+                (answer is java.lang.Number n ? n.doubleValue() : double.NaN).Should().BeGreaterThan(0, sql);
+            }
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -130,6 +130,7 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_CONVEXHULL` | convex on the sphere, so its edges bow poleward of a planar hull's |
 | `ST_GEOG_SIMPLIFY` | vertices removed within a tolerance in metres |
 | `ST_GEOG_CENTROID` | the centre as a direction from the Earth's centre, so it lands in the shape across the antimeridian |
+| `ST_GEOG_BUFFER` | the region within a distance in metres, so it covers the same ground at every latitude |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -127,6 +127,8 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_DENSIFY` | vertices inserted along the geodesic so no edge exceeds a distance in metres |
 | `ST_GEOG_PROJECTPOINT` | a point projected onto a line, landing on the geodesic |
 | `ST_GEOG_INTERSECTION`, `ST_GEOG_DIFFERENCE`, `ST_GEOG_SYMDIFFERENCE`, `ST_GEOG_UNARYUNION` | the overlay set, over areas, bounded by geodesics |
+| `ST_GEOG_CONVEXHULL` | convex on the sphere, so its edges bow poleward of a planar hull's |
+| `ST_GEOG_SIMPLIFY` | vertices removed within a tolerance in metres |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -129,6 +129,7 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_INTERSECTION`, `ST_GEOG_DIFFERENCE`, `ST_GEOG_SYMDIFFERENCE`, `ST_GEOG_UNARYUNION` | the overlay set, over areas, bounded by geodesics |
 | `ST_GEOG_CONVEXHULL` | convex on the sphere, so its edges bow poleward of a planar hull's |
 | `ST_GEOG_SIMPLIFY` | vertices removed within a tolerance in metres |
+| `ST_GEOG_CENTROID` | the centre as a direction from the Earth's centre, so it lands in the shape across the antimeridian |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1407,6 +1407,124 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_BUFFER</c>. Returns the region within the given distance in metres of the geography.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <param name="distance"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The one operation here that S2 does not have. Its Java release has no buffer, so this is built
+        /// rather than called, and what it is built from is the definition: the set of places within the
+        /// distance of any part of the shape. Every vertex contributes a ring of points at exactly that
+        /// distance, traced with <c>Wgs84.Offset</c> so the ring is the true geodesic circle rather than a
+        /// circle of constant angular radius; the rings are unioned, and an areal shape is unioned with its
+        /// own interior so the buffer grows outward rather than only skinning the boundary.
+        ///
+        /// <para>An edge is longer than the gaps between the rings its two ends make, so the edges are
+        /// divided first — every part of the boundary gets a ring within a quarter of the distance of it.
+        /// That is what bounds the error: the result is contained in the true buffer and contains everything
+        /// more than a small fraction of the distance inside it, and the fraction falls as the division
+        /// tightens.</para>
+        ///
+        /// <para>An inscribed polygon is used for each ring, as JTS uses one, so the answer is a little
+        /// inside the true circle rather than straddling it. Thirty-two sides, which is what JTS's default of
+        /// eight per quadrant comes to.</para>
+        ///
+        /// <para>The work is bounded rather than unbounded: a shape with a great many vertices, or one
+        /// enormous beside the distance, would otherwise trace millions of rings. Past a limit the division
+        /// coarsens instead, which loses accuracy and keeps the answer finite, and is the honest trade for an
+        /// operation with no exact form.</para>
+        /// </remarks>
+        public static Geometry? Buffer(Geometry? geog, java.lang.Object? distance)
+        {
+            if (geog is null || distance is null)
+                return null;
+
+            var metres = Double(distance);
+            if (metres <= 0 || geog.isEmpty())
+                return Wgs84Of(Factory.createPolygon());
+
+            var seeds = Seeds(geog, metres);
+            if (seeds.Count == 0)
+                return Wgs84Of(Factory.createPolygon());
+
+            var union = S2Geographies.Of(geog).Polygon ?? new com.google.common.geometry.S2Polygon();
+
+            foreach (var seed in seeds)
+            {
+                var ring = Circle(seed, metres);
+                var merged = new com.google.common.geometry.S2Polygon();
+
+                merged.initToUnion(union, ring);
+                union = merged;
+            }
+
+            return Wgs84Of(Areal(union));
+        }
+
+        /// <summary>
+        /// The places a ring is drawn around, which is every vertex plus enough of every edge.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <param name="metres"></param>
+        /// <returns></returns>
+        static List<org.locationtech.jts.geom.Coordinate> Seeds(Geometry geog, double metres)
+        {
+            var coordinates = geog.getCoordinates();
+            var seeds = new List<org.locationtech.jts.geom.Coordinate>();
+
+            if (coordinates.Length == 0)
+                return seeds;
+
+            // a quarter of the distance keeps the gap between neighbouring rings small beside their radius;
+            // the limit is what keeps a large shape from tracing more rings than anyone wants to wait for
+            const int most = 512;
+
+            var step = metres / 4;
+            var length = Ellipsoid.Length(S2Geographies.Of(geog).Edges);
+
+            if (length / step > most)
+                step = length / most;
+
+            seeds.Add(coordinates[0]);
+
+            for (var i = 0; i < coordinates.Length - 1; i++)
+            {
+                foreach (var between in Ellipsoid.Divide(coordinates[i], coordinates[i + 1], step))
+                    seeds.Add(between);
+
+                seeds.Add(coordinates[i + 1]);
+            }
+
+            return seeds;
+        }
+
+        /// <summary>
+        /// The ring of places at exactly the given distance from one coordinate.
+        /// </summary>
+        /// <param name="centre"></param>
+        /// <param name="metres"></param>
+        /// <returns></returns>
+        static com.google.common.geometry.S2Polygon Circle(org.locationtech.jts.geom.Coordinate centre, double metres)
+        {
+            const int sides = 32;
+
+            var vertices = new java.util.ArrayList();
+
+            for (var i = 0; i < sides; i++)
+            {
+                var point = Ellipsoid.Offset(centre, i * 360.0 / sides, metres);
+
+                vertices.add(com.google.common.geometry.S2LatLng.fromDegrees(point.getY(), point.getX()).toPoint());
+            }
+
+            var loop = new com.google.common.geometry.S2Loop(vertices);
+            loop.normalize();
+
+            return new com.google.common.geometry.S2Polygon(loop);
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_CENTROID</c>. Returns the centre of the geography.
         /// </summary>
         /// <param name="geog"></param>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1407,6 +1407,30 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_CENTROID</c>. Returns the centre of the geography.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The same dimensional rule Calcite's follows — an area outranks a line and a line outranks a point
+        /// — computed on the sphere. The difference is not a refinement. A planar centroid averages
+        /// longitudes, so the centre of a shape straddling the antimeridian lands on the far side of the
+        /// planet; this sums directions from the Earth's centre, and answers a point in the shape.
+        ///
+        /// <para>Null where there is no centre to name: an empty geography, or one symmetric about the
+        /// Earth's centre, where every direction is as good as its opposite.</para>
+        /// </remarks>
+        public static Geometry? Centroid(Geometry? geog)
+        {
+            if (geog is null)
+                return null;
+
+            var centre = S2Geographies.Centroid(S2Geographies.Of(geog));
+
+            return centre is null ? Wgs84Of(Factory.createPoint()) : Wgs84Of(Factory.createPoint(Coordinate(centre)));
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_CONVEXHULL</c>. Returns the smallest convex geography containing this one.
         /// </summary>
         /// <param name="geog"></param>

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1407,6 +1407,72 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_CONVEXHULL</c>. Returns the smallest convex geography containing this one.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Convex on the sphere, which is a different region from convex on a plane: the hull's edges are
+        /// geodesics, so away from the equator they bow poleward of the straight lines a planar hull draws
+        /// between the same vertices. A point can be inside one and outside the other.
+        ///
+        /// <para>Only the vertices are offered to the query, which is enough — every edge of the input is a
+        /// geodesic between two of them, and a convex region containing the ends of a geodesic contains the
+        /// geodesic.</para>
+        /// </remarks>
+        public static Geometry? ConvexHull(Geometry? geog)
+        {
+            if (geog is null)
+                return null;
+
+            var query = new com.google.common.geometry.S2ConvexHullQuery();
+            var any = false;
+
+            foreach (var vertex in S2Geographies.Of(geog).Vertices)
+            {
+                query.addPoint(vertex);
+                any = true;
+            }
+
+            if (any == false)
+                return Wgs84Of(Factory.createPolygon());
+
+            return Wgs84Of(Areal(new com.google.common.geometry.S2Polygon(query.getConvexHull())));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_SIMPLIFY</c>. Returns the geography with vertices removed that move its boundary by no
+        /// more than the given distance in metres.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <param name="tolerance"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Metres rather than degrees, and the boundary the tolerance is measured against is made of
+        /// geodesics. Areas only, as the overlay operations are, and for the same reason: S2 simplifies a
+        /// polygon and answering a line by falling back to the plane would put two models in one expression.
+        ///
+        /// <para>There is no <c>ST_GEOG_SIMPLIFYPRESERVETOPOLOGY</c>. Calcite has both because JTS has both,
+        /// the second promising the result is still valid and still disjoint from what it was disjoint from.
+        /// S2's simplification makes no such promise, and a function that claimed it without keeping it would
+        /// be worse than one that is missing.</para>
+        /// </remarks>
+        public static Geometry? Simplify(Geometry? geog, java.lang.Object? tolerance)
+        {
+            if (geog is null || tolerance is null)
+                return null;
+
+            var polygon = S2Geographies.Of(geog).Polygon;
+            if (polygon is null)
+                return null;
+
+            var simplified = new com.google.common.geometry.S2Polygon();
+            simplified.initToSimplified(polygon, Ellipsoid.AngleFor(Double(tolerance)), false);
+
+            return Wgs84Of(Areal(simplified));
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_INTERSECTION</c>. Returns the area common to two geographies.
         /// </summary>
         /// <param name="geog1"></param>

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -1033,6 +1033,74 @@ namespace Apache.Calcite.Geography.Runtime
             return min;
         }
 
+
+        /// <summary>
+        /// Returns the centroid of the geography as a point on the sphere, or <see langword="null"/> where it
+        /// has none.
+        /// </summary>
+        /// <param name="g"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The dimensional rule JTS uses: an area outranks a line and a line outranks a point, so a shape
+        /// with any areal part is answered by that part's centroid alone. What differs is the space it is
+        /// computed in. S2 sums the centroid of each spherical triangle of a loop, weighted by that
+        /// triangle's area, and the answer is a direction from the Earth's centre rather than an average of
+        /// two coordinates — which is what makes it right across the antimeridian, where averaging longitudes
+        /// puts the centre of a shape on the far side of the planet.
+        ///
+        /// <para>The sum can vanish. Two antipodal points have no centroid, and a shape symmetric about the
+        /// centre has none either; there is no direction to answer and this says so rather than choosing.
+        /// </para>
+        /// </remarks>
+        public static S2Point? Centroid(S2Geographies g)
+        {
+            if (g.polygon is not null && g.polygon.numLoops() > 0)
+                return Normalized(g.polygon.getCentroid(), g.polygon.getArea());
+
+            var sum = new S2Point(0, 0, 0);
+            var weight = 0.0;
+
+            foreach (var (p, q) in g.Edges)
+            {
+                // weighted by the length of the edge it stands for, so a long edge counts for more
+                var length = new S1Angle(p, q).radians();
+
+                sum = S2Point.add(sum, S2Point.mul(S2Point.add(p, q).normalize(), length));
+                weight += length;
+            }
+
+            if (weight > 0)
+                return Normalized(sum, weight);
+
+            foreach (var vertex in g.Vertices)
+            {
+                sum = S2Point.add(sum, vertex);
+                weight += 1;
+            }
+
+            return weight > 0 ? Normalized(sum, weight) : null;
+        }
+
+        /// <summary>
+        /// Returns the direction of a weighted sum of directions, or <see langword="null"/> where it has
+        /// none.
+        /// </summary>
+        /// <param name="sum"></param>
+        /// <param name="weight">The total weight that went into the sum.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Against the weight rather than against zero, and that is not a nicety. Two antipodal points cancel
+        /// exactly in arithmetic and leave about <c>1e-16</c> in floating point, so a test for zero never
+        /// fires and the answer is whatever direction the rounding error happened to point in. What says
+        /// there is no centre is that the sum is negligible <em>beside what went into it</em> — a mean
+        /// direction of no length — which is a question about the ratio and not about the magnitude. A very
+        /// small polygon has a very small centroid sum and a perfectly good centre.
+        /// </remarks>
+        static S2Point? Normalized(S2Point sum, double weight)
+        {
+            return sum.norm() <= weight * 1e-12 ? null : sum.normalize();
+        }
+
         /// <summary>
         /// Returns the least angle between any part of one geography and any part of the other, without
         /// regard to whether one encloses the other.

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -83,6 +83,31 @@ namespace Apache.Calcite.Geography.Runtime
             return Geodesic.WGS84.Inverse(a.getY(), a.getX(), b.getY(), b.getX()).s12;
         }
 
+
+        /// <summary>
+        /// Returns the point reached by travelling the given distance from a coordinate along the given
+        /// azimuth.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="azimuth">Degrees clockwise from north.</param>
+        /// <param name="metres"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The true geodesic, so the ring of points this traces at a fixed distance is the set of places
+        /// actually that far away — which is what makes a buffer built from it agree with
+        /// <c>ST_GEOG_DWITHIN</c>. A circle of constant angular radius on a sphere would not: the two differ
+        /// by the same half percent every other measurement here differs by.
+        /// </remarks>
+        public static org.locationtech.jts.geom.Coordinate Offset(
+            org.locationtech.jts.geom.Coordinate from,
+            double azimuth,
+            double metres)
+        {
+            var step = Geodesic.WGS84.Direct(from.getY(), from.getX(), azimuth, metres);
+
+            return new org.locationtech.jts.geom.Coordinate(step.lon2, step.lat2);
+        }
+
         /// <summary>
         /// Returns the points that divide the geodesic between two coordinates into segments no longer than
         /// the given distance, excluding the two ends.

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,13 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_BUFFER(GEOGRAPHY, DOUBLE)</c>. Returns the region within the given distance in metres of the geography.
+        /// </summary>
+        public static readonly SqlFunction StGeogBuffer =
+            Function("ST_GEOG_BUFFER", nameof(GeographyFunctions.Buffer), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Fractional], ["geog", "distance"]);
+
+        /// <summary>
         /// <c>ST_GEOG_CENTROID(GEOGRAPHY)</c>. Returns the centre of the geography.
         /// </summary>
         public static readonly SqlFunction StGeogCentroid =
@@ -1118,6 +1125,7 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogBuffer,
                 StGeogCentroid,
                 StGeogConvexHull,
                 StGeogSimplify,

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,13 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_CENTROID(GEOGRAPHY)</c>. Returns the centre of the geography.
+        /// </summary>
+        public static readonly SqlFunction StGeogCentroid =
+            Function("ST_GEOG_CENTROID", nameof(GeographyFunctions.Centroid), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
         /// <c>ST_GEOG_CONVEXHULL(GEOGRAPHY)</c>. Returns the smallest convex geography containing this one.
         /// </summary>
         public static readonly SqlFunction StGeogConvexHull =
@@ -1111,6 +1118,7 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogCentroid,
                 StGeogConvexHull,
                 StGeogSimplify,
                 StGeogIntersection,

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,20 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_CONVEXHULL(GEOGRAPHY)</c>. Returns the smallest convex geography containing this one.
+        /// </summary>
+        public static readonly SqlFunction StGeogConvexHull =
+            Function("ST_GEOG_CONVEXHULL", nameof(GeographyFunctions.ConvexHull), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_SIMPLIFY(GEOGRAPHY, DOUBLE)</c>. Returns the geography with vertices removed that move its boundary by no more than the given distance in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogSimplify =
+            Function("ST_GEOG_SIMPLIFY", nameof(GeographyFunctions.Simplify), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Fractional], ["geog", "tolerance"]);
+
+        /// <summary>
         /// <c>ST_GEOG_INTERSECTION(GEOGRAPHY, GEOGRAPHY)</c>. Returns the area common to two geographies.
         /// </summary>
         public static readonly SqlFunction StGeogIntersection =
@@ -1097,6 +1111,8 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogConvexHull,
+                StGeogSimplify,
                 StGeogIntersection,
                 StGeogDifference,
                 StGeogSymDifference,


### PR DESCRIPTION
## Why this carries four operators and not one

Three of these were pushed to `feature/geography-nearest` **after #92 had already been merged**, so they were never in it:

| | |
| --- | --- |
| #92 merged | 09:37:16 |
| `097b49d` convex hull, simplification | 09:42:59 |
| `59dc453` centroid | 15:49:44 |

Nothing was dropped by the merge — the commits did not exist yet. I kept pushing to a closed branch and kept editing the merged PR's body, which GitHub permits and gives no warning about. This branch is cut from `feature/geography-nearest` so `ST_GEOG_CONVEXHULL`, `ST_GEOG_SIMPLIFY` and `ST_GEOG_CENTROID` land here along with the buffer.

## The buffer

`ST_GEOG_BUFFER` is the one operation in this package that **S2 does not have**. Everything else geodesic here turned out to be an S2 call — the overlay set, the hull, simplification, the centroid. S2's Java release has no buffer, so this is built from the definition rather than called: the set of places within the distance of any part of the shape.

Every vertex contributes a ring of points at exactly that distance, traced with GeographicLib rather than as a circle of constant angular radius — so the ring is where `ST_GEOG_DWITHIN` says it is, not half a percent off it. An edge is longer than the gap between the rings its two ends make, so edges are divided first and every part of the boundary gets a ring within a quarter of the distance of it. An areal shape is unioned with its own interior, so the buffer grows outward rather than skinning the boundary.

## How it is tested

There is no exact form to compare against, so the tests assert the **property** instead: a place nearer than the distance is in the answer and a place further is not — walked around the compass at eight azimuths, because a buffer that was right to the east and wrong to the north would be a buffer measured in degrees.

`ShouldCoverTheSameGroundAtEveryLatitude` is the one that separates the readings. Ours agree within a percent between the equator and 60°N. Calcite's, buffered by a fixed number of degrees, differ by more than a quarter.

## Two costs, stated rather than hidden

Each ring is a **32-sided polygon inscribed in the circle** — what JTS's default of eight per quadrant comes to — so the answer sits a little inside the true buffer. The area test asserts it is under πr² and within two percent of it.

The division is **bounded past a limit**. A shape with a great many vertices, or one enormous beside the distance, would otherwise trace millions of rings; past the limit the division coarsens instead. That loses accuracy and keeps the answer finite, which is the honest trade for an operation with no exact form.

## Where the surface stands

With this and the two recovered commits, 33 of Calcite's spatial names remain unmirrored: **triangulation and grids** from #86's step five, the four predicates withdrawn earlier for divergence, `ST_SETSRID`/`ST_TRANSFORM` which one reference system makes meaningless, `ST_POINTONSURFACE` and `ST_ISSIMPLE` (both looked at and left — the first needs a guaranteed-interior point S2 does not provide, the second needs pairwise edge crossing on open lines), and a tail of planar-only coordinate helpers with no geodesic meaning to give them.

162 tests, green on net8.0 and net10.0.

