### PR TITLE
Uncollect a column of type ANY

### DIFF
--- a/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableUncollect.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/AsyncEnumerable/ClrAsyncEnumerableUncollect.cs
@@ -26,7 +26,8 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
 
         /// <summary>
         /// Creates a <see cref="ClrAsyncEnumerableUncollect"/>. Each field of the input must be an array or a
-        /// multiset.
+        /// multiset, or the input must be the single column of type ANY that
+        /// <see cref="IsSingleAnyColumn"/> is about.
         /// </summary>
         /// <param name="traitSet"></param>
         /// <param name="input"></param>
@@ -69,33 +70,52 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
             org.apache.calcite.linq4j.tree.Expression? flatListForSingleItem = null;
 
             var fields = child.getRowType().getFieldList();
-            for (int i = 0; i < fields.size(); i++)
+            var ordinality = withOrdinality;
+
+            if (IsSingleAnyColumn(fields))
             {
-                var type = ((RelDataTypeField)fields.get(i)).getType();
+                // the same pair every non-struct element type emits below, which SqlFunctions.flatProduct
+                // answers with LIST_AS_ENUMERABLE: it reads the run-time value as a java.util.List and takes
+                // a null as the empty sequence, which is what UNNEST of a null array answers anyway
+                fieldCounts.add(java.lang.Integer.valueOf(-1));
+                inputTypes.add(SqlFunctions.FlatProductInputType.SCALAR);
 
-                if (type is MapSqlType)
+                // the ordinality goes with the row type rather than with the request, because that ANY branch
+                // of deriveUncollectRowType builds one column whatever WITH ORDINALITY said, as
+                // SqlUnnestOperator.inferReturnType does before it. An ordinal here would be a second value
+                // in a row the physical type has one field for.
+                ordinality = false;
+            }
+            else
+            {
+                for (int i = 0; i < fields.size(); i++)
                 {
-                    fieldCounts.add(java.lang.Integer.valueOf(2));
-                    inputTypes.add(SqlFunctions.FlatProductInputType.MAP);
-                    continue;
-                }
+                    var type = ((RelDataTypeField)fields.get(i)).getType();
 
-                var elementType = org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow(type);
-                if (elementType.isStruct() == false)
-                {
-                    fieldCounts.add(java.lang.Integer.valueOf(-1));
-                    inputTypes.add(SqlFunctions.FlatProductInputType.SCALAR);
-                    continue;
-                }
+                    if (type is MapSqlType)
+                    {
+                        fieldCounts.add(java.lang.Integer.valueOf(2));
+                        inputTypes.add(SqlFunctions.FlatProductInputType.MAP);
+                        continue;
+                    }
 
-                // CALCITE-4063: one field, itself a struct of one item, and no ordinality, means the result is
-                // a scalar rather than a list of one
-                if (elementType.getFieldCount() == 1 && fields.size() == 1 && withOrdinality == false)
-                    flatListForSingleItem = org.apache.calcite.linq4j.tree.Expressions.call(BuiltInMethod.FLAT_LIST.method);
-                else
-                {
-                    fieldCounts.add(java.lang.Integer.valueOf(elementType.getFieldCount()));
-                    inputTypes.add(SqlFunctions.FlatProductInputType.LIST);
+                    var elementType = org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow(type);
+                    if (elementType.isStruct() == false)
+                    {
+                        fieldCounts.add(java.lang.Integer.valueOf(-1));
+                        inputTypes.add(SqlFunctions.FlatProductInputType.SCALAR);
+                        continue;
+                    }
+
+                    // CALCITE-4063: one field, itself a struct of one item, and no ordinality, means the result is
+                    // a scalar rather than a list of one
+                    if (elementType.getFieldCount() == 1 && fields.size() == 1 && withOrdinality == false)
+                        flatListForSingleItem = org.apache.calcite.linq4j.tree.Expressions.call(BuiltInMethod.FLAT_LIST.method);
+                    else
+                    {
+                        fieldCounts.add(java.lang.Integer.valueOf(elementType.getFieldCount()));
+                        inputTypes.add(SqlFunctions.FlatProductInputType.LIST);
+                    }
                 }
             }
 
