### PR TITLE
Read the adapter's rows without blocking a thread on the provider

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,6 +96,259 @@ opens a connection to read the server version, and `AdoConvention.Dialect` is re
 that matches while planning. What is left is caching *across* metadata instances, which only matters
 when several schemas point at one database. Lowest priority; measure before assuming it matters.
 
+## ADO.NET adapter: what more it could push, audited 2026-09-07
+
+The section above compares us to `org.apache.calcite.adapter.jdbc` and lists where we fall short of it.
+This one asks the other question — what the adapter could do that Calcite's does not — and the answer is
+that the JDBC adapter pushes far less than `RelToSqlConverter` can write. `RelToSqlConverter` has a `visit`
+for `Join`, `Correlate`, `Filter`, `Project`, `Window`, `Aggregate`, `TableScan`, `Union`, `Intersect`,
+`Minus`, `Calc`, `Values`, `Sample`, `Sort`, `TableModify`, `Match`, `Uncollect` and `TableFunctionScan`.
+Nine of those have a node in this adapter. **Every gap below is a node rel2sql can already write SQL for**,
+so the work is a rel class and a converter rule, not a SQL generator.
+
+### How this was measured
+
+Thirty statements against the SQLite fixture through the Calcite JDBC driver, each run twice: once as
+`EXPLAIN PLAN FOR` to read the physical plan, once for real with a `Hook.QUERY_PLAN` handler counting the
+statements the adapter sent. A query that pushes fully sends one statement; a query that does not sends one
+per pushed subtree, and the plan names what was left in `EnumerableConvention`. The probe was a scratch test
+class in `Apache.Calcite.Adapter.AdoNet.Tests`, deleted afterwards; every number below came out of it.
+
+**Pushing fully today**, one statement each: filter, project, `HAVING`, `ORDER BY` with `OFFSET`/`FETCH`,
+`COUNT(DISTINCT)`, aggregate `FILTER`, `UNION ALL`, `INTERSECT` (through Calcite's count rewrite), `VALUES`
+joined to a table, a non-equi inner join, `DISTINCT`, and `NOT EXISTS` after decorrelation. The nine nodes
+we have carry a lot.
+
+### 1. A window function does not merely fail to push — it throws
+
+**`SELECT NAME, SUM(SALARY) OVER (PARTITION BY DEPTNO) FROM ADO.EMPS` fails with an `AssertionError`**:
+*"Relational expression LogicalWindow.ADO.ADO … has calling-convention ADO.ADO but does not implement the
+required interface AdoRel"*. So does a second one with two different `OVER` clauses, and so does
+`… ORDER BY x.SALARY DESC LIMIT 1` inside a `LATERAL`, which Calcite rewrites to `ROW_NUMBER()`.
+
+The cause is that `AdoProjectRule` deliberately admits a project containing `OVER` when the dialect
+supports window functions (`AdoProjectRule.cs:38`, upstream's condition), and
+`CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW` — registered by `RelOptUtil.registerDefaultRules` and
+matching any `Project` in any convention — then rewrites that `AdoProject` into a `LogicalWindow` carrying
+the trait set it took from the project. The trait says ADO; the class is `LogicalWindow`; the convention
+declares `AdoRel`; the assertion fires. Nothing in the suite reaches it because no adapter test uses `OVER`.
+
+`AdoWindow` is both the fix and the capability: `RelToSqlConverter.visit(Window)` writes the `OVER` list
+already. Gate the rule on `dialect.supportsWindowFunctions()`, which is what the project rule's condition
+was for.
+
+### 2. `GROUPING SETS`, `ROLLUP` and `CUBE` fetch the whole table
+
+`AdoAggregateRule.cs:44` refuses any aggregate with more than one group set, which is upstream's
+CALCITE-734 refusal. Measured: `GROUP BY ROLLUP(DEPTNO)`, `GROUP BY CUBE(DEPTNO, NAME)` and an explicit
+`GROUPING SETS` each plan to an `EnumerableAggregate` over `SELECT * FROM "EMPS"` — the whole table crosses
+the wire and is grouped in memory.
+
+`RelToSqlConverter.generateGroupList` writes `CUBE`, `ROLLUP` and `GROUPING SETS`, picking the form from
+`dialect.supportsGroupByWithRollup()` and `supportsGroupByWithCube()`, and `SqlImplementor` handles the
+`HAVING GROUPING(…) <> 0` case where the group set is wider than the union of the group sets. The refusal
+is older than the renderer. Lift it and gate on the two dialect methods.
+
+### 3. Semi- and anti-joins are two statements
+
+`AdoJoinRule.cs:83` returns null for `SEMI` and `ANTI`, on upstream's stated grounds that "it's not
+possible to convert semi-joins or anti-joins; they have fewer columns than regular joins". That is no longer
+true of the renderer: `RelToSqlConverter.visit(Join)` dispatches both to `visitAntiOrSemiJoin`, which writes
+`EXISTS` / `NOT EXISTS`. `Join.deriveRowType` gives a semi-join the left row type without help.
+
+Measured, `WHERE DEPTNO IN (SELECT …)` and `WHERE EXISTS (SELECT …)` both plan to `EnumerableHashJoin
+(joinType=[semi])` over two `AdoToEnumerableConverter`s — two statements, and the join done here.
+
+### 4. A `Correlate` that survives decorrelation runs one statement per row
+
+`AdoCorrelationDataContext` and its builder exist so that a correlation variable referenced from inside a
+pushed subtree becomes a dynamic parameter, bound per outer row. That is the JDBC adapter's answer and it
+costs a statement — and, because `AdoEnumerable.enumerator()` opens its own connection
+(`AdoEnumerable.cs:353`), a connection — for every row of the left input.
+
+`RelToSqlConverter.visit(Correlate)` writes the whole thing as `CROSS JOIN LATERAL`. An `AdoCorrelate` would
+turn N+1 statements into one wherever both sides are the same convention. The parameter path stays for the
+cases it is still the only answer: the right side in another convention, or a dialect without `LATERAL`.
+
+Top-N-per-group is the shape that makes this matter, and it is also blocked by §1 today.
+
+### 5. `TABLESAMPLE` becomes `RAND()`, and SQLite has no `RAND()`
+
+`SELECT * FROM ADO.EMPS TABLESAMPLE BERNOULLI(50)` plans to `AdoFilter(condition=[<(RAND(), 0.5)])` — 
+`CoreRules.SAMPLE_TO_FILTER` rewrote the sample and we pushed the rewrite — and execution fails with
+*"SQLite Error 1: 'no such function: RAND'"*. `RelToSqlConverter.visit(Sample)` writes a real `TABLESAMPLE`
+clause, so an `AdoSample` gated on the dialect both pushes the operator and stops the rewrite from being
+pushed in its place.
+
+This is one instance of a general hole — see §7.
+
+### 6. `MATCH_RECOGNIZE` over an ADO table cannot be implemented at all
+
+`SELECT * FROM (SELECT EMPNO, SALARY FROM ADO.EMPS) MATCH_RECOGNIZE (…)` plans to an `EnumerableMatch` over
+`AdoToEnumerableConverter` and then fails: *"Unable to implement EnumerableMatch … AdoToEnumerableConverter"*.
+So the operator is unreachable over this adapter today by either route. `RelToSqlConverter.visit(Match)`
+writes the clause, and Oracle and SQL Server 2022 have it. Whether that is worth a node is a separate
+question from the fact that the query currently has no plan; the failure should at least be understood.
+
+### 7. Nothing checks whether the target has the function or the type
+
+`SqlDialect.supportsFunction(SqlOperator, RelDataType, List<RelDataType>)` and
+`SqlDialect.supportsDataType(RelDataType)` are declared, are overridden by Firebolt, JethroData, Postgres,
+Vertica and Oracle — and **are called from nowhere in `calcite-core`**, measured by `git grep` over the
+1.42.0 tag. So `AdoFilterRule` and `AdoProjectRule` push any expression at all and the provider decides.
+§5 is that hole firing on `RAND`; `CHAR_LENGTH` happens to survive because `SqliteSqlDialect` renders it as
+`LENGTH`.
+
+A `RexVisitor` over the condition and the projects, refusing where `supportsFunction` says no, is the same
+shape as `CheckingUserDefinedFunctionVisitor`, which is already there and already runs on both. It costs a
+walk that is already being done and it converts a class of run-time provider errors into an operator that
+stays in memory.
+
+The same visitor is what would let a *user-defined* function push when the target has one. The current
+refusal is blanket: any `SqlFunction` whose `getFunctionType().isUserDefined()` stops the whole project or
+filter, whether or not the target could evaluate it.
+
+### 8. A `FULL JOIN` is pushed to dialects that cannot do one
+
+Upstream's `JdbcJoinRule.matches` refuses a join whose type the dialect rejects
+(`JdbcRules.java:372`, `dialect.supportsJoinType(joinType)`). `AdoJoinRule` has no `matches` override, so a
+`FULL JOIN` planned against MySQL is pushed and the server refuses it. This is a divergence that pushes
+*more* than upstream, which is why it has not shown up: SQLite and SQL Server both do full joins.
+
+### 9. The converters are not cheap, and it costs whole joins — measured
+
+`JdbcToEnumerableConverter.computeSelfCost` multiplies by `.1` (`JdbcToEnumerableConverter.java:88`).
+Neither `AdoToEnumerableConverter` nor `AdoToClrEnumerableConverter` overrides `computeSelfCost` at all, so
+leaving the adapter is priced at full row count and a plan that leaves it twice is not obviously worse than
+one that leaves it once.
+
+Measured by adding the `.1` to both converters and re-running the probe:
+
+| statement | statements before | after |
+|---|---|---|
+| `EMPS FULL JOIN DEPTS` | 2, `EnumerableHashJoin(full)` | 1, `AdoJoin(full)` |
+| `SELECT DNAME, (SELECT COUNT(*) FROM EMPS e WHERE e.DEPTNO = d.DEPTNO) FROM DEPTS d` | 2, `EnumerableMergeJoin(left)` | 1, the whole decorrelated tree pushed |
+
+Nothing else in the thirty changed except the semi-join, which got *worse*: with cheap converters the
+planner stops pushing the `GROUP BY` under the semi-join and pulls both tables whole, because §3 leaves it
+no way to push the join itself. The two belong together — the multiplier is upstream's number and the reason
+it is safe upstream is that upstream's rule set covers the join it makes attractive.
+
+### 10. The adapter tells the planner nothing about the data
+
+`AdoTable` does not implement `Statistic`; `RelOptTable.getStatistic()` answers Calcite's default, so every
+table has 100 rows, no keys, no collations and no referential constraints. That is not only a costing
+problem — three rules Calcite registers by default cannot fire without key metadata:
+`CoreRules.AGGREGATE_REMOVE`, `CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN` and the join-removal rules. Measured:
+`SELECT DISTINCT EMPNO FROM ADO.EMPS` pushes as `SELECT "EMPNO" FROM "EMPS" GROUP BY "EMPNO"`, and `EMPNO`
+is the table's key — with a `Statistic` saying so the aggregate disappears entirely.
+
+`AdoDatabaseMetadata` (`Metadata/AdoDatabaseMetadata.cs`) has `GetSchemas`, `GetTables` and `GetFields` and
+nothing else, so this starts with an SPI addition. The inputs exist on every provider:
+`DbConnection.GetSchema("Indexes")` / `"IndexColumns"`, `"ForeignKeys"`, and the information schema's
+`TABLE_CONSTRAINTS` / `KEY_COLUMN_USAGE`. Row counts are per-target — `sys.dm_db_partition_stats` on SQL
+Server, `pg_class.reltuples` on Postgres, `sqlite_stat1` where `ANALYZE` has run — which is an argument for
+a virtual method with a null default rather than a required one, and for the time-to-live the plan-cache
+section already argues for.
+
+### 11. Two schemas over one database do not join server-side
+
+`AdoConvention` is created per `AdoSchema`. Measured: two `AdoSchema`s registered over the *same* SQLite
+file join through `EnumerableMergeJoin` and two statements, because the two conventions are distinct and
+neither rule can see across. Calcite has the same shape and the same limitation.
+
+Keying the convention by data source rather than by schema — the pool `JdbcUtils.DataSourcePool` already
+implies, listed as §6 above — makes a multi-schema database one convention, and a three-way join across
+`dbo`, `sales` and `staging` becomes one statement. This is the cheapest of the structural items and it is
+the one a catalog schema (§4 above) makes reachable, since a catalog exposes exactly this shape.
+
+### 12. Cross-source: ship the small side rather than pulling both
+
+Nothing above helps a join whose sides are genuinely different databases. ADO.NET has three ways to make
+that a server-side join that JDBC's adapter never used: a table-valued parameter, a temporary table filled
+by a bulk copy, or a `VALUES` list inlined into the statement. The planner already knows which side is
+smaller — it is the one whose estimated row count is lower, which needs §10 to be true rather than
+defaulted.
+
+The rule shape is a converter that takes a join with one side in another convention, plans that side
+independently, and emits a statement whose right operand is the shipped rows. It is the largest item here
+and the only one with no Calcite precedent to copy; it is also the one that makes the adapter something
+other than a JDBC adapter.
+
+### 13. `INSERT` / `UPDATE` / `DELETE` still do not plan
+
+Already §1 of the section above; the probe confirms the failure mode is not a fallback but a planning
+error — *"There are not enough rules to produce a node with desired properties: convention=ENUMERABLE …
+Missing conversion is LogicalTableModify\[convention: NONE -> ENUMERABLE\]"* — for `INSERT … VALUES`,
+`INSERT … SELECT`, `UPDATE` and `DELETE` alike. Noted here because two capabilities hang off it that
+Calcite's adapter does not have: a `DbBatch` for a multi-row modify, and a bulk-copy path
+(`SqlBulkCopy`, `NpgsqlBinaryImporter`) for `INSERT … SELECT` whose source is another convention, which is
+§12's machinery pointed at a write.
+
+### 14. Execution was synchronous; cancellation and timeout are still not wired
+
+**The converter is written.** `AdoToClrAsyncEnumerableConverter` and its rule are registered beside the
+other two, so a plan asked for in `ClrAsyncEnumerableConvention` — which is what the provider plans by
+default — converts straight out of the adapter and reads its rows through
+`AdoSequences.ReadAsync`, over `OpenConnectionAsync`, `ExecuteReaderAsync` and `ReadAsync`. The route it
+replaced was `EnumerableToClrAsyncEnumerableConverter` over `AdoToEnumerableConverter`: two crossings, a
+linq4j enumerator, and `DbDataReader.Read()` at the bottom, so the one place in a plan with network I/O to
+suspend on was the one place that blocked.
+
+The statement it sends is the synchronous converter's — same implementor, same writer, same row builder,
+shared rather than written again. One thing differs and is stated at the site: `ReadAsync` sends the
+statement on the first `MoveNextAsync` rather than where it is called, because a method returning an
+`IAsyncEnumerable` cannot await before it returns. `AdoSequencesTests` pins that, and
+`AdoClrEnumerableTests.ShouldReadTheSameRowsInBothConventions` holds the rows.
+
+Three remain:
+
+- **Cancellation.** `AdoSequences.ReadAsync` observes the token the caller passes to
+  `GetAsyncEnumerator`, and `AdoSequencesTests.ShouldObserveACancelledToken` holds that. What is not wired
+  is where such a token comes from: `DataContext.Variable.CANCEL_FLAG` is Calcite's cancellation channel
+  and nothing in the adapter reads it, so a statement a plan sent still runs to completion when the
+  statement is cancelled. On the synchronous path there is no token at all and `DbCommand.Cancel()` is what
+  it maps to.
+- **Timeout.** `DbCommand.CommandTimeout` is never set, so every statement takes the provider default.
+- **Connection lifetime.** `AdoEnumerable.enumerator()` and `AdoSequences` open a connection per enumeration
+  (`AdoEnumerable.cs:353`). For a plan with two pushed subtrees that is two connections, and for the
+  per-row correlated path it is one per row. A connection held on the `DataContext` for the life of the
+  execution, and `DbCommand.Prepare()` on the statement that is about to be run per row, are both things
+  ADO.NET offers and this does not use. `CommandBehavior` is left at its default too — `SequentialAccess`
+  matters for wide rows and `SingleResult` is free.
+
+### 15. The catalog shows tables only
+
+`AdoSchema.cs:76` builds every discovered object as `Schema.TableType.TABLE` — already §2 above. Beyond
+that, `AdoBaseSchema.getFunctions` and `getTypeNames` return the empty defaults, so a server-side
+table-valued function or stored procedure cannot be named in a query. `RelToSqlConverter.visit
+(TableFunctionScan)` writes `TABLE(f(…))`, and ADO.NET reads a procedure's shape through
+`CommandType.StoredProcedure` and `DbDataReader.GetSchemaTable`. The same reader-shape route would give a
+raw-SQL passthrough table macro, which is the escape hatch every adapter of this kind ends up wanting.
+
+### What this adds up to
+
+Ordered by what a query gains per unit of work:
+
+| | item | why first |
+|---|---|---|
+| 1 | `AdoWindow` (§1) | a live crash, and the fix is the capability |
+| 2 | converter cost multiplier (§9) | two lines, measured to turn 2 statements into 1 twice |
+| 3 | semi/anti join (§3) | one rule; pairs with §9, which makes its absence worse |
+| 4 | grouping sets (§2) | one guard removed, two dialect calls added |
+| 5 | `supportsFunction` gate (§7) | converts run-time provider failures into in-memory operators |
+| 6 | `supportsJoinType` guard (§8) | a divergence that is wrong today |
+| 7 | `AdoCorrelate` (§4) | N+1 statements to one, but needs §1 first to be reachable |
+| 8 | statistics SPI (§10) | unlocks three core rules and everything cost-based |
+| 9 | DML (§13) | the known feature gap |
+| 10 | ~~async converter (§14)~~ | **done**; cancellation and timeout are what is left of §14 |
+| 11 | convention per data source (§11) | multi-schema databases join server-side |
+| 12 | `AdoSample`, `AdoUncollect`, `AdoTableFunctionScan`, `AdoMatch` | renderable, narrower demand |
+| 13 | cross-source shipping (§12) | the largest, and the one with no precedent to copy |
+
+`Calc` is on rel2sql's list and is deliberately not on this one: `JdbcCalc` exists upstream with no rule
+that produces it, and `AdoProject` and `AdoFilter` already push everything a calc would.
+
 ## A plan cache on the data source's root — *medium, and measured*
 
 Every statement pays parse, validate, Volcano, translation and `LambdaExpression.Compile` on every

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
@@ -65,7 +65,18 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         /// <returns></returns>
         List<string> Rows(string sql)
         {
-            using var cmd = _connection.CreateCommand();
+            return Rows(_connection, sql);
+        }
+
+        /// <summary>
+        /// Runs a query on the given connection and returns its rows as strings.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static List<string> Rows(CalciteConnection connection, string sql)
+        {
+            using var cmd = connection.CreateCommand();
             cmd.CommandText = sql;
 
             var rows = new List<string>();
@@ -120,19 +131,55 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// By default the adapter's subtree is carried into the asynchronous convention, pushed down intact.
+        /// By default the adapter converts straight into the asynchronous convention, pushed down intact.
         /// </summary>
         /// <remarks>
-        /// The subtree under the converter is the adapter's own — an <c>AdoProject</c> rather than a scan
-        /// with the work done above it — so the crossing costs a wrapper and loses no pushdown.
+        /// One converter, and it is that convention's own. The route this replaced was
+        /// <c>EnumerableToClrAsyncEnumerableConverter</c> over <c>AdoToEnumerableConverter</c> — two
+        /// crossings and a linq4j enumerator between the data reader and the plan — and it answered
+        /// correctly, which is why nothing but this assertion notices. What it could not do is suspend: the
+        /// reader underneath was synchronous, so the one place in the plan with network I/O to await on was
+        /// the one place that blocked.
+        ///
+        /// <para>The subtree under the converter is the adapter's own — an <c>AdoProject</c> rather than a
+        /// scan with the work done above it — so the crossing loses no pushdown.</para>
         /// </remarks>
         [TestMethod]
-        public void ShouldCarryTheAdapterIntoTheAsyncConvention()
+        public void ShouldConvertStraightIntoTheAsyncConvention()
         {
             var plan = Explain(_connection, "SELECT empno, name FROM ADO.emps WHERE deptno = 10");
 
-            StringAssert.Contains(plan, "EnumerableToClrAsyncEnumerableConverter");
+            StringAssert.Contains(plan, "AdoToClrAsyncEnumerableConverter");
             StringAssert.Contains(plan, "AdoProject");
+            Assert.IsFalse(plan.Contains("EnumerableToClrAsyncEnumerableConverter"), plan);
+            Assert.IsFalse(plan.Contains("AdoToEnumerableConverter"), plan);
+        }
+
+        /// <summary>
+        /// The two conventions answer the same rows over the same statements.
+        /// </summary>
+        /// <remarks>
+        /// The statement each sends is the same statement — <c>AdoToClrAsyncEnumerableConverter</c> writes
+        /// it with the implementor and the writer <c>AdoToClrEnumerableConverter</c> uses, and reads a row
+        /// with the same builder — so what this holds is that the only two things that differ, the sequence
+        /// type and the two calls that await, carry the rows across unchanged.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldReadTheSameRowsInBothConventions()
+        {
+            using var synchronous = OpenConnection(synchronous: true);
+
+            foreach (var sql in new[]
+            {
+                "SELECT empno, name, deptno FROM ADO.emps ORDER BY empno",
+                "SELECT name FROM ADO.emps WHERE deptno = 20 ORDER BY name",
+                "SELECT deptno, COUNT(*) FROM ADO.emps GROUP BY deptno ORDER BY deptno",
+                "SELECT salary FROM ADO.emps ORDER BY empno",
+                "SELECT e.name, d.dname FROM ADO.emps e JOIN ADO.depts d ON e.deptno = d.deptno ORDER BY e.name",
+            })
+            {
+                CollectionAssert.AreEqual(Rows(synchronous, sql), Rows(_connection, sql), sql);
+            }
         }
 
         [TestMethod]

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSequencesTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoSequencesTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Apache.Calcite.Adapter.AdoNet.Metadata;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Apache.Calcite.Adapter.AdoNet.Tests
+{
+
+    /// <summary>
+    /// <see cref="AdoSequences.Read{TRow}"/> and <see cref="AdoSequences.ReadAsync{TRow}"/> read by
+    /// themselves, without a plan around them.
+    /// </summary>
+    /// <remarks>
+    /// The two are twins with one stated difference — when the statement is sent — and a plan cannot show
+    /// that, because a plan evaluates its expression and enumerates the result in one breath. Counting the
+    /// connections a source has opened at each point is what shows it.
+    /// </remarks>
+    [TestClass]
+    public class AdoSequencesTests
+    {
+
+        /// <summary>
+        /// An <see cref="AdoDataSource"/> over the fixture that counts what it has opened.
+        /// </summary>
+        sealed class CountingDataSource(DbDataSource dataSource) : AdoDataSource
+        {
+
+            readonly AdoDatabaseMetadata _metadata = AdoDatabaseMetadataFactoryImpl.Instance.Create(dataSource);
+
+            /// <summary>
+            /// Gets how many connections have been opened, by either route.
+            /// </summary>
+            public int Opened { get; private set; }
+
+            /// <summary>
+            /// Gets how many of those were opened by <see cref="OpenConnectionAsync"/>.
+            /// </summary>
+            public int OpenedAsynchronously { get; private set; }
+
+            /// <inheritdoc />
+            public override DbConnection OpenConnection()
+            {
+                Opened++;
+                return dataSource.OpenConnection();
+            }
+
+            /// <inheritdoc />
+            public override async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            {
+                Opened++;
+                OpenedAsynchronously++;
+                return await dataSource.OpenConnectionAsync(cancellationToken);
+            }
+
+            /// <inheritdoc />
+            public override string ConnectionString => dataSource.ConnectionString;
+
+            /// <inheritdoc />
+            public override AdoDatabaseMetadata Metadata => _metadata;
+
+        }
+
+        SqliteFixture _sqlite = null!;
+        CountingDataSource _dataSource = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _sqlite = new SqliteFixture();
+            _dataSource = new CountingDataSource(_sqlite.DataSource);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _sqlite?.Dispose();
+        }
+
+        const string Sql = "SELECT NAME FROM EMPS ORDER BY EMPNO";
+
+        static string Name(DbDataReader reader) => reader.GetString(0);
+
+        static readonly string[] Names = ["Alice", "Bob", "Carol", "Dave", "Erin"];
+
+        [TestMethod]
+        public async Task ShouldReadTheRowsAsynchronously()
+        {
+            var rows = new List<string>();
+            await foreach (var row in AdoSequences.ReadAsync(_dataSource, Sql, Name, null))
+                rows.Add(row);
+
+            CollectionAssert.AreEqual(Names, rows);
+            Assert.AreEqual(1, _dataSource.OpenedAsynchronously);
+        }
+
+        /// <summary>
+        /// The statement is sent on the first <c>MoveNextAsync</c> and not before.
+        /// </summary>
+        /// <remarks>
+        /// The one place <see cref="AdoSequences.ReadAsync{TRow}"/> differs from
+        /// <see cref="AdoSequences.Read{TRow}"/>, and it is a CLR limit rather than a choice: a method
+        /// returning an <c>IAsyncEnumerable</c> cannot await before it returns, and opening the connection
+        /// is an await. Pinned so that the difference is a stated one rather than a discovered one.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldNotSendTheStatementUntilEnumerated()
+        {
+            var rows = AdoSequences.ReadAsync(_dataSource, Sql, Name, null);
+            Assert.AreEqual(0, _dataSource.Opened);
+
+            var enumerator = rows.GetAsyncEnumerator();
+            Assert.AreEqual(0, _dataSource.Opened, "GetAsyncEnumerator alone opens nothing.");
+
+            try
+            {
+                Assert.IsTrue(await enumerator.MoveNextAsync());
+                Assert.AreEqual(1, _dataSource.Opened);
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// The synchronous twin sends it where it is called, which is what linq4j's leaf does in
+        /// <c>enumerator()</c>.
+        /// </summary>
+        [TestMethod]
+        public void ShouldSendTheStatementWhereTheSynchronousOneIsCalled()
+        {
+            var rows = AdoSequences.Read(_dataSource, Sql, Name, null);
+
+            Assert.AreEqual(1, _dataSource.Opened);
+            CollectionAssert.AreEqual(Names, new List<string>(rows));
+        }
+
+        /// <summary>
+        /// A statement the provider refuses arrives as an <see cref="AdoCalciteException"/>, as it does from
+        /// the synchronous twin, rather than as whichever exception the driver chose.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldWrapAFailureFromTheProvider()
+        {
+            var rows = AdoSequences.ReadAsync(_dataSource, "SELECT NOPE FROM EMPS", Name, null);
+
+            await Assert.ThrowsExactlyAsync<AdoCalciteException>(async () =>
+            {
+                await foreach (var row in rows)
+                    Assert.Fail("a row was read from a statement the provider refused.");
+            });
+        }
+
+        /// <summary>
+        /// The connection is released when the sequence is, whether or not it was drained.
+        /// </summary>
+        /// <remarks>
+        /// SQLite holds the file, so a fixture whose connections leaked cannot be deleted; this asserts the
+        /// pool rather than the file, because the pool is what a provider with a network connection has.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldReleaseTheConnectionOnAnAbandonedSequence()
+        {
+            var enumerator = AdoSequences.ReadAsync(_dataSource, Sql, Name, null).GetAsyncEnumerator();
+            Assert.IsTrue(await enumerator.MoveNextAsync());
+            await enumerator.DisposeAsync();
+
+            // if the first sequence had held its connection open this would be reading over a released one
+            var rows = new List<string>();
+            await foreach (var row in AdoSequences.ReadAsync(_dataSource, Sql, Name, null))
+                rows.Add(row);
+
+            CollectionAssert.AreEqual(Names, rows);
+        }
+
+        /// <summary>
+        /// A token cancelled before enumeration stops the sequence, and no row is read.
+        /// </summary>
+        /// <remarks>
+        /// The token reaches the sequence at <c>GetAsyncEnumerator</c>, which is where .NET puts it and
+        /// where the <c>[EnumeratorCancellation]</c> parameter receives it — not at the call, which is why
+        /// the plan can build this with <c>default</c> and still be cancellable. Which
+        /// <see cref="OperationCanceledException"/> arrives is the provider's choice;
+        /// <c>Microsoft.Data.Sqlite</c> answers a <see cref="TaskCanceledException"/> from the open.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldObserveACancelledToken()
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var row in AdoSequences.ReadAsync(_dataSource, Sql, Name, null).WithCancellation(source.Token))
+                    Assert.Fail("a row was read under a cancelled token.");
+            });
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoClrCorrelationDataContextBuilder.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoClrCorrelationDataContextBuilder.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 
 using Apache.Calcite.Extensions;
+using Apache.Calcite.Extensions.Linq4j.Tree;
 
 using org.apache.calcite.rel.core;
+using org.apache.calcite.adapter.enumerable;
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
 
 namespace Apache.Calcite.Adapter.AdoNet
@@ -24,6 +27,11 @@ namespace Apache.Calcite.Adapter.AdoNet
     /// <para>The second is that nothing here is linq4j. The other builds a linq4j tree and declares its field
     /// reads into a block; this reads each field as an expression and builds the context directly, so no
     /// block is needed and nothing is left to translate.</para>
+    ///
+    /// <para>Both CLR conventions use it, and it takes the two members it reads rather than an implementor,
+    /// because the two implementors share neither a base class nor a public interface carrying them. A
+    /// correlation variable is looked up on the implementor that registered it whichever convention that is,
+    /// and the translator that turns the field read into an expression is that implementor's own.</para>
     /// </remarks>
     public class AdoClrCorrelationDataContextBuilder : IAdoCorrelationDataContextBuilder
     {
@@ -32,20 +40,48 @@ namespace Apache.Calcite.Adapter.AdoNet
             ?? throw new InvalidOperationException($"{nameof(AdoCorrelationDataContext)} has no (DataContext, object[]) constructor.");
 
         readonly List<Expression> _parameters = [];
-        readonly ClrEnumerableRelImplementor _implementor;
+        readonly Func<string, RexToLixTranslator.InputGetter> _correlVariableGetter;
+        readonly LixToClrTranslator _translator;
         readonly Expression _dataContext;
 
         int offset = AdoCorrelationDataContext.Offset;
 
         /// <summary>
-        /// Initializes a new instance.
+        /// Initializes a new instance for a plan of the synchronous convention.
         /// </summary>
         /// <param name="implementor">The implementor of the plan the correlation variables are registered on.</param>
         /// <param name="dataContext">The context the outer query was bound with.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public AdoClrCorrelationDataContextBuilder(ClrEnumerableRelImplementor implementor, Expression dataContext)
+        public AdoClrCorrelationDataContextBuilder(ClrEnumerableRelImplementor implementor, Expression dataContext) :
+            this((implementor ?? throw new ArgumentNullException(nameof(implementor))).GetCorrelVariableGetter, implementor.Translator, dataContext)
         {
-            _implementor = implementor ?? throw new ArgumentNullException(nameof(implementor));
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance for a plan of the asynchronous convention.
+        /// </summary>
+        /// <param name="implementor">The implementor of the plan the correlation variables are registered on.</param>
+        /// <param name="dataContext">The context the outer query was bound with.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public AdoClrCorrelationDataContextBuilder(ClrAsyncEnumerableRelImplementor implementor, Expression dataContext) :
+            this((implementor ?? throw new ArgumentNullException(nameof(implementor))).GetCorrelVariableGetter, implementor.Translator, dataContext)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="correlVariableGetter">Looks a correlation variable up by name on the implementor it
+        /// was registered on.</param>
+        /// <param name="translator">That implementor's translator, which is bound to that plan's root.</param>
+        /// <param name="dataContext">The context the outer query was bound with.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        AdoClrCorrelationDataContextBuilder(Func<string, RexToLixTranslator.InputGetter> correlVariableGetter, LixToClrTranslator translator, Expression dataContext)
+        {
+            _correlVariableGetter = correlVariableGetter ?? throw new ArgumentNullException(nameof(correlVariableGetter));
+            _translator = translator ?? throw new ArgumentNullException(nameof(translator));
             _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
         }
 
@@ -56,9 +92,9 @@ namespace Apache.Calcite.Adapter.AdoNet
 
             // the getter reads the field as linq4j and declares into the block it was created with, not one
             // passed to it, so there is nothing for a block of this builder's to receive
-            var field = _implementor.GetCorrelVariableGetter(id.getName()).field(null, ordinal, type);
+            var field = _correlVariableGetter(id.getName()).field(null, ordinal, type);
 
-            _parameters.Add(_implementor.Translator.Translate(field));
+            _parameters.Add(_translator.Translate(field));
             return offset++;
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoDataSource.cs
@@ -1,4 +1,6 @@
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 
@@ -21,6 +23,25 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// </summary>
         /// <returns>An open <see cref="DbConnection"/> ready for query execution.</returns>
         public abstract DbConnection OpenConnection();
+
+        /// <summary>
+        /// Opens a new connection to the underlying data source without blocking the calling thread.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns>An open <see cref="DbConnection"/> ready for query execution.</returns>
+        /// <remarks>
+        /// The default opens the connection synchronously and returns a completed task, because a source
+        /// that cannot open without blocking still has to answer. That is not the sync-over-async the
+        /// asynchronous convention refuses — nothing here waits on a task — it is a caller that is simply
+        /// not asynchronous over the open. Both sources this assembly ships override it, and a source whose
+        /// provider offers a real asynchronous open should.
+        /// </remarks>
+        public virtual ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return new ValueTask<DbConnection>(OpenConnection());
+        }
 
         /// <summary>
         /// Gets the connection string used to open connections to the underlying data source.

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoRules.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoRules.cs
@@ -56,6 +56,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             yield return AdoToEnumerableConverterRule.Create(convention);
             yield return AdoToClrEnumerableConverterRule.Create(convention);
+            yield return AdoToClrAsyncEnumerableConverterRule.Create(convention);
             yield return AdoJoinRule.Create(convention);
             yield return AdoProjectRule.Create(convention);
             yield return AdoFilterRule.Create(convention);
@@ -77,6 +78,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             yield return AdoToEnumerableConverterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoToClrEnumerableConverterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
+            yield return AdoToClrAsyncEnumerableConverterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoJoinRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoProjectRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoFilterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSequences.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSequences.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
 
 namespace Apache.Calcite.Adapter.AdoNet
@@ -14,6 +16,10 @@ namespace Apache.Calcite.Adapter.AdoNet
     /// <c>ClrEnumerableConvention</c>: the same connection, command and enricher, and the same row builder,
     /// yielding an <see cref="IEnumerable{T}"/> rather than a linq4j <c>Enumerable</c>. A plan that ends here
     /// reads its rows without a linq4j enumerator between the reader and the operator above it.
+    ///
+    /// <para><see cref="ReadAsync{TRow}"/> is the same again for <c>ClrAsyncEnumerableConvention</c>, over
+    /// the <c>Async</c> members of the same three types. It is the only place in a plan of that convention
+    /// where there is network I/O to suspend on.</para>
     /// </remarks>
     public static class AdoSequences
     {
@@ -53,6 +59,62 @@ namespace Apache.Calcite.Adapter.AdoNet
             }
 
             return Rows(connection, command, reader, rowBuilder);
+        }
+
+        /// <summary>
+        /// Executes a query and returns its rows, without blocking a thread on the provider.
+        /// </summary>
+        /// <param name="dataSource">The source to open a connection against.</param>
+        /// <param name="sql">The statement to execute.</param>
+        /// <param name="rowBuilder">Builds one row from the reader's current position.</param>
+        /// <param name="enricher">Fills the command's parameters, or <see langword="null"/> where it has
+        /// none.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The rows, read as the query is enumerated.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="AdoCalciteException">The query could not be executed.</exception>
+        /// <remarks>
+        /// <para><b>The statement is sent on the first <c>MoveNextAsync</c> and not before.</b>
+        /// <see cref="Read{TRow}"/> opens the connection and executes the reader where it is called, and
+        /// yields from a separate iterator, so acquisition happens when the plan's expression is evaluated.
+        /// This cannot do the same: a method returning an <see cref="IAsyncEnumerable{T}"/> cannot await
+        /// before it returns, and opening the connection and executing the reader are the two awaits. That
+        /// is the CLR limit the asynchronous convention states at every site it reaches, and it is the one
+        /// place this sequence differs from its synchronous twin.</para>
+        ///
+        /// <para>The row builder is the synchronous one and stays so: <c>ReadAsync</c> has fetched the row
+        /// before the builder reads a field out of it, so reading a field awaits nothing.</para>
+        /// </remarks>
+        public static async IAsyncEnumerable<TRow> ReadAsync<TRow>(AdoDataSource dataSource, string sql, Func<DbDataReader, TRow> rowBuilder, DbCommandEnricher? enricher, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(dataSource);
+            ArgumentNullException.ThrowIfNull(sql);
+            ArgumentNullException.ThrowIfNull(rowBuilder);
+
+            DbConnection connection;
+            DbCommand command;
+            DbDataReader reader;
+
+            try
+            {
+                connection = await dataSource.OpenConnectionAsync(cancellationToken);
+                command = connection.CreateCommand();
+                command.CommandText = sql;
+                enricher?.Enrich(command);
+                reader = await command.ExecuteReaderAsync(cancellationToken);
+            }
+            catch (DbException e)
+            {
+                throw new AdoCalciteException("Exception while enumerating query.", e);
+            }
+
+            await using (connection)
+            await using (command)
+            await using (reader)
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                    yield return rowBuilder(reader);
+            }
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Adapter.AdoNet/DbDataSourceAdoDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/DbDataSourceAdoDataSource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data.Common;
 
 using Apache.Calcite.Adapter.AdoNet.Metadata;

--- a/src/Apache.Calcite.Adapter.AdoNet/DbProviderAdoDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/DbProviderAdoDataSource.cs
@@ -1,5 +1,7 @@
-using System;
+﻿using System;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 
@@ -41,6 +43,15 @@ namespace Apache.Calcite.Adapter.AdoNet
             var cnn = _factory.CreateConnection() ?? throw new AdoCalciteException("Null result creating connection.");
             cnn.ConnectionString = _connectionString;
             cnn.Open();
+            return cnn;
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var cnn = _factory.CreateConnection() ?? throw new AdoCalciteException("Null result creating connection.");
+            cnn.ConnectionString = _connectionString;
+            await cnn.OpenAsync(cancellationToken);
             return cnn;
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -178,7 +178,7 @@ The adapter provides Calcite conversion rules for these operators, which become 
 - `AdoValues` — constant value sets
 - `AdoTableScan` — the scan itself
 
-Anything that cannot be pushed down runs in-process. Converters exist into both execution conventions — `AdoToClrEnumerableConverter` for the compiled-.NET convention that `Apache.Calcite.Data` plans into, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under either.
+Anything that cannot be pushed down runs in-process. Converters exist into all three execution conventions — `AdoToClrAsyncEnumerableConverter` for the asynchronous compiled-.NET convention that `Apache.Calcite.Data` plans into by default, `AdoToClrEnumerableConverter` for the synchronous one, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under any of them. Under the asynchronous convention the rows are read through `DbCommand.ExecuteReaderAsync` and `DbDataReader.ReadAsync`, so no thread waits on the provider.
 
 Correlated sub-queries are supported: `AdoCorrelationDataContext` carries the outer row's values into the inner query.
 

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverter.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq.Expressions;
+using System.Threading;
+
+using Apache.Calcite.Extensions;
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using org.apache.calcite.adapter.java;
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+using org.apache.calcite.runtime;
+using org.apache.calcite.schema;
+
+namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
+{
+
+    /// <summary>
+    /// Relational operator that converts a tree of <see cref="AdoConvention"/> nodes into a
+    /// <see cref="ClrAsyncEnumerableConvention"/> result by executing the generated SQL against the
+    /// underlying ADO.NET data source.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of <see cref="AdoToClrEnumerableConverter"/>, and it sends the same statement: the
+    /// SQL, the parameter enrichment and the row builder are that converter's own, shared rather than
+    /// written again. What differs is two calls — <see cref="AdoSequences.ReadAsync{TRow}"/> where the other
+    /// names <see cref="AdoSequences.Read{TRow}"/> — and what those give back, which is an
+    /// <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/> the operators above can await.
+    ///
+    /// <para><b>Why the asynchronous convention needs one of these at all.</b> Without it a pushed-down
+    /// subtree reaches an asynchronous plan through
+    /// <c>EnumerableToClrAsyncEnumerableConverter</c> over <see cref="AdoToEnumerableConverter"/> — two
+    /// converters and a linq4j enumerator between the data reader and the plan. Both of those crossings are
+    /// honest about costing no thread, and they are right: nothing under them suspends, because the reader
+    /// underneath is synchronous. That is the whole problem. The ADO leaf is the one place in a plan where
+    /// there is network I/O to suspend on, so a plan that is asynchronous everywhere except there is
+    /// asynchronous nowhere that matters.</para>
+    ///
+    /// <para>Nothing here awaits. <c>Implement</c> runs while the statement is being prepared and builds an
+    /// expression tree, as every node of this convention does; the <c>await</c>s are all inside
+    /// <see cref="AdoSequences.ReadAsync{TRow}"/>, which is what the tree calls.</para>
+    /// </remarks>
+    public class AdoToClrAsyncEnumerableConverter : ConverterImpl, ClrAsyncEnumerableRel
+    {
+
+        static readonly System.Reflection.MethodInfo ReadAsyncMethod = typeof(AdoSequences).GetMethod(nameof(AdoSequences.ReadAsync))
+            ?? throw new InvalidOperationException($"'{nameof(AdoSequences.ReadAsync)}' is missing from {nameof(AdoSequences)}.");
+
+        static readonly System.Reflection.MethodInfo CreateEnricherMethod = typeof(AdoEnumerable).GetMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(java.util.List), typeof(org.apache.calcite.DataContext)])
+            ?? throw new InvalidOperationException($"'{nameof(AdoEnumerable.CreateEnricher)}' is missing from {nameof(AdoEnumerable)}.");
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <param name="traits"></param>
+        /// <param name="input"></param>
+        public AdoToClrAsyncEnumerableConverter(RelOptCluster cluster, RelTraitSet traits, RelNode input) :
+            base(cluster, ConventionTraitDef.INSTANCE, traits, input)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode copy(RelTraitSet traitSet, java.util.List inputs)
+        {
+            return new AdoToClrAsyncEnumerableConverter(getCluster(), traitSet, (RelNode)sole(inputs));
+        }
+
+        /// <inheritdoc />
+        public ClrAsyncEnumerableResult Implement(ClrAsyncEnumerableRelImplementor implementor, ClrEnumerablePrefer pref)
+        {
+            if (getInput() is not AdoRel self)
+                throw new AdoCalciteException("Unsupported input type.");
+
+            var physType = ClrPhysTypeImpl.Of(implementor.TypeFactory, getRowType(), pref.PreferArray());
+            var rowType = physType.RowType;
+
+            if (self.getConvention() is not AdoConvention convention)
+                throw new AdoCalciteException($"getConvention() is null for {self}.");
+
+            var dataContextBuilder = new AdoClrCorrelationDataContextBuilder(implementor, implementor.Root);
+
+            var writer = AdoToClrEnumerableConverter.GenerateSql(convention, dataContextBuilder, self, (JavaTypeFactory)getCluster().getTypeFactory(), out var sqlImplementor);
+            var parameters = writer.Indexes;
+            var parameterTypeNames = AdoToEnumerableConverter.GetParameterTypeNames(sqlImplementor, parameters);
+
+            var sql = writer.toSqlString().getSql();
+            Hook.QUERY_PLAN.run(sql);
+
+            // the schema SPI defines a convention's expression as linq4j, so this is the one thing here that
+            // arrives as a linq4j tree, and it is translated where it is produced rather than composed into
+            // anything first. Everything else this node builds is an expression tree from the start.
+            var dataSource = implementor.Translator.Translate(Schemas.unwrap(convention.Expression, typeof(AdoDataSource)));
+
+            // a correlated sub-query leaves a parameter per correlation variable in the SQL, and the values
+            // live on the context the builder closed over the outer row. Without the enricher the command is
+            // handed to the provider unfilled.
+            var enricher = parameters.isEmpty()
+                ? (Expression)Expression.Constant(null, typeof(DbCommandEnricher))
+                : Expression.Call(null, CreateEnricherMethod, dataSource, Expression.Constant(parameters), Expression.Constant(parameterTypeNames), dataContextBuilder.Build());
+
+            return implementor.Result(physType,
+                Expression.Call(null,
+                    ReadAsyncMethod.MakeGenericMethod(rowType),
+                    dataSource,
+                    Expression.Constant(sql),
+                    AdoToClrEnumerableConverter.RowBuilder(physType, rowType, getRowType().getFieldCount()),
+                    enricher,
+                    // every operator of this convention ends in a token and is called with default here: the
+                    // token the caller passes to GetAsyncEnumerator is what the [EnumeratorCancellation]
+                    // parameter receives, and it arrives at enumeration rather than at build time
+                    Expression.Default(typeof(CancellationToken))));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverterRule.cs
@@ -1,0 +1,57 @@
+using Apache.Calcite.Extensions;
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+
+using java.util.function;
+
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+
+namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
+{
+
+    /// <summary>
+    /// Rule to convert a relational expression from <see cref="AdoConvention"/> to
+    /// <see cref="ClrAsyncEnumerableConvention"/>.
+    /// </summary>
+    /// <remarks>
+    /// The third of the adapter's converter rules, beside <see cref="AdoToEnumerableConverterRule"/> and
+    /// <see cref="AdoToClrEnumerableConverterRule"/>, so that a plan whose root is asked for in any of the
+    /// three conventions has a route out of the adapter. A plan ending in
+    /// <see cref="ClrAsyncEnumerableConvention"/> reaches it without a second converter, and reads its rows
+    /// without blocking a thread on the provider.
+    /// </remarks>
+    public class AdoToClrAsyncEnumerableConverterRule : ConverterRule
+    {
+
+        /// <summary>
+        /// Creates a rule instance bound to the specified <see cref="AdoConvention"/>.
+        /// </summary>
+        /// <param name="convention">The ADO convention whose nodes will be converted.</param>
+        /// <returns></returns>
+        public static AdoToClrAsyncEnumerableConverterRule Create(AdoConvention convention)
+        {
+            return (AdoToClrAsyncEnumerableConverterRule)Config.INSTANCE
+                .withConversion(typeof(RelNode), convention, ClrAsyncEnumerableConvention.Instance, "AdoToClrAsyncEnumerableConverterRule")
+                .withRuleFactory(new DelegateFunction<Config, AdoToClrAsyncEnumerableConverterRule>(c => new AdoToClrAsyncEnumerableConverterRule(c)))
+                .toRule(typeof(AdoToClrAsyncEnumerableConverterRule));
+        }
+
+        /// <summary>
+        /// Initializes a new instance using the supplied rule configuration.
+        /// </summary>
+        /// <param name="config">The rule configuration produced by <see cref="Create"/>.</param>
+        public AdoToClrAsyncEnumerableConverterRule(Config config) :
+            base(config)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode? convert(RelNode rel)
+        {
+            return new AdoToClrAsyncEnumerableConverter(rel.getCluster(), rel.getTraitSet().replace(getOutConvention()), rel);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
@@ -83,7 +83,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
 
             var dataContextBuilder = new AdoClrCorrelationDataContextBuilder(implementor, implementor.Root);
 
-            var writer = GenerateSql(convention, dataContextBuilder, self, out var sqlImplementor);
+            var writer = GenerateSql(convention, dataContextBuilder, self, (JavaTypeFactory)getCluster().getTypeFactory(), out var sqlImplementor);
             var parameters = writer.Indexes;
             var parameterTypeNames = AdoToEnumerableConverter.GetParameterTypeNames(sqlImplementor, parameters);
 
@@ -107,7 +107,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
                     ReadMethod.MakeGenericMethod(rowType),
                     dataSource,
                     Expression.Constant(sql),
-                    RowBuilder(physType, rowType),
+                    RowBuilder(physType, rowType, getRowType().getFieldCount()),
                     enricher));
         }
 
@@ -116,17 +116,20 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         /// </summary>
         /// <param name="physType"></param>
         /// <param name="rowType"></param>
+        /// <param name="fieldCount"></param>
         /// <returns></returns>
         /// <remarks>
         /// The shape of a row is decided by how many fields it has, exactly as
         /// <see cref="AdoToEnumerableConverter"/> decides it, because <c>JavaRowFormat.optimize</c> has
         /// already told the physical type the same thing: no field is a null, one field is the value itself,
         /// and only beyond that is a row an array.
+        ///
+        /// <para>Shared with <see cref="AdoToClrAsyncEnumerableConverter"/>, which reads a row the same way:
+        /// the reader has fetched it before a field is read, so nothing on this path awaits.</para>
         /// </remarks>
-        Expression RowBuilder(ClrPhysType physType, Type rowType)
+        internal static Expression RowBuilder(ClrPhysType physType, Type rowType, int fieldCount)
         {
             var reader = Expression.Parameter(typeof(DbDataReader), "reader");
-            var fieldCount = getRowType().getFieldCount();
 
             Expression body;
             if (fieldCount == 0)
@@ -179,10 +182,16 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         /// <param name="convention"></param>
         /// <param name="dataContextBuilder"></param>
         /// <param name="input"></param>
+        /// <param name="typeFactory"></param>
+        /// <param name="implementor"></param>
         /// <returns></returns>
-        AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input, out AdoImplementor implementor)
+        /// <remarks>
+        /// Shared with <see cref="AdoToClrAsyncEnumerableConverter"/>: the statement a plan of either CLR
+        /// convention sends is the same statement, written by the same implementor from the same tree.
+        /// </remarks>
+        internal static AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input, JavaTypeFactory typeFactory, out AdoImplementor implementor)
         {
-            implementor = new AdoImplementor(convention.Dialect, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder);
+            implementor = new AdoImplementor(convention.Dialect, typeFactory, dataContextBuilder);
             var result = implementor.visitRoot(input);
 
             var writer = new AdoSqlWriter(convention.Dialect, convention.Syntax);


### PR DESCRIPTION
Closes #103.

A plan of `ClrAsyncEnumerableConvention` — which is what `Apache.Calcite.Data` plans by default —
reached a pushed-down subtree through `EnumerableToClrAsyncEnumerableConverter` over
`AdoToEnumerableConverter`: two crossings, a linq4j enumerator, and `DbDataReader.Read()` at the
bottom.

Both of those crossings cost no thread and both are right about that, because nothing under them
suspends. That is the problem rather than the defence. The ADO leaf is the one place in a plan
where there is network I/O to suspend on, so a plan asynchronous everywhere except there is
asynchronous nowhere that matters.

## What is here

`AdoToClrAsyncEnumerableConverter` and its rule, the third converter out of the adapter beside the
two that were there. It sends the synchronous converter's statement — same implementor, same
writer, same row builder, shared rather than written again — and reads it through
`AdoSequences.ReadAsync`, over `OpenConnectionAsync`, `ExecuteReaderAsync` and `ReadAsync`.

The plan for `SELECT empno, name FROM ADO.emps WHERE deptno = 10` on a default connection, before:

```
EnumerableToClrAsyncEnumerableConverter
  AdoToEnumerableConverter
    AdoProject(empno=[$0], name=[$1])
      AdoFilter(condition=[=($2, 10)])
        AdoTableScan(table=[[ADO, EMPS]])
```

and after:

```
AdoToClrAsyncEnumerableConverter
  AdoProject(empno=[$0], name=[$1])
    AdoFilter(condition=[=($2, 10)])
      AdoTableScan(table=[[ADO, EMPS]])
```

`AdoDataSource` gains `OpenConnectionAsync`, virtual rather than abstract so that a source outside
this assembly still answers. Both sources here override it. The default opens synchronously and
returns a completed task, which is not the sync-over-async the convention refuses — nothing waits
on a task — but a caller that is simply not asynchronous over the open, stated at the site.

`AdoClrCorrelationDataContextBuilder` now takes the two members it reads rather than an
implementor, because the two CLR implementors share neither a base class nor a public interface
carrying them. Both conventions get the same builder.

## The one thing that differs, and why

`AdoSequences.ReadAsync` sends the statement on the first `MoveNextAsync` rather than where it is
called, which is not what `Read` does: a method returning an `IAsyncEnumerable` cannot await before
it returns, and opening the connection is an await. That is the CLR limit the asynchronous
convention states at every site it reaches, and it is stated here too.
`AdoSequencesTests.ShouldNotSendTheStatementUntilEnumerated` and
`ShouldSendTheStatementWhereTheSynchronousOneIsCalled` pin both halves so the difference stays a
stated one.

The row builder is the synchronous one and stays so: `ReadAsync` has fetched the row before a field
is read out of it, so reading a field awaits nothing.

## Tests

`AdoSequencesTests` is new — rows, acquisition timing against `Read`'s, the provider failure
arriving as an `AdoCalciteException`, connection release on an abandoned sequence, and a cancelled
token.

`AdoClrEnumerableTests.ShouldCarryTheAdapterIntoTheAsyncConvention` becomes
`ShouldConvertStraightIntoTheAsyncConvention` and asserts the absence of both nodes on the old
route. `ShouldReadTheSameRowsInBothConventions` runs five statements through a synchronous and an
asynchronous connection and compares.

Adapter suite 490, `Apache.Calcite.Tests` 827, `Apache.Calcite.Data.Tests` 422 — all green, none
skipped.

## Not in scope

Cancellation and timeout, which #103 named as adjacent and not part of it. `ReadAsync` observes the
token the caller passes to `GetAsyncEnumerator`, and a test holds that; what is not wired is
`DataContext.Variable.CANCEL_FLAG`, which nothing in the adapter reads, and
`DbCommand.CommandTimeout`, which nothing sets. Connection-per-enumeration is unchanged. All three
stay recorded in `TODO.md` §14.

## The second commit

`TODO.md` gains the capability audit this came out of: fifteen items, each measured with a probe
that ran thirty statements against the SQLite fixture twice — once as `EXPLAIN PLAN FOR`, once with
a `Hook.QUERY_PLAN` handler counting statements sent. They are filed as #103 through #117.
