### PR TITLE
Type a GUID column as UUID in the ADO adapter

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
@@ -99,6 +99,44 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
+        /// The read path from the report, through this convention's own converter: a
+        /// <c>uniqueidentifier</c> cast to the <c>UUID</c> a view gives it, projected. The cast is pushed
+        /// into the ADO convention, so the reader is handed a <c>UUID</c> column and the row holds a
+        /// <c>java.util.UUID</c> — which is the only thing <c>GetGuid</c> on this provider reads.
+        /// </summary>
+        /// <remarks>
+        /// SQL Server rather than the fixture's SQLite because SQLite has no type for the sixteen bytes:
+        /// a type name it does not recognise gives a cast numeric affinity, so the value coming back would
+        /// be a number rather than anything a GUID could be read out of.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadAUuidCastThroughThisConvention()
+        {
+            if (SqlServerFixture.IsAvailable == false)
+                Assert.Inconclusive("No SQL Server LocalDB instance is reachable on this machine.");
+
+            var server = SqlServerFixture.Shared;
+
+            using var connection = new CalciteDataSourceBuilder(new CalciteConnectionStringBuilder
+            {
+                Lex = "JAVA",
+                CaseSensitive = false,
+                Synchronous = true,
+            }.ToString())
+                .ConfigureRootSchema(root => root.add("ADO", AdoSchema.Create(root, "ADO", server.DataSource, null, "dbo")))
+                .Build()
+                .OpenConnection();
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT CAST(C_GUID AS UUID) FROM ADO.TYPES WHERE ID = 1";
+
+            using var r = cmd.ExecuteReader();
+            Assert.IsTrue(r.Read(), "expected one row");
+            Assert.AreEqual(new System.Guid("3f2504e0-4f89-11d3-9a0c-0305e82c3301"), r.GetGuid(0));
+            Assert.IsFalse(r.Read(), "and only that one");
+        }
+
+        /// <summary>
         /// In synchronous mode the adapter converts straight into the synchronous convention.
         /// </summary>
         /// <remarks>

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoReaderUtilTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoReaderUtilTests.cs
@@ -425,6 +425,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
                 SqlTypeName.BOOLEAN, SqlTypeName.TINYINT, SqlTypeName.SMALLINT, SqlTypeName.INTEGER,
                 SqlTypeName.BIGINT, SqlTypeName.FLOAT, SqlTypeName.DOUBLE, SqlTypeName.CHAR,
                 SqlTypeName.VARCHAR, SqlTypeName.OTHER, SqlTypeName.DATE, SqlTypeName.TIMESTAMP,
+                SqlTypeName.UUID,
             ];
 
             foreach (var type in types)

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OdbcQueryTests.cs
@@ -202,7 +202,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_DATETIMEOFFSET", nameof(SqlTypeName.TIMESTAMP_TZ))]
         [DataRow("C_BINARY", nameof(SqlTypeName.VARBINARY))]
         [DataRow("C_VARBINARY", nameof(SqlTypeName.VARBINARY))]
