### PR TITLE
Add the bounding circle

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographyBoundingCircleTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyBoundingCircleTests.cs
@@ -1,0 +1,154 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// The smallest circle containing a geography, on the Earth rather than on a map.
+    /// </summary>
+    /// <remarks>
+    /// A planar smallest circle measures its radius in degrees, so what it draws is an ellipse on the ground
+    /// everywhere off the equator, and the centre it picks is the one that minimises a distance nobody
+    /// travels. This is a circle of constant distance about a centre chosen by distance.
+    ///
+    /// <para>Containment is exact and minimality is approximate, which is the deliberate way round: the
+    /// centre is walked toward rather than solved for, and the radius is measured afterwards from wherever
+    /// the walk settled. A circle a fraction of a percent too wide is a worse bound and still a bound; one a
+    /// fraction too narrow is wrong.</para>
+    /// </remarks>
+    [TestClass]
+    public class GeographyBoundingCircleTests
+    {
+
+        const double Kilometre = 1000.0;
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static Geometry Circle(string wkt)
+        {
+            return GeographyFunctions.BoundingCircle(Wkt(wkt))!;
+        }
+
+        /// <summary>
+        /// The circle holds what it was built from. Every vertex, and every edge between them.
+        /// </summary>
+        [TestMethod]
+        public void ShouldContainWhatItBounds()
+        {
+            foreach (var wkt in new[]
+            {
+                "MULTIPOINT((0 0), (1 0), (0.5 1))",
+                "POLYGON((0 50, 2 50, 2 52, 0 52, 0 50))",
+                "LINESTRING(-10 60, 10 60, 10 65)",
+                "MULTIPOINT((0 0), (0 80))",
+            })
+            {
+                GeographyFunctions.Covers(Circle(wkt), Wkt(wkt))!.booleanValue()
+                    .Should().BeTrue(wkt);
+            }
+        }
+
+        /// <summary>
+        /// Two points are bounded by the circle on the geodesic between them, centred at its middle.
+        /// </summary>
+        /// <remarks>
+        /// The case with a known answer. The centre is the midpoint of the geodesic and the radius is half
+        /// its length, so both can be checked against a measurement rather than against another circle.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldCentreTwoPointsOnTheirMidpoint()
+        {
+            var a = Wkt("POINT(-1 0)");
+            var b = Wkt("POINT(1 0)");
+            var circle = Circle("MULTIPOINT((-1 0), (1 0))");
+
+            var centre = GeographyFunctions.Centroid(circle)!;
+            centre.getCoordinate().getX().Should().BeApproximately(0, 0.01);
+            centre.getCoordinate().getY().Should().BeApproximately(0, 0.01);
+
+            var half = GeographyFunctions.Distance(a, b)!.doubleValue() / 2;
+            var reach = GeographyFunctions.Distance(centre, a)!.doubleValue();
+
+            reach.Should().BeApproximately(half, half * 0.01);
+        }
+
+        /// <summary>
+        /// The radius is metres, so the circle is the same size wherever the shape sits.
+        /// </summary>
+        /// <remarks>
+        /// The one that separates the readings. Two shapes of the same size on the ground, one at the equator
+        /// and one at sixty north, get circles of the same area. A planar bounding circle would give the
+        /// northern one a smaller area, its degrees being worth less there.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldBoundTheSameSizeAtEveryLatitude()
+        {
+            // a degree of longitude at 60 north is half of one at the equator, so this pair is the same
+            // width on the ground
+            var equator = GeographyFunctions.Area(Circle("MULTIPOINT((-1 0), (1 0))"))!.doubleValue();
+            var north = GeographyFunctions.Area(Circle("MULTIPOINT((-2 60), (2 60))"))!.doubleValue();
+
+            north.Should().BeApproximately(equator, equator * 0.02);
+        }
+
+        /// <summary>
+        /// A circle is not much larger than it must be.
+        /// </summary>
+        /// <remarks>
+        /// For two points the least possible radius is half the distance between them, so the circle's area
+        /// has a floor of π times that squared. The walk stops a little short of the exact centre and the ring
+        /// is drawn a little wide to hold the shape between its vertices, so a few percent over is expected;
+        /// far more than that would mean the walk was not converging.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldNotBeMuchLargerThanItMustBe()
+        {
+            var span = GeographyFunctions.Distance(Wkt("POINT(-1 0)"), Wkt("POINT(1 0)"))!.doubleValue();
+            var least = Math.PI * Math.Pow(span / 2, 2);
+
+            var area = GeographyFunctions.Area(Circle("MULTIPOINT((-1 0), (1 0))"))!.doubleValue();
+
+            area.Should().BeGreaterThan(least * 0.99);
+            area.Should().BeLessThan(least * 1.1);
+        }
+
+        /// <summary>
+        /// One point has no width, and nothing has no circle.
+        /// </summary>
+        [TestMethod]
+        public void ShouldDegenerateWhereThereIsNothingToBound()
+        {
+            Circle("POINT(1 2)").getGeometryType().Should().Be("Point");
+            Circle("POINT EMPTY").isEmpty().Should().BeTrue();
+            GeographyFunctions.BoundingCircle(null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldStampTheCircleWithWgs84()
+        {
+            Circle("MULTIPOINT((0 0), (1 1))").getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldRunAsAnOperator()
+        {
+            var area = GeographyExecutionTests.Run(
+                "SELECT ST_GEOG_AREA(ST_GEOG_BOUNDINGCIRCLE(ST_GEOG_GEOMFROMTEXT('MULTIPOINT((0 0), (1 0))')))")[0][0];
+
+            (area is java.lang.Number n ? n.doubleValue() : double.NaN).Should().BeGreaterThan(0);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -132,6 +132,7 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_CENTROID` | the centre as a direction from the Earth's centre, so it lands in the shape across the antimeridian |
 | `ST_GEOG_BUFFER` | the region within a distance in metres, so it covers the same ground at every latitude |
 | `ST_GEOG_ISSIMPLE`, `ST_GEOG_ISRING` | whether a shape touches itself, asked of geodesic edges |
+| `ST_GEOG_BOUNDINGCIRCLE` | the smallest circle holding a shape, of constant distance rather than constant degrees |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1407,6 +1407,94 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_BOUNDINGCIRCLE</c>. Returns the smallest circle containing the geography.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// A circle on the Earth rather than on a map, which is a different shape and a different centre. A
+        /// planar smallest circle measures its radius in degrees, so the circle it draws is an ellipse on the
+        /// ground everywhere off the equator, and the centre it picks is the one that minimises a distance
+        /// nobody travels.
+        ///
+        /// <para>The centre is found by walking toward whichever vertex is furthest, in steps that shrink as
+        /// the walk goes on. That converges on the point whose greatest distance to the shape is least, and
+        /// it converges from any start; what it does not do is arrive exactly. So the radius is taken
+        /// afterwards as the true greatest distance from the centre it settled on, which makes containment
+        /// exact and minimality approximate — the circle certainly holds the shape, and may be a fraction of
+        /// a percent wider than the smallest one that would.</para>
+        ///
+        /// <para>Only the vertices are walked, which is enough: a cap is convex and a geodesic between two
+        /// points inside one stays inside it, so a circle holding every vertex holds every edge.</para>
+        ///
+        /// <para>The ring is drawn a little wide — by <c>1 / cos(π / sides)</c> — because it is a polygon of
+        /// thirty-two sides rather than a circle, and an inscribed polygon would cut inside the radius
+        /// between its vertices and leave the shape sticking out.</para>
+        /// </remarks>
+        public static Geometry? BoundingCircle(Geometry? geog)
+        {
+            if (geog is null)
+                return null;
+
+            var vertices = geog.getCoordinates();
+            if (vertices.Length == 0)
+                return Wgs84Of(Factory.createPolygon());
+
+            var centre = Centre(vertices);
+            var radius = 0.0;
+
+            foreach (var vertex in vertices)
+                radius = System.Math.Max(radius, Ellipsoid.Distance(centre, vertex));
+
+            if (radius == 0)
+                return Wgs84Of(Factory.createPoint(centre));
+
+            return Wgs84Of(Areal(Circle(centre, radius / System.Math.Cos(System.Math.PI / CircleSides))));
+        }
+
+        /// <summary>
+        /// The place whose greatest distance to any of the given coordinates is least, near enough.
+        /// </summary>
+        /// <param name="vertices"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Steps of <c>d / (i + 1)</c> toward the furthest vertex, which is the shrinking-step walk that
+        /// converges on the one-centre from any start. The count is what decides how close it gets; a
+        /// thousand puts it within a small fraction of a percent, and the radius is measured afterwards so
+        /// that being short of the true centre widens the circle rather than letting anything escape it.
+        /// </remarks>
+        static org.locationtech.jts.geom.Coordinate Centre(org.locationtech.jts.geom.Coordinate[] vertices)
+        {
+            const int steps = 1000;
+
+            var centre = vertices[0];
+
+            for (var i = 1; i <= steps; i++)
+            {
+                var furthest = vertices[0];
+                var distance = 0.0;
+
+                foreach (var vertex in vertices)
+                {
+                    var candidate = Ellipsoid.Distance(centre, vertex);
+
+                    if (candidate > distance)
+                    {
+                        distance = candidate;
+                        furthest = vertex;
+                    }
+                }
+
+                if (distance == 0)
+                    break;
+
+                centre = Ellipsoid.Offset(centre, Ellipsoid.Azimuth(centre, furthest), distance / (i + 1));
+            }
+
+            return centre;
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_ISSIMPLE</c>. Returns whether the geography touches itself nowhere it should not.
         /// </summary>
         /// <param name="geog"></param>
@@ -1527,6 +1615,11 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// How many sides a circle is drawn with, which is what JTS's default of eight per quadrant comes to.
+        /// </summary>
+        const int CircleSides = 32;
+
+        /// <summary>
         /// The ring of places at exactly the given distance from one coordinate.
         /// </summary>
         /// <param name="centre"></param>
@@ -1534,7 +1627,7 @@ namespace Apache.Calcite.Geography.Runtime
         /// <returns></returns>
         static com.google.common.geometry.S2Polygon Circle(org.locationtech.jts.geom.Coordinate centre, double metres)
         {
-            const int sides = 32;
+            const int sides = CircleSides;
 
             var vertices = new java.util.ArrayList();
 

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -84,6 +84,21 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
 
+
+        /// <summary>
+        /// Returns the azimuth at the first coordinate of the geodesic to the second, in degrees clockwise
+        /// from north.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <returns></returns>
+        public static double Azimuth(
+            org.locationtech.jts.geom.Coordinate from,
+            org.locationtech.jts.geom.Coordinate to)
+        {
+            return Geodesic.WGS84.Inverse(from.getY(), from.getX(), to.getY(), to.getX()).azi1;
+        }
+
         /// <summary>
         /// Returns the point reached by travelling the given distance from a coordinate along the given
         /// azimuth.

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,13 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_BOUNDINGCIRCLE(GEOGRAPHY)</c>. Returns the smallest circle containing the geography.
+        /// </summary>
+        public static readonly SqlFunction StGeogBoundingCircle =
+            Function("ST_GEOG_BOUNDINGCIRCLE", nameof(GeographyFunctions.BoundingCircle), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
         /// <c>ST_GEOG_ISSIMPLE(GEOGRAPHY)</c>. Returns whether the geography touches itself nowhere it should not.
         /// </summary>
         public static readonly SqlFunction StGeogIsSimple =
@@ -1139,6 +1146,7 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogBoundingCircle,
                 StGeogIsSimple,
                 StGeogIsRing,
                 StGeogBuffer,


### PR DESCRIPTION
`ST_GEOG_BOUNDINGCIRCLE` — a circle on the Earth rather than on a map.

A planar smallest circle measures its radius in degrees, so what it draws is an ellipse on the ground everywhere off the equator, and the centre it picks minimises a distance nobody travels.

## How the centre is found

Walked toward rather than solved for: step toward whichever vertex is furthest, in steps that shrink as the walk goes on. That converges on the point whose greatest distance is least, from any start. What it does not do is *arrive* exactly — so the radius is measured afterwards as the true greatest distance from wherever the walk settled.

**That makes containment exact and minimality approximate, which is the deliberate way round.** A circle a fraction of a percent too wide is a worse bound and still a bound; one a fraction too narrow is simply wrong. `ShouldContainWhatItBounds` asserts the first across four shapes; `ShouldNotBeMuchLargerThanItMustBe` bounds the second against the least possible radius for a pair of points.

Only the vertices are walked, which is enough: a cap is convex and a geodesic between two points inside one stays inside it, so a circle holding every vertex holds every edge.

The ring is drawn wide by `1 / cos(π / sides)`, because a 32-sided polygon inscribed in the circle would cut inside the radius between its vertices and leave the shape sticking out. Same side count the buffer uses — now shared rather than written twice.

## Stack

```
main
 └── #95  feature/geography-buffer          buffer + the two commits #92 left behind
      └── #96  feature/geography-validity   ST_GEOG_ISSIMPLE, ST_GEOG_ISRING
           └── #97 (this)                   ST_GEOG_BOUNDINGCIRCLE
```

Base branches are set so GitHub shows each PR's own diff and enforces the order. Merge bottom-up.

178 tests, green on net8.0 and net10.0.
