### PR TITLE
Add the simplicity predicates

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographySimplicityTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographySimplicityTests.cs
@@ -1,0 +1,154 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// Whether a geography touches itself, which is a question about where its edges go — and its edges are
+    /// geodesics.
+    /// </summary>
+    /// <remarks>
+    /// This joins <c>ST_GEOG_ISVALID</c>, which was here from the first increment. The rule is JTS's: a point
+    /// is simple, a set of points is simple when none repeats, a line is simple when no two of its edges meet
+    /// except where they are joined, an area is simple because its self-intersections are a question of
+    /// validity instead, and a collection is simple when its parts are.
+    /// </remarks>
+    [TestClass]
+    public class GeographySimplicityTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static bool Simple(string wkt)
+        {
+            return GeographyFunctions.IsSimple(Wkt(wkt))!.booleanValue();
+        }
+
+        static bool Ring(string wkt)
+        {
+            return GeographyFunctions.IsRing(Wkt(wkt))!.booleanValue();
+        }
+
+        /// <summary>
+        /// The one that separates the two readings: a line simple on the map and not on the Earth.
+        /// </summary>
+        /// <remarks>
+        /// The first edge runs sixty degrees of longitude along the 60th parallel, and a geodesic between two
+        /// points on a parallel bows poleward — this one to 63.4 degrees at its middle. The last edge is drawn
+        /// at latitude 62 but spans only twenty-five degrees, so it bows to 62.6 and stays under the first
+        /// edge's peak while sitting above its ends. They therefore cross. On a plane they are two horizontal
+        /// segments two degrees apart and never meet, so Calcite calls the line simple.
+        ///
+        /// <para>How much an edge bows is <c>atan(tan φ / cos(Δλ/2))</c>, which grows with the span. It is the
+        /// difference in span rather than the difference in latitude that puts one edge over the other: two
+        /// edges spanning the same longitude bow alike however far apart their parallels are.</para>
+        /// </remarks>
+        [TestMethod]
+        public void ShouldSeeACrossingThatOnlyExistsOnTheEarth()
+        {
+            const string wkt = "LINESTRING(0 60, 60 60, 30 62, 5 62)";
+
+            Wkt(wkt).isSimple().Should().BeTrue("the planar edges are two parallels two degrees apart");
+            Simple(wkt).Should().BeFalse("the first edge bows to 63.4 and the last only to 62.6, so they cross");
+        }
+
+        /// <summary>
+        /// An ordinary self-crossing line is not simple either way.
+        /// </summary>
+        [TestMethod]
+        public void ShouldSeeAnOrdinaryCrossing()
+        {
+            Simple("LINESTRING(0 0, 2 2, 0 2, 2 0)").Should().BeFalse();
+            Wkt("LINESTRING(0 0, 2 2, 0 2, 2 0)").isSimple().Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A line that does not touch itself is simple, and so is one that closes.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAcceptALineAndARing()
+        {
+            Simple("LINESTRING(0 0, 1 0, 1 1)").Should().BeTrue();
+            Simple("LINESTRING(0 0, 1 0, 1 1, 0 1, 0 0)").Should().BeTrue("closing is not touching");
+        }
+
+        /// <summary>
+        /// A vertex reached twice is a touch, save for the one that closes a ring.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseARepeatedVertex()
+        {
+            Simple("LINESTRING(0 0, 1 0, 0 0, 1 1)").Should().BeFalse();
+            Simple("MULTIPOINT((0 0), (1 1), (0 0))").Should().BeFalse();
+            Simple("MULTIPOINT((0 0), (1 1))").Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A point is simple, and so is an area whatever it does to itself.
+        /// </summary>
+        [TestMethod]
+        public void ShouldCallAPointAndAnAreaSimple()
+        {
+            Simple("POINT(1 2)").Should().BeTrue();
+            Simple("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))").Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Only a closed, simple line is a ring.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAskBothQuestionsOfARing()
+        {
+            Ring("LINESTRING(0 0, 1 0, 1 1, 0 1, 0 0)").Should().BeTrue();
+            Ring("LINESTRING(0 0, 1 0, 1 1)").Should().BeFalse("it does not close");
+            Ring("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))").Should().BeFalse("only a line can be a ring");
+            Ring("POINT(0 0)").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A ring whose edges cross on the Earth is not a ring here either.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRefuseARingThatCrossesOnlyOnTheEarth()
+        {
+            const string wkt = "LINESTRING(0 60, 60 60, 30 62, 5 62, 0 60)";
+
+            ((org.locationtech.jts.geom.LineString)Wkt(wkt)).isRing().Should().BeTrue("the planar edges do not cross");
+            Ring(wkt).Should().BeFalse("the geodesic ones do");
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            GeographyFunctions.IsSimple(null).Should().BeNull();
+            GeographyFunctions.IsRing(null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            var simple = GeographyExecutionTests.Run(
+                "SELECT ST_GEOG_ISSIMPLE(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0, 1 1)'))")[0][0];
+            (simple is java.lang.Boolean a && a.booleanValue()).Should().BeTrue();
+
+            var ring = GeographyExecutionTests.Run(
+                "SELECT ST_GEOG_ISRING(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 0, 1 0, 1 1, 0 1, 0 0)'))")[0][0];
+            (ring is java.lang.Boolean b && b.booleanValue()).Should().BeTrue();
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -131,6 +131,7 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_SIMPLIFY` | vertices removed within a tolerance in metres |
 | `ST_GEOG_CENTROID` | the centre as a direction from the Earth's centre, so it lands in the shape across the antimeridian |
 | `ST_GEOG_BUFFER` | the region within a distance in metres, so it covers the same ground at every latitude |
+| `ST_GEOG_ISSIMPLE`, `ST_GEOG_ISRING` | whether a shape touches itself, asked of geodesic edges |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1407,6 +1407,33 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_ISSIMPLE</c>. Returns whether the geography touches itself nowhere it should not.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The edges are geodesics, which is what makes this a different question from Calcite's. Two edges a
+        /// planar reading draws as straight lines in degrees may cross on the Earth and not on the map,
+        /// because a geodesic between two points on a parallel bows poleward and can reach over a line drawn
+        /// north of it.
+        /// </remarks>
+        public static java.lang.Boolean? IsSimple(Geometry? geog)
+        {
+            return geog is null ? null : java.lang.Boolean.valueOf(S2Geographies.IsSimple(geog));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_ISRING</c>. Returns whether the geography is a line that is closed and simple.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <inheritdoc cref="IsSimple" />
+        public static java.lang.Boolean? IsRing(Geometry? geog)
+        {
+            return geog is null ? null : java.lang.Boolean.valueOf(S2Geographies.IsRing(geog));
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_BUFFER</c>. Returns the region within the given distance in metres of the geography.
         /// </summary>
         /// <param name="geog"></param>

--- a/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
+++ b/src/Apache.Calcite.Geography/Runtime/S2Geographies.cs
@@ -117,6 +117,111 @@ namespace Apache.Calcite.Geography.Runtime
             }
         }
 
+        /// <summary>
+        /// Returns whether the geography touches itself nowhere it should not.
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// JTS's rule, on the sphere. A point is always simple; a set of points is simple when none repeats;
+        /// a line is simple when no two of its edges meet except where they are joined, save that its two ends
+        /// may coincide and make a ring; an area is simple, its self-intersections being a question of
+        /// validity instead; and a collection is simple when its parts are.
+        ///
+        /// <para>The edges are geodesics, which is the whole difference. Two edges that a planar reading draws
+        /// as straight lines in degrees may cross on the Earth and not on the map, because a geodesic between
+        /// two points on a parallel bows poleward and can reach over a line drawn north of it.</para>
+        /// </remarks>
+        public static bool IsSimple(Geometry geometry)
+        {
+            ArgumentNullException.ThrowIfNull(geometry);
+
+            switch (geometry)
+            {
+                case Point _:
+                    return true;
+                case MultiPoint multi:
+                    return NoRepeatedPoint(multi);
+                case LineString line:
+                    return line.isEmpty() || IsSimpleLine(line);
+                // an area's self-intersections are a question of validity rather than simplicity, which is
+                // where JTS puts them too
+                case Polygon _:
+                case MultiPolygon _:
+                    return true;
+                case GeometryCollection collection:
+                    for (var i = 0; i < collection.getNumGeometries(); i++)
+                        if (IsSimple(collection.getGeometryN(i)) == false)
+                            return false;
+
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the geography is a line that is closed and simple.
+        /// </summary>
+        /// <param name="geometry"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// What JTS asks: only a line can be a ring, and it must both return to where it began and touch
+        /// itself nowhere else.
+        /// </remarks>
+        public static bool IsRing(Geometry geometry)
+        {
+            ArgumentNullException.ThrowIfNull(geometry);
+
+            return geometry is LineString line
+                && line.isEmpty() == false
+                && line.isClosed()
+                && IsSimpleLine(line);
+        }
+
+        static bool NoRepeatedPoint(MultiPoint multi)
+        {
+            var seen = new java.util.HashSet();
+
+            for (var i = 0; i < multi.getNumGeometries(); i++)
+                if (seen.add(multi.getGeometryN(i).getCoordinate().toString()) == false)
+                    return false;
+
+            return true;
+        }
+
+        static bool IsSimpleLine(LineString line)
+        {
+            var vertices = ToPath(line);
+            if (vertices is null || vertices.Length < 2)
+                return false;
+
+            var closed = vertices[0].Equals(vertices[^1]);
+            var count = vertices.Length - 1;
+
+            // a vertex reached twice is a self-touch, save for the one that closes a ring
+            var seen = new java.util.HashSet();
+            for (var i = 0; i < (closed ? count : vertices.Length); i++)
+                if (seen.add(vertices[i].toString()) == false)
+                    return false;
+
+            for (var i = 0; i < count; i++)
+            {
+                for (var j = i + 1; j < count; j++)
+                {
+                    // edges joined at a vertex meet there by construction, and the first and last edge of a
+                    // ring are joined the same way
+                    if (j == i + 1 || (closed && i == 0 && j == count - 1))
+                        continue;
+
+                    if (S2EdgeUtil.edgeOrVertexCrossing(vertices[i], vertices[i + 1], vertices[j], vertices[j + 1]))
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
         static bool IsValidCoordinate(Coordinate coordinate)
         {
             return S2LatLng.fromDegrees(coordinate.getY(), coordinate.getX()).isValid();

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,20 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_ISSIMPLE(GEOGRAPHY)</c>. Returns whether the geography touches itself nowhere it should not.
+        /// </summary>
+        public static readonly SqlFunction StGeogIsSimple =
+            Function("ST_GEOG_ISSIMPLE", nameof(GeographyFunctions.IsSimple), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_ISRING(GEOGRAPHY)</c>. Returns whether the geography is a line that is closed and simple.
+        /// </summary>
+        public static readonly SqlFunction StGeogIsRing =
+            Function("ST_GEOG_ISRING", nameof(GeographyFunctions.IsRing), GeographyReturnTypes.Boolean,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
         /// <c>ST_GEOG_BUFFER(GEOGRAPHY, DOUBLE)</c>. Returns the region within the given distance in metres of the geography.
         /// </summary>
         public static readonly SqlFunction StGeogBuffer =
@@ -1125,6 +1139,8 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogIsSimple,
+                StGeogIsRing,
                 StGeogBuffer,
                 StGeogCentroid,
                 StGeogConvexHull,


### PR DESCRIPTION
`ST_GEOG_ISSIMPLE` and `ST_GEOG_ISRING`, joining `ST_GEOG_ISVALID` from the first increment.

JTS's rule throughout: a point is simple, a set of points is simple when none repeats, a line is simple when no two of its edges meet except where they are joined, an area is simple because its self-intersections are a question of validity instead, and a collection is simple when its parts are.

What differs is that the edges are **geodesics**, and `S2EdgeUtil.edgeOrVertexCrossing` is asked about each pair.

## The demonstration, and the mistake behind it

`LINESTRING(0 60, 60 60, 30 62, 5 62)` is two horizontal segments two degrees apart on a plane and never meets itself. On the Earth the first edge crosses the last twice. Calcite calls it simple; this does not.

**The example took two attempts and the first was wrong**, which is worth recording because the reasoning was the trap. How far an edge bows is `atan(tan φ / cos(Δλ/2))` — it grows with the **span**, not with the latitude. My first attempt ran the far edge at latitude 62 across forty degrees, which bows to 63.45° — *higher* than the 63.43° of the edge at latitude 60 it was supposed to be crossed by. Two edges spanning the same longitude bow alike however far apart their parallels are.

The code was right and the geometry in the test was not. I only found it because the test failed and I checked the arithmetic rather than the implementation.

## Stacking

Branches off `feature/geography-buffer` (#95), which itself carries the two commits #92 left behind. Merge order is #95 then this.

171 tests, green on net8.0 and net10.0.
