### PR TITLE
Give linq4j's predicates an adapter each

### DIFF
--- a/src/Apache.Calcite.Extensions/Linq4j/Function/DelegatePredicates.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Function/DelegatePredicates.cs
@@ -1,0 +1,48 @@
+using System;
+
+using Apache.Calcite.Extensions.Interop;
+
+using org.apache.calcite.linq4j.function;
+
+namespace Apache.Calcite.Extensions.Linq4j.Function
+{
+
+    /// <summary>
+    /// A linq4j <see cref="Predicate1"/> backed by a delegate.
+    /// </summary>
+    /// <typeparam name="T0"></typeparam>
+    /// <param name="predicate"></param>
+    /// <remarks>
+    /// The counterpart of <see cref="DelegateFunction1Of{T0, TResult}"/> for the interface linq4j uses where
+    /// the answer is a <see cref="bool"/> rather than a value. It is separate from the function adapters
+    /// because <c>Predicate1</c> is not a <c>Function1</c> of <c>Boolean</c>: it declares its own
+    /// <c>apply</c> returning a primitive, so a <c>Function1</c> put in its place does not implement it.
+    /// </remarks>
+    sealed class DelegatePredicate1<T0>(Func<T0, bool> predicate) : Predicate1
+    {
+
+        readonly Func<T0, bool> predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+
+        /// <inheritdoc />
+        public bool apply(object? v0) => predicate(JavaValues.As<T0>(v0));
+
+    }
+
+    /// <summary>
+    /// A linq4j <see cref="Predicate2"/> backed by a delegate.
+    /// </summary>
+    /// <typeparam name="T0"></typeparam>
+    /// <typeparam name="T1"></typeparam>
+    /// <param name="predicate"></param>
+    /// <inheritdoc cref="DelegatePredicate1{T0}" path="/remarks"/>
+    sealed class DelegatePredicate2<T0, T1>(Func<T0, T1, bool> predicate) : Predicate2
+    {
+
+        readonly Func<T0, T1, bool> predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+
+        /// <inheritdoc />
+        public bool apply(object? v0, object? v1) => predicate(JavaValues.As<T0>(v0), JavaValues.As<T1>(v1));
+
+    }
+
+}

--- a/src/Apache.Calcite.Extensions/Linq4j/Tree/AnonymousClasses.cs
+++ b/src/Apache.Calcite.Extensions/Linq4j/Tree/AnonymousClasses.cs
@@ -32,6 +32,8 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
             [typeof(org.apache.calcite.linq4j.function.Function0)] = typeof(DelegateFunction0<>),
             [typeof(org.apache.calcite.linq4j.function.Function1)] = typeof(DelegateFunction1Of<,>),
             [typeof(org.apache.calcite.linq4j.function.Function2)] = typeof(DelegateFunction2<,,>),
+            [typeof(org.apache.calcite.linq4j.function.Predicate1)] = typeof(DelegatePredicate1<>),
+            [typeof(org.apache.calcite.linq4j.function.Predicate2)] = typeof(DelegatePredicate2<,>),
         };
 
         /// <summary>
@@ -42,6 +44,17 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
         /// a boolean. Neither has a result worth naming the adapter by.
         /// </remarks>
         static readonly HashSet<Type> ByArgument = [typeof(DelegateComparator<>), typeof(DelegatePredicate<>)];
+
+        /// <summary>
+        /// The interfaces named by every type they take, with no result to name them by.
+        /// </summary>
+        /// <remarks>
+        /// A linq4j predicate answers a primitive <see cref="bool"/> declared on itself rather than a
+        /// <c>Function</c>'s value, so the adapter is closed over what it takes and nothing else. That is
+        /// what separates these from <see cref="ByArgument"/>, which names an interface by its first
+        /// parameter because the rest repeat it.
+        /// </remarks>
+        static readonly HashSet<Type> ByArguments = [typeof(DelegatePredicate1<>), typeof(DelegatePredicate2<,>)];
 
         /// <summary>
         /// The interfaces an anonymous class implements with more than one method, and the order its methods