@@ -111,7 +131,7 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 ?? org.apache.calcite.linq4j.tree.Expressions.call(
                     BuiltInMethod.FLAT_PRODUCT.method,
                     org.apache.calcite.linq4j.tree.Expressions.constant(counts),
-                    org.apache.calcite.linq4j.tree.Expressions.constant(java.lang.Boolean.valueOf(withOrdinality)),
+                    org.apache.calcite.linq4j.tree.Expressions.constant(java.lang.Boolean.valueOf(ordinality)),
                     org.apache.calcite.linq4j.tree.Expressions.constant(types));
 
             var sourceType = result.PhysType.RowType;
@@ -121,6 +141,30 @@ namespace Apache.Calcite.Extensions.Adapter.AsyncEnumerable
                 ClrAsyncBuiltInMethod.Call(ClrAsyncBuiltInMethod.SelectMany.MakeGenericMethod(sourceType, rowType),
                     result.Expression,
                     ClrEnumUtils.Convert(implementor.Translator.Translate(lambda), typeof(org.apache.calcite.linq4j.function.Function1))));
+        }
+
+        /// <summary>
+        /// Whether the input is the one column of type ANY that <c>Uncollect.deriveUncollectRowType</c>
+        /// answers with a single ANY column of its own.
+        /// </summary>
+        /// <param name="fields">the input's fields</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Not a port, and an addition rather than a defect: <c>EnumerableUncollect</c> cannot implement this
+        /// shape either, and fails before a row is read — it asks
+        /// <c>NonNullableAccessors.getComponentTypeOrThrow</c> for an element type an ANY has not got, which
+        /// is a plan Calcite forms and then throws <c>componentType is null for ANY</c> over.
+        /// <see cref="ClrAnyAggImplementors"/> is the same argument for the aggregates, and says more about
+        /// why a column of type ANY is the ordinary case rather than an exotic one.
+        ///
+        /// <para>The test is <c>deriveUncollectRowType</c>'s own, which is what makes it exact rather than a
+        /// guess: one field and ANY is the only shape that reaches the branch, because two fields of which
+        /// one is ANY throws <c>unnestArgument</c> while the node is being built and never arrives here.</para>
+        /// </remarks>
+        static bool IsSingleAnyColumn(java.util.List fields)
+        {
+            return fields.size() == 1
+                && ((RelDataTypeField)fields.get(0)).getType().getSqlTypeName() == SqlTypeName.ANY;
         }
 
     }

--- a/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableUncollect.cs
+++ b/src/Apache.Calcite.Extensions/Adapter/Enumerable/ClrEnumerableUncollect.cs
@@ -24,7 +24,8 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
 
         /// <summary>
         /// Creates a <see cref="ClrEnumerableUncollect"/>. Each field of the input must be an array or a
-        /// multiset.
+        /// multiset, or the input must be the single column of type ANY that
+        /// <see cref="IsSingleAnyColumn"/> is about.
         /// </summary>
         /// <param name="traitSet"></param>
         /// <param name="input"></param>
@@ -67,33 +68,52 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
             org.apache.calcite.linq4j.tree.Expression? flatListForSingleItem = null;
 
             var fields = child.getRowType().getFieldList();
