### PR TITLE
Give the ADO.NET adapter an asynchronous path

### DIFF
--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
@@ -1,5 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
+using Apache.Calcite.Adapter.AdoNet.Metadata;
 using Apache.Calcite.Data;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,10 +22,10 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
     /// Every other test in this project opens <c>jdbc:calcite:</c> through <c>DriverManager</c>, which is
     /// Calcite's connection and Calcite's prepare. None of them says anything about this path. A plan over
     /// an ADO.NET schema is necessarily a mixed one — the adapter's own subtree stays in its convention —
-    /// and the crossing depends on the connection's mode: by default the rows go through
-    /// <c>AdoToEnumerableConverter</c>, Calcite's convention, under the converter into the asynchronous one;
-    /// in synchronous mode the adapter converts straight into <c>ClrEnumerableConvention</c> through
-    /// <c>AdoToClrEnumerableConverter</c>, with no linq4j layer between.
+    /// and the crossing depends on the connection's mode: by default the adapter converts straight into
+    /// <c>ClrAsyncEnumerableConvention</c> through <c>AdoToClrAsyncEnumerableConverter</c>, and in
+    /// synchronous mode straight into <c>ClrEnumerableConvention</c> through
+    /// <c>AdoToClrEnumerableConverter</c>. Either way there is no linq4j layer between.
     /// </remarks>
     [TestClass]
     public class AdoClrEnumerableTests
@@ -39,13 +46,30 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         /// </summary>
         CalciteConnection OpenConnection(bool synchronous = false)
         {
+            return OpenConnection(root => root.add("ADO", AdoSchema.Create(root, "ADO", _sqlite.DataSource, null, null)), synchronous);
+        }
+
+        /// <summary>
+        /// Opens a connection over the given <see cref="AdoDataSource"/>, in the mode asked for.
+        /// </summary>
+        static CalciteConnection OpenConnection(AdoDataSource dataSource, bool synchronous = false, bool decorrelate = true)
+        {
+            return OpenConnection(root => root.add("ADO", AdoSchema.Create(root, "ADO", dataSource, null, null)), synchronous, decorrelate);
+        }
+
+        /// <summary>
+        /// Opens a connection whose root schema is built by <paramref name="configure"/>.
+        /// </summary>
+        static CalciteConnection OpenConnection(Action<org.apache.calcite.schema.SchemaPlus> configure, bool synchronous, bool decorrelate = true)
+        {
             return new CalciteDataSourceBuilder(new CalciteConnectionStringBuilder
             {
                 Lex = "JAVA",
                 CaseSensitive = false,
                 Synchronous = synchronous ? true : null,
+                ForceDecorrelate = decorrelate ? null : false,
             }.ToString())
-                .ConfigureRootSchema(root => root.add("ADO", AdoSchema.Create(root, "ADO", _sqlite.DataSource, null, null)))
+                .ConfigureRootSchema(configure)
                 .Build()
                 .OpenConnection();
         }
@@ -142,9 +166,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         /// <remarks>
         /// One converter, and it is that convention's own. Reaching <c>AdoToEnumerableConverter</c> instead
         /// would still answer correctly, by way of a second converter, and no other assertion here would
-        /// notice. The mode is pinned because the default plans asynchronously, where the routes tie on the
-        /// planner's row-count-only cost and the adapter's rows go through Calcite's converter —
-        /// <see cref="ShouldCarryTheAdapterIntoTheAsyncConvention"/> holds that plan.
+        /// notice. The mode is pinned because the default plans asynchronously and reaches a different
+        /// converter — <see cref="ShouldCarryTheAdapterIntoTheAsyncConvention"/> holds that plan.
         /// </remarks>
         [TestMethod]
         public void ShouldConvertStraightIntoThisConvention()
@@ -158,19 +181,26 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// By default the adapter's subtree is carried into the asynchronous convention, pushed down intact.
+        /// By default the adapter converts straight into the asynchronous convention, pushed down intact.
         /// </summary>
         /// <remarks>
         /// The subtree under the converter is the adapter's own — an <c>AdoProject</c> rather than a scan
-        /// with the work done above it — so the crossing costs a wrapper and loses no pushdown.
+        /// with the work done above it — so the crossing loses no pushdown.
+        ///
+        /// <para>One converter, and no synchronous node between it and the reader. The route this replaced
+        /// was a converter over <c>AdoToEnumerableConverter</c>, which answers the same rows and blocks a
+        /// thread on the socket for every one of them, the ADO leaf being the one place in a plan with real
+        /// network I/O to wait on.</para>
         /// </remarks>
         [TestMethod]
         public void ShouldCarryTheAdapterIntoTheAsyncConvention()
         {
             var plan = Explain(_connection, "SELECT empno, name FROM ADO.emps WHERE deptno = 10");
 
-            StringAssert.Contains(plan, "EnumerableToClrAsyncEnumerableConverter");
+            StringAssert.Contains(plan, "AdoToClrAsyncEnumerableConverter");
             StringAssert.Contains(plan, "AdoProject");
+            Assert.IsFalse(plan.Contains("AdoToEnumerableConverter"), plan);
+            Assert.IsFalse(plan.Contains("AdoToClrEnumerableConverter"), plan);
         }
 
         [TestMethod]
@@ -203,6 +233,278 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             CollectionAssert.AreEquivalent(
                 new[] { "Alice|Sales", "Bob|Sales", "Carol|Engineering", "Dave|Engineering" },
                 Rows("SELECT e.name, d.dname FROM ADO.emps e JOIN ADO.depts d ON e.deptno = d.deptno ORDER BY e.name"));
