### PR TITLE
Add locate-along and the minimum diameter

### DIFF
--- a/src/Apache.Calcite.Geography.Tests/GeographyAlongTests.cs
+++ b/src/Apache.Calcite.Geography.Tests/GeographyAlongTests.cs
@@ -1,0 +1,180 @@
+using System;
+
+using Apache.Calcite.Geography.Runtime;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.runtime;
+
+using Geometry = org.locationtech.jts.geom.Geometry;
+
+namespace Apache.Calcite.Geography.Tests
+{
+
+    /// <summary>
+    /// Positions taken relative to a line, and the narrowest way across a shape.
+    /// </summary>
+    /// <remarks>
+    /// Both turn on the same fact as the rest of this package: the line between two coordinates is a geodesic
+    /// and not a straight line in degrees, so a point partway along it is somewhere else, sideways is a
+    /// different direction, and the pair of parallel lines that hold a shape are great circles.
+    /// </remarks>
+    [TestClass]
+    public class GeographyAlongTests
+    {
+
+        static Geometry Wkt(string wkt)
+        {
+            return GeographyFunctions.FromWkt(wkt) ?? throw new InvalidOperationException($"'{wkt}' did not parse.");
+        }
+
+        static Geometry Along(string wkt, double fraction, double offset)
+        {
+            return GeographyFunctions.LocateAlong(Wkt(wkt), java.lang.Double.valueOf(fraction), java.lang.Double.valueOf(offset))!;
+        }
+
+        /// <summary>
+        /// Halfway along a geodesic is not halfway along a line drawn in degrees.
+        /// </summary>
+        /// <remarks>
+        /// Across sixty degrees of longitude on the 60th parallel the geodesic bows to 63.4 at its middle, so
+        /// the halfway point is three and a half degrees north of where Calcite puts it. The longitude agrees
+        /// and the latitude does not, which is the bow and nothing else.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldPlaceTheMidpointOnTheGeodesic()
+        {
+            const string line = "LINESTRING(0 60, 60 60)";
+
+            var theirs = SpatialTypeFunctions.ST_LocateAlong(Wkt(line), java.math.BigDecimal.valueOf(0.5), java.math.BigDecimal.ZERO)
+                .getCoordinate();
+            theirs.getY().Should().BeApproximately(60, 1e-9, "a planar midpoint stays on the parallel");
+
+            var ours = Along(line, 0.5, 0).getCoordinate();
+
+            ours.getX().Should().BeApproximately(30, 1e-6);
+            ours.getY().Should().BeApproximately(63.435, 0.01);
+        }
+
+        /// <summary>
+        /// The fraction runs from one end to the other.
+        /// </summary>
+        [TestMethod]
+        public void ShouldRunFromEndToEnd()
+        {
+            const string line = "LINESTRING(0 0, 10 0)";
+
+            Along(line, 0, 0).getCoordinate().getX().Should().BeApproximately(0, 1e-9);
+            Along(line, 1, 0).getCoordinate().getX().Should().BeApproximately(10, 1e-9);
+            Along(line, 0.25, 0).getCoordinate().getX().Should().BeApproximately(2.5, 0.01);
+        }
+
+        /// <summary>
+        /// The offset is metres, to the left of the way the line is going.
+        /// </summary>
+        [TestMethod]
+        public void ShouldOffsetInMetresToTheLeft()
+        {
+            const string line = "LINESTRING(0 0, 10 0)";
+
+            var left = Along(line, 0.5, 10000).getCoordinate();
+            var right = Along(line, 0.5, -10000).getCoordinate();
+
+            left.getY().Should().BeGreaterThan(0, "left of due east is north");
+            right.getY().Should().BeLessThan(0);
+
+            var middle = Wkt("POINT(5 0)");
+            GeographyFunctions.Distance(middle, Wkt($"POINT({left.getX()} {left.getY()})"))!.doubleValue()
+                .Should().BeApproximately(10000, 1);
+        }
+
+        /// <summary>
+        /// One point for every segment, of every part, as Calcite answers.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerOnePointPerSegment()
+        {
+            Along("LINESTRING(0 0, 1 0, 2 0, 3 0)", 0.5, 0).getNumGeometries().Should().Be(3);
+            Along("MULTILINESTRING((0 0, 1 0), (5 0, 6 0))", 0.5, 0).getNumGeometries().Should().Be(2);
+        }
+
+        /// <summary>
+        /// A shape's width is measured between great circles, not between lines drawn in degrees.
+        /// </summary>
+        /// <remarks>
+        /// The narrow way across this sliver is north to south, and its two long edges bow. A planar diameter
+        /// measures the gap between two horizontal lines and gets the full two degrees; the geodesic one is
+        /// narrower, because the southern edge bows up into the shape.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldMeasureWidthBetweenGreatCircles()
+        {
+            var sliver = Wkt("POLYGON((0 60, 60 60, 60 62, 0 62, 0 60))");
+
+            var diameter = GeographyFunctions.MinimumDiameter(sliver)!;
+            diameter.isEmpty().Should().BeFalse();
+
+            var width = GeographyFunctions.Length(diameter)!.doubleValue();
+            var twoDegrees = GeographyFunctions.Distance(Wkt("POINT(0 60)"), Wkt("POINT(0 62)"))!.doubleValue();
+
+            width.Should().BeGreaterThan(0);
+            width.Should().BeLessThan(twoDegrees, "the southern edge bows north into the shape");
+        }
+
+        /// <summary>
+        /// The diameter of a square is its side, near enough.
+        /// </summary>
+        [TestMethod]
+        public void ShouldMeasureASquareAcrossItsSide()
+        {
+            var square = Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+            var width = GeographyFunctions.Length(GeographyFunctions.MinimumDiameter(square)!)!.doubleValue();
+            var side = GeographyFunctions.Distance(Wkt("POINT(0 0)"), Wkt("POINT(0 1)"))!.doubleValue();
+
+            width.Should().BeApproximately(side, side * 0.01);
+        }
+
+        /// <summary>
+        /// A shape with no width has no diameter to name.
+        /// </summary>
+        [TestMethod]
+        public void ShouldAnswerNothingForSomethingWithNoWidth()
+        {
+            GeographyFunctions.MinimumDiameter(Wkt("POINT(1 2)"))!.isEmpty().Should().BeTrue();
+            GeographyFunctions.MinimumDiameter(Wkt("LINESTRING(0 0, 1 0)"))!.isEmpty().Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ShouldAnswerNullForANullArgument()
+        {
+            GeographyFunctions.LocateAlong(null, java.lang.Double.valueOf(0.5), java.lang.Double.valueOf(0)).Should().BeNull();
+            GeographyFunctions.LocateAlong(Wkt("LINESTRING(0 0, 1 0)"), null, java.lang.Double.valueOf(0)).Should().BeNull();
+            GeographyFunctions.MinimumDiameter(null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ShouldStampBothWithWgs84()
+        {
+            Along("LINESTRING(0 0, 1 0)", 0.5, 0).getSRID().Should().Be(GeographyFunctions.Wgs84);
+            GeographyFunctions.MinimumDiameter(Wkt("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"))!
+                .getSRID().Should().Be(GeographyFunctions.Wgs84);
+        }
+
+        [TestMethod]
+        public void ShouldRunEachAsAnOperator()
+        {
+            var along = GeographyExecutionTests.Run(
+                // through the centroid, a multi-point of one being its own centre, because ST_GEOG_Y wants a point
+                "SELECT ST_GEOG_Y(ST_GEOG_CENTROID(ST_GEOG_LOCATEALONG(ST_GEOG_GEOMFROMTEXT('LINESTRING(0 60, 60 60)'), 0.5, 0.0)))")[0][0];
+            (along is java.lang.Number a ? a.doubleValue() : double.NaN).Should().BeApproximately(63.435, 0.01);
+
+            var width = GeographyExecutionTests.Run(
+                "SELECT ST_GEOG_LENGTH(ST_GEOG_MINIMUMDIAMETER(ST_GEOG_GEOMFROMTEXT('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')))")[0][0];
+            (width is java.lang.Number w ? w.doubleValue() : double.NaN).Should().BeGreaterThan(0);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Geography/README.md
+++ b/src/Apache.Calcite.Geography/README.md
@@ -133,6 +133,8 @@ The two halves run on different engines, and deliberately. The predicates are S2
 | `ST_GEOG_BUFFER` | the region within a distance in metres, so it covers the same ground at every latitude |
 | `ST_GEOG_ISSIMPLE`, `ST_GEOG_ISRING` | whether a shape touches itself, asked of geodesic edges |
 | `ST_GEOG_BOUNDINGCIRCLE` | the smallest circle holding a shape, of constant distance rather than constant degrees |
+| `ST_GEOG_LOCATEALONG` | a point a fraction along each segment, offset sideways in metres |
+| `ST_GEOG_MINIMUMDIAMETER` | the narrowest way across, measured between great circles |
 | `ST_GEOG_LENGTH`, `ST_GEOG_PERIMETER` | metres |
 | `ST_GEOG_AREA` | square metres |
 

--- a/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
+++ b/src/Apache.Calcite.Geography/Runtime/GeographyFunctions.cs
@@ -1407,6 +1407,147 @@ namespace Apache.Calcite.Geography.Runtime
         }
 
         /// <summary>
+        /// <c>ST_GEOG_LOCATEALONG</c>. Returns a point on every segment of the geography, a fraction of the
+        /// way along it and offset sideways by a distance in metres.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <param name="fraction"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Every segment of every part, and a multi-point of the answers, as Calcite's does. What differs is
+        /// that the segment is a geodesic: halfway along one is not halfway along a straight line in degrees,
+        /// and the offset is taken to the left of the direction of travel <em>where the point lands</em>,
+        /// which on a geodesic is not the direction it set out in. The offset is metres rather than degrees,
+        /// like every other distance here.
+        /// </remarks>
+        public static Geometry? LocateAlong(Geometry? geog, java.lang.Object? fraction, java.lang.Object? offset)
+        {
+            if (geog is null || fraction is null || offset is null)
+                return null;
+
+            var along = Double(fraction);
+            var aside = Double(offset);
+            var found = new List<org.locationtech.jts.geom.Coordinate>();
+
+            for (var i = 0; i < geog.getNumGeometries(); i++)
+            {
+                var part = geog.getGeometryN(i).getCoordinates();
+
+                for (var j = 0; j < part.Length - 1; j++)
+                    found.Add(Ellipsoid.Along(part[j], part[j + 1], along, aside));
+            }
+
+            return Wgs84Of(Factory.createMultiPointFromCoords([.. found]));
+        }
+
+        /// <summary>
+        /// <c>ST_GEOG_MINIMUMDIAMETER</c>. Returns the shortest line across the geography's width.
+        /// </summary>
+        /// <param name="geog"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The width of a shape is the least distance between two parallel lines that hold it, and on the
+        /// Earth those lines are great circles rather than straight lines in degrees. The narrowest direction
+        /// is found the way it is found on a plane — the supporting line must lie along an edge of the convex
+        /// hull, so only those directions need trying — and for each the width is the greatest distance any
+        /// vertex stands from that edge's great circle.
+        ///
+        /// <para>The answer is the segment realising that width: from the vertex that stands furthest out to
+        /// the point on the great circle nearest it. A shape with no width — a single point, or points all on
+        /// one great circle — has no diameter to name, and answers an empty line.</para>
+        /// </remarks>
+        public static Geometry? MinimumDiameter(Geometry? geog)
+        {
+            if (geog is null)
+                return null;
+
+            // asked of the input rather than of the hull, because the hull of one point is not one point:
+            // S2 answers a degenerate loop with vertices enough to pass a count and no width to measure
+            var distinct = new java.util.HashSet();
+            foreach (var coordinate in geog.getCoordinates())
+                distinct.add(coordinate.toString());
+
+            if (distinct.size() < 3)
+                return Wgs84Of(Factory.createLineString([]));
+
+            var hull = ConvexHull(geog);
+            var ring = hull is null || hull.isEmpty() ? geog.getCoordinates() : hull.getCoordinates();
+
+            if (ring.Length < 3)
+                return Wgs84Of(Factory.createLineString([]));
+
+            var best = double.MaxValue;
+            org.locationtech.jts.geom.Coordinate? from = null;
+            org.locationtech.jts.geom.Coordinate? to = null;
+
+            for (var i = 0; i < ring.Length - 1; i++)
+            {
+                var normal = Normal(ring[i], ring[i + 1]);
+                if (normal is null)
+                    continue;
+
+                var width = 0.0;
+                org.locationtech.jts.geom.Coordinate? outer = null;
+                org.locationtech.jts.geom.Coordinate? foot = null;
+
+                foreach (var vertex in ring)
+                {
+                    var landing = Project(vertex, normal);
+                    var distance = Ellipsoid.Distance(vertex, landing);
+
+                    if (distance > width)
+                    {
+                        width = distance;
+                        outer = vertex;
+                        foot = landing;
+                    }
+                }
+
+                if (outer is not null && width < best)
+                {
+                    best = width;
+                    from = outer;
+                    to = foot;
+                }
+            }
+
+            return from is null || to is null
+                ? Wgs84Of(Factory.createLineString([]))
+                : Wgs84Of(Factory.createLineString([from, to]));
+        }
+
+        /// <summary>
+        /// The pole of the great circle through two coordinates, or <see langword="null"/> where they name
+        /// no circle.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        static com.google.common.geometry.S2Point? Normal(org.locationtech.jts.geom.Coordinate a, org.locationtech.jts.geom.Coordinate b)
+        {
+            var p = com.google.common.geometry.S2LatLng.fromDegrees(a.getY(), a.getX()).toPoint();
+            var q = com.google.common.geometry.S2LatLng.fromDegrees(b.getY(), b.getX()).toPoint();
+            var cross = com.google.common.geometry.S2Point.crossProd(p, q);
+
+            return cross.norm() == 0 ? null : cross.normalize();
+        }
+
+        /// <summary>
+        /// The point of a great circle nearest a coordinate.
+        /// </summary>
+        /// <param name="vertex"></param>
+        /// <param name="normal">The pole of the circle.</param>
+        /// <returns></returns>
+        static org.locationtech.jts.geom.Coordinate Project(org.locationtech.jts.geom.Coordinate vertex, com.google.common.geometry.S2Point normal)
+        {
+            var p = com.google.common.geometry.S2LatLng.fromDegrees(vertex.getY(), vertex.getX()).toPoint();
+            var lifted = com.google.common.geometry.S2Point.sub(p, com.google.common.geometry.S2Point.mul(normal, p.dotProd(normal)));
+
+            return Coordinate(lifted.norm() == 0 ? p : lifted.normalize());
+        }
+
+        /// <summary>
         /// <c>ST_GEOG_BOUNDINGCIRCLE</c>. Returns the smallest circle containing the geography.
         /// </summary>
         /// <param name="geog"></param>

--- a/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
+++ b/src/Apache.Calcite.Geography/Runtime/Wgs84.cs
@@ -85,6 +85,39 @@ namespace Apache.Calcite.Geography.Runtime
 
 
 
+
+        /// <summary>
+        /// Returns the coordinate a fraction of the way along the geodesic between two coordinates, offset
+        /// sideways by a distance in metres.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="fraction"></param>
+        /// <param name="offset">Metres to the left of the direction of travel, negative for the right.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Two things a planar reading gets wrong at once. The point a fraction along a geodesic is not the
+        /// point that fraction along a straight line in degrees, and sideways is a direction that turns as
+        /// the geodesic goes — so the offset is taken from the azimuth <em>at the point reached</em>, which
+        /// is what <c>Direct</c> answers alongside it, rather than from the azimuth the geodesic set out on.
+        /// </remarks>
+        public static org.locationtech.jts.geom.Coordinate Along(
+            org.locationtech.jts.geom.Coordinate from,
+            org.locationtech.jts.geom.Coordinate to,
+            double fraction,
+            double offset)
+        {
+            var line = Geodesic.WGS84.Inverse(from.getY(), from.getX(), to.getY(), to.getX());
+            var at = Geodesic.WGS84.Direct(from.getY(), from.getX(), line.azi1, line.s12 * fraction);
+
+            if (offset == 0)
+                return new org.locationtech.jts.geom.Coordinate(at.lon2, at.lat2);
+
+            var aside = Geodesic.WGS84.Direct(at.lat2, at.lon2, at.azi2 - 90, offset);
+
+            return new org.locationtech.jts.geom.Coordinate(aside.lon2, aside.lat2);
+        }
+
         /// <summary>
         /// Returns the azimuth at the first coordinate of the geodesic to the second, in degrees clockwise
         /// from north.

--- a/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
+++ b/src/Apache.Calcite.Geography/Sql/GeographyOperatorTable.cs
@@ -897,6 +897,20 @@ namespace Apache.Calcite.Geography.Sql
                 [GeographyOperand.Geometry], ["geog"]);
 
         /// <summary>
+        /// <c>ST_GEOG_LOCATEALONG(GEOGRAPHY, DOUBLE, DOUBLE)</c>. Returns a point on every segment, a fraction of the way along it and offset sideways by a distance in metres.
+        /// </summary>
+        public static readonly SqlFunction StGeogLocateAlong =
+            Function("ST_GEOG_LOCATEALONG", nameof(GeographyFunctions.LocateAlong), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry, GeographyOperand.Fractional, GeographyOperand.Fractional], ["geog", "fraction", "offset"]);
+
+        /// <summary>
+        /// <c>ST_GEOG_MINIMUMDIAMETER(GEOGRAPHY)</c>. Returns the shortest line across the geography's width.
+        /// </summary>
+        public static readonly SqlFunction StGeogMinimumDiameter =
+            Function("ST_GEOG_MINIMUMDIAMETER", nameof(GeographyFunctions.MinimumDiameter), GeographyReturnTypes.Geography,
+                [GeographyOperand.Geometry], ["geog"]);
+
+        /// <summary>
         /// <c>ST_GEOG_BOUNDINGCIRCLE(GEOGRAPHY)</c>. Returns the smallest circle containing the geography.
         /// </summary>
         public static readonly SqlFunction StGeogBoundingCircle =
@@ -1146,6 +1160,8 @@ namespace Apache.Calcite.Geography.Sql
                 StGeogLength,
                 StGeogPerimeter,
                 StGeogMaxDistance,
+                StGeogLocateAlong,
+                StGeogMinimumDiameter,
                 StGeogBoundingCircle,
                 StGeogIsSimple,
                 StGeogIsRing,


### PR DESCRIPTION
`ST_GEOG_LOCATEALONG` and `ST_GEOG_MINIMUMDIAMETER`. Both turn on the line between two coordinates being a geodesic.

## Locate along

A point a fraction along a segment is not the point that fraction along a straight line in degrees. Across sixty degrees of longitude on the 60th parallel the geodesic bows to 63.4° at its middle, so **the halfway point is three and a half degrees north of where Calcite puts it** — the longitude agrees and the latitude does not, which is the bow and nothing else. `ShouldPlaceTheMidpointOnTheGeodesic` asserts both.

Sideways is also a direction that *turns* as a geodesic goes, so the offset is taken from the azimuth **at the point reached** rather than the one the geodesic set out on. `Direct` answers that alongside the point, so it costs nothing to be right about. The offset is metres, like every other distance here.

## Minimum diameter

A shape's width is the least distance between two parallel lines that hold it, and on the Earth those are great circles. The narrowest direction is found the way it is on a plane — the supporting line must lie along an edge of the convex hull, so only those directions need trying — and the width for each is the greatest distance any vertex stands from that edge's great circle.

Over a sliver along the 60th parallel the answer is **narrower** than the two degrees a planar reading measures, because the southern edge bows north into the shape.

## One thing the tests found

A shape with no width has to be recognised *before* the hull is taken, not after. S2 answers the convex hull of a single point with a degenerate loop carrying vertices enough to pass a count, so my `< 3` guard never fired. The guard is on the input's distinct coordinates now.

## Stack

```
main
 └── #95  buffer + the two commits #92 left behind
      └── #96  ST_GEOG_ISSIMPLE, ST_GEOG_ISRING
           └── #97  ST_GEOG_BOUNDINGCIRCLE
                └── #98 (this)  ST_GEOG_LOCATEALONG, ST_GEOG_MINIMUMDIAMETER
```

Base branches set, so each PR shows its own diff. Merge bottom-up.

188 tests, green on net8.0 and net10.0.