-            for (int i = 0; i < fields.size(); i++)
+            var ordinality = withOrdinality;
+
+            if (IsSingleAnyColumn(fields))
             {
-                var type = ((RelDataTypeField)fields.get(i)).getType();
+                // the same pair every non-struct element type emits below, which SqlFunctions.flatProduct
+                // answers with LIST_AS_ENUMERABLE: it reads the run-time value as a java.util.List and takes
+                // a null as the empty sequence, which is what UNNEST of a null array answers anyway
+                fieldCounts.add(java.lang.Integer.valueOf(-1));
+                inputTypes.add(SqlFunctions.FlatProductInputType.SCALAR);
 
-                if (type is MapSqlType)
+                // the ordinality goes with the row type rather than with the request, because that ANY branch
+                // of deriveUncollectRowType builds one column whatever WITH ORDINALITY said, as
+                // SqlUnnestOperator.inferReturnType does before it. An ordinal here would be a second value
+                // in a row the physical type has one field for.
+                ordinality = false;
+            }
+            else
+            {
+                for (int i = 0; i < fields.size(); i++)
                 {
-                    fieldCounts.add(java.lang.Integer.valueOf(2));
-                    inputTypes.add(SqlFunctions.FlatProductInputType.MAP);
-                    continue;
-                }
+                    var type = ((RelDataTypeField)fields.get(i)).getType();
 
-                var elementType = org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow(type);
-                if (elementType.isStruct() == false)
-                {
-                    fieldCounts.add(java.lang.Integer.valueOf(-1));
-                    inputTypes.add(SqlFunctions.FlatProductInputType.SCALAR);
-                    continue;
-                }
+                    if (type is MapSqlType)
+                    {
+                        fieldCounts.add(java.lang.Integer.valueOf(2));
+                        inputTypes.add(SqlFunctions.FlatProductInputType.MAP);
+                        continue;
+                    }
 
-                // CALCITE-4063: one field, itself a struct of one item, and no ordinality, means the result is
-                // a scalar rather than a list of one
-                if (elementType.getFieldCount() == 1 && fields.size() == 1 && withOrdinality == false)
-                    flatListForSingleItem = org.apache.calcite.linq4j.tree.Expressions.call(BuiltInMethod.FLAT_LIST.method);
-                else
-                {
-                    fieldCounts.add(java.lang.Integer.valueOf(elementType.getFieldCount()));
-                    inputTypes.add(SqlFunctions.FlatProductInputType.LIST);
+                    var elementType = org.apache.calcite.sql.type.NonNullableAccessors.getComponentTypeOrThrow(type);
+                    if (elementType.isStruct() == false)
+                    {
+                        fieldCounts.add(java.lang.Integer.valueOf(-1));
+                        inputTypes.add(SqlFunctions.FlatProductInputType.SCALAR);
+                        continue;
+                    }
+
+                    // CALCITE-4063: one field, itself a struct of one item, and no ordinality, means the result is
+                    // a scalar rather than a list of one
+                    if (elementType.getFieldCount() == 1 && fields.size() == 1 && withOrdinality == false)
+                        flatListForSingleItem = org.apache.calcite.linq4j.tree.Expressions.call(BuiltInMethod.FLAT_LIST.method);
+                    else
+                    {
+                        fieldCounts.add(java.lang.Integer.valueOf(elementType.getFieldCount()));
+                        inputTypes.add(SqlFunctions.FlatProductInputType.LIST);
+                    }
                 }
             }
 
@@ -109,7 +129,7 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                 ?? org.apache.calcite.linq4j.tree.Expressions.call(
                     BuiltInMethod.FLAT_PRODUCT.method,
                     org.apache.calcite.linq4j.tree.Expressions.constant(counts),
-                    org.apache.calcite.linq4j.tree.Expressions.constant(java.lang.Boolean.valueOf(withOrdinality)),
+                    org.apache.calcite.linq4j.tree.Expressions.constant(java.lang.Boolean.valueOf(ordinality)),
                     org.apache.calcite.linq4j.tree.Expressions.constant(types));
 
             var sourceType = result.PhysType.RowType;
@@ -120,6 +140,30 @@ namespace Apache.Calcite.Extensions.Adapter.Enumerable
                     ClrBuiltInMethod.SelectMany.MakeGenericMethod(sourceType, rowType),
                     result.Expression,
                     ClrEnumUtils.Convert(implementor.Translator.Translate(lambda), typeof(org.apache.calcite.linq4j.function.Function1))));
+        }
+
+        /// <summary>
+        /// Whether the input is the one column of type ANY that <c>Uncollect.deriveUncollectRowType</c>
+        /// answers with a single ANY column of its own.
+        /// </summary>
+        /// <param name="fields">the input's fields</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Not a port, and an addition rather than a defect: <c>EnumerableUncollect</c> cannot implement this
+        /// shape either, and fails before a row is read — it asks
+        /// <c>NonNullableAccessors.getComponentTypeOrThrow</c> for an element type an ANY has not got, which
+        /// is a plan Calcite forms and then throws <c>componentType is null for ANY</c> over.
+        /// <see cref="ClrAnyAggImplementors"/> is the same argument for the aggregates, and says more about
+        /// why a column of type ANY is the ordinary case rather than an exotic one.
+        ///
+        /// <para>The test is <c>deriveUncollectRowType</c>'s own, which is what makes it exact rather than a
+        /// guess: one field and ANY is the only shape that reaches the branch, because two fields of which
+        /// one is ANY throws <c>unnestArgument</c> while the node is being built and never arrives here.</para>
+        /// </remarks>
+        static bool IsSingleAnyColumn(java.util.List fields)
+        {
+            return fields.size() == 1
+                && ((RelDataTypeField)fields.get(0)).getType().getSqlTypeName() == SqlTypeName.ANY;
         }
 
     }