+        }
+
+        /// <summary>
+        /// The default plan opens its connection without blocking, which is the whole point of the converter
+        /// it reaches.
+        /// </summary>
+        /// <remarks>
+        /// The plan is what is being asserted, read through the one observable the data source has: a plan
+        /// under <c>AdoToClrAsyncEnumerableConverter</c> calls <see cref="AdoDataSource.OpenConnectionAsync"/>
+        /// and the synchronous route calls <see cref="AdoDataSource.OpenConnection"/>. Metadata's own
+        /// connections do not reach either: those are opened against the <c>DbDataSource</c> the metadata was
+        /// built from.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldOpenTheConnectionWithoutBlocking()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource);
+            using var connection = OpenConnection(source);
+
+            CollectionAssert.AreEquivalent(new[] { "1|Alice", "2|Bob" }, await RowsAsync(connection, "SELECT empno, name FROM ADO.emps WHERE deptno = 10"));
+
+            Assert.AreEqual(1, source.OpenedAsync);
+            Assert.AreEqual(0, source.Opened);
+        }
+
+        /// <summary>
+        /// In synchronous mode it is the blocking open, there being no asynchronous plan to open for.
+        /// </summary>
+        [TestMethod]
+        public void ShouldOpenTheConnectionSynchronouslyInSynchronousMode()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource);
+            using var connection = OpenConnection(source, synchronous: true);
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT empno, name FROM ADO.emps WHERE deptno = 10";
+            using (var r = cmd.ExecuteReader())
+                while (r.Read()) { }
+
+            Assert.AreEqual(1, source.Opened);
+            Assert.AreEqual(0, source.OpenedAsync);
+        }
+
+        /// <summary>
+        /// A correlated sub-query pushed down asynchronously still gets its parameters.
+        /// </summary>
+        /// <remarks>
+        /// The one thing the asynchronous converter does not share with the synchronous one is the
+        /// implementor it reads correlation variables from, and a variable is registered on the implementor
+        /// implementing the plan and is unknown to every other. Nothing below here would notice the wrong one
+        /// at planning time. <c>forceDecorrelate=false</c> is what leaves a correlate in the plan at all —
+        /// Calcite rewrites one into a join wherever it can, and by default always tries.
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldEnrichACorrelatedSubQueryOnTheAsyncPath()
+        {
+            using var connection = OpenConnection(new CountingAdoDataSource(_sqlite.DataSource), decorrelate: false);
+            const string Sql = "SELECT e.name, (SELECT d.dname FROM ADO.depts d WHERE d.deptno = e.deptno) FROM ADO.emps e";
+
+            // the correlate has to still be there, and the inner sub-plan has to still be the adapter's, or
+            // the query below proves nothing about the enricher
+            var plan = Explain(connection, Sql);
+            StringAssert.Contains(plan, "ClrAsyncEnumerableCorrelate");
+            StringAssert.Contains(plan, "AdoFilter(condition=[=($0, $cor0.DEPTNO)])");
+            StringAssert.Contains(plan, "AdoToClrAsyncEnumerableConverter");
+
+            CollectionAssert.AreEquivalent(
+                new[] { "Alice|Sales", "Bob|Sales", "Carol|Engineering", "Dave|Engineering", "Erin|null" },
+                await RowsAsync(connection, Sql));
+        }
+
+        /// <summary>
+        /// <see cref="AdoSequences.ReadAsync{TRow}"/> on its own, without a plan around it.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldReadRowsAsynchronously()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource);
+
+            var names = new List<string>();
+            await foreach (var name in AdoSequences.ReadAsync(source, "SELECT NAME FROM EMPS WHERE DEPTNO = 10 ORDER BY EMPNO", r => r.GetString(0), null))
+                names.Add(name);
+
+            CollectionAssert.AreEqual(new[] { "Alice", "Bob" }, names);
+            Assert.AreEqual(1, source.OpenedAsync);
+            Assert.AreEqual(1, source.Closed);
+        }
+
+        /// <summary>
+        /// The statement is not sent until the first row is asked for, an <see cref="IAsyncEnumerable{T}"/>
+        /// having nowhere earlier to await.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldNotOpenUntilTheFirstRowIsAskedFor()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource);
+
+            var rows = AdoSequences.ReadAsync(source, "SELECT NAME FROM EMPS", r => r.GetString(0), null);
+            Assert.AreEqual(0, source.OpenedAsync);
+
+            var enumerator = rows.GetAsyncEnumerator();
+
+            try
+            {
+                Assert.IsTrue(await enumerator.MoveNextAsync());
+                Assert.AreEqual(1, source.OpenedAsync);
+            }
+            finally
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// A statement the provider rejects closes what was opened for it.
+        /// </summary>
+        [TestMethod]
+        public async Task ShouldCloseTheConnectionWhenTheStatementFails()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource);
+
+            await Assert.ThrowsExactlyAsync<AdoCalciteException>(async () =>
+            {
+                await foreach (var _ in AdoSequences.ReadAsync(source, "SELECT NAME FROM NO_SUCH_TABLE", r => r.GetString(0), null))
+                {
+
+                }
+            });
+
+            Assert.AreEqual(1, source.Closed);
+        }
+
+        /// <summary>
+        /// Runs a query through the asynchronous reader and returns its rows as strings.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        static async Task<List<string>> RowsAsync(CalciteConnection connection, string sql)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+
+            var rows = new List<string>();
+            await using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                var values = new string[r.FieldCount];
+                for (int i = 0; i < r.FieldCount; i++)
+                    values[i] = await r.IsDBNullAsync(i) ? "null" : r.GetValue(i).ToString()!;
+
+                rows.Add(string.Join("|", values));
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// The fixture's data source, counting which of the two opens a plan reached for and how many of the
+        /// connections it handed out were disposed.
+        /// </summary>
+        /// <param name="dataSource"></param>
+        sealed class CountingAdoDataSource(DbDataSource dataSource) : AdoDataSource
+        {
+
+            readonly AdoDatabaseMetadata _metadata = AdoDatabaseMetadataFactoryImpl.Instance.Create(dataSource);
+
+            int _opened;
+            int _openedAsync;
+            int _closed;
+
+            /// <summary>
+            /// Gets the number of blocking opens.
+            /// </summary>
+            public int Opened => Volatile.Read(ref _opened);
+
+            /// <summary>
+            /// Gets the number of asynchronous opens.
+            /// </summary>
+            public int OpenedAsync => Volatile.Read(ref _openedAsync);
+
+            /// <summary>
+            /// Gets the number of connections handed out that were disposed.
+            /// </summary>
+            public int Closed => Volatile.Read(ref _closed);
+
+            /// <inheritdoc />
+            public override DbConnection OpenConnection()
+            {
+                Interlocked.Increment(ref _opened);
+
+                return new Counted(dataSource.OpenConnection(), this);
+            }
+
+            /// <inheritdoc />
+            public override async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _openedAsync);
+
+                return new Counted(await dataSource.OpenConnectionAsync(cancellationToken), this);
+            }
+
+            /// <inheritdoc />
+            public override string ConnectionString => dataSource.ConnectionString;
+
+            /// <inheritdoc />
+            public override AdoDatabaseMetadata Metadata => _metadata;
+
+            /// <summary>
+            /// A connection that tells the source it was disposed.
+            /// </summary>
+            /// <param name="connection"></param>
+            /// <param name="source"></param>
+            sealed class Counted(DbConnection connection, CountingAdoDataSource source) : DbConnection
+            {
+
+                /// <inheritdoc />
+                [AllowNull]
+                public override string ConnectionString { get => connection.ConnectionString; set => connection.ConnectionString = value; }
+
+                /// <inheritdoc />
+                public override string Database => connection.Database;
+
+                /// <inheritdoc />
+                public override string DataSource => connection.DataSource;
+
+                /// <inheritdoc />
+                public override string ServerVersion => connection.ServerVersion;
+
+                /// <inheritdoc />
+                public override ConnectionState State => connection.State;
+
+                /// <inheritdoc />
+                public override void ChangeDatabase(string databaseName) => connection.ChangeDatabase(databaseName);
+
+                /// <inheritdoc />
+                public override void Close() => connection.Close();
+
+                /// <inheritdoc />
+                public override void Open() => connection.Open();
+
+                /// <inheritdoc />
+                public override Task OpenAsync(CancellationToken cancellationToken) => connection.OpenAsync(cancellationToken);
+
+                /// <inheritdoc />
+                protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => connection.BeginTransaction(isolationLevel);
+
+                /// <inheritdoc />
+                protected override DbCommand CreateDbCommand() => connection.CreateCommand();
+
+                /// <inheritdoc />
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        Interlocked.Increment(ref source._closed);
+                        connection.Dispose();
+                    }
+
+                    base.Dispose(disposing);
+                }
+
+                /// <inheritdoc />
+                public override async ValueTask DisposeAsync()
+                {
+                    Interlocked.Increment(ref source._closed);
+                    await connection.DisposeAsync();
+                    GC.SuppressFinalize(this);
+                }
+
+            }
+
         }
 
     }

--- a/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet.Tests/AdoClrEnumerableTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 using Apache.Calcite.Data;
 
+using Microsoft.Data.Sqlite;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Apache.Calcite.Adapter.AdoNet.Tests
@@ -236,44 +237,22 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// The default plan opens its connection without blocking, which is the whole point of the converter
-        /// it reaches.
+        /// The default plan opens one connection and reads its rows without parking a thread.
         /// </summary>
         /// <remarks>
-        /// The plan is what is being asserted, read through the one observable the data source has: a plan
-        /// under <c>AdoToClrAsyncEnumerableConverter</c> calls <see cref="AdoDataSource.OpenConnectionAsync"/>
-        /// and the synchronous route calls <see cref="AdoDataSource.OpenConnection"/>. Metadata's own
-        /// connections do not reach either: those are opened against the <c>DbDataSource</c> the metadata was
-        /// built from.
+        /// Metadata's own connections do not reach this source: those are opened against the
+        /// <c>DbDataSource</c> the metadata was built from, so what is counted here is the plan's.
         /// </remarks>
         [TestMethod]
-        public async Task ShouldOpenTheConnectionWithoutBlocking()
+        public async Task ShouldReadTheAdapterThroughTheAsyncConverter()
         {
             var source = new CountingAdoDataSource(_sqlite.DataSource);
             using var connection = OpenConnection(source);
 
             CollectionAssert.AreEquivalent(new[] { "1|Alice", "2|Bob" }, await RowsAsync(connection, "SELECT empno, name FROM ADO.emps WHERE deptno = 10"));
 
-            Assert.AreEqual(1, source.OpenedAsync);
-            Assert.AreEqual(0, source.Opened);
-        }
-
-        /// <summary>
-        /// In synchronous mode it is the blocking open, there being no asynchronous plan to open for.
-        /// </summary>
-        [TestMethod]
-        public void ShouldOpenTheConnectionSynchronouslyInSynchronousMode()
-        {
-            var source = new CountingAdoDataSource(_sqlite.DataSource);
-            using var connection = OpenConnection(source, synchronous: true);
-
-            using var cmd = connection.CreateCommand();
-            cmd.CommandText = "SELECT empno, name FROM ADO.emps WHERE deptno = 10";
-            using (var r = cmd.ExecuteReader())
-                while (r.Read()) { }
-
             Assert.AreEqual(1, source.Opened);
-            Assert.AreEqual(0, source.OpenedAsync);
+            Assert.AreEqual(1, source.Closed);
         }
 
         /// <summary>
@@ -317,33 +296,42 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
                 names.Add(name);
 
             CollectionAssert.AreEqual(new[] { "Alice", "Bob" }, names);
-            Assert.AreEqual(1, source.OpenedAsync);
+            Assert.AreEqual(1, source.Opened);
             Assert.AreEqual(1, source.Closed);
         }
 
         /// <summary>
-        /// The statement is not sent until the first row is asked for, an <see cref="IAsyncEnumerable{T}"/>
-        /// having nowhere earlier to await.
+        /// The statement is sent at <c>GetAsyncEnumerator</c>, before any row is asked for.
         /// </summary>