@@ -118,7 +131,10 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
             // an adapter whose every parameter type is fixed has nothing to close over
             var closed = adapter.IsGenericTypeDefinition == false
                 ? adapter
-                : adapter.MakeGenericType(ByArgument.Contains(adapter) ? [lambda.Parameters[0].Type] : Arguments(lambda));
+                : adapter.MakeGenericType(
+                    ByArgument.Contains(adapter) ? [lambda.Parameters[0].Type] :
+                    ByArguments.Contains(adapter) ? Parameters(lambda) :
+                    Arguments(lambda));
             var constructor = closed.GetConstructor([lambda.Type])
                 ?? closed.GetConstructors()[0];
 
@@ -147,6 +163,20 @@ namespace Apache.Calcite.Extensions.Linq4j.Tree
                 return inner;
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns the parameter types of a lambda.
+        /// </summary>
+        /// <param name="lambda"></param>
+        /// <returns></returns>
+        static Type[] Parameters(LambdaExpression lambda)
+        {
+            var parameters = new Type[lambda.Parameters.Count];
+            for (int i = 0; i < parameters.Length; i++)
+                parameters[i] = lambda.Parameters[i].Type;
+
+            return parameters;
         }
 
         /// <summary>

--- a/src/Apache.Calcite.Tests/AnonymousPredicateTests.cs
+++ b/src/Apache.Calcite.Tests/AnonymousPredicateTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq.Expressions;
+
+using Apache.Calcite.Extensions.Linq4j.Tree;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using org.apache.calcite.linq4j.function;
+
+namespace Apache.Calcite.Tests
+{
+
+    /// <summary>
+    /// Requires that a lambda declared as one of linq4j's predicates is wrapped to be one.
+    /// </summary>
+    /// <remarks>
+    /// A block of Calcite's making passes a lambda to an operator of its own, whose parameter is the
+    /// functional interface the lambda was declared against. <see cref="AnonymousClasses"/> is what turns the
+    /// delegate into that interface, and an interface missing from its table is not refused: the lambda is
+    /// left a delegate and the conversion to the interface is emitted anyway, which the expression compiler
+    /// accepts — a delegate and an interface are both references — and which throws
+    /// <see cref="InvalidCastException"/> the first time the compiled plan runs.
+    ///
+    /// <para>That is how <c>Predicate1</c> and <c>Predicate2</c> were missed. They are not
+    /// <c>Function1</c> and <c>Function2</c> of <c>Boolean</c>: each declares its own <c>apply</c> returning
+    /// a primitive, so a function adapter put in their place does not implement them either. The failure has
+    /// no compile-time symptom and does not appear until a plan that mixes this convention with Calcite's own
+    /// reaches such an operator, so the table is checked here directly.</para>
+    /// </remarks>
+    [TestClass]
+    public class AnonymousPredicateTests
+    {
+
+        /// <summary>
+        /// Every functional interface a linq4j tree may declare a lambda against has to be one
+        /// <see cref="AnonymousClasses"/> handles, or the conversion is emitted unwrapped.
+        /// </summary>
+        [TestMethod]
+        public void ShouldHandleLinq4jPredicates()
+        {
+            AnonymousClasses.Handles(typeof(Predicate1)).Should().BeTrue();
+            AnonymousClasses.Handles(typeof(Predicate2)).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// A one-argument predicate answers what its delegate answers, through the interface.
+        /// </summary>
+        [TestMethod]
+        public void ShouldWrapPredicate1()
+        {
+            Expression<Func<string, bool>> lambda = s => s.Length > 2;
+
+            var wrapped = AnonymousClasses.Wrap(typeof(Predicate1), lambda);
+            wrapped.Type.Should().Be(typeof(Predicate1));
+
+            var predicate = (Predicate1)Expression.Lambda<Func<Predicate1>>(wrapped).Compile()();
+            predicate.apply("abc").Should().BeTrue();
+            predicate.apply("ab").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A two-argument predicate is closed over both of the types it takes, neither of them its result:
+        /// the pair the join in a mixed plan hands it is a row and a key, and they are not the same type.
+        /// </summary>
+        [TestMethod]
+        public void ShouldWrapPredicate2()
+        {
+            Expression<Func<object[], int, bool>> lambda = (row, key) => (int)row[0] == key;
+
+            var wrapped = AnonymousClasses.Wrap(typeof(Predicate2), lambda);
+            wrapped.Type.Should().Be(typeof(Predicate2));
+
+            var predicate = (Predicate2)Expression.Lambda<Func<Predicate2>>(wrapped).Compile()();
+            predicate.apply(new object[] { 1 }, 1).Should().BeTrue();
+            predicate.apply(new object[] { 1 }, 2).Should().BeFalse();
+        }
+
+    }
+
+}


### PR DESCRIPTION
A lambda a linq4j tree declares against one of its functional interfaces is wrapped to be that
interface by `AnonymousClasses`, and its table had no entry for `Predicate1` or `Predicate2`.

A missing entry is not refused. `LixToClrTranslator.Coerce` wraps only what `Handles` answers for:

```csharp
if (value is LambdaExpression lambda && AnonymousClasses.Handles(type))
    return AnonymousClasses.Wrap(type, lambda);

return ClrEnumUtils.Convert(value, type);
```

so the delegate was converted to the interface instead — which the expression compiler accepts, a
delegate and an interface both being references, and which throws `InvalidCastException` the first
time the compiled plan runs. There is no compile-time symptom and nothing to see in the tree.

## Why these two were missed

They look like functions that answer a boolean and are not. `Predicate1<T0>` and `Predicate2<T0,T1>`
extend `Function<Boolean>` but each declares its own `apply` returning a **primitive** `boolean`, so
`DelegateFunction1Of` and `DelegateFunction2` do not implement them and could not have stood in.

## The third closing rule

The adapters are closed over what they take and nothing else, which is a rule beside the two already
in the file:

| shape | closed over |
|---|---|
| `Function0/1/2` | its arguments and its result |
| `Comparator`, `java.util.function.Predicate` | its first argument, the rest repeating it |
| `Predicate1`, `Predicate2` | all of its arguments, with no result to name |

That distinction is load-bearing rather than tidy: a `Predicate2` in a plan that mixes this
convention with Calcite's own is handed a row and a key, and those are not the same type, so the
first-argument rule would close it wrong.

## Where it came from

Found from **calcite-efcore**, whose EF Core adapter reaches Calcite's own `EnumerableConvention`
through the bridge. One spec-suite query — `NorthwindGroupByQueryCalciteTest
.Complex_query_with_group_by_in_subquery5` — failed in both its synchronous and asynchronous
variants with:

```
InvalidCastException : Unable to cast object of type
  'System.Func`3[System.Object[],System.Int32,System.Boolean]'
  to type 'org.apache.calcite.linq4j.function.Predicate2'
   at lambda_method…(Closure, DataContext)
```

It surfaced there when that adapter's one outgoing arc moved from `ClrAsyncEnumerableConvention` to
`ClrEnumerableConvention` after #126: the route shortened from
EfCore → ClrAsyncEnumerable → ClrEnumerable → Enumerable to EfCore → ClrEnumerable → Enumerable, a
different mix of nodes won, and the latent boundary reached a `Predicate2`. The bug predates that —
nothing about it is specific to the adapter, and any mixed plan reaching one of these operators would
have hit it.

## Testing

- `Apache.Calcite.Tests` — **849 passed, 0 failed**.
- Three new tests over the adapter table in `AnonymousPredicateTests`. They are regression tests,
  not decoration: verified failing against this branch's parent (`Wrap` throws `NotSupportedException`)
  and passing with the change.
- Verified end to end: `Apache.Calcite.Extensions` packed from this branch and consumed by
  calcite-efcore in place of `2.0.1-pre.96` makes the failing query pass in both variants.