--- a/src/Apache.Calcite.Tests/AsyncTestSchema.cs
+++ b/src/Apache.Calcite.Tests/AsyncTestSchema.cs
@@ -97,6 +97,21 @@ namespace Apache.Calcite.Tests
         ];
 
         /// <summary>
+        /// The values a document store puts behind a path that holds a JSON array.
+        /// </summary>
+        /// <remarks>
+        /// The same rows as <c>ClrEnumerableDifferentialTests.DocsTable</c>, which is what makes the
+        /// synchronous convention an oracle for this one — and it is the only oracle there is, because
+        /// Calcite cannot implement an UNNEST over a column of type ANY at all.
+        /// </remarks>
+        public static readonly object?[][] Docs =
+        [
+            [java.lang.Integer.valueOf(1), List("red", "green"), List(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2))],
+            [java.lang.Integer.valueOf(2), List("blue"), List()],
+            [java.lang.Integer.valueOf(3), null, List(java.lang.Integer.valueOf(3), java.lang.Double.valueOf(4.5))],
+        ];
+
+        /// <summary>
         /// The values a document store puts behind an ANY column — a GUID, a timestamp and a number, each
         /// written the way JSON writes it.
         /// </summary>
@@ -174,6 +189,33 @@ namespace Apache.Calcite.Tests
                 .add("V", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
                 .add("S", typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
                 .build();
+        }
+
+        /// <summary>
+        /// Returns the DOCS row type.
+        /// </summary>
+        public static RelDataType DocsRowType(RelDataTypeFactory typeFactory)
+        {
+            RelDataType Any() => typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true);
+
+            return typeFactory.builder()
+                .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                .add("TAGS", Any())
+                .add("NUMS", Any())
+                .build();
+        }
+
+        /// <summary>
+        /// Returns a <c>java.util.List</c> of the items given, which is what a collection behind an ANY
+        /// column has to be for <c>SqlFunctions.flatProduct</c> to read it.
+        /// </summary>
+        static java.util.List List(params object?[] items)
+        {
+            var list = new java.util.ArrayList();
+            foreach (var item in items)
+                list.add(item);
+
+            return list;
         }
 
     }

--- a/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrAsyncEnumerableDifferentialTests.cs
@@ -56,6 +56,7 @@ namespace Apache.Calcite.Tests
                 rootSchema.add("WIDE", new AsyncRowsTable(AsyncTestRows.Wide, AsyncTestRows.WideRowType, false));
                 rootSchema.add("ANYS", new AsyncRowsTable(AsyncTestRows.Anys, AsyncTestRows.AnysRowType, false));
                 rootSchema.add("CASTS", new AsyncRowsTable(AsyncTestRows.Casts, AsyncTestRows.CastsRowType, false));
+                rootSchema.add("DOCS", new AsyncRowsTable(AsyncTestRows.Docs, AsyncTestRows.DocsRowType, false));
             }
             else
             {
@@ -64,6 +65,7 @@ namespace Apache.Calcite.Tests
                 rootSchema.add("WIDE", new SyncRowsTable(AsyncTestRows.Wide, AsyncTestRows.WideRowType, false));
                 rootSchema.add("ANYS", new SyncRowsTable(AsyncTestRows.Anys, AsyncTestRows.AnysRowType, false));
                 rootSchema.add("CASTS", new SyncRowsTable(AsyncTestRows.Casts, AsyncTestRows.CastsRowType, false));
+                rootSchema.add("DOCS", new SyncRowsTable(AsyncTestRows.Docs, AsyncTestRows.DocsRowType, false));
             }
 
             // a table function, which this convention has no node for: Calcite plans it and the converter