+        /// <remarks>
+        /// Where this convention acquires, and the reason a failing statement reaches the caller from the
+        /// call that executed it: <c>CalciteSession</c> runs <c>GetAsyncEnumerator</c> inside
+        /// <c>ExecuteReaderAsync</c>. A leaf that opened on its first <c>MoveNextAsync</c> would still
+        /// answer the same rows and would report a rejected statement from <c>ReadAsync</c>.
+        ///
+        /// <para>Composing the sequence opens nothing, because acquisition belongs to the enumerator and
+        /// not to the call — one enumeration, one connection.</para>
+        /// </remarks>
         [TestMethod]
-        public async Task ShouldNotOpenUntilTheFirstRowIsAskedFor()
+        public async Task ShouldSendTheStatementAtAcquisition()
         {
             var source = new CountingAdoDataSource(_sqlite.DataSource);
 
             var rows = AdoSequences.ReadAsync(source, "SELECT NAME FROM EMPS", r => r.GetString(0), null);
-            Assert.AreEqual(0, source.OpenedAsync);
+            Assert.AreEqual(0, source.Opened, "composing the sequence opens nothing");
 
             var enumerator = rows.GetAsyncEnumerator();
 
             try
             {
-                Assert.IsTrue(await enumerator.MoveNextAsync());
-                Assert.AreEqual(1, source.OpenedAsync);
+                Assert.AreEqual(1, source.Opened, "and obtaining its enumerator sends the statement");
             }
             finally
             {
                 await enumerator.DisposeAsync();
             }
+
+            Assert.AreEqual(1, source.Closed, "an enumerator abandoned without a row still closes it");
         }
 
         /// <summary>
@@ -363,6 +351,51 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             });
 
             Assert.AreEqual(1, source.Closed);
+        }
+
+        /// <summary>
+        /// A statement the source rejects fails from the call that executed it, on either surface.
+        /// </summary>
+        /// <remarks>
+        /// <c>DbCommand.ExecuteReaderAsync</c> sends the command text and builds the reader, so a caller
+        /// expects a bad statement back from there rather than from the first <c>ReadAsync</c>. Nothing in
+        /// the adapter can promise that on its own: the leaf opens its connection and executes on the first
+        /// <c>MoveNextAsync</c>, because <c>GetAsyncEnumerator</c> cannot await. What holds it is the
+        /// provider reading one row inside <c>ExecuteReaderAsync</c>.
+        ///
+        /// <para>The leaf is failed rather than the schema, because the schema is read again while planning:
+        /// dropping the table would make this a validation failure and say nothing about where the statement
+        /// was sent. Metadata is read through the <c>DbDataSource</c> and never through
+        /// <see cref="AdoDataSource"/>, so arming the source after the connection is open fails the plan's
+        /// own connection and nothing else.</para>
+        /// </remarks>
+        [TestMethod]
+        public async Task ShouldFailFromExecuteRatherThanFromTheFirstRead()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource) { Failing = true };
+            using var connection = OpenConnection(source);
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT empno, name FROM ADO.emps";
+
+            // the call itself, not the block: a reader handed back and failing on its first ReadAsync is
+            // exactly what this is here to refuse
+            await Assert.ThrowsExactlyAsync<CalciteException>(async () => await cmd.ExecuteReaderAsync());
+        }
+
+        /// <summary>
+        /// The synchronous route has always done this, and still does.
+        /// </summary>
+        [TestMethod]
+        public void ShouldFailFromExecuteInSynchronousMode()
+        {
+            var source = new CountingAdoDataSource(_sqlite.DataSource) { Failing = true };
+            using var connection = OpenConnection(source, synchronous: true);
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT empno, name FROM ADO.emps";
+
+            Assert.ThrowsExactly<CalciteException>(() => cmd.ExecuteReader());
         }
 
         /// <summary>
@@ -391,8 +424,8 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
         }
 
         /// <summary>
-        /// The fixture's data source, counting which of the two opens a plan reached for and how many of the
-        /// connections it handed out were disposed.
+        /// The fixture's data source, counting the connections a plan opened and how many of them were
+        /// disposed.
         /// </summary>
         /// <param name="dataSource"></param>
         sealed class CountingAdoDataSource(DbDataSource dataSource) : AdoDataSource
@@ -401,38 +434,32 @@ namespace Apache.Calcite.Adapter.AdoNet.Tests
             readonly AdoDatabaseMetadata _metadata = AdoDatabaseMetadataFactoryImpl.Instance.Create(dataSource);
 
             int _opened;
-            int _openedAsync;
             int _closed;
 
             /// <summary>
-            /// Gets the number of blocking opens.
+            /// Gets the number of connections opened.
             /// </summary>
             public int Opened => Volatile.Read(ref _opened);
-
-            /// <summary>
-            /// Gets the number of asynchronous opens.
-            /// </summary>
-            public int OpenedAsync => Volatile.Read(ref _openedAsync);
 
             /// <summary>
             /// Gets the number of connections handed out that were disposed.
             /// </summary>
             public int Closed => Volatile.Read(ref _closed);
 
+            /// <summary>
+            /// Gets or sets whether every open fails as the provider rejecting the statement would.
+            /// </summary>
+            public bool Failing { get; init; }
+
             /// <inheritdoc />
             public override DbConnection OpenConnection()
             {
                 Interlocked.Increment(ref _opened);
 
+                if (Failing)
+                    throw new SqliteException("armed", 1);
+
                 return new Counted(dataSource.OpenConnection(), this);
-            }
-
-            /// <inheritdoc />
-            public override async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
-            {
-                Interlocked.Increment(ref _openedAsync);
-
-                return new Counted(await dataSource.OpenConnectionAsync(cancellationToken), this);
             }
 
             /// <inheritdoc />

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoClrCorrelationDataContextBuilder.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoClrCorrelationDataContextBuilder.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 
 using Apache.Calcite.Extensions;
+using Apache.Calcite.Extensions.Linq4j.Tree;
 
+using org.apache.calcite.adapter.enumerable;
 using org.apache.calcite.rel.core;
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
 
 namespace Apache.Calcite.Adapter.AdoNet
@@ -12,18 +15,23 @@ namespace Apache.Calcite.Adapter.AdoNet
 
     /// <summary>
     /// Collects the correlation variables needed to construct an <see cref="AdoCorrelationDataContext"/> for a
-    /// correlated sub-query, for a plan of the <see cref="ClrEnumerableConvention"/> calling convention.
+    /// correlated sub-query, for a plan of the <see cref="ClrEnumerableConvention"/> or
+    /// <see cref="ClrAsyncEnumerableConvention"/> calling convention.
     /// </summary>
     /// <remarks>
     /// What <see cref="AdoCorrelationDataContextBuilderImpl"/> does for a plan of Calcite's convention. Two
     /// things differ, and the first is why this exists at all: a correlation variable is registered on the
     /// implementor that is implementing the plan and is unknown to every other, so the variable has to be
-    /// read from this convention's implementor rather than Calcite's. Handing over the wrong one does not
-    /// fail while planning — it fails looking the variable up.
+    /// read from the implementor of the convention the plan is in rather than Calcite's. Handing over the
+    /// wrong one does not fail while planning — it fails looking the variable up.
     ///
     /// <para>The second is that nothing here is linq4j. The other builds a linq4j tree and declares its field
     /// reads into a block; this reads each field as an expression and builds the context directly, so no
     /// block is needed and nothing is left to translate.</para>