-        [DataRow("C_GUID", nameof(SqlTypeName.CHAR))]
+        [DataRow("C_GUID", nameof(SqlTypeName.UUID))]
         [DataRow("C_XML", nameof(SqlTypeName.VARCHAR))]
         public void AColumnGetsItsCalciteType(string columnName, string expected)
         {

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/OleDbQueryTests.cs
@@ -194,7 +194,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_DATETIMEOFFSET", nameof(SqlTypeName.TIMESTAMP_TZ))]
         [DataRow("C_BINARY", nameof(SqlTypeName.VARBINARY))]
         [DataRow("C_VARBINARY", nameof(SqlTypeName.VARBINARY))]
-        [DataRow("C_GUID", nameof(SqlTypeName.CHAR))]
+        [DataRow("C_GUID", nameof(SqlTypeName.UUID))]
         [DataRow("C_XML", nameof(SqlTypeName.VARCHAR))]
         public void AColumnGetsItsCalciteType(string columnName, string expected)
         {

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerQueryTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using org.apache.calcite.jdbc;
 using org.apache.calcite.rel.type;
+using org.apache.calcite.runtime;
 using org.apache.calcite.sql.type;
 
 using System;
@@ -259,7 +260,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         [DataRow("C_DATETIMEOFFSET", nameof(SqlTypeName.TIMESTAMP_TZ))]
         [DataRow("C_BINARY", nameof(SqlTypeName.VARBINARY))]
         [DataRow("C_VARBINARY", nameof(SqlTypeName.VARBINARY))]
-        [DataRow("C_GUID", nameof(SqlTypeName.CHAR))]
+        [DataRow("C_GUID", nameof(SqlTypeName.UUID))]
         [DataRow("C_XML", nameof(SqlTypeName.VARCHAR))]
         public void AColumnGetsItsCalciteType(string columnName, string expected)
         {
@@ -300,13 +301,52 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// A <c>uniqueidentifier</c> is a <see cref="Guid"/> to the provider and a <c>CHAR(36)</c> to
-        /// Calcite, so what the reader hands over has to be the text.
+        /// A <c>uniqueidentifier</c> is a <c>UUID</c>, and a row holds one as the <c>java.util.UUID</c>
+        /// Calcite's runtime holds a UUID in. The class is the assertion rather than the text: a string of
+        /// the same characters stringifies identically and is a different value to everything that
+        /// compares, joins or groups.
         /// </summary>
         [TestMethod]
-        public void AUniqueIdentifierComesBackAsItsText()
+        public void AUniqueIdentifierComesBackAsAUuid()
         {
-            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", Scalar("SELECT C_GUID FROM ADO.TYPES WHERE ID = 1"));
+            using var statement = _connection.createStatement();
+            var results = statement.executeQuery("SELECT C_GUID FROM ADO.TYPES WHERE ID = 1");
+
+            Assert.IsTrue(results.next(), "expected one row");
+            var value = results.getObject(1);
+
+            Assert.IsInstanceOfType<java.util.UUID>(value);
+            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", value.ToString());
+        }
+
+        /// <summary>
+        /// The statement from the report, which is the same column cast to the type it already has.
+        /// </summary>
+        /// <remarks>
+        /// It is a no-op now, and the statement is read off <c>Hook.QUERY_PLAN</c> to say so: a column
+        /// already typed <c>UUID</c> leaves nothing for the cast to do, so none reaches the wire. Stating a
+        /// type the column already has is what a view does, and what the report's schema did.
+        /// </remarks>
+        [TestMethod]
+        public void AUniqueIdentifierCastToUuidIsRead()
+        {
+            var generated = new GeneratedSql();
+            var handle = Hook.QUERY_PLAN.addThread(generated);
+
+            List<string> rows;
+            try
+            {
+                rows = Rows("SELECT CAST(C_GUID AS UUID) FROM ADO.TYPES ORDER BY ID");
+            }
+            finally
+            {
+                handle.close();
+            }
+
+            CollectionAssert.AreEqual(new[] { "3f2504e0-4f89-11d3-9a0c-0305e82c3301", "NULL" }, rows);
+            Assert.IsFalse(
+                generated.Statements.Any(s => s.Contains("CAST", StringComparison.OrdinalIgnoreCase)),
+                string.Join("; ", generated.Statements));
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerReaderUtilTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/SqlServerReaderUtilTests.cs
@@ -116,14 +116,41 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// A <c>uniqueidentifier</c> is a <see cref="Guid"/> to the provider, and Calcite is holding the
-        /// column as a <c>CHAR(36)</c>: <see cref="DbDataReader.GetString"/> casts and refuses it.
+        /// A <c>uniqueidentifier</c> is not a character column and is not read as one. Formatting it would
+        /// be the mapping answering for a type the column does not have, and the text it produced could
+        /// not be told from a <c>CHAR(36)</c> that really is text.
         /// </summary>
         [TestMethod]
-        public void AUniqueIdentifierIsReadAsItsText()
+        public void AUniqueIdentifierIsNotReadAsAString()
         {
             using var reader = Row("CAST('3f2504e0-4f89-11d3-9a0c-0305e82c3301' AS UNIQUEIDENTIFIER)");
-            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.CHAR));
+
+            Assert.Throws<InvalidCastException>(
+                () => AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.CHAR));
+        }
+
+        /// <summary>
+        /// It is a <c>UUID</c>, and the value is the sixteen bytes rather than the text:
+        /// <c>java.util.UUID</c> is the class Calcite's runtime holds them in.
+        /// </summary>
+        [TestMethod]
+        public void AUniqueIdentifierIsReadAsAJavaUuid()
+        {
+            using var reader = Row("CAST('3f2504e0-4f89-11d3-9a0c-0305e82c3301' AS UNIQUEIDENTIFIER)");
+            var value = AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.UUID);
+
+            Assert.IsInstanceOfType<java.util.UUID>(value);
+            Assert.AreEqual("3f2504e0-4f89-11d3-9a0c-0305e82c3301", value!.ToString());
+        }
+
+        /// <summary>
+        /// A null <c>uniqueidentifier</c> is a null, the class being a reference.
+        /// </summary>
+        [TestMethod]
+        public void ANullUniqueIdentifierIsNull()
+        {
+            using var reader = Row("CAST(NULL AS UNIQUEIDENTIFIER)");
+            Assert.IsNull(AdoReaderUtil.GetDbReaderValue(reader, 0, SqlTypeName.UUID));
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoReaderUtil.cs
@@ -2,6 +2,8 @@ using System;
 using System.Data.Common;
 using System.Globalization;
 
+using Apache.Calcite.Extensions.Interop;
+
 using org.apache.calcite.rel.type;
 using org.apache.calcite.sql.type;
 
@@ -83,6 +85,8 @@ namespace Apache.Calcite.Adapter.AdoNet
                     return GetTimestampTz(reader, index);
                 case nameof(SqlTypeName.VARCHAR):
                     return GetString(reader, index);
+                case nameof(SqlTypeName.UUID):
+                    return GetUuid(reader, index);
                 case nameof(SqlTypeName.OTHER):
                     return GetValue(reader, index);
                 default:
@@ -429,19 +433,45 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="index"></param>
         /// <returns></returns>
         /// <remarks>
-        /// A column Calcite holds as <see cref="SqlTypeName.CHAR"/> or <see cref="SqlTypeName.VARCHAR"/> need
-        /// not be a string to the provider: SQL Server hands back a <see cref="Guid"/> for a
-        /// <c>uniqueidentifier</c>, which <c>AdoTable</c> types as <c>CHAR(36)</c>, and
-        /// <see cref="DbDataReader.GetString"/> casts rather than converts and refuses it. Formatting the
-        /// value is what the type says it is.
+        /// A column Calcite holds as <see cref="SqlTypeName.CHAR"/> or <see cref="SqlTypeName.VARCHAR"/> is
+        /// a character column, so this is <see cref="DbDataReader.GetString"/> and nothing else. Formatting
+        /// whatever the provider handed back would make the mapping answer for types the column does not
+        /// have; every type that is not a string has a case of its own.
         /// </remarks>
         public static object? GetString(DbDataReader reader, int index)
         {
             if (reader.IsDBNull(index))
                 return null;
 
-            var value = reader.GetValue(index);
-            return value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture);
+            return reader.GetString(index);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="SqlTypeName.UUID"/> as the <see cref="java.util.UUID"/> Calcite holds one in.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// <para>
+        /// A <c>UUID</c> is the sixteen bytes and <see cref="DbDataReader.GetGuid"/> is what a provider
+        /// answers them with, so the transfer is those bytes rather than a string round trip. Named for
+        /// what it returns, as every accessor here is: what the provider is asked for is a
+        /// <see cref="Guid"/> and what Calcite's runtime holds is a <see cref="java.util.UUID"/>.
+        /// </para>
+        /// <para>
+        /// Text in canonical GUID form is a character column and goes to <see cref="GetString"/>. It is not
+        /// a GUID, and a cast is how a caller says it means one — which is this provider's rule at the
+        /// other end too, <c>CalciteResultValue.GetGuid</c> reading a <c>java.util.UUID</c> and nothing
+        /// else.
+        /// </para>
+        /// </remarks>
+        public static object? GetUuid(DbDataReader reader, int index)
+        {
+            if (reader.IsDBNull(index))
+                return null;
+
+            return JavaUuids.ToUuid(reader.GetGuid(index));
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSchema.cs
@@ -372,7 +372,7 @@ namespace Apache.Calcite.Adapter.AdoNet
                 case DbType.Double:
                     return typeFactory.createSqlType(SqlTypeName.DOUBLE);
                 case DbType.Guid:
-                    return typeFactory.createSqlType(SqlTypeName.CHAR, 36);
+                    return typeFactory.createSqlType(SqlTypeName.UUID);
                 case DbType.Int16:
                     return typeFactory.createSqlType(SqlTypeName.SMALLINT);
                 case DbType.Int32:


### PR DESCRIPTION
`AdoSchema.SqlType` typed every `DbType.Guid` column as `CHAR(36)` — a GUID as its text. So a schema that meant GUID semantics for an identifier column had to state them with a cast, which is what a view does, and `AdoReaderUtil` had no case for the `UUID` that cast produced: every read of one was `AdoCalciteException: Unsupported SQL type mapping: UUID`, thrown by the adapter while reading the row rather than by the server.

It presented as intermittent because the cast only reached the mapping where it was pushed into the ADO convention. Anything above it that forced evaluation in process — a schema function in the select list, a `COUNT` — answered fine, so `SELECT *` succeeded on one view and failed on the next by whether that view happened to hold a computed column.

Calcite has a type for the sixteen bytes, so a `uniqueidentifier` is a `UUID`. Three changes, one cause:

- **`AdoSchema.SqlType`** — `DbType.Guid` is `SqlTypeName.UUID`. The cast a view writes is then a no-op. Measured: the report's statement generates `SELECT [C_GUID], [ID] FROM …` with **no cast reaching the wire**.
- **`AdoReaderUtil.GetUuid`** — reads those bytes and hands them over as the `java.util.UUID` Calcite's runtime holds one in. Named for what it returns, as every accessor in that file is: `GetShort` answers a `java.lang.Short`, `GetTimestamp` a `Long` of epoch millis, `GetBinary` a `ByteString`.
- **`AdoReaderUtil.GetString`** — loses its `Convert.ToString` fallback, which existed only to format the `Guid` that arrived at a column typed `CHAR(36)`. A character column is a character column; every type that is not a string has a case of its own.

## Measured

- `Apache.Calcite.Adapter.AdoNet.Tests`: **487 passed, 0 failed, 0 skipped**, against LocalDB, ODBC and OLE DB.
- `Apache.Calcite.Data.Tests`: **422 passed, 0 failed, 0 skipped**.
- With the reader case reverted, every new test reproduces `Unsupported SQL type mapping: UUID` at `AdoReaderUtil.cs:92` — including `AdoClrEnumerableTests.ShouldReadAUuidCastThroughThisConvention`, which is the reported path exactly: `Apache.Calcite.Data` in synchronous mode over `AdoToClrEnumerableConverter`, ending at `GetGuid`.

Tests that encoded the old typing are corrected rather than deleted: `C_GUID` is `UUID` in all three `AColumnGetsItsCalciteType` sets; the test that read a `uniqueidentifier` as its text is now a refusal test, since `GetString` no longer converts; and `AUniqueIdentifierComesBackAsAUuid` asserts the **class**, which nothing at query level did before — a string of the same characters stringifies identically and is a different value to everything that compares, joins or groups.

## Still true, and not addressed here

A UUID *literal* unparses as `UUID '…'`, which no server parses. `SqlUuidLiteral.unparse` is `writer.literal(this.toString())` and consults no dialect, unlike the character, boolean, numeric, datetime and interval literals, which all route through a `SqlDialect.unparse*` hook; `git grep -l UUID` over `core/src/main/java/org/apache/calcite/sql/dialect/` at `calcite-1.42.0` returns nothing, and upstream's only rel-to-sql test for one asserts the Calcite spelling, under CALCITE-7128. Reachable from a query that writes a UUID literal.

Separately, and a measured cost of this change rather than a diagnosis: with the column genuinely a `UUID`, `WHERE guidcol = '<text>'` coerces by casting the *column* to `CHAR(36)`, so it no longer seeks. That is Calcite's implicit type coercion, it answers correctly, and I have not read its UUID rules.

Fixes #100