@@ -557,6 +559,37 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public Task ShouldAgreeOnAnUncollect() =>
             Same("SELECT * FROM UNNEST(ARRAY[1, 2, 3]) AS t(x)");
+
+        // UNNEST over a column of type ANY, whose element type is not known until a row is read. Neither
+        // convention gets this from Calcite — ClrEnumerableUncollect says why and
+        // ClrEnumerableDifferentialTests asserts the answers by hand — so what is checked here is that the
+        // asynchronous convention gives what the synchronous one gives, through its own node. The plan is a
+        // correlate over the uncollect in both, because decorrelation cannot take an UNNEST of a correlation
+        // variable apart.
+
+        [TestMethod]
+        public Task ShouldAgreeOnUncollectingAnAnyColumn() =>
+            SameThrough("ClrAsyncEnumerableUncollect", "SELECT d.ID, t.X FROM DOCS d, UNNEST(d.TAGS) AS t(X)");
+
+        [TestMethod]
+        public Task ShouldAgreeOnUncollectingAnAnyColumnOfMixedNumericTypes() =>
+            SameThrough("ClrAsyncEnumerableUncollect", "SELECT d.ID, t.X FROM DOCS d, UNNEST(d.NUMS) AS t(X)");
+
+        [TestMethod]
+        public Task ShouldAgreeOnOuterUncollectingAnAnyColumn() =>
+            SameThrough("ClrAsyncEnumerableUncollect", "SELECT d.ID, t.X FROM DOCS d LEFT JOIN UNNEST(d.TAGS) AS t(X) ON TRUE");
+
+        [TestMethod]
+        public Task ShouldAgreeOnUncollectingAnAnyColumnWithOrdinality() =>
+            SameThrough("ClrAsyncEnumerableUncollect", "SELECT d.ID, t.X FROM DOCS d, UNNEST(d.TAGS) WITH ORDINALITY AS t(X)");
+
+        [TestMethod]
+        public Task ShouldAgreeOnAggregatingOverAnUncollectedAnyColumn() =>
+            SameThrough("ClrAsyncEnumerableUncollect", "SELECT d.ID, COUNT(*), MIN(t.X), MAX(t.X) FROM DOCS d, UNNEST(d.NUMS) AS t(X) GROUP BY d.ID ORDER BY 1");
+
+        [TestMethod]
+        public Task ShouldAgreeOnFilteringTheOuterRowOfAnUncollectedAnyColumn() =>
+            SameThrough("ClrAsyncEnumerableUncollect", "SELECT t.X FROM DOCS d, UNNEST(d.TAGS) AS t(X) WHERE d.ID = 1");
 
         [TestMethod]
         public Task ShouldAgreeOnACaseAndCoalesce() =>

--- a/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
+++ b/src/Apache.Calcite.Tests/ClrEnumerableDifferentialTests.cs
@@ -241,6 +241,63 @@ namespace Apache.Calcite.Tests
         }
 
         /// <summary>