+    ///
+    /// <para>One class serves both Clr conventions because everything it touches is about a <em>row</em> —
+    /// the getter and the translator — and a row is the same thing in each. Nothing here is about a
+    /// sequence.</para>
     /// </remarks>
     public class AdoClrCorrelationDataContextBuilder : IAdoCorrelationDataContextBuilder
     {
@@ -32,7 +40,8 @@ namespace Apache.Calcite.Adapter.AdoNet
             ?? throw new InvalidOperationException($"{nameof(AdoCorrelationDataContext)} has no (DataContext, object[]) constructor.");
 
         readonly List<Expression> _parameters = [];
-        readonly ClrEnumerableRelImplementor _implementor;
+        readonly Func<string, RexToLixTranslator.InputGetter> _correlVariableGetter;
+        readonly LixToClrTranslator _translator;
         readonly Expression _dataContext;
 
         int offset = AdoCorrelationDataContext.Offset;
@@ -43,9 +52,41 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// <param name="implementor">The implementor of the plan the correlation variables are registered on.</param>
         /// <param name="dataContext">The context the outer query was bound with.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public AdoClrCorrelationDataContextBuilder(ClrEnumerableRelImplementor implementor, Expression dataContext)
+        public AdoClrCorrelationDataContextBuilder(ClrEnumerableRelImplementor implementor, Expression dataContext) :
+            this(
+                (implementor ?? throw new ArgumentNullException(nameof(implementor))).GetCorrelVariableGetter,
+                implementor.Translator,
+                dataContext)
         {
-            _implementor = implementor ?? throw new ArgumentNullException(nameof(implementor));
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="implementor">The implementor of the plan the correlation variables are registered on.</param>
+        /// <param name="dataContext">The context the outer query was bound with.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public AdoClrCorrelationDataContextBuilder(ClrAsyncEnumerableRelImplementor implementor, Expression dataContext) :
+            this(
+                (implementor ?? throw new ArgumentNullException(nameof(implementor))).GetCorrelVariableGetter,
+                implementor.Translator,
+                dataContext)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="correlVariableGetter">Answers the getter a correlation variable was registered with.</param>
+        /// <param name="translator">Turns the getter's linq4j field read into an expression.</param>
+        /// <param name="dataContext">The context the outer query was bound with.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        AdoClrCorrelationDataContextBuilder(Func<string, RexToLixTranslator.InputGetter> correlVariableGetter, LixToClrTranslator translator, Expression dataContext)
+        {
+            _correlVariableGetter = correlVariableGetter ?? throw new ArgumentNullException(nameof(correlVariableGetter));
+            _translator = translator ?? throw new ArgumentNullException(nameof(translator));
             _dataContext = dataContext ?? throw new ArgumentNullException(nameof(dataContext));
         }
 
@@ -56,9 +97,9 @@ namespace Apache.Calcite.Adapter.AdoNet
 
             // the getter reads the field as linq4j and declares into the block it was created with, not one
             // passed to it, so there is nothing for a block of this builder's to receive
-            var field = _implementor.GetCorrelVariableGetter(id.getName()).field(null, ordinal, type);
+            var field = _correlVariableGetter(id.getName()).field(null, ordinal, type);
 
-            _parameters.Add(_implementor.Translator.Translate(field));
+            _parameters.Add(_translator.Translate(field));
             return offset++;
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoDataSource.cs
@@ -1,4 +1,6 @@
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 
@@ -10,8 +12,9 @@ namespace Apache.Calcite.Adapter.AdoNet
     /// </summary>
     /// <remarks>
     /// Implement this class to connect Calcite's ADO.NET adapter to a specific data source.
-    /// The adapter calls <see cref="OpenConnection"/> for each query it needs to execute and
-    /// <see cref="Metadata"/> to discover schemas, tables, and column definitions at planning time.
+    /// The adapter calls <see cref="OpenConnection"/>, or <see cref="OpenConnectionAsync"/> where the plan
+    /// is asynchronous, for each query it needs to execute, and <see cref="Metadata"/> to discover schemas,
+    /// tables, and column definitions at planning time.
     /// </remarks>
     public abstract class AdoDataSource
     {
@@ -21,6 +24,23 @@ namespace Apache.Calcite.Adapter.AdoNet
         /// </summary>
         /// <returns>An open <see cref="DbConnection"/> ready for query execution.</returns>
         public abstract DbConnection OpenConnection();
+
+        /// <summary>
+        /// Opens a new connection to the underlying data source, without blocking.
+        /// </summary>
+        /// <param name="cancellationToken">Abandons the attempt.</param>
+        /// <returns>An open <see cref="DbConnection"/> ready for query execution.</returns>
+        /// <remarks>
+        /// What a plan of <c>ClrAsyncEnumerableConvention</c> opens its connection by. The default blocks on
+        /// <see cref="OpenConnection"/>, so a source written before this member still answers; a source over
+        /// a provider that opens asynchronously should override it, as both sources here do.
+        /// </remarks>
+        public virtual ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return new ValueTask<DbConnection>(OpenConnection());
+        }
 
         /// <summary>
         /// Gets the connection string used to open connections to the underlying data source.

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoRules.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoRules.cs
@@ -56,6 +56,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             yield return AdoToEnumerableConverterRule.Create(convention);
             yield return AdoToClrEnumerableConverterRule.Create(convention);
+            yield return AdoToClrAsyncEnumerableConverterRule.Create(convention);
             yield return AdoJoinRule.Create(convention);
             yield return AdoProjectRule.Create(convention);
             yield return AdoFilterRule.Create(convention);
@@ -77,6 +78,7 @@ namespace Apache.Calcite.Adapter.AdoNet
         {
             yield return AdoToEnumerableConverterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoToClrEnumerableConverterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
+            yield return AdoToClrAsyncEnumerableConverterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoJoinRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoProjectRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();
             yield return AdoFilterRule.Create(convention).config.withRelBuilderFactory(relBuilderFactory).toRule();

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSequences.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSequences.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Runtime.CompilerServices;
 using System.Threading;
+
 using Apache.Calcite.Extensions.Adapter.Enumerable;
+using Apache.Calcite.Extensions.Runtime;
 
 namespace Apache.Calcite.Adapter.AdoNet
 {
@@ -18,9 +19,9 @@ namespace Apache.Calcite.Adapter.AdoNet
     /// reads its rows without a linq4j enumerator between the reader and the operator above it.
     ///
     /// <para><see cref="ReadAsync{TRow}"/> is the same query for a plan of
-    /// <c>ClrAsyncEnumerableConvention</c>, over <c>OpenConnectionAsync</c>, <c>ExecuteReaderAsync</c> and
-    /// <c>ReadAsync</c>. This is the one leaf in a plan with real network I/O to suspend on, which is why it
-    /// has an asynchronous side at all when nothing else in the adapter does.</para>
+    /// <c>ClrAsyncEnumerableConvention</c>, reading its rows through <c>DbDataReader.ReadAsync</c>. This is
+    /// the one leaf in a plan with real network I/O to suspend on, which is why it has an asynchronous side
+    /// at all when nothing else in the adapter does.</para>
     /// </remarks>
     public static class AdoSequences
     {
@@ -42,30 +43,103 @@ namespace Apache.Calcite.Adapter.AdoNet
             ArgumentNullException.ThrowIfNull(sql);
             ArgumentNullException.ThrowIfNull(rowBuilder);
 
-            DbConnection? connection = null;
-            DbCommand? command = null;
-            DbDataReader? reader = null;
+            Execute(dataSource, sql, enricher, out var connection, out var command, out var reader);
+
+            return Rows(connection, command, reader, rowBuilder);
+        }
+
+        /// <summary>
+        /// Executes a query and returns its rows, reading each without blocking a thread.
+        /// </summary>
+        /// <param name="dataSource">The source to open a connection against.</param>
+        /// <param name="sql">The statement to execute.</param>
+        /// <param name="rowBuilder">Builds one row from the reader's current position.</param>
+        /// <param name="enricher">Fills the command's parameters, or <see langword="null"/> where it has
+        /// none.</param>
+        /// <param name="cancellationToken">Unused. Every generated call site passes <c>default</c>, as it
+        /// does for every operator of this convention; the token that reaches the provider is the one the
+        /// consumer hands <c>GetAsyncEnumerator</c>, and the parameter is declared so that the operator ends
+        /// in one.</param>
+        /// <returns>The rows, read as the query is enumerated.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="AdoCalciteException">The query could not be executed.</exception>
+        /// <remarks>
+        /// <see cref="Read{TRow}"/> reading its rows through <c>ReadAsync</c>. The statement, the enricher
+        /// and the row builder are the same, and a row is built from the reader synchronously in both, there
+        /// being nothing in reading a materialized row to await.
+        ///
+        /// <para><b>The statement is sent at <c>GetAsyncEnumerator</c>, and sent synchronously.</b> That is
+        /// where this convention puts acquisition — linq4j acquires inside <c>enumerator()</c>, and
+        /// <c>AcquisitionTimingTests</c> holds that the whole cascade runs there — and
+        /// <c>GetAsyncEnumerator</c> cannot await, so acquisition-time work is synchronous work, exactly as
+        /// it is for a table whose <c>ScanAsync</c> opens something before returning its sequence.
+        /// <c>CalciteSession</c> calls <c>GetAsyncEnumerator</c> inside <c>ExecuteReaderAsync</c>, so a
+        /// statement the provider rejects fails from the call that executed it rather than from the first
+        /// <c>ReadAsync</c> — which is what an ADO.NET consumer expects, and what a leaf that opened on its
+        /// first <c>MoveNextAsync</c> could not give.</para>
+        ///
+        /// <para><b>So connecting and executing block a thread and only the rows do not.</b> That is the
+        /// trade this convention's acquisition model imposes, and it is the whole of what is left: the row
+        /// loop is where a query spends its time. Making the connect asynchronous as well would mean
+        /// awaiting it somewhere, and the only place earlier than the first row is
+        /// <c>ExecuteReaderAsync</c> itself — which <c>ShouldReadNothingUntilTheFirstRead</c> and
+        /// <c>AcquisitionTimingTests</c> deliberately hold to reading nothing.</para>
+        /// </remarks>
+        public static IAsyncEnumerable<TRow> ReadAsync<TRow>(AdoDataSource dataSource, string sql, Func<DbDataReader, TRow> rowBuilder, DbCommandEnricher? enricher, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(dataSource);
+            ArgumentNullException.ThrowIfNull(sql);
+            ArgumentNullException.ThrowIfNull(rowBuilder);
+
+            // the factory is where linq4j's enumerator() is, and the owner disposes what it acquired whether
+            // or not a row was ever read -- an async iterator that never moved runs none of its finally
+            // blocks, so the row loop below cannot be trusted with them
+            return new ClrAsyncEnumerable<TRow>(token =>
+            {
+                Execute(dataSource, sql, enricher, out var connection, out var command, out var reader);
+
+                return new AcquiredAsyncEnumerator<TRow>(RowsAsync(reader, rowBuilder, token), reader, command, connection);
+            });
+        }
+
+        /// <summary>
+        /// Opens a connection, fills the command and executes the statement.
+        /// </summary>
+        /// <param name="dataSource"></param>
+        /// <param name="sql"></param>
+        /// <param name="enricher"></param>
+        /// <param name="connection"></param>
+        /// <param name="command"></param>
+        /// <param name="reader"></param>
+        /// <exception cref="AdoCalciteException">The query could not be executed.</exception>
+        /// <remarks>
+        /// Shared by both sequences, which acquire the same way and differ only in how they read a row.
+        /// </remarks>
+        static void Execute(AdoDataSource dataSource, string sql, DbCommandEnricher? enricher, out DbConnection connection, out DbCommand command, out DbDataReader reader)
+        {
+            DbConnection? opened = null;
+            DbCommand? created = null;
 
             try
             {
-                connection = dataSource.OpenConnection();
-                command = connection.CreateCommand();
-                command.CommandText = sql;
-                enricher?.Enrich(command);
-                reader = command.ExecuteReader();
+                opened = dataSource.OpenConnection();
+                created = opened.CreateCommand();
+                created.CommandText = sql;
+                enricher?.Enrich(created);
+
+                connection = opened;
+                command = created;
+                reader = created.ExecuteReader();
             }
             catch (DbException e)
             {
                 // what was opened before the failure is nobody else's to close: the sequence that would have
                 // owned it is never returned
-                reader?.Dispose();
-                command?.Dispose();
-                connection?.Dispose();
+                created?.Dispose();
+                opened?.Dispose();
 
                 throw new AdoCalciteException("Exception while enumerating query.", e);
             }
-
-            return Rows(connection, command, reader, rowBuilder);
         }
 
         /// <summary>
@@ -88,85 +162,16 @@ namespace Apache.Calcite.Adapter.AdoNet
         }
 
         /// <summary>
-        /// Executes a query and returns its rows, without blocking a thread on the provider.
+        /// Yields the reader's rows, over an already executed reader the owner will close.
         /// </summary>
-        /// <param name="dataSource">The source to open a connection against.</param>
-        /// <param name="sql">The statement to execute.</param>
-        /// <param name="rowBuilder">Builds one row from the reader's current position.</param>
-        /// <param name="enricher">Fills the command's parameters, or <see langword="null"/> where it has
-        /// none.</param>
-        /// <param name="cancellationToken">Abandons the query. Every generated call site passes
-        /// <c>default</c> for this; the token that reaches the provider is the one the consumer hands
-        /// <c>GetAsyncEnumerator</c>.</param>
-        /// <returns>The rows, read as the query is enumerated.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="AdoCalciteException">The query could not be executed.</exception>
-        /// <remarks>
-        /// <see cref="Read{TRow}"/> over <c>OpenConnectionAsync</c>, <c>ExecuteReaderAsync</c> and
-        /// <c>ReadAsync</c>. The statement, the enricher and the row builder are the same; a row is built
-        /// from the reader synchronously in both, there being nothing in reading a materialized row to
-        /// await.
-        ///
-        /// <para><b>Forced by the CLR:</b> <see cref="Read{TRow}"/> opens the connection and executes the
-        /// statement when it is called, and the rest of the convention's leaves acquire at
-        /// <c>GetAsyncEnumerator</c>. Neither is available here — a method returning an
-        /// <see cref="IAsyncEnumerable{T}"/> cannot await before it returns, and neither can
-        /// <c>GetAsyncEnumerator</c> — so the connection is opened and the statement executed on the first
-        /// <c>MoveNextAsync</c>. Nothing observes the difference but the moment the provider is first
-        /// spoken to.</para>
-        /// </remarks>
-        public static IAsyncEnumerable<TRow> ReadAsync<TRow>(AdoDataSource dataSource, string sql, Func<DbDataReader, TRow> rowBuilder, DbCommandEnricher? enricher, CancellationToken cancellationToken = default)
-        {
-            ArgumentNullException.ThrowIfNull(dataSource);
-            ArgumentNullException.ThrowIfNull(sql);
-            ArgumentNullException.ThrowIfNull(rowBuilder);
-
-            return RowsAsync(dataSource, sql, rowBuilder, enricher, cancellationToken);
-        }
-
-        /// <summary>
-        /// Opens, executes, yields the reader's rows, and closes what was opened for them.
-        /// </summary>
-        /// <param name="dataSource"></param>
-        /// <param name="sql"></param>
+        /// <param name="reader"></param>
         /// <param name="rowBuilder"></param>
-        /// <param name="enricher"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        static async IAsyncEnumerable<TRow> RowsAsync<TRow>(AdoDataSource dataSource, string sql, Func<DbDataReader, TRow> rowBuilder, DbCommandEnricher? enricher, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        static async IAsyncEnumerator<TRow> RowsAsync<TRow>(DbDataReader reader, Func<DbDataReader, TRow> rowBuilder, CancellationToken cancellationToken)
         {
-            DbConnection? connection = null;
-            DbCommand? command = null;
-            DbDataReader? reader = null;
-
-            try
-            {
-                connection = await dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-                command = connection.CreateCommand();
-                command.CommandText = sql;
-                enricher?.Enrich(command);
-                reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (DbException e)
-            {
-                // as in Read: the loop below owns these once it is entered, and it is not entered
-                if (reader is not null)
-                    await reader.DisposeAsync().ConfigureAwait(false);
-                if (command is not null)
-                    await command.DisposeAsync().ConfigureAwait(false);
-                if (connection is not null)
-                    await connection.DisposeAsync().ConfigureAwait(false);
-
-                throw new AdoCalciteException("Exception while enumerating query.", e);
-            }
-
-            await using (connection)
-            await using (command)
-            await using (reader)
-            {
-                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-                    yield return rowBuilder(reader);
-            }
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                yield return rowBuilder(reader);
         }
 
     }

--- a/src/Apache.Calcite.Adapter.AdoNet/AdoSequences.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/AdoSequences.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Apache.Calcite.Extensions.Adapter.Enumerable;
 
 namespace Apache.Calcite.Adapter.AdoNet
@@ -14,6 +16,11 @@ namespace Apache.Calcite.Adapter.AdoNet
     /// <c>ClrEnumerableConvention</c>: the same connection, command and enricher, and the same row builder,
     /// yielding an <see cref="IEnumerable{T}"/> rather than a linq4j <c>Enumerable</c>. A plan that ends here
     /// reads its rows without a linq4j enumerator between the reader and the operator above it.
+    ///
+    /// <para><see cref="ReadAsync{TRow}"/> is the same query for a plan of
+    /// <c>ClrAsyncEnumerableConvention</c>, over <c>OpenConnectionAsync</c>, <c>ExecuteReaderAsync</c> and
+    /// <c>ReadAsync</c>. This is the one leaf in a plan with real network I/O to suspend on, which is why it
+    /// has an asynchronous side at all when nothing else in the adapter does.</para>
     /// </remarks>
     public static class AdoSequences
     {
@@ -35,9 +42,9 @@ namespace Apache.Calcite.Adapter.AdoNet
             ArgumentNullException.ThrowIfNull(sql);
             ArgumentNullException.ThrowIfNull(rowBuilder);
 
-            DbConnection connection;
-            DbCommand command;
-            DbDataReader reader;
+            DbConnection? connection = null;
+            DbCommand? command = null;
+            DbDataReader? reader = null;
 
             try
             {
@@ -49,6 +56,12 @@ namespace Apache.Calcite.Adapter.AdoNet
             }
             catch (DbException e)
             {
+                // what was opened before the failure is nobody else's to close: the sequence that would have
+                // owned it is never returned
+                reader?.Dispose();
+                command?.Dispose();
+                connection?.Dispose();
+
                 throw new AdoCalciteException("Exception while enumerating query.", e);
             }
 
@@ -70,6 +83,88 @@ namespace Apache.Calcite.Adapter.AdoNet
             using (reader)
             {
                 while (reader.Read())
+                    yield return rowBuilder(reader);
+            }
+        }
+
+        /// <summary>
+        /// Executes a query and returns its rows, without blocking a thread on the provider.
+        /// </summary>
+        /// <param name="dataSource">The source to open a connection against.</param>
+        /// <param name="sql">The statement to execute.</param>
+        /// <param name="rowBuilder">Builds one row from the reader's current position.</param>
+        /// <param name="enricher">Fills the command's parameters, or <see langword="null"/> where it has
+        /// none.</param>
+        /// <param name="cancellationToken">Abandons the query. Every generated call site passes
+        /// <c>default</c> for this; the token that reaches the provider is the one the consumer hands
+        /// <c>GetAsyncEnumerator</c>.</param>
+        /// <returns>The rows, read as the query is enumerated.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="AdoCalciteException">The query could not be executed.</exception>
+        /// <remarks>
+        /// <see cref="Read{TRow}"/> over <c>OpenConnectionAsync</c>, <c>ExecuteReaderAsync</c> and
+        /// <c>ReadAsync</c>. The statement, the enricher and the row builder are the same; a row is built
+        /// from the reader synchronously in both, there being nothing in reading a materialized row to
+        /// await.
+        ///
+        /// <para><b>Forced by the CLR:</b> <see cref="Read{TRow}"/> opens the connection and executes the
+        /// statement when it is called, and the rest of the convention's leaves acquire at
+        /// <c>GetAsyncEnumerator</c>. Neither is available here — a method returning an
+        /// <see cref="IAsyncEnumerable{T}"/> cannot await before it returns, and neither can
+        /// <c>GetAsyncEnumerator</c> — so the connection is opened and the statement executed on the first
+        /// <c>MoveNextAsync</c>. Nothing observes the difference but the moment the provider is first
+        /// spoken to.</para>
+        /// </remarks>
+        public static IAsyncEnumerable<TRow> ReadAsync<TRow>(AdoDataSource dataSource, string sql, Func<DbDataReader, TRow> rowBuilder, DbCommandEnricher? enricher, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(dataSource);
+            ArgumentNullException.ThrowIfNull(sql);
+            ArgumentNullException.ThrowIfNull(rowBuilder);
+
+            return RowsAsync(dataSource, sql, rowBuilder, enricher, cancellationToken);
+        }
+
+        /// <summary>
+        /// Opens, executes, yields the reader's rows, and closes what was opened for them.
+        /// </summary>
+        /// <param name="dataSource"></param>
+        /// <param name="sql"></param>
+        /// <param name="rowBuilder"></param>
+        /// <param name="enricher"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        static async IAsyncEnumerable<TRow> RowsAsync<TRow>(AdoDataSource dataSource, string sql, Func<DbDataReader, TRow> rowBuilder, DbCommandEnricher? enricher, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            DbConnection? connection = null;
+            DbCommand? command = null;
+            DbDataReader? reader = null;
+
+            try
+            {
+                connection = await dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+                command = connection.CreateCommand();
+                command.CommandText = sql;
+                enricher?.Enrich(command);
+                reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbException e)
+            {
+                // as in Read: the loop below owns these once it is entered, and it is not entered
+                if (reader is not null)
+                    await reader.DisposeAsync().ConfigureAwait(false);
+                if (command is not null)
+                    await command.DisposeAsync().ConfigureAwait(false);
+                if (connection is not null)
+                    await connection.DisposeAsync().ConfigureAwait(false);
+
+                throw new AdoCalciteException("Exception while enumerating query.", e);
+            }
+
+            await using (connection)
+            await using (command)
+            await using (reader)
+            {
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
                     yield return rowBuilder(reader);
             }
         }

--- a/src/Apache.Calcite.Adapter.AdoNet/DbDataSourceAdoDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/DbDataSourceAdoDataSource.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 
@@ -34,6 +36,9 @@ namespace Apache.Calcite.Adapter.AdoNet
 
         /// <inheritdoc />
         public override DbConnection OpenConnection() => _dataSource.OpenConnection();
+
+        /// <inheritdoc />
+        public override ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default) => _dataSource.OpenConnectionAsync(cancellationToken);
 
         /// <inheritdoc />
         public override string ConnectionString => _dataSource.ConnectionString;

--- a/src/Apache.Calcite.Adapter.AdoNet/DbProviderAdoDataSource.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/DbProviderAdoDataSource.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Apache.Calcite.Adapter.AdoNet.Metadata;
 
@@ -41,6 +43,15 @@ namespace Apache.Calcite.Adapter.AdoNet
             var cnn = _factory.CreateConnection() ?? throw new AdoCalciteException("Null result creating connection.");
             cnn.ConnectionString = _connectionString;
             cnn.Open();
+            return cnn;
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var cnn = _factory.CreateConnection() ?? throw new AdoCalciteException("Null result creating connection.");
+            cnn.ConnectionString = _connectionString;
+            await cnn.OpenAsync(cancellationToken).ConfigureAwait(false);
             return cnn;
         }
 

--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -178,7 +178,7 @@ The adapter provides Calcite conversion rules for these operators, which become 
 - `AdoValues` — constant value sets
 - `AdoTableScan` — the scan itself
 
-Anything that cannot be pushed down runs in-process. Converters exist into each of the three execution conventions — `AdoToClrAsyncEnumerableConverter` and `AdoToClrEnumerableConverter` for the two compiled-.NET conventions that `Apache.Calcite.Data` plans into, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under any of them. The asynchronous converter reads its rows through `ExecuteReaderAsync` and `ReadAsync`, so an asynchronous plan does not block a thread on the provider; it is the route a connection takes by default.
+Anything that cannot be pushed down runs in-process. Converters exist into each of the three execution conventions — `AdoToClrAsyncEnumerableConverter` and `AdoToClrEnumerableConverter` for the two compiled-.NET conventions that `Apache.Calcite.Data` plans into, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under any of them. The asynchronous converter reads its rows through `DbDataReader.ReadAsync`, so an asynchronous plan does not park a thread per row; it is the route a connection takes by default. The statement itself is still sent when the plan is executed, which is where this convention acquires.
 
 Correlated sub-queries are supported: `AdoCorrelationDataContext` carries the outer row's values into the inner query.
 

--- a/src/Apache.Calcite.Adapter.AdoNet/README.md
+++ b/src/Apache.Calcite.Adapter.AdoNet/README.md
@@ -178,7 +178,7 @@ The adapter provides Calcite conversion rules for these operators, which become 
 - `AdoValues` — constant value sets
 - `AdoTableScan` — the scan itself
 