+        /// A table whose ANY columns hold collections, which is what a document store puts behind a path
+        /// that holds a JSON array.
+        /// </summary>
+        /// <remarks>
+        /// Its own table rather than two more columns on <c>ANYS</c>, because these values are not
+        /// aggregable and <c>ANYS</c> is read by every aggregate test there is.
+        ///
+        /// <para><c>TAGS</c> holds strings and has a null, which is the row an inner UNNEST drops and an
+        /// outer one keeps; <c>NUMS</c> holds two numeric classes and has an empty list, which is the other
+        /// row that produces nothing. The lists are <c>java.util.List</c> because that is what
+        /// <c>SqlFunctions.flatProduct</c> reads a collection as — an array column's value is one there
+        /// too.</para>
+        /// </remarks>
+        sealed class DocsTable : AbstractTable, ScannableTable
+        {
+
+            static java.util.List List(params object?[] items)
+            {
+                var list = new java.util.ArrayList();
+                foreach (var item in items)
+                    list.add(item);
+
+                return list;
+            }
+
+            static readonly object?[][] Rows =
+            [
+                [java.lang.Integer.valueOf(1), List("red", "green"), List(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2))],
+                [java.lang.Integer.valueOf(2), List("blue"), List()],
+                [java.lang.Integer.valueOf(3), null, List(java.lang.Integer.valueOf(3), java.lang.Double.valueOf(4.5))],
+            ];
+
+            /// <inheritdoc />
+            public override RelDataType getRowType(RelDataTypeFactory typeFactory)
+            {
+                RelDataType Any() => typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true);
+
+                return typeFactory.builder()
+                    .add("ID", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .add("TAGS", Any())
+                    .add("NUMS", Any())
+                    .build();
+            }
+
+            /// <inheritdoc />
+            public org.apache.calcite.linq4j.Enumerable scan(DataContext root)
+            {
+                var list = new java.util.ArrayList();
+                foreach (var row in Rows)
+                    list.add(row);
+
+                return Linq4j.asEnumerable(list);
+            }
+
+        }
+
+        /// <summary>
         /// A table whose ANY columns hold the values a document store puts behind one — a GUID, a
         /// timestamp and a number, each written the way JSON writes it.
         /// </summary>
@@ -450,6 +507,7 @@ namespace Apache.Calcite.Tests
             rootSchema.add("WIDE", new WideTable());
             rootSchema.add("ANYS", new AnysTable());
             rootSchema.add("CASTS", new CastsTable());
+            rootSchema.add("DOCS", new DocsTable());
             rootSchema.add("FIB", org.apache.calcite.schema.impl.TableFunctionImpl.create(org.apache.calcite.util.Smalls.FIBONACCI_LIMIT_100_TABLE_METHOD));
 
             // A CUSTOM-format fixture, which every other table here is not. HrSchema's rows are instances of
@@ -1103,6 +1161,88 @@ namespace Apache.Calcite.Tests
         [TestMethod]
         public void ShouldAggregateDistinctlyOverAnAnyColumn() => Gives("SELECT COUNT(DISTINCT \"V\"), SUM(DISTINCT \"V\") FROM \"ANYS\"", "4|65.5");
 
+        // UNNEST over a column of type ANY, which is the other half of what a schema of ANY columns needs
+        // and has the same standing as the aggregates above: EnumerableUncollect asks
+        // NonNullableAccessors.getComponentTypeOrThrow for an element type an ANY has not got and throws
+        // before a row is read, so Calcite forms these plans and cannot run them. The answers are asserted by
+        // hand for that reason, and ShouldStillBeBeyondCalcite says when to come back.
+        //
+        // The plan every one of these takes is a correlate whose right input is the uncollect — Calcite's
+        // decorrelation cannot take an UNNEST of a correlation variable apart, which is why the correlate
+        // survives, and why this is the shape a document store's array traversal actually reaches.
+
+        [TestMethod]
+        public void ShouldUncollectAnAnyColumn() =>
+            Gives("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d, UNNEST(d.\"TAGS\") AS t(\"X\")", "1|red", "1|green", "2|blue");
+
+        /// <summary>
+        /// UNNEST over an ANY column whose lists hold two numeric classes.
+        /// </summary>
+        /// <remarks>
+        /// Nothing converts an element on its way out — <c>SqlFunctions.flatProduct</c> answers a single
+        /// SCALAR field with <c>LIST_AS_ENUMERABLE</c>, which enumerates the list as it stands — so an
+        /// <c>Integer</c> and a <c>Double</c> in one column come through as themselves, which is what an ANY
+        /// column means.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldUncollectAnAnyColumnOfMixedNumericTypes() =>
+            Gives("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d, UNNEST(d.\"NUMS\") AS t(\"X\")", "1|1", "1|2", "3|3", "3|4.5");
+
+        /// <summary>
+        /// An outer UNNEST over an ANY column, which is where a null one shows.
+        /// </summary>
+        /// <remarks>
+        /// A null and an empty list answer alike, and for the same reason an array column's do:
+        /// <c>LIST_AS_ENUMERABLE</c> takes a null as the empty sequence, and a correlate emits nothing for an
+        /// outer row whose right side is empty. So an inner UNNEST drops the row — row 3 has a null
+        /// <c>TAGS</c> and row 2 an empty <c>NUMS</c>, and neither appears in the two tests above — and an
+        /// outer one keeps it against a null, which is what this asserts.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldOuterUncollectANullAnyColumn() =>
+            Gives("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d LEFT JOIN UNNEST(d.\"TAGS\") AS t(\"X\") ON TRUE",
+                "1|red", "1|green", "2|blue", "3|<null>");
+
+        /// <summary>
+        /// WITH ORDINALITY over an ANY column, which has no ordinal.
+        /// </summary>
+        /// <remarks>
+        /// Not a choice of this convention's. <c>SqlUnnestOperator.inferReturnType</c> answers a single
+        /// <c>$unnest</c> column of type ANY and stops, ordinality or not, and
+        /// <c>Uncollect.deriveUncollectRowType</c> does the same — so the validator already reports the table
+        /// as having one column, and naming two aliases for it is a validation error rather than anything a
+        /// node could answer. The node still carries <c>withOrdinality</c>, so what
+        /// <c>ClrEnumerableUncollect</c> does is keep the rows it emits to the width the row type declares.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldDropTheOrdinalityOfAnUncollectedAnyColumn() =>
+            Gives("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d, UNNEST(d.\"TAGS\") WITH ORDINALITY AS t(\"X\")",
+                "1|red", "1|green", "2|blue");
+
+        /// <summary>
+        /// An aggregate over the column an UNNEST of an ANY column produces, which is itself ANY.
+        /// </summary>
+        /// <remarks>
+        /// The two additions meeting: the element type is unknown to the uncollect, so the column it produces
+        /// is ANY, and MIN and MAX over it are <see cref="ClrAnyAggImplementors"/>'s. A document store
+        /// counting and ranging over the elements of a path is the reason either of them exists.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldAggregateOverAnUncollectedAnyColumn() =>
+            Gives("SELECT d.\"ID\", COUNT(*), MIN(t.\"X\"), MAX(t.\"X\") FROM \"DOCS\" d, UNNEST(d.\"NUMS\") AS t(\"X\") GROUP BY d.\"ID\" ORDER BY 1",
+                "1|2|1|2", "3|2|3|4.5");
+
+        /// <summary>
+        /// A filter on the outer row of an UNNEST over an ANY column.
+        /// </summary>
+        /// <remarks>
+        /// The calc lands under the correlate rather than over the uncollect, so this measures that the
+        /// correlate's left input can be something other than a bare scan while its right is the ANY path.
+        /// </remarks>
+        [TestMethod]
+        public void ShouldFilterTheOuterRowOfAnUncollectedAnyColumn() =>
+            Gives("SELECT t.\"X\" FROM \"DOCS\" d, UNNEST(d.\"TAGS\") AS t(\"X\") WHERE d.\"ID\" = 1", "red", "green");
+
         /// <summary>
         /// Requires that these are still queries Calcite itself cannot run.
         /// </summary>
@@ -1146,6 +1286,10 @@ namespace Apache.Calcite.Tests
             StillBeyondCalcite("SELECT VAR_POP(\"V\") FROM \"ANYS\"");
             StillBeyondCalcite("SELECT MIN(\"V\") FILTER (WHERE \"ID\" > 1) FROM \"ANYS\"");
             StillBeyondCalcite("SELECT \"K\", MIN(\"V\"), SUM(\"V\") FROM \"ANYS\" GROUP BY \"K\"");
+
+            StillBeyondCalcite("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d, UNNEST(d.\"TAGS\") AS t(\"X\")");
+            StillBeyondCalcite("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d LEFT JOIN UNNEST(d.\"TAGS\") AS t(\"X\") ON TRUE");
+            StillBeyondCalcite("SELECT d.\"ID\", t.\"X\" FROM \"DOCS\" d, UNNEST(d.\"TAGS\") WITH ORDINALITY AS t(\"X\")");
         }
 
         // and the same column read every way that already worked, so that a change here is known to be about


### PR DESCRIPTION
Closes #47. This is the uncollect half; the aggregate half was #48.

## What was wrong