-Anything that cannot be pushed down runs in-process. Converters exist into both execution conventions — `AdoToClrEnumerableConverter` for the compiled-.NET convention that `Apache.Calcite.Data` plans into, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under either.
+Anything that cannot be pushed down runs in-process. Converters exist into each of the three execution conventions — `AdoToClrAsyncEnumerableConverter` and `AdoToClrEnumerableConverter` for the two compiled-.NET conventions that `Apache.Calcite.Data` plans into, and `AdoToEnumerableConverter` for Calcite's own — so the adapter works under any of them. The asynchronous converter reads its rows through `ExecuteReaderAsync` and `ReadAsync`, so an asynchronous plan does not block a thread on the provider; it is the route a connection takes by default.
 
 Correlated sub-queries are supported: `AdoCorrelationDataContext` carries the outer row's values into the inner query.
 

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverter.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq.Expressions;
+
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+using Apache.Calcite.Extensions.Adapter.Enumerable;
+
+using org.apache.calcite;
+using org.apache.calcite.adapter.java;
+using org.apache.calcite.plan;
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+using org.apache.calcite.runtime;
+using org.apache.calcite.schema;
+
+namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
+{
+
+    /// <summary>
+    /// Relational operator that converts a tree of <see cref="AdoConvention"/> nodes into a
+    /// <see cref="ClrAsyncEnumerableConvention"/> result by executing the generated SQL against the
+    /// underlying ADO.NET data source.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of <see cref="AdoToClrEnumerableConverter"/>, and the same node in every way but the
+    /// sequence: the SQL, the parameter enrichment and the row builder are that node's own code, called from
+    /// here, and what differs is that the rows come from <see cref="AdoSequences.ReadAsync{TRow}"/> rather
+    /// than <see cref="AdoSequences.Read{TRow}"/>.
+    ///
+    /// <para><b>Why the adapter has this and Calcite's JDBC adapter has no counterpart.</b> JDBC has no
+    /// asynchronous API; ADO.NET does. Without this node an asynchronous plan reaches the adapter through a
+    /// converter over a synchronous leaf, which is honest for every other sub-plan — nothing under one
+    /// suspends — and wrong for this one. The ADO leaf is the single place in a plan with real network I/O
+    /// to wait on, so a plan whose whole purpose is not to hold a thread would have held one for every
+    /// row.</para>
+    ///
+    /// <para>Cancellation is the convention's: the token the consumer hands <c>GetAsyncEnumerator</c> is
+    /// what reaches <c>ExecuteReaderAsync</c> and <c>ReadAsync</c>, and the tree passes <c>default</c>, as
+    /// it does for every other operator. Calcite's own channel,
+    /// <c>DataContext.Variable.CANCEL_FLAG</c>, is read by nothing in this adapter and is not read
+    /// here.</para>
+    /// </remarks>
+    public class AdoToClrAsyncEnumerableConverter : ConverterImpl, ClrAsyncEnumerableRel
+    {
+
+        static readonly System.Reflection.MethodInfo ReadAsyncMethod = typeof(AdoSequences).GetMethod(nameof(AdoSequences.ReadAsync))
+            ?? throw new InvalidOperationException($"'{nameof(AdoSequences.ReadAsync)}' is missing from {nameof(AdoSequences)}.");
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <param name="cluster"></param>
+        /// <param name="traits"></param>
+        /// <param name="input"></param>
+        public AdoToClrAsyncEnumerableConverter(RelOptCluster cluster, RelTraitSet traits, RelNode input) :
+            base(cluster, ConventionTraitDef.INSTANCE, traits, input)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode copy(RelTraitSet traitSet, java.util.List inputs)
+        {
+            return new AdoToClrAsyncEnumerableConverter(getCluster(), traitSet, (RelNode)sole(inputs));
+        }
+
+        /// <inheritdoc />
+        public ClrAsyncEnumerableResult Implement(ClrAsyncEnumerableRelImplementor implementor, ClrEnumerablePrefer pref)
+        {
+            if (getInput() is not AdoRel self)
+                throw new AdoCalciteException("Unsupported input type.");
+
+            var physType = ClrPhysTypeImpl.Of(implementor.TypeFactory, getRowType(), pref.PreferArray());
+            var rowType = physType.RowType;
+
+            if (self.getConvention() is not AdoConvention convention)
+                throw new AdoCalciteException($"getConvention() is null for {self}.");
+
+            var dataContextBuilder = new AdoClrCorrelationDataContextBuilder(implementor, implementor.Root);
+
+            var writer = AdoToClrEnumerableConverter.GenerateSql(convention, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder, self, out var sqlImplementor);
+            var parameters = writer.Indexes;
+            var parameterTypeNames = AdoToEnumerableConverter.GetParameterTypeNames(sqlImplementor, parameters);
+
+            var sql = writer.toSqlString().getSql();
+            Hook.QUERY_PLAN.run(sql);
+
+            // the schema SPI defines a convention's expression as linq4j, so this is the one thing here that
+            // arrives as a linq4j tree, and it is translated where it is produced rather than composed into
+            // anything first. Everything else this node builds is an expression tree from the start.
+            var dataSource = implementor.Translator.Translate(Schemas.unwrap(convention.Expression, typeof(AdoDataSource)));
+
+            // a correlated sub-query leaves a parameter per correlation variable in the SQL, and the values
+            // live on the context the builder closed over the outer row. Without the enricher the command is
+            // handed to the provider unfilled.
+            var enricher = parameters.isEmpty()
+                ? (Expression)Expression.Constant(null, typeof(DbCommandEnricher))
+                : Expression.Call(null, AdoToClrEnumerableConverter.CreateEnricherMethod, dataSource, Expression.Constant(parameters), Expression.Constant(parameterTypeNames), dataContextBuilder.Build());
+
+            // through ClrAsyncBuiltInMethod.Call rather than Expression.Call, because the operator ends in a
+            // CancellationToken like every other one of this convention, and that is what appends the
+            // default the [EnumeratorCancellation] attribute reads
+            return implementor.Result(physType,
+                ClrAsyncBuiltInMethod.Call(
+                    ReadAsyncMethod.MakeGenericMethod(rowType),
+                    dataSource,
+                    Expression.Constant(sql),
+                    AdoToClrEnumerableConverter.RowBuilder(physType, rowType),
+                    enricher));
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverter.cs
@@ -33,11 +33,16 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
     /// to wait on, so a plan whose whole purpose is not to hold a thread would have held one for every
     /// row.</para>
     ///
+    /// <para><b>What is asynchronous here is the row loop, and only that.</b> The statement is still sent
+    /// at <c>GetAsyncEnumerator</c>, synchronously, because that is where this convention acquires and
+    /// <c>GetAsyncEnumerator</c> cannot await — <see cref="AdoSequences.ReadAsync{TRow}"/> says what that
+    /// buys and what it costs. The row loop is where a query spends its time, and it is the part that no
+    /// longer parks a thread.</para>
+    ///
     /// <para>Cancellation is the convention's: the token the consumer hands <c>GetAsyncEnumerator</c> is
-    /// what reaches <c>ExecuteReaderAsync</c> and <c>ReadAsync</c>, and the tree passes <c>default</c>, as
-    /// it does for every other operator. Calcite's own channel,
-    /// <c>DataContext.Variable.CANCEL_FLAG</c>, is read by nothing in this adapter and is not read
-    /// here.</para>
+    /// what reaches <c>ReadAsync</c>, and the tree passes <c>default</c>, as it does for every other
+    /// operator. Calcite's own channel, <c>DataContext.Variable.CANCEL_FLAG</c>, is read by nothing in this
+    /// adapter and is not read here.</para>
     /// </remarks>
     public class AdoToClrAsyncEnumerableConverter : ConverterImpl, ClrAsyncEnumerableRel
     {

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverterRule.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrAsyncEnumerableConverterRule.cs
@@ -1,0 +1,57 @@
+using Apache.Calcite.Extensions;
+using Apache.Calcite.Extensions.Adapter.AsyncEnumerable;
+
+using java.util.function;
+
+using org.apache.calcite.rel;
+using org.apache.calcite.rel.convert;
+
+namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
+{
+
+    /// <summary>
+    /// Rule to convert a relational expression from <see cref="AdoConvention"/> to
+    /// <see cref="ClrAsyncEnumerableConvention"/>.
+    /// </summary>
+    /// <remarks>
+    /// The third route out of the adapter, beside <see cref="AdoToEnumerableConverterRule"/> and
+    /// <see cref="AdoToClrEnumerableConverterRule"/>. All three are registered, so a plan whose root is asked
+    /// for in any of the conventions has a route out; which one a query uses is the planner's choice, and a
+    /// plan ending in <see cref="ClrAsyncEnumerableConvention"/> reaches it without a second converter over a
+    /// leaf that would have blocked.
+    /// </remarks>
+    public class AdoToClrAsyncEnumerableConverterRule : ConverterRule
+    {
+
+        /// <summary>
+        /// Creates a rule instance bound to the specified <see cref="AdoConvention"/>.
+        /// </summary>
+        /// <param name="convention">The ADO convention whose nodes will be converted.</param>
+        /// <returns></returns>
+        public static AdoToClrAsyncEnumerableConverterRule Create(AdoConvention convention)
+        {
+            return (AdoToClrAsyncEnumerableConverterRule)Config.INSTANCE
+                .withConversion(typeof(RelNode), convention, ClrAsyncEnumerableConvention.Instance, "AdoToClrAsyncEnumerableConverterRule")
+                .withRuleFactory(new DelegateFunction<Config, AdoToClrAsyncEnumerableConverterRule>(c => new AdoToClrAsyncEnumerableConverterRule(c)))
+                .toRule(typeof(AdoToClrAsyncEnumerableConverterRule));
+        }
+
+        /// <summary>
+        /// Initializes a new instance using the supplied rule configuration.
+        /// </summary>
+        /// <param name="config">The rule configuration produced by <see cref="Create"/>.</param>
+        public AdoToClrAsyncEnumerableConverterRule(Config config) :
+            base(config)
+        {
+
+        }
+
+        /// <inheritdoc />
+        public override RelNode? convert(RelNode rel)
+        {
+            return new AdoToClrAsyncEnumerableConverter(rel.getCluster(), rel.getTraitSet().replace(getOutConvention()), rel);
+        }
+
+    }
+
+}

--- a/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
+++ b/src/Apache.Calcite.Adapter.AdoNet/Rel/Convert/AdoToClrEnumerableConverter.cs
@@ -45,10 +45,10 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         static readonly System.Reflection.MethodInfo ReadMethod = typeof(AdoSequences).GetMethod(nameof(AdoSequences.Read))
             ?? throw new InvalidOperationException($"'{nameof(AdoSequences.Read)}' is missing from {nameof(AdoSequences)}.");
 
-        static readonly System.Reflection.MethodInfo GetDbReaderValueMethod = typeof(AdoReaderUtil).GetMethod(nameof(AdoReaderUtil.GetDbReaderValue), [typeof(DbDataReader), typeof(int), typeof(SqlTypeName)])
+        internal static readonly System.Reflection.MethodInfo GetDbReaderValueMethod = typeof(AdoReaderUtil).GetMethod(nameof(AdoReaderUtil.GetDbReaderValue), [typeof(DbDataReader), typeof(int), typeof(SqlTypeName)])
             ?? throw new InvalidOperationException($"'{nameof(AdoReaderUtil.GetDbReaderValue)}' is missing from {nameof(AdoReaderUtil)}.");
 
-        static readonly System.Reflection.MethodInfo CreateEnricherMethod = typeof(AdoEnumerable).GetMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(java.util.List), typeof(DataContext)])
+        internal static readonly System.Reflection.MethodInfo CreateEnricherMethod = typeof(AdoEnumerable).GetMethod(nameof(AdoEnumerable.CreateEnricher), [typeof(AdoDataSource), typeof(java.util.List), typeof(java.util.List), typeof(DataContext)])
             ?? throw new InvalidOperationException($"'{nameof(AdoEnumerable.CreateEnricher)}' is missing from {nameof(AdoEnumerable)}.");
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
 
             var dataContextBuilder = new AdoClrCorrelationDataContextBuilder(implementor, implementor.Root);
 
-            var writer = GenerateSql(convention, dataContextBuilder, self, out var sqlImplementor);
+            var writer = GenerateSql(convention, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder, self, out var sqlImplementor);
             var parameters = writer.Indexes;
             var parameterTypeNames = AdoToEnumerableConverter.GetParameterTypeNames(sqlImplementor, parameters);
 
@@ -122,11 +122,15 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         /// <see cref="AdoToEnumerableConverter"/> decides it, because <c>JavaRowFormat.optimize</c> has
         /// already told the physical type the same thing: no field is a null, one field is the value itself,
         /// and only beyond that is a row an array.
+        ///
+        /// <para>Shared with <see cref="AdoToClrAsyncEnumerableConverter"/>, which builds the same delegate
+        /// against the same reader: a row is the same thing in both conventions and nothing about building
+        /// one from a materialized reader position awaits.</para>
         /// </remarks>
-        Expression RowBuilder(ClrPhysType physType, Type rowType)
+        internal static Expression RowBuilder(ClrPhysType physType, Type rowType)
         {
             var reader = Expression.Parameter(typeof(DbDataReader), "reader");
-            var fieldCount = getRowType().getFieldCount();
+            var fieldCount = physType.RelRowType.getFieldCount();
 
             Expression body;
             if (fieldCount == 0)
@@ -177,12 +181,17 @@ namespace Apache.Calcite.Adapter.AdoNet.Rel.Convert
         /// Generates the SQL string to implement the sequence.
         /// </summary>
         /// <param name="convention"></param>
+        /// <param name="typeFactory"></param>
         /// <param name="dataContextBuilder"></param>
         /// <param name="input"></param>
         /// <returns></returns>
-        AdoSqlWriter GenerateSql(AdoConvention convention, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input, out AdoImplementor implementor)
+        /// <remarks>
+        /// Shared with <see cref="AdoToClrAsyncEnumerableConverter"/>: the statement a subtree of the
+        /// adapter's convention becomes does not depend on how its rows are read.
+        /// </remarks>
+        internal static AdoSqlWriter GenerateSql(AdoConvention convention, JavaTypeFactory typeFactory, IAdoCorrelationDataContextBuilder dataContextBuilder, AdoRel input, out AdoImplementor implementor)
         {
-            implementor = new AdoImplementor(convention.Dialect, (JavaTypeFactory)getCluster().getTypeFactory(), dataContextBuilder);
+            implementor = new AdoImplementor(convention.Dialect, typeFactory, dataContextBuilder);
             var result = implementor.visitRoot(input);
 
             var writer = new AdoSqlWriter(convention.Dialect, convention.Syntax);


### PR DESCRIPTION
Closes #103.

`Apache.Calcite.Adapter.AdoNet` had two converters out of `AdoConvention` and neither was asynchronous, so a plan that had asked not to hold a thread reached the one leaf in it with real network I/O to wait on and blocked on the socket for every row. JDBC has no asynchronous API and upstream has nothing to port; ADO.NET has `DbDataReader.ReadAsync`, and the providers targeted here implement it natively.

## What is here

- **`AdoToClrAsyncEnumerableConverter` and its rule**, the counterpart of `AdoToClrEnumerableConverter`, over a new `AdoSequences.ReadAsync`. The SQL generation, the parameter enrichment and the row builder are that node's own code — now `internal static` and shared — because none of them depends on how the rows are read. The rule is registered beside the other two in `AdoRules.GetRules`, so all three conventions have a route out and which one a query uses stays the planner's choice.
- **`AdoClrCorrelationDataContextBuilder` now takes either Clr implementor.** A correlation variable is registered on the implementor implementing the plan and is unknown to every other, which is why the class exists; everything it touches is about a row, and a row is the same thing in both conventions, so one class serves both.
- **`Read` and `ReadAsync` share one `Execute`, which disposes what it opened when the statement fails.** `Read` did not, and the sequence that would have owned the connection is never returned.

The default plan for `SELECT empno, name FROM ADO.emps WHERE deptno = 10` was

```
EnumerableToClrAsyncEnumerableConverter
  AdoProject(...)
```

and is now

```
AdoToClrAsyncEnumerableConverter
  AdoProject(...)
```

## What is asynchronous, and what is not

**The row loop, and only the row loop.** The statement is still sent at `GetAsyncEnumerator`, synchronously.

That is where this convention acquires — linq4j acquires inside `enumerator()`, `AcquisitionTimingTests` holds that the whole cascade runs there, and `ClrAsyncEnumerableAdoNetTests` states outright that acquisition-time work is synchronous work because `GetAsyncEnumerator` cannot await. It also decides where a rejected statement surfaces, because `CalciteSession` calls `GetAsyncEnumerator` inside `ExecuteReaderAsync`.

The first draft of this branch opened and executed on the first `MoveNextAsync` instead, which is the only other thing an `IAsyncEnumerable`-returning method can do. Measured, that moved the failure:

| route | where a statement the source rejects surfaces |
|---|---|
| synchronous (`Synchronous=true`) | `ExecuteReader`, as `CalciteException` |
| asynchronous, before this branch | `ExecuteReaderAsync`, as `CalciteException` |
| asynchronous, first draft | first `ReadAsync`, as a bare `AdoCalciteException` |
| asynchronous, as merged | `ExecuteReaderAsync`, as `CalciteException` |

`ShouldFailFromExecuteRatherThanFromTheFirstRead` and `ShouldFailFromExecuteInSynchronousMode` hold that, and both fail against the first draft.

**So connecting and executing block a thread.** That is unchanged from before this branch — the old route reached `AdoEnumerable.enumerator()`, which opens and executes synchronously, inside the same `GetAsyncEnumerator` — so nothing regresses, and the row loop, where a query spends its time, no longer parks a thread.

Making the connect asynchronous as well means awaiting it somewhere earlier than the first row, and the only place is `ExecuteReaderAsync` itself. Priming one row there was written and reverted: it fails `ShouldReadNothingUntilTheFirstRead`, `ExecuteAsyncShouldAcquireTheLeafWithoutReading` and `AnAsynchronousSortShouldAcquireAtExecuteAndDrainAtTheFirstRead`, which pin the opposite promise deliberately. That is a change to the convention's execution contract rather than to this adapter, and it is not made here.

## The two decisions the issue asked for

- **Cancellation** is the convention's own: the token the consumer hands `GetAsyncEnumerator` reaches `ReadAsync`, and the tree passes `default` as it does for every other operator. `DataContext.Variable.CANCEL_FLAG` is still read by nothing in the adapter.
- **Connection lifetime** is unchanged: a plan opens a connection per enumeration, and the per-row correlated path still opens one per row.

## Tests

Six new tests in `AdoClrEnumerableTests`, and `ShouldCarryTheAdapterIntoTheAsyncConvention` rewritten to the plan above. A counting `AdoDataSource` records the connections a plan opened and closed, so `ShouldSendTheStatementAtAcquisition` pins the acquisition point directly rather than only the rows. `ShouldEnrichACorrelatedSubQueryOnTheAsyncPath` runs with `forceDecorrelate=false` and checks the correlate is still in the plan with `$cor0.DEPTNO` pushed into an `AdoFilter` before checking the rows, because otherwise it would prove nothing about the enricher.

`Apache.Calcite.Adapter.AdoNet.Tests` 494/494, `Apache.Calcite.Tests` 827/827, `Apache.Calcite.Data.Tests` 422/422, nothing skipped.