The issue records two shapes the asynchronous convention forms a plan for and then cannot implement, and reads the second as a correlate problem: *"The correlated `Calc` on the right — the one reading `$cor0` — looks like the piece that has nowhere to get its correlation value from."*

It is not the correlate. A correlate over an uncollect already runs in both conventions, over a typed array column, and `ClrEnumerableQueryTests.ShouldCorrelateThroughTheShippedProgram` has held that for a while. What fails is the UNNEST itself, because the column it reads is ANY:

- `SqlUnnestOperator.inferReturnType` sees an ANY operand and answers **one column named `$unnest`, of type ANY**, ordinality or not.
- `Uncollect.deriveUncollectRowType` has the matching branch and answers one ANY column for a single ANY field.
- `EnumerableUncollect.implement` then asks `NonNullableAccessors.getComponentTypeOrThrow` for the element type, and an ANY has none: **`componentType is null for ANY`**, thrown before a row is read.

So `EnumerableConvention` fails on this too, measured at the commit before this one. `UNNEST(c."_MAP"['tags'])` reaches it because `ITEM` over a `(VARCHAR, ANY) MAP` is ANY — which is the ordinary case in a document store, not an exotic one. There is nothing upstream to port, and this is an addition rather than a defect, exactly as `ClrAnyAggImplementors` is.

## What it does

`ClrEnumerableUncollect` and `ClrAsyncEnumerableUncollect` recognise the shape `deriveUncollectRowType` already special-cases — one field, type ANY — and emit for it the pair every non-struct element type emits anyway: a field count of `-1` and `FlatProductInputType.SCALAR`.

That is enough, and it is still Calcite's own runtime doing the work. `SqlFunctions.flatProduct` answers a single SCALAR field with `LIST_AS_ENUMERABLE`, which reads the run-time value as a `java.util.List` and takes a null as the empty sequence; and `JavaRowFormat.optimize` makes a one-field row type SCALAR, so the element arrives as the row rather than as a list of one. Nothing converts an element on the way out, which is what an ANY column means: an `Integer` and a `Double` in one list come through as themselves.

**The ordinality follows the row type, not the request.** That ANY branch builds one column whatever `WITH ORDINALITY` said, so the validator already reports the table as having one column and naming two aliases for it is a validation error rather than anything a node could answer. The node still carries `withOrdinality`, so what these do is keep the rows they emit to the width the row type declares — an ordinal would be a second value in a row the physical type has one field for.

## Tests

A `DOCS` table whose ANY columns hold `java.util.List`, in both harnesses and with the same rows, so the synchronous convention is an oracle for the asynchronous one. `TAGS` holds strings and has a null; `NUMS` holds two numeric classes and has an empty list.

- **Answers asserted by hand** on the synchronous side, because Calcite is no oracle here, and **`ShouldStillBeBeyondCalcite`** grows three entries pinning that it still cannot run them. If that goes red, that is the moment to compare the two row by row rather than let them drift.
- **The asynchronous side** compares against the synchronous one and names the node it went through (`SameThrough`), so a plan reached by some other route cannot pass.
- Inner and outer, mixed numeric classes, `WITH ORDINALITY`, a filter on the outer row, and **MIN and MAX over the column the uncollect produces** — which is itself ANY, so this is the one test where both ANY additions are on the same plan.

Every one of these plans is a correlate whose right input is the uncollect, which is the shape the issue reports: decorrelation cannot take an UNNEST of a correlation variable apart.

839 tests in `Apache.Calcite.Tests` on net8.0 and net10.0, 488 in `Apache.Calcite.Adapter.AdoNet.Tests`, 422 in `Apache.Calcite.Data.Tests`. All green, none skipped.

## Not covered

Only a **single** ANY field reaches the new branch, which is exact rather than conservative: two fields of which one is ANY throws `unnestArgument` while the node is being built and never arrives at an implementor. An ANY value that holds a map rather than a list is read as a list and fails there, because the MAP branch is chosen from the static type and an ANY has not got one — the same thing an array column whose value is a map would do.

The correlate's left input is a scan of this convention in every test here. In the issue it is the Cosmos adapter's own converter, which nothing in this repository can stand in for without writing an adapter convention to be converted from — and the aggregate half of the same issue had the identical left and was closed by #48 without touching a converter.
